### PR TITLE
Optimize 14030 open search aws config cant be disabled

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/db/DatabaseConnection.java
@@ -19,13 +19,12 @@ public class DatabaseConnection {
   protected Integer timeout;
 
   protected Integer responseConsumerBufferLimitInMb;
-
-  private ProxyConfiguration proxy;
-
   protected String pathPrefix;
-
   protected Boolean skipHostnameVerification;
 
   @JsonProperty("nodes")
   protected List<DatabaseConnectionNodeConfiguration> connectionNodes;
+
+  private ProxyConfiguration proxy;
+  private Boolean awsEnabled;
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -101,7 +101,7 @@ public class OpenSearchClientBuilder {
 
   private static OpenSearchTransport getAwsTransport(final ConfigurationService osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
-    SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
+    final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     return new AwsSdk2Transport(
         httpClient,
         osConfig.getOpenSearchConfiguration().getFirstConnectionNode().getHost(),
@@ -111,21 +111,25 @@ public class OpenSearchClientBuilder {
             .build());
   }
 
-  private static boolean isAws() {
-    AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
-    try {
-      credentialsProvider.resolveCredentials();
-      log.info("AWS Credentials can be resolved. Use AWS OpenSearch");
-      return true;
-    } catch (Exception e) {
-      log.info("Use standard OpenSearch since AWS not configured ({}) ", e.getMessage());
-      return false;
+  private static boolean useAwsCredentials(final ConfigurationService configurationService) {
+    if (configurationService.getOpenSearchConfiguration().getConnection().getAwsEnabled()) {
+      final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+      try {
+        credentialsProvider.resolveCredentials();
+        log.info("AWS Credentials can be resolved. Use AWS OpenSearch");
+        return true;
+      } catch (final Exception e) {
+        log.info("Use standard OpenSearch since AWS not configured ({}) ", e.getMessage());
+        return false;
+      }
     }
+    log.info("Not using AWS credentials for OpenSearch");
+    return false;
   }
 
   private static OpenSearchTransport buildOpenSearchTransport(
       final ConfigurationService configurationService) {
-    if (isAws()) {
+    if (useAwsCredentials(configurationService)) {
       return getAwsTransport(configurationService);
     }
     final HttpHost[] hosts = buildOpenSearchConnectionNodes(configurationService);

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/upgrade/os/OpenSearchClientBuilder.java
@@ -123,7 +123,7 @@ public class OpenSearchClientBuilder {
         return false;
       }
     }
-    log.info("Not using AWS credentials for OpenSearch");
+    log.info("AWS Credentials are disabled. Using basic auth.");
     return false;
   }
 

--- a/optimize/util/optimize-commons/src/main/resources/service-config.yaml
+++ b/optimize/util/optimize-commons/src/main/resources/service-config.yaml
@@ -335,6 +335,8 @@ import:
 # a connection to it.
 opensearch:
   connection:
+    # Use AWS credentials for authentication
+    awsEnabled: ${CAMUNDA_OPTIMIZE_OPENSEARCH_AWS_ENABLED:false}
     # Maximum time without connection to Opensearch, Optimize should
     # wait until a timeout triggers.
     timeout: 10000


### PR DESCRIPTION
## Description

relates to https://github.com/camunda/camunda-optimize/issues/14030
Optimize can be used with OpenSearch on AWS even if a AWS configuration exists in the environment.

Had to be recreated due to name change on branch

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->


## Related issues

closes [#14030](https://github.com/camunda/camunda-optimize/issues/14030)
