### PR TITLE
Migrate script task instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -52,7 +52,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.EVENT_SUB_PROCESS,
           BpmnElementType.EXCLUSIVE_GATEWAY,
           BpmnElementType.EVENT_BASED_GATEWAY,
-          BpmnElementType.BUSINESS_RULE_TASK);
+          BpmnElementType.BUSINESS_RULE_TASK,
+          BpmnElementType.SCRIPT_TASK);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBusinessRuleTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBusinessRuleTaskTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -88,9 +87,18 @@ public class MigrateBusinessRuleTaskTest {
         .addMappingInstruction("businessRuleTask1", "businessRuleTask2")
         .migrate();
 
-    RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .await();
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersion(1)
+        .describedAs("Expect that element id is left unchanged")
+        .hasElementId("businessRuleTask2");
 
     ENGINE.incident().ofInstance(processInstanceKey).resolve();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateScriptTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateScriptTaskTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateScriptTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateFeelExpressionScriptTaskWithAnIncident() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .scriptTask(
+                        "scriptTask1",
+                        t ->
+                            t.zeebeExpression("assert(x, x != null)").zeebeResultVariable("result"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .scriptTask(
+                        "scriptTask2", t -> t.zeebeExpression("true").zeebeResultVariable("result"))
+                    .endEvent("target_process_end")
+                    .done())
+            .deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("scriptTask1")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("scriptTask1", "scriptTask2")
+        .migrate();
+
+    RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to successfully evaluate the feel expression to reach the end event")
+        .hasElementId("target_process_end");
+  }
+
+  @Test
+  public void shouldMigrateJobWorkerBasedScriptTask() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .scriptTask("scriptTask1", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .scriptTask("scriptTask2", a -> a.zeebeJobType("B"))
+                    .userTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("scriptTask1", "scriptTask2")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SCRIPT_TASK)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersion(1)
+        .describedAs("Expect that element id is left unchanged")
+        .hasElementId("scriptTask2");
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasProcessDefinitionVersion(1)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("scriptTask2")
+        .describedAs(
+            "Expect that the type did not change even though it's different in the target process."
+                + " Re-evaluation of the job type expression is not enabled for this migration")
+        .hasType("A");
+  }
+}


### PR DESCRIPTION
## Description

Migrating a Script Task should be possible. There can be two different implementations of a Script Task:
- A FEEL expression
- Job worker implementation

### FEEL expression

The FEEL expression is evaluated immediately after the Script Task is activated. Still, a process instance may be waiting on a Script Task if there is an incident on it.

### Job Worker Implementation
A Script Task can be based on job worker. This case is already handled here:

https://github.com/camunda/camunda/blob/3ee2a8cf7b1490eb58570727f7dd289630b11a3c/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java#L255-L273

### Test Cases

Following test cases should be added to verify possible use cases:

- Migrating Script Task with an Incident
- Migrating Job Worker based Script Task

## Related issues

closes #21671 
