### PR TITLE
Define a cluster change operation for adding a new partition

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -412,6 +413,11 @@ public class ProtoBufSerializer
       case final PartitionEnableExporterOperation enableExporterOperation ->
           builder.setPartitionEnableExporter(
               encodeEnabledExporterOperation(enableExporterOperation));
+      case final PartitionBootstrapOperation bootstrapOperation ->
+          builder.setPartitionBootstrap(
+              Topology.PartitionBootstrapOperation.newBuilder()
+                  .setPartitionId(bootstrapOperation.partitionId())
+                  .build());
       default ->
           throw new IllegalArgumentException(
               "Unknown operation type: " + operation.getClass().getSimpleName());
@@ -558,6 +564,10 @@ public class ProtoBufSerializer
           enableExporterOperation.getPartitionId(),
           enableExporterOperation.getExporterId(),
           initializeFrom);
+    } else if (topologyChangeOperation.hasPartitionBootstrap()) {
+      return new PartitionBootstrapOperation(
+          MemberId.from(topologyChangeOperation.getMemberId()),
+          topologyChangeOperation.getPartitionBootstrap().getPartitionId());
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -107,5 +107,15 @@ public sealed interface ClusterConfigurationChangeOperation {
     record PartitionEnableExporterOperation(
         MemberId memberId, int partitionId, String exporterId, Optional<String> initializeFrom)
         implements PartitionChangeOperation {}
+
+    /**
+     * Operation to bootstrap a new partition in the given member. The operation starts the
+     * partitions as a single replica. More replicas should be added in subsequent operations.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     * @param partitionId id of the partition to bootstrap
+     */
+    record PartitionBootstrapOperation(MemberId memberId, int partitionId)
+        implements PartitionChangeOperation {}
   }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -636,6 +636,11 @@
                 "id": 10,
                 "name": "partitionEnableExporter",
                 "type": "PartitionEnableExporterOperation"
+              },
+              {
+                "id": 11,
+                "name": "partitionBootstrap",
+                "type": "PartitionBootstrapOperation"
               }
             ]
           },
@@ -742,6 +747,16 @@
                 "id": 3,
                 "name": "initializeFrom",
                 "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PartitionBootstrapOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
               }
             ]
           },

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -88,6 +88,7 @@ message TopologyChangeOperation {
     MemberRemoveOperation memberRemove = 8;
     PartitionDisableExporterOperation partitionDisableExporter = 9;
     PartitionEnableExporterOperation partitionEnableExporter = 10;
+    PartitionBootstrapOperation partitionBootstrap = 11;
   }
 }
 
@@ -124,6 +125,10 @@ message PartitionEnableExporterOperation {
   int32 partitionId = 1;
   string exporterId = 2;
   optional string initializeFrom = 3;
+}
+
+message PartitionBootstrapOperation {
+  int32 partitionId = 1;
 }
 
 message MemberJoinOperation {}


### PR DESCRIPTION
## Description

This PR adds a new `ClusterConfigurationChangeOperation` to bootstrap a new partition. On bootstrap, the partition will be started with only a single replica. More replicas should be added in subsequent operation using the existing `PartitionJoinOperation`. 

## Related issues

closes #21478 
