### PR TITLE
feat: Implement `pin` Clock REST endpoint

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.application.commons.service;
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.CamundaServices;
+import io.camunda.service.ClockServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.DecisionRequirementsServices;
 import io.camunda.service.DocumentServices;
@@ -98,5 +99,10 @@ public class CamundaServicesConfiguration {
   @Bean
   public AuthorizationServices authorizationServices(final CamundaServices camundaServices) {
     return camundaServices.authorizationServices();
+  }
+
+  @Bean
+  public ClockServices clockServices(final CamundaServices camundaServices) {
+    return camundaServices.clockServices();
   }
 }

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -73,6 +73,10 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
     return new AuthorizationServices<>(brokerClient, searchClient, transformers, authentication);
   }
 
+  public ClockServices clockServices() {
+    return new ClockServices(brokerClient, searchClient, transformers, authentication);
+  }
+
   @Override
   public CamundaServices withAuthentication(final Authentication authentication) {
     return new CamundaServices(brokerClient, searchClient, transformers, authentication);

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockPinRequest;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import java.util.concurrent.CompletableFuture;
+
+public final class ClockServices extends ApiServices<ClockServices> {
+
+  public ClockServices(
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(brokerClient, searchClient, transformers, authentication);
+  }
+
+  @Override
+  public ClockServices withAuthentication(final Authentication authentication) {
+    return new ClockServices(brokerClient, searchClient, transformers, authentication);
+  }
+
+  public CompletableFuture<ClockRecord> pinClock(final long pinnedEpoch) {
+    return sendBrokerRequest(new BrokerClockPinRequest(pinnedEpoch));
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -578,6 +578,44 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+
+  /administration/clock/pin:
+    post:
+      tags:
+        - Administration
+        - Clock control
+      summary: Pin the Zeebe engine’s internal clock to a specific time (experimental)
+      description: |
+        Set a precise, static time for the Zeebe engine’s internal clock. When the clock is pinned,
+        it remains at the specified time and does not advance. To change the time, the clock must be
+        pinned again with a new timestamp.
+
+        :::note
+        This endpoint is experimental. It may undergo changes or improvements in future releases.
+        :::
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClockPinRequest"
+      responses:
+        "204":
+          description: >
+            The clock was successfully pinned to the specified time in epoch milliseconds.
+        "400":
+          description: The required timestamp parameter is missing.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          description: An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
   /process-instances/search:
     post:
       tags:
@@ -1553,6 +1591,15 @@ components:
           default: 50
           maximum: 100
           nullable: true
+    ClockPinRequest:
+      type: object
+      properties:
+        timestamp:
+          description: The exact time in epoch milliseconds to which the clock should be pinned.
+          type: integer
+          format: int64
+      required:
+        - timestamp
     JobActivationRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationAssignRequest;
+import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentMetadata;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobErrorRequest;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationAssignRequest;
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
+import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
@@ -99,6 +101,10 @@ public class RequestMapper {
                 userTaskKey,
                 getRecordWithChangedAttributes(updateRequest),
                 getStringOrEmpty(updateRequest, UserTaskUpdateRequest::getAction)));
+  }
+
+  public static Either<ProblemDetail, Long> getPinnedEpoch(final ClockPinRequest pinRequest) {
+    return getResult(validateClockPinRequest(pinRequest), pinRequest::getTimestamp);
   }
 
   public static Either<ProblemDetail, ActivateJobsRequest> toJobsActivationRequest(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.ClockServices;
+import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/administration")
+public class AdministrationController {
+
+  private final ClockServices clockServices;
+
+  @Autowired
+  public AdministrationController(final ClockServices clockServices) {
+    this.clockServices = clockServices;
+  }
+
+  @PostMapping(
+      path = "/clock/pin",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> pinClock(
+      @RequestBody final ClockPinRequest pinRequest) {
+
+    return RequestMapper.getPinnedEpoch(pinRequest)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::pinClock);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> pinClock(final long pinnedEpoch) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            clockServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .pinClock(pinnedEpoch));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+
+import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public class ClockValidator {
+
+  public static Optional<ProblemDetail> validateClockPinRequest(final ClockPinRequest pinRequest) {
+    return validate(
+        violations -> {
+          if (pinRequest.getTimestamp() == null) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("timestamp"));
+          }
+        });
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RequestValidator.java
@@ -14,8 +14,10 @@ import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 
@@ -48,5 +50,13 @@ public final class RequestValidator {
             && changeset.getCandidateGroups() == null
             && changeset.getCandidateUsers() == null
             && changeset.getPriority() == null);
+  }
+
+  public static Optional<ProblemDetail> validate(Consumer<List<String>> customValidation) {
+    final List<String> violations = new ArrayList<>();
+
+    customValidation.accept(violations);
+
+    return createProblemDetail(violations);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ClockServices;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ProblemDetail;
+
+@WebMvcTest(AdministrationController.class)
+public class AdministrationControllerTest extends RestControllerTest {
+
+  private static final String PIN_CLOCK_URL = "/v2/administration/clock/pin";
+
+  @MockBean private ClockServices clockServices;
+
+  @BeforeEach
+  void setup() {
+    when(clockServices.withAuthentication(any(Authentication.class))).thenReturn(clockServices);
+  }
+
+  @Test
+  void pinClockShouldReturnNoContent() {
+    // given
+    final long timestamp = 2693098555055L;
+    final var request = new ClockPinRequest().timestamp(timestamp);
+    final var clockRecord = new ClockRecord().pinAt(timestamp);
+
+    when(clockServices.pinClock(timestamp))
+        .thenReturn(CompletableFuture.completedFuture(clockRecord));
+
+    // when - then
+    webClient
+        .post()
+        .uri(PIN_CLOCK_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clockServices).pinClock(timestamp);
+  }
+
+  @Test
+  public void pinClockShouldReturnBadRequestIfTimestampIsNotProvided() {
+    // given
+    final var request = new ClockPinRequest();
+
+    final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+    expectedBody.setTitle(INVALID_ARGUMENT.name());
+    expectedBody.setInstance(URI.create(PIN_CLOCK_URL));
+    expectedBody.setDetail("No timestamp provided.");
+
+    // when - then
+    webClient
+        .post()
+        .uri(PIN_CLOCK_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerClockPinRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerClockPinRequest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerClockPinRequest extends BrokerExecuteCommand<ClockRecord> {
+
+  private final ClockRecord requestDto = new ClockRecord();
+
+  public BrokerClockPinRequest(final long pinnedEpoch) {
+    super(ValueType.CLOCK, ClockIntent.PIN);
+
+    requestDto.pinAt(pinnedEpoch);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ClockRecord toResponseDto(final DirectBuffer buffer) {
+    final ClockRecord responseDto = new ClockRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
@@ -12,8 +12,10 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 
 public final class ClockRecord extends UnifiedRecordValue implements ClockRecordValue {
-  // depending on the intent, the value may be a timestamp (epoch milliseconds) or an offset (in
-  // milliseconds)
+
+  // depending on the intent, the value may be a:
+  // - timestamp (epoch milliseconds)
+  // - offset (in milliseconds)
   private final LongProperty timeProperty = new LongProperty("time", 0);
 
   public ClockRecord() {


### PR DESCRIPTION
## Description
This pull request implements the REST API endpoint for pinning the Zeebe clock to a specific time, as part of the remaining scope for the Control Zeebe Clock epic.

### Changes:
- **Gateway:**
  - Added `BrokerClockPinRequest` to handle pin clock requests.
- **Services:**
  - Created `ClockServices` class and implemented the `pinClock` method to manage clock pinning logic.
- **Gateway-Rest:**
  - Created a new `AdministrationController`.
  - Implemented the [`pin clock`](https://docs.google.com/document/d/1rS989EESojWRrCMLH7Nscy1UppbgOanvzVeOljCc_iA/edit#bookmark=id.y4atmhfkqc07) REST endpoint in `AdministrationController`, which accepts a timestamp parameter in epoch milliseconds and calls the `pinClock` method in `ClockServices` after request validation.

### Notes:
- The endpoint is designed to be straightforward, with a single `timestamp` parameter representing the time in epoch milliseconds to which the clock should be pinned.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21645
