### PR TITLE
CI: re-add passing GHA secrets to Zeebe CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'
     needs: [detect-changes]
     uses: ./.github/workflows/zeebe-ci.yml
+    secrets: inherit
 
   optimize-frontend-unit-tests:
     if: needs.detect-changes.outputs.optimize-frontend-changes == 'true'

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
-    timeout-minutes: 25
+    timeout-minutes: 20
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -195,7 +195,7 @@ jobs:
   go-client:
     name: Go client tests
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
## Description

This PR has a story and the story is longer. _TL;DR: an [innocent looking typo](https://github.com/camunda/camunda/commit/c1783ea3b0e39c65c3f9530b01c4fc266edeb803#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR421) in https://github.com/camunda/camunda/pull/21063 caused seemingly unrelated problems in the Zeebe CI running into timeouts while using Maven and not being able to push to DockerHub._

This PR primarily aims to fix https://github.com/camunda/camunda/issues/21664 but will most likely also fix https://github.com/camunda/camunda/issues/21602 since the root cause for both issues is to be believed the same.

In https://github.com/camunda/camunda/pull/21063 the line `secrets: inherit` got lost from the `zeebe-ci` job in `ci.yml` which explains retrospectively why only this PR had so much trouble getting through the merge queue - it was a change on this PR! But nobody identified that change in over a week and out of desperation we merged it increasing the timeouts that fixed the symptoms, not the problems.

The problems got worse and thus https://github.com/camunda/camunda/issues/21602 was raised and @Zelldon as Zeebe medic then also noticed https://github.com/camunda/camunda/issues/21664 which couldn't be reproduced by @cmur2 (since the DockerHub credentials were actually fine, no ratelimits, but Zeebe CI didn't use the credentials anymore!). Since Zeebe CI is designed to work on forks without access to credentials, it fell back to gracefully only building the Docker image without pushing.

@lenaschoenburg [realized](https://camunda.slack.com/archives/C013MEVQ4M9/p1724839364078269?thread_ts=1724837728.167309&cid=C013MEVQ4M9) that Zeebe CI is not even attempting to log in using any credentials

Related discussions:

* https://camunda.slack.com/archives/C013MEVQ4M9/p1724680653951889
* https://camunda.slack.com/archives/C013MEVQ4M9/p1724837728167309
* https://camunda.slack.com/archives/C071KP5BTHB/p1724833546143439

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21664 and probably #21602
