### PR TITLE
build: add buf configuration file

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,14 @@
+version: v2
+modules:
+  - path: zeebe/dynamic-config/src/main/resources/proto
+    breaking:
+      # as we use this only internally, only break on wire incompatibility; ignore source breaking
+      # changes
+      use:
+        - WIRE
+  - path: zeebe/gateway-protocol/src/main/proto
+    breaking:
+      # as this is meant to be consumed by clients for code generation, we do care about source
+      # backwards compatibility
+      use:
+        - FILE


### PR DESCRIPTION
## Description

This PR is the first part to resolve #18821. It adds a configuration file for the [buf CLI](https://github.com/bufbuild/buf) which specifies the path for the modules we wish to ensure backwards compatibility for. 

The configuration is added at the root of the project, and anything not in one of the modules is completely ignored by the buf CLI. If you wish to add new protocol files to track, you would need to add a new module. I will document this in our Wiki :slightly_smiling_face: 

To test that this works, you can install `buf` locally, or run it through Docker:

```sh
buf build -o image.json
docker run -v "$(pwd):/workspace" --workdir "/workspace" bufbuild/buf build -o image.json
```

This will produce an image of the two modules in JSON format, which you can briefly inspect to check it does what's expected. If you want to test the breaking changes, you can use my other branch, `np-18821-buf-breaking` as a base for comparison:

```sh
buf breaking --against '.git#branch=np-18821-buf-breaking'
```

If you want to test that the dynamic config module only checks binary compatibility (but not source code), you can open `topology.proto`, rename `ClusterTopology.version` to `ClusterTopology.versions` (with an `s` at the end), and run the above again. You will not get any error.

If you want to test that it breaks on binary compatibility, simply delete the version field entirely, and run the command again. You should get the following error:

> zeebe/dynamic-config/src/main/resources/proto/topology.proto:12:1:Previously present field "1" with name "version" on message "ClusterTopology" was deleted without reserving the number "1".

You can do similar things with the gateway protocol, however there renaming a field should trigger an error because we check for source compatibility (since clients will consume this for code generation).

CI changes will come after, as we first need the buf configuration to be present on the base branches before comparing anything.

## Related issues

related to #18821 
