### PR TITLE
build: smoektest using service versions from pom.xml

### DIFF
--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -80,6 +80,8 @@ jobs:
       env:
         OPTIMIZE_IMAGE_TAG: ${{ env.DOCKER_TAG }}
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+        ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
+        IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
 
     - name: Wait for Optimize to start
       run: ./.github/optimize/scripts/wait-for.sh http://localhost:8090/ready

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -291,6 +291,8 @@ jobs:
         env:
           OPTIMIZE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
           ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
+          ZEEBE_VERSION: ${{ steps.pom-info.outputs.x_zeebe_version }}
+          IDENTITY_VERSION: ${{ steps.pom-info.outputs.x_identity_version }}
 
       - name: Wait for Optimize to start
         run: ./.github/optimize/scripts/wait-for.sh http://localhost:8090/ready


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With [this PR](https://github.com/camunda/camunda/pull/21464) when I was fixing smoke tests I removed setting the zeebe and identity versions read from `pom.xml` for the smoke tests, relying on `latest` versions, but we should use proper versions specified in pom instead.

- [successful release run](https://github.com/camunda/camunda/actions/runs/10611522246/job/29411220812)
- [successful CI deployment run](https://github.com/camunda/camunda/actions/runs/10611562967/job/29411816561)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
