### PR TITLE
Remove unused `id` property from `UserWithPasswordRequest`

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1487,9 +1487,6 @@ components:
       properties:
         password:
           type: "string"
-        id:
-          type: "integer"
-          format: "int64"
         username:
           type: "string"
         name:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This id property is never used. The endpoint is not yet publicly available, at this point we can break backwards compatibility by removing it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21673 
