### PR TITLE
feat: add implementation for flownode instance entity, filter, sort, transformer

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -13,7 +13,7 @@ import io.camunda.service.CamundaServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.service.DocumentServices;
-import io.camunda.service.FlownodeInstanceServices;
+import io.camunda.service.FlowNodeInstanceServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.MessageServices;
@@ -82,7 +82,7 @@ public class CamundaServicesConfiguration {
   }
 
   @Bean
-  public FlownodeInstanceServices flownodeInstanceServices(final CamundaServices camundaServices) {
+  public FlowNodeInstanceServices flownodeInstanceServices(final CamundaServices camundaServices) {
     return camundaServices.flownodeInstanceServices();
   }
 

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -57,8 +57,8 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
     return new IncidentServices(brokerClient, searchClient, transformers, authentication);
   }
 
-  public FlownodeInstanceServices flownodeInstanceServices() {
-    return new FlownodeInstanceServices(brokerClient, searchClient, transformers, authentication);
+  public FlowNodeInstanceServices flownodeInstanceServices() {
+    return new FlowNodeInstanceServices(brokerClient, searchClient, transformers, authentication);
   }
 
   public UserServices userServices() {

--- a/service/src/main/java/io/camunda/service/FlowNodeInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/FlowNodeInstanceServices.java
@@ -8,9 +8,9 @@
 package io.camunda.service;
 
 import io.camunda.search.clients.CamundaSearchClient;
-import io.camunda.service.entities.FlownodeInstanceEntity;
+import io.camunda.service.entities.FlowNodeInstanceEntity;
 import io.camunda.service.search.core.SearchQueryService;
-import io.camunda.service.search.query.FlownodeInstanceQuery;
+import io.camunda.service.search.query.FlowNodeInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
@@ -19,16 +19,16 @@ import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.function.Function;
 
-public final class FlownodeInstanceServices
+public final class FlowNodeInstanceServices
     extends SearchQueryService<
-        FlownodeInstanceServices, FlownodeInstanceQuery, FlownodeInstanceEntity> {
+        FlowNodeInstanceServices, FlowNodeInstanceQuery, FlowNodeInstanceEntity> {
 
-  public FlownodeInstanceServices(
+  public FlowNodeInstanceServices(
       final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
     this(brokerClient, dataStoreClient, null, null);
   }
 
-  public FlownodeInstanceServices(
+  public FlowNodeInstanceServices(
       final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
@@ -37,17 +37,17 @@ public final class FlownodeInstanceServices
   }
 
   @Override
-  public FlownodeInstanceServices withAuthentication(final Authentication authentication) {
-    return new FlownodeInstanceServices(brokerClient, searchClient, transformers, authentication);
+  public FlowNodeInstanceServices withAuthentication(final Authentication authentication) {
+    return new FlowNodeInstanceServices(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override
-  public SearchQueryResult<FlownodeInstanceEntity> search(final FlownodeInstanceQuery query) {
-    return executor.search(query, FlownodeInstanceEntity.class);
+  public SearchQueryResult<FlowNodeInstanceEntity> search(final FlowNodeInstanceQuery query) {
+    return executor.search(query, FlowNodeInstanceEntity.class);
   }
 
-  public SearchQueryResult<FlownodeInstanceEntity> search(
-      final Function<FlownodeInstanceQuery.Builder, ObjectBuilder<FlownodeInstanceQuery>> fn) {
+  public SearchQueryResult<FlowNodeInstanceEntity> search(
+      final Function<FlowNodeInstanceQuery.Builder, ObjectBuilder<FlowNodeInstanceQuery>> fn) {
     return search(SearchQueryBuilders.flownodeInstanceSearchQuery(fn));
   }
 }

--- a/service/src/main/java/io/camunda/service/entities/FlowNodeInstanceEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/FlowNodeInstanceEntity.java
@@ -10,7 +10,7 @@ package io.camunda.service.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record FlownodeInstanceEntity(
+public record FlowNodeInstanceEntity(
     Long key,
     Long processInstanceKey,
     Long processDefinitionKey,

--- a/service/src/main/java/io/camunda/service/entities/FlowNodeInstanceEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/FlowNodeInstanceEntity.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record FlowNodeInstanceEntity(
-    Long key,
+    Long flowNodeInstanceKey,
     Long processInstanceKey,
     Long processDefinitionKey,
     String startDate,

--- a/service/src/main/java/io/camunda/service/entities/FlownodeInstanceEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/FlownodeInstanceEntity.java
@@ -7,4 +7,20 @@
  */
 package io.camunda.service.entities;
 
-public record FlownodeInstanceEntity() {}
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record FlownodeInstanceEntity(
+    Long key,
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String startDate,
+    String endDate,
+    String flowNodeId,
+    String flowNodeName,
+    String treePath,
+    String type,
+    String state,
+    Boolean incident,
+    Long incidentKey,
+    String tenantId) {}

--- a/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
@@ -30,8 +30,8 @@ public final class FilterBuilders {
     return new DecisionRequirementsFilter.Builder();
   }
 
-  public static FlownodeInstanceFilter.Builder flownodeInstance() {
-    return new FlownodeInstanceFilter.Builder();
+  public static FlowNodeInstanceFilter.Builder flownodeInstance() {
+    return new FlowNodeInstanceFilter.Builder();
   }
 
   public static UserFilter.Builder user() {

--- a/service/src/main/java/io/camunda/service/search/filter/FlowNodeInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FlowNodeInstanceFilter.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 public record FlowNodeInstanceFilter(
-    List<Long> keys,
+    List<Long> flowNodeInstanceKeys,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
     List<String> states,
@@ -31,7 +31,7 @@ public record FlowNodeInstanceFilter(
 
   public static final class Builder implements ObjectBuilder<FlowNodeInstanceFilter> {
 
-    private List<Long> keys;
+    private List<Long> flowNodeInstanceKeys;
     private List<Long> processInstanceKeys;
     private List<Long> processDefinitionKeys;
     private List<String> states;
@@ -43,13 +43,13 @@ public record FlowNodeInstanceFilter(
     private List<Long> incidentKeys;
     private List<String> tenantIds;
 
-    public FlowNodeInstanceFilter.Builder keys(final List<Long> values) {
-      keys = addValuesToList(keys, values);
+    public FlowNodeInstanceFilter.Builder flowNodeInstanceKeys(final List<Long> values) {
+      flowNodeInstanceKeys = addValuesToList(flowNodeInstanceKeys, values);
       return this;
     }
 
     public FlowNodeInstanceFilter.Builder keys(final Long... values) {
-      return keys(collectValuesAsList(values));
+      return flowNodeInstanceKeys(collectValuesAsList(values));
     }
 
     public FlowNodeInstanceFilter.Builder processInstanceKeys(final List<Long> values) {
@@ -141,7 +141,7 @@ public record FlowNodeInstanceFilter(
     @Override
     public FlowNodeInstanceFilter build() {
       return new FlowNodeInstanceFilter(
-          Objects.requireNonNullElse(keys, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(states, Collections.emptyList()),

--- a/service/src/main/java/io/camunda/service/search/filter/FlowNodeInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FlowNodeInstanceFilter.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public record FlownodeInstanceFilter(
+public record FlowNodeInstanceFilter(
     List<Long> keys,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
@@ -29,7 +29,7 @@ public record FlownodeInstanceFilter(
     List<String> tenantIds)
     implements FilterBase {
 
-  public static final class Builder implements ObjectBuilder<FlownodeInstanceFilter> {
+  public static final class Builder implements ObjectBuilder<FlowNodeInstanceFilter> {
 
     private List<Long> keys;
     private List<Long> processInstanceKeys;
@@ -43,104 +43,104 @@ public record FlownodeInstanceFilter(
     private List<Long> incidentKeys;
     private List<String> tenantIds;
 
-    public FlownodeInstanceFilter.Builder keys(final List<Long> values) {
+    public FlowNodeInstanceFilter.Builder keys(final List<Long> values) {
       keys = addValuesToList(keys, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder keys(final Long... values) {
+    public FlowNodeInstanceFilter.Builder keys(final Long... values) {
       return keys(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder processInstanceKeys(final List<Long> values) {
+    public FlowNodeInstanceFilter.Builder processInstanceKeys(final List<Long> values) {
       processInstanceKeys = addValuesToList(processInstanceKeys, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder processInstanceKeys(final Long... values) {
+    public FlowNodeInstanceFilter.Builder processInstanceKeys(final Long... values) {
       return processInstanceKeys(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder processDefinitionKeys(final List<Long> values) {
+    public FlowNodeInstanceFilter.Builder processDefinitionKeys(final List<Long> values) {
       processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder processDefinitionKeys(final Long... values) {
+    public FlowNodeInstanceFilter.Builder processDefinitionKeys(final Long... values) {
       return processDefinitionKeys(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder states(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder states(final List<String> values) {
       states = addValuesToList(states, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder states(final String... values) {
+    public FlowNodeInstanceFilter.Builder states(final String... values) {
       return states(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder types(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder types(final List<String> values) {
       types = addValuesToList(types, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder types(final String... values) {
+    public FlowNodeInstanceFilter.Builder types(final String... values) {
       return types(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder flowNodeIds(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder flowNodeIds(final List<String> values) {
       flowNodeIds = addValuesToList(flowNodeIds, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder flowNodeIds(final String... values) {
+    public FlowNodeInstanceFilter.Builder flowNodeIds(final String... values) {
       return flowNodeIds(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder flowNodeNames(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder flowNodeNames(final List<String> values) {
       flowNodeNames = addValuesToList(flowNodeNames, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder flowNodeNames(final String... values) {
+    public FlowNodeInstanceFilter.Builder flowNodeNames(final String... values) {
       return flowNodeNames(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder treePaths(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder treePaths(final List<String> values) {
       treePaths = addValuesToList(treePaths, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder treePaths(final String... values) {
+    public FlowNodeInstanceFilter.Builder treePaths(final String... values) {
       return treePaths(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder incident(final Boolean value) {
+    public FlowNodeInstanceFilter.Builder incident(final Boolean value) {
       incident = value;
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder incidentKeys(final List<Long> values) {
+    public FlowNodeInstanceFilter.Builder incidentKeys(final List<Long> values) {
       incidentKeys = addValuesToList(incidentKeys, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder incidentKeys(final Long... values) {
+    public FlowNodeInstanceFilter.Builder incidentKeys(final Long... values) {
       return incidentKeys(collectValuesAsList(values));
     }
 
-    public FlownodeInstanceFilter.Builder tenantIds(final List<String> values) {
+    public FlowNodeInstanceFilter.Builder tenantIds(final List<String> values) {
       tenantIds = addValuesToList(tenantIds, values);
       return this;
     }
 
-    public FlownodeInstanceFilter.Builder tenantIds(final String... values) {
+    public FlowNodeInstanceFilter.Builder tenantIds(final String... values) {
       return tenantIds(collectValuesAsList(values));
     }
 
     @Override
-    public FlownodeInstanceFilter build() {
-      return new FlownodeInstanceFilter(
+    public FlowNodeInstanceFilter build() {
+      return new FlowNodeInstanceFilter(
           Objects.requireNonNullElse(keys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),

--- a/service/src/main/java/io/camunda/service/search/filter/FlownodeInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FlownodeInstanceFilter.java
@@ -7,15 +7,151 @@
  */
 package io.camunda.service.search.filter;
 
-import io.camunda.util.ObjectBuilder;
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValuesAsList;
 
-public record FlownodeInstanceFilter() implements FilterBase {
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public record FlownodeInstanceFilter(
+    List<Long> keys,
+    List<Long> processInstanceKeys,
+    List<Long> processDefinitionKeys,
+    List<String> states,
+    List<String> types,
+    List<String> flowNodeIds,
+    List<String> flowNodeNames,
+    List<String> treePaths,
+    Boolean incident,
+    List<Long> incidentKeys,
+    List<String> tenantIds)
+    implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<FlownodeInstanceFilter> {
 
+    private List<Long> keys;
+    private List<Long> processInstanceKeys;
+    private List<Long> processDefinitionKeys;
+    private List<String> states;
+    private List<String> types;
+    private List<String> flowNodeIds;
+    private List<String> flowNodeNames;
+    private List<String> treePaths;
+    private Boolean incident;
+    private List<Long> incidentKeys;
+    private List<String> tenantIds;
+
+    public FlownodeInstanceFilter.Builder keys(final List<Long> values) {
+      keys = addValuesToList(keys, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder keys(final Long... values) {
+      return keys(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder processInstanceKeys(final List<Long> values) {
+      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder processInstanceKeys(final Long... values) {
+      return processInstanceKeys(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder processDefinitionKeys(final List<Long> values) {
+      processDefinitionKeys = addValuesToList(processDefinitionKeys, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder processDefinitionKeys(final Long... values) {
+      return processDefinitionKeys(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder states(final List<String> values) {
+      states = addValuesToList(states, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder states(final String... values) {
+      return states(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder types(final List<String> values) {
+      types = addValuesToList(types, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder types(final String... values) {
+      return types(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder flowNodeIds(final List<String> values) {
+      flowNodeIds = addValuesToList(flowNodeIds, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder flowNodeIds(final String... values) {
+      return flowNodeIds(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder flowNodeNames(final List<String> values) {
+      flowNodeNames = addValuesToList(flowNodeNames, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder flowNodeNames(final String... values) {
+      return flowNodeNames(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder treePaths(final List<String> values) {
+      treePaths = addValuesToList(treePaths, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder treePaths(final String... values) {
+      return treePaths(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder incident(final Boolean value) {
+      incident = value;
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder incidentKeys(final List<Long> values) {
+      incidentKeys = addValuesToList(incidentKeys, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder incidentKeys(final Long... values) {
+      return incidentKeys(collectValuesAsList(values));
+    }
+
+    public FlownodeInstanceFilter.Builder tenantIds(final List<String> values) {
+      tenantIds = addValuesToList(tenantIds, values);
+      return this;
+    }
+
+    public FlownodeInstanceFilter.Builder tenantIds(final String... values) {
+      return tenantIds(collectValuesAsList(values));
+    }
+
     @Override
     public FlownodeInstanceFilter build() {
-      return new FlownodeInstanceFilter();
+      return new FlownodeInstanceFilter(
+          Objects.requireNonNullElse(keys, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(states, Collections.emptyList()),
+          Objects.requireNonNullElse(types, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeIds, Collections.emptyList()),
+          Objects.requireNonNullElse(flowNodeNames, Collections.emptyList()),
+          Objects.requireNonNullElse(treePaths, Collections.emptyList()),
+          Objects.requireNonNullElse(incident, false),
+          Objects.requireNonNullElse(incidentKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/search/query/FlowNodeInstanceQuery.java
+++ b/service/src/main/java/io/camunda/service/search/query/FlowNodeInstanceQuery.java
@@ -8,27 +8,27 @@
 package io.camunda.service.search.query;
 
 import io.camunda.service.search.filter.FilterBuilders;
-import io.camunda.service.search.filter.FlownodeInstanceFilter;
+import io.camunda.service.search.filter.FlowNodeInstanceFilter;
 import io.camunda.service.search.page.SearchQueryPage;
-import io.camunda.service.search.sort.FlownodeInstanceSort;
+import io.camunda.service.search.sort.FlowNodeInstanceSort;
 import io.camunda.service.search.sort.SortOptionBuilders;
 import java.util.Objects;
 
-public record FlownodeInstanceQuery(
-    FlownodeInstanceFilter filter, FlownodeInstanceSort sort, SearchQueryPage page)
-    implements TypedSearchQuery<FlownodeInstanceFilter, FlownodeInstanceSort> {
+public record FlowNodeInstanceQuery(
+    FlowNodeInstanceFilter filter, FlowNodeInstanceSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<FlowNodeInstanceFilter, FlowNodeInstanceSort> {
 
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
       implements TypedSearchQueryBuilder<
-          FlownodeInstanceQuery, Builder, FlownodeInstanceFilter, FlownodeInstanceSort> {
+          FlowNodeInstanceQuery, Builder, FlowNodeInstanceFilter, FlowNodeInstanceSort> {
 
-    private static final FlownodeInstanceFilter EMPTY_FILTER =
+    private static final FlowNodeInstanceFilter EMPTY_FILTER =
         FilterBuilders.flownodeInstance().build();
-    private static final FlownodeInstanceSort EMPTY_SORT =
+    private static final FlowNodeInstanceSort EMPTY_SORT =
         SortOptionBuilders.flownodeInstance().build();
 
-    private FlownodeInstanceFilter filter;
-    private FlownodeInstanceSort sort;
+    private FlowNodeInstanceFilter filter;
+    private FlowNodeInstanceSort sort;
 
     @Override
     protected Builder self() {
@@ -36,22 +36,22 @@ public record FlownodeInstanceQuery(
     }
 
     @Override
-    public Builder filter(final FlownodeInstanceFilter value) {
+    public Builder filter(final FlowNodeInstanceFilter value) {
       filter = value;
       return this;
     }
 
     @Override
-    public Builder sort(final FlownodeInstanceSort value) {
+    public Builder sort(final FlowNodeInstanceSort value) {
       sort = value;
       return this;
     }
 
     @Override
-    public FlownodeInstanceQuery build() {
+    public FlowNodeInstanceQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
-      return new FlownodeInstanceQuery(filter, sort, page());
+      return new FlowNodeInstanceQuery(filter, sort, page());
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
@@ -60,12 +60,12 @@ public final class SearchQueryBuilders {
     return fn.apply(decisionRequirementsSearchQuery()).build();
   }
 
-  public static FlownodeInstanceQuery.Builder flownodeInstanceSearchQuery() {
-    return new FlownodeInstanceQuery.Builder();
+  public static FlowNodeInstanceQuery.Builder flownodeInstanceSearchQuery() {
+    return new FlowNodeInstanceQuery.Builder();
   }
 
-  public static FlownodeInstanceQuery flownodeInstanceSearchQuery(
-      final Function<FlownodeInstanceQuery.Builder, ObjectBuilder<FlownodeInstanceQuery>> fn) {
+  public static FlowNodeInstanceQuery flownodeInstanceSearchQuery(
+      final Function<FlowNodeInstanceQuery.Builder, ObjectBuilder<FlowNodeInstanceQuery>> fn) {
     return fn.apply(flownodeInstanceSearchQuery()).build();
   }
 

--- a/service/src/main/java/io/camunda/service/search/sort/FlowNodeInstanceSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/FlowNodeInstanceSort.java
@@ -26,7 +26,7 @@ public record FlowNodeInstanceSort(List<FieldSorting> orderings) implements Sort
   public static final class Builder extends AbstractBuilder<Builder>
       implements ObjectBuilder<FlowNodeInstanceSort> {
 
-    public Builder key() {
+    public Builder flowNodeInstanceKey() {
       currentOrdering = new FieldSorting("key", null);
       return this;
     }

--- a/service/src/main/java/io/camunda/service/search/sort/FlowNodeInstanceSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/FlowNodeInstanceSort.java
@@ -11,20 +11,20 @@ import io.camunda.util.ObjectBuilder;
 import java.util.List;
 import java.util.function.Function;
 
-public record FlownodeInstanceSort(List<FieldSorting> orderings) implements SortOption {
+public record FlowNodeInstanceSort(List<FieldSorting> orderings) implements SortOption {
 
   @Override
   public List<FieldSorting> getFieldSortings() {
     return orderings;
   }
 
-  public static FlownodeInstanceSort of(
-      final Function<FlownodeInstanceSort.Builder, ObjectBuilder<FlownodeInstanceSort>> fn) {
+  public static FlowNodeInstanceSort of(
+      final Function<FlowNodeInstanceSort.Builder, ObjectBuilder<FlowNodeInstanceSort>> fn) {
     return SortOptionBuilders.flownodeInstance(fn);
   }
 
   public static final class Builder extends AbstractBuilder<Builder>
-      implements ObjectBuilder<FlownodeInstanceSort> {
+      implements ObjectBuilder<FlowNodeInstanceSort> {
 
     public Builder key() {
       currentOrdering = new FieldSorting("key", null);
@@ -82,8 +82,8 @@ public record FlownodeInstanceSort(List<FieldSorting> orderings) implements Sort
     }
 
     @Override
-    public FlownodeInstanceSort build() {
-      return new FlownodeInstanceSort(orderings);
+    public FlowNodeInstanceSort build() {
+      return new FlowNodeInstanceSort(orderings);
     }
 
     @Override

--- a/service/src/main/java/io/camunda/service/search/sort/FlownodeInstanceSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/FlownodeInstanceSort.java
@@ -9,25 +9,86 @@ package io.camunda.service.search.sort;
 
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
+import java.util.function.Function;
 
-public record FlownodeInstanceSort() implements SortOption {
+public record FlownodeInstanceSort(List<FieldSorting> orderings) implements SortOption {
 
   @Override
   public List<FieldSorting> getFieldSortings() {
-    return List.of();
+    return orderings;
   }
 
-  public static final class Builder extends AbstractBuilder<FlownodeInstanceSort.Builder>
+  public static FlownodeInstanceSort of(
+      final Function<FlownodeInstanceSort.Builder, ObjectBuilder<FlownodeInstanceSort>> fn) {
+    return SortOptionBuilders.flownodeInstance(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
       implements ObjectBuilder<FlownodeInstanceSort> {
 
-    @Override
-    protected Builder self() {
+    public Builder key() {
+      currentOrdering = new FieldSorting("key", null);
+      return this;
+    }
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public Builder processDefinitionKey() {
+      currentOrdering = new FieldSorting("processDefinitionKey", null);
+      return this;
+    }
+
+    public Builder startDate() {
+      currentOrdering = new FieldSorting("startDate", null);
+      return this;
+    }
+
+    public Builder endDate() {
+      currentOrdering = new FieldSorting("endDate", null);
+      return this;
+    }
+
+    public Builder flowNodeId() {
+      currentOrdering = new FieldSorting("flowNodeId", null);
+      return this;
+    }
+
+    public Builder flowNodeName() {
+      currentOrdering = new FieldSorting("flowNodeName", null);
+      return this;
+    }
+
+    public Builder type() {
+      currentOrdering = new FieldSorting("type", null);
+      return this;
+    }
+
+    public Builder state() {
+      currentOrdering = new FieldSorting("state", null);
+      return this;
+    }
+
+    public Builder incidentKey() {
+      currentOrdering = new FieldSorting("incidentKey", null);
+      return this;
+    }
+
+    public Builder tenantId() {
+      currentOrdering = new FieldSorting("tenantId", null);
       return this;
     }
 
     @Override
     public FlownodeInstanceSort build() {
-      return new FlownodeInstanceSort();
+      return new FlownodeInstanceSort(orderings);
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
@@ -38,6 +38,11 @@ public final class SortOptionBuilders {
     return new FlownodeInstanceSort.Builder();
   }
 
+  public static FlownodeInstanceSort flownodeInstance(
+      final Function<FlownodeInstanceSort.Builder, ObjectBuilder<FlownodeInstanceSort>> fn) {
+    return fn.apply(flownodeInstance()).build();
+  }
+
   public static UserSort.Builder user() {
     return new UserSort.Builder();
   }

--- a/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
@@ -34,12 +34,12 @@ public final class SortOptionBuilders {
     return new DecisionRequirementsSort.Builder();
   }
 
-  public static FlownodeInstanceSort.Builder flownodeInstance() {
-    return new FlownodeInstanceSort.Builder();
+  public static FlowNodeInstanceSort.Builder flownodeInstance() {
+    return new FlowNodeInstanceSort.Builder();
   }
 
-  public static FlownodeInstanceSort flownodeInstance(
-      final Function<FlownodeInstanceSort.Builder, ObjectBuilder<FlownodeInstanceSort>> fn) {
+  public static FlowNodeInstanceSort flownodeInstance(
+      final Function<FlowNodeInstanceSort.Builder, ObjectBuilder<FlowNodeInstanceSort>> fn) {
     return fn.apply(flownodeInstance()).build();
   }
 

--- a/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
+++ b/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
@@ -14,6 +14,7 @@ import io.camunda.service.search.filter.DateValueFilter;
 import io.camunda.service.search.filter.DecisionDefinitionFilter;
 import io.camunda.service.search.filter.DecisionRequirementsFilter;
 import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.filter.FlownodeInstanceFilter;
 import io.camunda.service.search.filter.ProcessInstanceFilter;
 import io.camunda.service.search.filter.UserFilter;
 import io.camunda.service.search.filter.UserTaskFilter;
@@ -21,6 +22,7 @@ import io.camunda.service.search.filter.VariableFilter;
 import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.query.DecisionDefinitionQuery;
 import io.camunda.service.search.query.DecisionRequirementsQuery;
+import io.camunda.service.search.query.FlownodeInstanceQuery;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.TypedSearchQuery;
@@ -29,6 +31,7 @@ import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.query.VariableQuery;
 import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.search.sort.DecisionRequirementsSort;
+import io.camunda.service.search.sort.FlownodeInstanceSort;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOption;
 import io.camunda.service.search.sort.UserSort;
@@ -41,6 +44,7 @@ import io.camunda.service.transformers.filter.DateValueFilterTransformer;
 import io.camunda.service.transformers.filter.DecisionDefinitionFilterTransformer;
 import io.camunda.service.transformers.filter.DecisionRequirementsFilterTransformer;
 import io.camunda.service.transformers.filter.FilterTransformer;
+import io.camunda.service.transformers.filter.FlownodeInstanceFilterTransformer;
 import io.camunda.service.transformers.filter.ProcessInstanceFilterTransformer;
 import io.camunda.service.transformers.filter.UserFilterTransformer;
 import io.camunda.service.transformers.filter.UserTaskFilterTransformer;
@@ -100,6 +104,9 @@ public final class ServiceTransformers {
         new TypedSearchQueryTransformer<DecisionRequirementsFilter, DecisionRequirementsSort>(
             mappers));
     mappers.put(UserQuery.class, new TypedSearchQueryTransformer<UserFilter, UserSort>(mappers));
+    mappers.put(
+        FlownodeInstanceQuery.class,
+        new TypedSearchQueryTransformer<FlownodeInstanceFilter, FlownodeInstanceSort>(mappers));
 
     // search query response -> search query result
     mappers.put(SearchQueryResult.class, new SearchQueryResultTransformer());
@@ -120,5 +127,6 @@ public final class ServiceTransformers {
     mappers.put(DecisionRequirementsFilter.class, new DecisionRequirementsFilterTransformer());
     mappers.put(UserFilter.class, new UserFilterTransformer());
     mappers.put(ComparableValueFilter.class, new ComparableValueFilterTransformer());
+    mappers.put(FlownodeInstanceFilter.class, new FlownodeInstanceFilterTransformer());
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
+++ b/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
@@ -14,7 +14,7 @@ import io.camunda.service.search.filter.DateValueFilter;
 import io.camunda.service.search.filter.DecisionDefinitionFilter;
 import io.camunda.service.search.filter.DecisionRequirementsFilter;
 import io.camunda.service.search.filter.FilterBase;
-import io.camunda.service.search.filter.FlownodeInstanceFilter;
+import io.camunda.service.search.filter.FlowNodeInstanceFilter;
 import io.camunda.service.search.filter.ProcessInstanceFilter;
 import io.camunda.service.search.filter.UserFilter;
 import io.camunda.service.search.filter.UserTaskFilter;
@@ -22,7 +22,7 @@ import io.camunda.service.search.filter.VariableFilter;
 import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.query.DecisionDefinitionQuery;
 import io.camunda.service.search.query.DecisionRequirementsQuery;
-import io.camunda.service.search.query.FlownodeInstanceQuery;
+import io.camunda.service.search.query.FlowNodeInstanceQuery;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.TypedSearchQuery;
@@ -31,7 +31,7 @@ import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.query.VariableQuery;
 import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.search.sort.DecisionRequirementsSort;
-import io.camunda.service.search.sort.FlownodeInstanceSort;
+import io.camunda.service.search.sort.FlowNodeInstanceSort;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOption;
 import io.camunda.service.search.sort.UserSort;
@@ -105,8 +105,8 @@ public final class ServiceTransformers {
             mappers));
     mappers.put(UserQuery.class, new TypedSearchQueryTransformer<UserFilter, UserSort>(mappers));
     mappers.put(
-        FlownodeInstanceQuery.class,
-        new TypedSearchQueryTransformer<FlownodeInstanceFilter, FlownodeInstanceSort>(mappers));
+        FlowNodeInstanceQuery.class,
+        new TypedSearchQueryTransformer<FlowNodeInstanceFilter, FlowNodeInstanceSort>(mappers));
 
     // search query response -> search query result
     mappers.put(SearchQueryResult.class, new SearchQueryResultTransformer());
@@ -127,6 +127,6 @@ public final class ServiceTransformers {
     mappers.put(DecisionRequirementsFilter.class, new DecisionRequirementsFilterTransformer());
     mappers.put(UserFilter.class, new UserFilterTransformer());
     mappers.put(ComparableValueFilter.class, new ComparableValueFilterTransformer());
-    mappers.put(FlownodeInstanceFilter.class, new FlownodeInstanceFilterTransformer());
+    mappers.put(FlowNodeInstanceFilter.class, new FlownodeInstanceFilterTransformer());
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -13,14 +13,14 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
-import io.camunda.service.search.filter.FlownodeInstanceFilter;
+import io.camunda.service.search.filter.FlowNodeInstanceFilter;
 import java.util.List;
 
 public class FlownodeInstanceFilterTransformer
-    implements FilterTransformer<FlownodeInstanceFilter> {
+    implements FilterTransformer<FlowNodeInstanceFilter> {
 
   @Override
-  public SearchQuery toSearchQuery(final FlownodeInstanceFilter filter) {
+  public SearchQuery toSearchQuery(final FlowNodeInstanceFilter filter) {
     return and(
         getKeysQuery(filter.keys()),
         longTerms("processInstanceKey", filter.processInstanceKeys()),
@@ -36,7 +36,7 @@ public class FlownodeInstanceFilterTransformer
   }
 
   @Override
-  public List<String> toIndices(final FlownodeInstanceFilter filter) {
+  public List<String> toIndices(final FlowNodeInstanceFilter filter) {
     return List.of("operate-flownode-instance-8.3.1_alias");
   }
 

--- a/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -22,7 +22,7 @@ public class FlownodeInstanceFilterTransformer
   @Override
   public SearchQuery toSearchQuery(final FlowNodeInstanceFilter filter) {
     return and(
-        getKeysQuery(filter.keys()),
+        longTerms("key", filter.flowNodeInstanceKeys()),
         longTerms("processInstanceKey", filter.processInstanceKeys()),
         longTerms("processDefinitionKey", filter.processDefinitionKeys()),
         stringTerms("state", filter.states()),
@@ -38,9 +38,5 @@ public class FlownodeInstanceFilterTransformer
   @Override
   public List<String> toIndices(final FlowNodeInstanceFilter filter) {
     return List.of("operate-flownode-instance-8.3.1_alias");
-  }
-
-  private SearchQuery getKeysQuery(final List<Long> keys) {
-    return longTerms("key", keys);
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.FlownodeInstanceFilter;
+import java.util.List;
+
+public class FlownodeInstanceFilterTransformer
+    implements FilterTransformer<FlownodeInstanceFilter> {
+
+  @Override
+  public SearchQuery toSearchQuery(final FlownodeInstanceFilter filter) {
+    return and(
+        getKeysQuery(filter.keys()),
+        longTerms("processInstanceKey", filter.processInstanceKeys()),
+        longTerms("processDefinitionKey", filter.processDefinitionKeys()),
+        stringTerms("state", filter.states()),
+        stringTerms("type", filter.types()),
+        stringTerms("flowNodeId", filter.flowNodeIds()),
+        stringTerms("flowNodeName", filter.flowNodeNames()),
+        stringTerms("treePath", filter.treePaths()),
+        term("incident", filter.incident()),
+        longTerms("incidentKey", filter.incidentKeys()),
+        stringTerms("tenantId", filter.tenantIds()));
+  }
+
+  @Override
+  public List<String> toIndices(final FlownodeInstanceFilter filter) {
+    return List.of("operate-flownode-instance-8.3.1_alias");
+  }
+
+  private SearchQuery getKeysQuery(final List<Long> keys) {
+    return longTerms("key", keys);
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1295,7 +1295,7 @@ components:
     FlowNodeInstanceFilterRequest:
       type: object
       properties:
-        key:
+        flowNodeInstanceKey:
           type: integer
           format: int64
         processInstanceKey:
@@ -1333,7 +1333,7 @@ components:
     FlowNodeInstanceItem:
       type: object
       properties:
-        key:
+        flowNodeInstanceKey:
           type: integer
           format: int64
         processInstanceKey:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -623,10 +623,10 @@ paths:
   /flownode-instances/search:
     post:
       tags:
-        - Flownode Instance
-      summary: Query flownode instances (experimental)
+        - Flow node Instance
+      summary: Query flow node instances (experimental)
       description: |
-        Search for flownode instances based on given criteria.
+        Search for flow node instances based on given criteria.
 
         :::note
         This endpoint is experimental and not enabled on Camunda clusters out of the box.
@@ -638,18 +638,18 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/FlownodeInstanceSearchQueryRequest"
+              $ref: "#/components/schemas/FlowNodeInstanceSearchQueryRequest"
       responses:
         "200":
           description: >
-            The Flownode Instance Search successful response.
+            The Flow node instance search successful response.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/FlownodeInstanceSearchQueryResponse"
+                $ref: "#/components/schemas/FlowNodeInstanceSearchQueryResponse"
         "400":
           description: >
-            The Flownode Instance Search Query failed.
+            The Flow node instance Search Query failed.
             More details are provided in the response body.
           content:
             application/problem+json:
@@ -1284,15 +1284,15 @@ components:
         endDate:
           type: string
           format: date-time
-    FlownodeInstanceSearchQueryRequest:
+    FlowNodeInstanceSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
       type: object
       properties:
         filter:
           allOf:
-            - $ref: "#/components/schemas/FlownodeInstanceFilterRequest"
-    FlownodeInstanceFilterRequest:
+            - $ref: "#/components/schemas/FlowNodeInstanceFilterRequest"
+    FlowNodeInstanceFilterRequest:
       type: object
       properties:
         key:
@@ -1321,7 +1321,7 @@ components:
           format: int64
         tenantId:
           type: string
-    FlownodeInstanceSearchQueryResponse:
+    FlowNodeInstanceSearchQueryResponse:
       allOf:
         - $ref: "#/components/schemas/SearchQueryResponse"
       type: object
@@ -1329,8 +1329,8 @@ components:
         items:
           type: array
           items:
-            $ref: "#/components/schemas/FlownodeInstanceItem"
-    FlownodeInstanceItem:
+            $ref: "#/components/schemas/FlowNodeInstanceItem"
+    FlowNodeInstanceItem:
       type: object
       properties:
         key:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -18,7 +18,7 @@ import io.camunda.service.search.filter.DecisionDefinitionFilter;
 import io.camunda.service.search.filter.DecisionRequirementsFilter;
 import io.camunda.service.search.filter.FilterBase;
 import io.camunda.service.search.filter.FilterBuilders;
-import io.camunda.service.search.filter.FlownodeInstanceFilter;
+import io.camunda.service.search.filter.FlowNodeInstanceFilter;
 import io.camunda.service.search.filter.ProcessInstanceFilter;
 import io.camunda.service.search.filter.UserFilter;
 import io.camunda.service.search.filter.UserTaskFilter;
@@ -26,7 +26,7 @@ import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.page.SearchQueryPage;
 import io.camunda.service.search.query.DecisionDefinitionQuery;
 import io.camunda.service.search.query.DecisionRequirementsQuery;
-import io.camunda.service.search.query.FlownodeInstanceQuery;
+import io.camunda.service.search.query.FlowNodeInstanceQuery;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.TypedSearchQueryBuilder;
@@ -34,7 +34,7 @@ import io.camunda.service.search.query.UserQuery;
 import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.search.sort.DecisionRequirementsSort;
-import io.camunda.service.search.sort.FlownodeInstanceSort;
+import io.camunda.service.search.sort.FlowNodeInstanceSort;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOption;
 import io.camunda.service.search.sort.SortOptionBuilders;
@@ -45,8 +45,8 @@ import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionFilterRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsFilterRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceFilterRequest;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceFilterRequest;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.PriorityValueFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilterRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryRequest;
@@ -116,8 +116,8 @@ public final class SearchQueryRequestMapper {
         filter, sort, page, SearchQueryBuilders::decisionRequirementsSearchQuery);
   }
 
-  public static Either<ProblemDetail, FlownodeInstanceQuery> toFlownodeInstanceQuery(
-      final FlownodeInstanceSearchQueryRequest request) {
+  public static Either<ProblemDetail, FlowNodeInstanceQuery> toFlownodeInstanceQuery(
+      final FlowNodeInstanceSearchQueryRequest request) {
     if (request == null) {
       return Either.right(SearchQueryBuilders.flownodeInstanceSearchQuery().build());
     }
@@ -217,8 +217,8 @@ public final class SearchQueryRequestMapper {
     return builder.build();
   }
 
-  private static FlownodeInstanceFilter toFlownodeInstanceFilter(
-      final FlownodeInstanceFilterRequest filter) {
+  private static FlowNodeInstanceFilter toFlownodeInstanceFilter(
+      final FlowNodeInstanceFilterRequest filter) {
     final var builder = FilterBuilders.flownodeInstance();
     return builder.build();
   }
@@ -353,7 +353,7 @@ public final class SearchQueryRequestMapper {
   }
 
   private static List<String> applyFlownodeInstanceSortField(
-      final String field, final FlownodeInstanceSort.Builder builder) {
+      final String field, final FlowNodeInstanceSort.Builder builder) {
     final List<String> validationErrors = new ArrayList<>();
     return validationErrors;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -11,7 +11,7 @@ import static java.util.Optional.ofNullable;
 
 import io.camunda.service.entities.DecisionDefinitionEntity;
 import io.camunda.service.entities.DecisionRequirementsEntity;
-import io.camunda.service.entities.FlownodeInstanceEntity;
+import io.camunda.service.entities.FlowNodeInstanceEntity;
 import io.camunda.service.entities.ProcessInstanceEntity;
 import io.camunda.service.entities.UserEntity;
 import io.camunda.service.entities.UserTaskEntity;
@@ -20,8 +20,8 @@ import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionItem;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionDefinitionSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsItem;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionRequirementsSearchQueryResponse;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceItem;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceItem;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.ProblemDetail;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceItem;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
@@ -72,10 +72,10 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
-  public static FlownodeInstanceSearchQueryResponse toFlownodeInstanceSearchQueryResponse(
-      final SearchQueryResult<FlownodeInstanceEntity> result) {
+  public static FlowNodeInstanceSearchQueryResponse toFlownodeInstanceSearchQueryResponse(
+      final SearchQueryResult<FlowNodeInstanceEntity> result) {
     final var page = toSearchQueryPageResponse(result);
-    return new FlownodeInstanceSearchQueryResponse()
+    return new FlowNodeInstanceSearchQueryResponse()
         .page(page)
         .items(
             ofNullable(result.items())
@@ -151,13 +151,13 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionRequirements).toList();
   }
 
-  private static List<FlownodeInstanceItem> toFlownodeInstance(
-      final List<FlownodeInstanceEntity> instances) {
-    return instances.stream().map(SearchQueryResponseMapper::toFlownodeInstance).toList();
+  private static List<FlowNodeInstanceItem> toFlownodeInstance(
+      final List<FlowNodeInstanceEntity> instances) {
+    return instances.stream().map(SearchQueryResponseMapper::toFlowNodeInstance).toList();
   }
 
-  private static FlownodeInstanceItem toFlownodeInstance(final FlownodeInstanceEntity instance) {
-    return new FlownodeInstanceItem();
+  private static FlowNodeInstanceItem toFlowNodeInstance(final FlowNodeInstanceEntity instance) {
+    return new FlowNodeInstanceItem();
   }
 
   private static DecisionDefinitionItem toDecisionDefinition(final DecisionDefinitionEntity d) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -157,7 +157,20 @@ public final class SearchQueryResponseMapper {
   }
 
   private static FlowNodeInstanceItem toFlowNodeInstance(final FlowNodeInstanceEntity instance) {
-    return new FlowNodeInstanceItem();
+    return new FlowNodeInstanceItem()
+        .flowNodeInstanceKey(instance.flowNodeInstanceKey())
+        .flowNodeId(instance.flowNodeId())
+        .flowNodeName(instance.flowNodeName())
+        .processDefinitionKey(instance.processDefinitionKey())
+        .processInstanceKey(instance.processInstanceKey())
+        .incidentKey(instance.incidentKey())
+        .incident(instance.incident())
+        .startDate(instance.startDate())
+        .endDate(instance.endDate())
+        .state(instance.state())
+        .treePath(instance.treePath())
+        .type(instance.type())
+        .tenantId(instance.tenantId());
   }
 
   private static DecisionDefinitionItem toDecisionDefinition(final DecisionDefinitionEntity d) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.service.FlownodeInstanceServices;
-import io.camunda.service.search.query.FlownodeInstanceQuery;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.FlownodeInstanceSearchQueryResponse;
+import io.camunda.service.FlowNodeInstanceServices;
+import io.camunda.service.search.query.FlowNodeInstanceQuery;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.FlowNodeInstanceSearchQueryResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
@@ -24,11 +24,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestQueryController
 @RequestMapping("/v2/flownode-instances")
-public class FlownodeInstanceQueryController {
+public class FlowNodeInstanceQueryController {
 
-  private final FlownodeInstanceServices flownodeInstanceServices;
+  private final FlowNodeInstanceServices flownodeInstanceServices;
 
-  public FlownodeInstanceQueryController(final FlownodeInstanceServices flownodeInstanceServices) {
+  public FlowNodeInstanceQueryController(final FlowNodeInstanceServices flownodeInstanceServices) {
     this.flownodeInstanceServices = flownodeInstanceServices;
   }
 
@@ -36,14 +36,14 @@ public class FlownodeInstanceQueryController {
       path = "/search",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<FlownodeInstanceSearchQueryResponse> searchFlownodeInstances(
-      @RequestBody(required = false) final FlownodeInstanceSearchQueryRequest query) {
+  public ResponseEntity<FlowNodeInstanceSearchQueryResponse> searchFlownodeInstances(
+      @RequestBody(required = false) final FlowNodeInstanceSearchQueryRequest query) {
     return SearchQueryRequestMapper.toFlownodeInstanceQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  private ResponseEntity<FlownodeInstanceSearchQueryResponse> search(
-      final FlownodeInstanceQuery query) {
+  private ResponseEntity<FlowNodeInstanceSearchQueryResponse> search(
+      final FlowNodeInstanceQuery query) {
     try {
       final var result =
           flownodeInstanceServices

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -11,9 +11,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.service.FlownodeInstanceServices;
-import io.camunda.service.entities.FlownodeInstanceEntity;
-import io.camunda.service.search.query.FlownodeInstanceQuery;
+import io.camunda.service.FlowNodeInstanceServices;
+import io.camunda.service.entities.FlowNodeInstanceEntity;
+import io.camunda.service.search.query.FlowNodeInstanceQuery;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.security.auth.Authentication;
@@ -26,9 +26,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
 @WebMvcTest(
-    value = FlownodeInstanceQueryController.class,
+    value = FlowNodeInstanceQueryController.class,
     properties = "camunda.rest.query.enabled=true")
-public class FlownodeInstanceQueryControllerTest extends RestControllerTest {
+public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
 
   static final String EXPECTED_SEARCH_RESPONSE =
       """
@@ -45,12 +45,12 @@ public class FlownodeInstanceQueryControllerTest extends RestControllerTest {
           }
       }""";
 
-  static final SearchQueryResult<FlownodeInstanceEntity> SEARCH_QUERY_RESULT =
-      new Builder<FlownodeInstanceEntity>()
+  static final SearchQueryResult<FlowNodeInstanceEntity> SEARCH_QUERY_RESULT =
+      new Builder<FlowNodeInstanceEntity>()
           .total(1L)
           .items(
               List.of(
-                  new FlownodeInstanceEntity(
+                  new FlowNodeInstanceEntity(
                       1L,
                       2L,
                       3L,
@@ -69,18 +69,18 @@ public class FlownodeInstanceQueryControllerTest extends RestControllerTest {
 
   static final String FLOWNODE_INSTANCES_SEARCH_URL = "/v2/flownode-instances/search";
 
-  @MockBean FlownodeInstanceServices flownodeInstanceServices;
+  @MockBean FlowNodeInstanceServices flowNodeInstanceServices;
 
   @BeforeEach
   void setupServices() {
-    when(flownodeInstanceServices.withAuthentication(any(Authentication.class)))
-        .thenReturn(flownodeInstanceServices);
+    when(flowNodeInstanceServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(flowNodeInstanceServices);
   }
 
   @Test
   void shouldSearchFlownodeInstancesDecisionWithEmptyBody() {
     // given
-    when(flownodeInstanceServices.search(any(FlownodeInstanceQuery.class)))
+    when(flowNodeInstanceServices.search(any(FlowNodeInstanceQuery.class)))
         .thenReturn(SEARCH_QUERY_RESULT);
     // when / then
     webClient
@@ -94,6 +94,6 @@ public class FlownodeInstanceQueryControllerTest extends RestControllerTest {
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE);
 
-    verify(flownodeInstanceServices).search(new FlownodeInstanceQuery.Builder().build());
+    verify(flowNodeInstanceServices).search(new FlowNodeInstanceQuery.Builder().build());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlownodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlownodeInstanceQueryControllerTest.java
@@ -48,7 +48,22 @@ public class FlownodeInstanceQueryControllerTest extends RestControllerTest {
   static final SearchQueryResult<FlownodeInstanceEntity> SEARCH_QUERY_RESULT =
       new Builder<FlownodeInstanceEntity>()
           .total(1L)
-          .items(List.of(new FlownodeInstanceEntity()))
+          .items(
+              List.of(
+                  new FlownodeInstanceEntity(
+                      1L,
+                      2L,
+                      3L,
+                      "2023-05-17",
+                      "2023-05-23",
+                      "flowNodeId",
+                      "flowNodeName",
+                      "processInstanceKey/flowNodeId",
+                      "SERVICE_TASK",
+                      "COMPLETED",
+                      false,
+                      null,
+                      "<default>")))
           .sortValues(new Object[] {"v"})
           .build();
 


### PR DESCRIPTION
## Description

* Add implementation for entity, filter, sort, transformer
* Test PR will follow
* Is rebased on [operate/c8-flownode-instances-endpoint](https://github.com/camunda/camunda/tree/operate/c8-flownode-instances-endpoint) 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
