### PR TITLE
feat: add authorization entity for ES queries

### DIFF
--- a/service/src/main/java/io/camunda/service/entities/AuthorizationEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/AuthorizationEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record AuthorizationEntity(Authorization value) {
+  public record Authorization(
+      String ownerKey,
+      String ownerType,
+      String resourceKey,
+      String resourceType,
+      Set<String> permissions) {}
+}


### PR DESCRIPTION
closes https://github.com/camunda/camunda/issues/21339

## Description
This PR adds in the entity for the authorization object that is retrieved from ES. There will be some changes necessary here when the changes are made to the authorization structure in follow up PRs but it will be just altering the fields.


