### PR TITLE
ci: skip docker setup for java checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
+          docker: false
           maven-cache-key-modifier: java-checks
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}


### PR DESCRIPTION
No docker login is required for those checks. 
Removing it helps reduce flakiness.

Relates to https://github.com/camunda/camunda/issues/21664