### PR TITLE
fix: scan for the identity index controller to serve the Identity UI

### DIFF
--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -15,6 +15,7 @@ import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.application.sources.DefaultObjectMapperConfiguration;
+import io.camunda.identity.IdentityModuleConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -43,6 +44,7 @@ public class StandaloneCamunda {
                 CommonsModuleConfiguration.class,
                 OperateModuleConfiguration.class,
                 TasklistModuleConfiguration.class,
+                IdentityModuleConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
                 GatewayModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/identity/IdentityModuleConfiguration.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.identity;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Profile;
+
+@Configuration(proxyBeanMethods = false)
+@ComponentScan(
+    basePackages = "io.camunda.identity.webapp",
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+@Profile("identity")
+public class IdentityModuleConfiguration {}

--- a/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
+++ b/dist/src/main/java/io/camunda/identity/webapp/controllers/IdentityIndexController.java
@@ -12,14 +12,12 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@Profile("identity")
 public class IdentityIndexController {
 
   @Autowired private ServletContext context;


### PR DESCRIPTION
## Description

I noticed that when starting the single image with the profile `identity` there is no UI for Identity as it returns a 404, further investigation of this lead me to find that the `IdentityIndexController` bean is not being picked up during scans and therefore there is no URLs to catch the webapp redirect.

This PR adds in a config to scan the controller and therefore serve the Identity UI.
