### PR TITLE
Migrate business rule task instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -49,7 +49,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.INTERMEDIATE_CATCH_EVENT,
           BpmnElementType.RECEIVE_TASK,
           BpmnElementType.EVENT_SUB_PROCESS,
-          BpmnElementType.EXCLUSIVE_GATEWAY);
+          BpmnElementType.EXCLUSIVE_GATEWAY,
+          BpmnElementType.BUSINESS_RULE_TASK);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBusinessRuleTaskTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateBusinessRuleTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String DMN_RESOURCE = "/dmn/decision-table.dmn";
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateCalledDecisionBasedBusinessRuleTaskWithAnIncident() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlClasspathResource(DMN_RESOURCE)
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .businessRuleTask(
+                        "businessRuleTask1",
+                        t ->
+                            t.zeebeCalledDecisionId("nonExistingDecision")
+                                .zeebeResultVariable("result"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .businessRuleTask(
+                        "businessRuleTask2",
+                        t ->
+                            t.zeebeCalledDecisionId("jedi_or_sith")
+                                .zeebeResultVariable("jedi_or_sith"))
+                    .endEvent("target_process_end")
+                    .done())
+            .deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(sourceProcessId)
+            .withVariable("lightsaberColor", "green")
+            .create();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("businessRuleTask1")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("businessRuleTask1", "businessRuleTask2")
+        .migrate();
+
+    RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    Assertions.assertThat(
+            RecordingExporter.decisionEvaluationRecords(DecisionEvaluationIntent.EVALUATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("businessRuleTask2")
+                .getFirst()
+                .getValue())
+        .hasDecisionOutput("\"Jedi\"");
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to successfully evaluate the called decision to reach the end event")
+        .hasElementId("target_process_end");
+  }
+
+  @Test
+  public void shouldMigrateJobWorkerBasedBusinessRuleTask() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .businessRuleTask("businessRuleTask1", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .businessRuleTask("businessRuleTask2", a -> a.zeebeJobType("B"))
+                    .userTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("businessRuleTask1", "businessRuleTask2")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersion(1)
+        .describedAs("Expect that element id is left unchanged")
+        .hasElementId("businessRuleTask2");
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasProcessDefinitionVersion(1)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("businessRuleTask2")
+        .describedAs(
+            "Expect that the type did not change even though it's different in the target process."
+                + " Re-evaluation of the job type expression is not enabled for this migration")
+        .hasType("A");
+  }
+}


### PR DESCRIPTION
<!-- Describe the goal and purpose of this PR. -->
## Description

Migrating a business rule task should be possible. There can be two different implementations of a business rule task:
- A called decision
- Job worker implementation

### Called Decision

In normal circumstances the called decision is evaluated immediately after the business rule task is activated. Still, a process instance may be waiting on a business rule task if there is an incident on it.

**Note:** There is an edge case where the migration command can come after the activation of the business rule task. When the `ACTIVATE_ELEMENT` command for the business rule task is the last command in a command batch (we have a limit for number of commands in a batch), `MIGRATE` command can come right after the activation but before completion of the business rule task as follows:

- ACTIVATE_ELEMENT business rule task
- MIGRATE process instance
- COMPLETE_ELEMENT business rule task

But the case mentioned above is not easy to test because the commands for business rule tasks should be written manually and that is not a trivial operation to do with our current test framework.

### Job Worker Implementation
The second case is already handled here:

https://github.com/camunda/camunda/blob/3ee2a8cf7b1490eb58570727f7dd289630b11a3c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java#L255-L273

### Test Cases

Following test cases should be added to verify possible use cases:

- Migrating decision based business rule task with an incident
- Migrating job worker based business rule task

## Related issues

closes #21588 
