### PR TITLE
fix: Reducing number of threads in unit tests for optimize to improve stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,7 @@ jobs:
         uses: ./.github/actions/run-maven
         with:
           parameters: -f optimize/pom.xml test -Dskip.fe.build -Dskip.docker
-          threads: 4C
+          threads: 1C
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4


### PR DESCRIPTION
## Description

The Optimize backend unit tests time out frequently, reducing the number of threads to improve stability

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21722
