### PR TITLE
Refactor component descriptor

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -157,7 +157,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                           deserializeJson(IndexTemplateSummary._DESERIALIZER, templateMappings)
                               .mappings()))
           .composedOf(indexTemplateDescriptor.getComposedOf())
-          .create(true)
+          .create(indexTemplateDescriptor.create())
           .build();
     } catch (final IOException e) {
       throw new ElasticsearchExporterException(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -116,7 +116,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   private PutComponentTemplateRequest putComponentTemplateRequest(
       final ComponentTemplateDescriptor templateDescriptor) {
     try (final var template =
-        getResourceAsStream(templateDescriptor.getTemplateClasspathFileName())) {
+        IOUtils.toInputStream(templateDescriptor.getTemplateJson(), "UTF-8")) {
       return new PutComponentTemplateRequest.Builder()
           .name(templateDescriptor.getTemplateName())
           .withJson(template)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/ComponentTemplateDescriptor.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/ComponentTemplateDescriptor.java
@@ -8,7 +8,7 @@
 package io.camunda.exporter.schema.descriptors;
 
 public interface ComponentTemplateDescriptor {
-  String getTemplateClasspathFileName();
+  String getTemplateJson();
 
   String getTemplateName();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/ComponentTemplateDescriptor.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/ComponentTemplateDescriptor.java
@@ -7,18 +7,6 @@
  */
 package io.camunda.exporter.schema.descriptors;
 
-public interface ComponentTemplateDescriptor {
+public interface ComponentTemplateDescriptor extends TemplateDetails {
   String getTemplateJson();
-
-  String getTemplateName();
-
-  /**
-   * Maps to the create query parameter, if true the corresponding request cannot replace or update
-   * an existing component template, defaults to false
-   *
-   * @return The component template request is create only
-   */
-  default Boolean create() {
-    return false;
-  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/TemplateDetails.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/descriptors/TemplateDetails.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.exporter.schema.descriptors;
 
-import java.util.List;
+public interface TemplateDetails {
+  String getTemplateName();
 
-public interface IndexTemplateDescriptor extends IndexDescriptor, TemplateDetails {
-
-  String getIndexPattern();
-
-  List<String> getComposedOf();
+  /**
+   * Maps to the create query parameter, if true the corresponding request cannot replace or update
+   * an existing template, defaults to false
+   *
+   * @return The template request is create only
+   */
+  default Boolean create() {
+    return false;
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -201,10 +201,17 @@ public class ElasticsearchEngineClientIT {
   }
 
   private void createComponentTemplate(
-      final String componentTemplateName, final String templateFileName) {
+      final String componentTemplateName, final String templateFileName) throws IOException {
     final var descriptor = mock(ComponentTemplateDescriptor.class);
     when(descriptor.getTemplateName()).thenReturn(componentTemplateName);
-    when(descriptor.getTemplateClasspathFileName()).thenReturn(templateFileName);
+
+    final var fileContents =
+        IOUtils.resourceToString(
+            templateFileName,
+            StandardCharsets.UTF_8,
+            Thread.currentThread().getContextClassLoader());
+
+    when(descriptor.getTemplateJson()).thenReturn(fileContents);
 
     elsEngineClient.createComponentTemplate(descriptor);
   }


### PR DESCRIPTION
## Description

Much easier to handle with the json string then a file as adding files to the class loader during run time is bad.

Also some refactoring to avoid repeated code with regards to `TemplateDetails`

## Related issues

relates to #19006 
