### PR TITLE
Create composite action to cache maven.

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -48,7 +48,7 @@ runs:
         EOF
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
-      if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
+      if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
       uses: actions/cache@v4
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
@@ -57,9 +57,9 @@ runs:
         path: ~/.m2/repository/cached/releases/
         # it matters for caching as absolute paths on self-hosted and GitHub runners differ
         # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-1-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-1-${{ inputs.maven-cache-key-modifier }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
       if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
@@ -67,6 +67,6 @@ runs:
       with:
         # This has to match the 'Cache local Maven repository' step above
         path: ~/.m2/repository/cached/releases/
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-2-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-2-${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -5,10 +5,6 @@ name: Setup Maven Cache
 description: Configured GHA cache for Maven global cache dir (no save on PRs), see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
 
 inputs:
-  java:
-    description: If true, will set up Java; defaults to true
-    required: false
-    default: "true"
   maven-cache-key-modifier:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "shared"
@@ -18,7 +14,6 @@ runs:
   using: composite
   steps:
     - name: Configure Maven
-      if: inputs.java == 'true'
       shell: bash
       # `--errors` ensures errors will also spit out a stack trace, which is always useful, and has no impact on normal builds
       #
@@ -53,21 +48,21 @@ runs:
         EOF
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
-      if: inputs.java == 'true' && (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
+      if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
       uses: actions/cache@v4
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
         # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
         # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
         path: ~/.m2/repository/cached/releases/
-        # it matters for caching as absolute paths on self-hosted and Github runners differ
+        # it matters for caching as absolute paths on self-hosted and GitHub runners differ
         # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
         key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
           ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
-      if: inputs.java == 'true' && !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
+      if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
       uses: actions/cache/restore@v4
       with:
         # This has to match the 'Cache local Maven repository' step above

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -1,0 +1,77 @@
+---
+name: Setup Maven Cache
+
+
+description: Configured GHA cache for Maven global cache dir (no save on PRs), see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
+
+inputs:
+  java:
+    description: If true, will set up Java; defaults to true
+    required: false
+    default: "true"
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "shared"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Maven
+      if: inputs.java == 'true'
+      shell: bash
+      # `--errors` ensures errors will also spit out a stack trace, which is always useful, and has no impact on normal builds
+      #
+      # `--update-snapshots` to force Maven into updating snapshots, but also to retry looking for
+      #    release artifacts when an earlier lookup failure made it into the cache.
+      #
+      # `maven.wagon.*` and `maven.resolver.transport` set the resolver's network transport to Wagon,
+      #    the old provider pre 3.9. Until Maven 3.9.2, we have to do this if we want to retry on
+      #    network issues, as otherwise any issue will fail the build.
+      #
+      # `aether.enhancedLocalRepository.split` splits between local and remote artifacts.
+      # `aether.enhancedLocalRepository.splitRemote` splits remote artifacts into released and snapshot
+      # `aether.syncContext.*` config ensures that maven uses file locks to prevent corruption
+      #      from downloading multiple artifacts at the same time.
+      run: |
+        tee .mvn/maven.config <<EOF
+        --errors
+        --batch-mode
+        --update-snapshots
+        -D maven.wagon.httpconnectionManager.ttlSeconds=120
+        -D maven.wagon.http.pool=false
+        -D maven.resolver.transport=wagon
+        -D maven.wagon.http.retryHandler.class=standard
+        -D maven.wagon.http.retryHandler.requestSentEnabled=true
+        -D maven.wagon.http.retryHandler.count=5
+        -D aether.enhancedLocalRepository.split=true
+        -D aether.enhancedLocalRepository.splitRemote=true
+        -D aether.syncContext.named.nameMapper=file-gav
+        -D aether.syncContext.named.factory=file-lock
+        -D aether.syncContext.named.time=120
+        -D maven.artifact.threads=32
+        EOF
+    - name: Cache local Maven repository
+      # Only use the full cache action if we're on main or stable/* branches
+      if: inputs.java == 'true' && (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
+      uses: actions/cache@v4
+      with:
+        # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
+        # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
+        # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
+        path: ~/.m2/repository/cached/releases/
+        # it matters for caching as absolute paths on self-hosted and Github runners differ
+        # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+    - name: Restore maven cache
+      # Restore cache (but don't save it) if we're not on main or stable/* branches
+      if: inputs.java == 'true' && !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
+      uses: actions/cache/restore@v4
+      with:
+        # This has to match the 'Cache local Maven repository' step above
+        path: ~/.m2/repository/cached/releases/
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -48,7 +48,7 @@ runs:
         EOF
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
-      if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
+      if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
       uses: actions/cache@v4
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
@@ -57,9 +57,9 @@ runs:
         path: ~/.m2/repository/cached/releases/
         # it matters for caching as absolute paths on self-hosted and GitHub runners differ
         # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-1-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-1-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
       if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
@@ -67,6 +67,6 @@ runs:
       with:
         # This has to match the 'Cache local Maven repository' step above
         path: ~/.m2/repository/cached/releases/
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-2-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-2-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -111,63 +111,10 @@ runs:
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
     - name: Configure Maven
-      if: inputs.java == 'true'
-      shell: bash
-      # `--errors` ensures errors will also spit out a stack trace, which is always useful, and has no impact on normal builds
-      #
-      # `--update-snapshots` to force Maven into updating snapshots, but also to retry looking for
-      #    release artifacts when an earlier lookup failure made it into the cache.
-      #
-      # `maven.wagon.*` and `maven.resolver.transport` set the resolver's network transport to Wagon,
-      #    the old provider pre 3.9. Until Maven 3.9.2, we have to do this if we want to retry on
-      #    network issues, as otherwise any issue will fail the build.
-      #
-      # `aether.enhancedLocalRepository.split` splits between local and remote artifacts.
-      # `aether.enhancedLocalRepository.splitRemote` splits remote artifacts into released and snapshot
-      # `aether.syncContext.*` config ensures that maven uses file locks to prevent corruption
-      #      from downloading multiple artifacts at the same time.
-      run: |
-        tee .mvn/maven.config <<EOF
-        --errors
-        --batch-mode
-        --update-snapshots
-        -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=false
-        -D maven.resolver.transport=wagon
-        -D maven.wagon.http.retryHandler.class=standard
-        -D maven.wagon.http.retryHandler.requestSentEnabled=true
-        -D maven.wagon.http.retryHandler.count=5
-        -D aether.enhancedLocalRepository.split=true
-        -D aether.enhancedLocalRepository.splitRemote=true
-        -D aether.syncContext.named.nameMapper=file-gav
-        -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=120
-        -D maven.artifact.threads=32
-        EOF
-    - name: Cache local Maven repository
-      # Only use the full cache action if we're on main or stable/* branches
-      if: inputs.java == 'true' && (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
-      uses: actions/cache@v4
+      uses: ./.github/actions/setup-maven-cache
       with:
-        # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
-        # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
-        # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
-        path: ~/.m2/repository/cached/releases/
-        # it matters for caching as absolute paths on self-hosted and Github runners differ
-        # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
-    - name: Restore maven cache
-      # Restore cache (but don't save it) if we're not on main or stable/* branches
-      if: inputs.java == 'true' && !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
-      uses: actions/cache/restore@v4
-      with:
-        # This has to match the 'Cache local Maven repository' step above
-        path: ~/.m2/repository/cached/releases/
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+        java: ${{ inputs.java }}
+        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v5
       with:

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -111,9 +111,9 @@ runs:
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
     - name: Configure Maven
+      if: inputs.java == 'true'
       uses: ./.github/actions/setup-maven-cache
       with:
-        java: ${{ inputs.java }}
         maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v5


### PR DESCRIPTION
## Description

Create composite action to cache maven. wraps the logic in setup-zeebe action in a composite action.

Usage of this composite action requires as inputs the maven cache key modifier.

```yaml
    - name: Configure Maven
      uses: ./.github/actions/setup-maven-cache
      with:
        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
```

To test the viability of the composite it is now used in setup-zeebe action.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/21423
