### PR TITLE
Validate user creation request

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -69,10 +69,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -9,7 +9,6 @@ package io.camunda.authentication;
 
 import io.camunda.service.UserServices;
 import io.camunda.service.search.query.SearchQueryBuilders;
-import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.Objects;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,9 +16,9 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 public class CamundaUserDetailsService implements UserDetailsService {
-  private final UserServices<UserRecord> userServices;
+  private final UserServices userServices;
 
-  public CamundaUserDetailsService(final UserServices<UserRecord> userServices) {
+  public CamundaUserDetailsService(final UserServices userServices) {
     this.userServices = userServices;
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -12,7 +12,6 @@ import static org.springframework.security.config.Customizer.withDefaults;
 import io.camunda.authentication.CamundaUserDetailsService;
 import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
@@ -35,8 +34,7 @@ public class WebSecurityConfig {
   private static final Logger LOG = LoggerFactory.getLogger(WebSecurityConfig.class);
 
   @Bean
-  public CamundaUserDetailsService camundaUserDetailsService(
-      final UserServices<UserRecord> userServices) {
+  public CamundaUserDetailsService camundaUserDetailsService(final UserServices userServices) {
     return new CamundaUserDetailsService(userServices);
   }
 

--- a/identity/migration/src/main/java/io/camunda/identity/migration/MigrationRunner.java
+++ b/identity/migration/src/main/java/io/camunda/identity/migration/MigrationRunner.java
@@ -12,7 +12,6 @@ import static java.util.Arrays.asList;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
-import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -23,14 +22,14 @@ import org.springframework.web.client.RestTemplate;
 @Profile("identity-migration")
 public class MigrationRunner implements ApplicationRunner {
 
-  final UserServices<UserRecord> userService;
+  final UserServices userService;
 
   final AuthorizationServices<AuthorizationRecord> authorizationServices;
 
   final RestTemplate restTemplate;
 
   public MigrationRunner(
-      final UserServices<UserRecord> userService,
+      final UserServices userService,
       final AuthorizationServices<AuthorizationRecord> authorizationServices) {
     this.userService = userService;
     this.authorizationServices = authorizationServices;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,6 +48,7 @@
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.17.1</version.commons-codec>
     <version.commons-compress>1.27.1</version.commons-compress>
+    <version.commons-validator>1.9.0</version.commons-validator>
     <version.zstd-jni>1.5.6-5</version.zstd-jni>
     <version.commons-text>1.12.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>
@@ -1332,6 +1333,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${version.commons-text}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-validator</groupId>
+        <artifactId>commons-validator</artifactId>
+        <version>${version.commons-validator}</version>
       </dependency>
 
       <dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -74,7 +74,11 @@ public class BasicAuthIT {
 
     content =
         objectMapper.writeValueAsString(
-            new UserWithPasswordRequest().username("demo").password("password").email("demo@e.c"));
+            new UserWithPasswordRequest()
+                .username("demo")
+                .name("foo")
+                .password("password")
+                .email("demo@demo.com"));
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -63,7 +63,7 @@ public class BasicAuthIT {
   @BeforeEach
   void setUp() throws JsonProcessingException {
     when(userService.withAuthentication(any(Authentication.class))).thenReturn(userService);
-    when(userService.createUser(any(), any(), any(), any()))
+    when(userService.createUser(any()))
         .thenReturn(CompletableFuture.completedFuture(new UserRecord()));
     when(userService.search(any()))
         .thenReturn(

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -52,4 +52,6 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
             .setEmail(email)
             .setPassword(password));
   }
+
+  public record CreateUserRequest(String username, String name, String email, String password) {}
 }

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.concurrent.CompletableFuture;
 
-public class UserServices<T> extends SearchQueryService<UserServices<T>, UserQuery, UserEntity> {
+public class UserServices extends SearchQueryService<UserServices, UserQuery, UserEntity> {
 
   public UserServices(final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
     this(brokerClient, dataStoreClient, null, null);
@@ -39,8 +39,8 @@ public class UserServices<T> extends SearchQueryService<UserServices<T>, UserQue
   }
 
   @Override
-  public UserServices<T> withAuthentication(final Authentication authentication) {
-    return new UserServices<>(brokerClient, searchClient, transformers, authentication);
+  public UserServices withAuthentication(final Authentication authentication) {
+    return new UserServices(brokerClient, searchClient, transformers, authentication);
   }
 
   public CompletableFuture<UserRecord> createUser(

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -43,14 +43,13 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
     return new UserServices(brokerClient, searchClient, transformers, authentication);
   }
 
-  public CompletableFuture<UserRecord> createUser(
-      final String username, final String name, final String email, final String password) {
+  public CompletableFuture<UserRecord> createUser(final CreateUserRequest request) {
     return sendBrokerRequest(
         new BrokerUserCreateRequest()
-            .setUsername(username)
-            .setName(name)
-            .setEmail(email)
-            .setPassword(password));
+            .setUsername(request.username())
+            .setName(request.name())
+            .setEmail(request.email())
+            .setPassword(request.password()));
   }
 
   public record CreateUserRequest(String username, String name, String email, String password) {}

--- a/service/src/test/java/io/camunda/service/query/filter/UserFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserFilterTest.java
@@ -19,7 +19,6 @@ import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.util.StubbedBrokerClient;
 import io.camunda.service.util.StubbedCamundaSearchClient;
 import io.camunda.util.ObjectBuilder;
-import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +28,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class UserFilterTest {
-  private UserServices<UserRecord> services;
+  private UserServices services;
   private StubbedCamundaSearchClient client;
   private StubbedBrokerClient brokerClient;
 
@@ -37,7 +36,7 @@ public class UserFilterTest {
   public void before() {
     client = new StubbedCamundaSearchClient();
     new UserSearchQueryStub().registerWith(client);
-    services = new UserServices<>(brokerClient, client);
+    services = new UserServices(brokerClient, client);
   }
 
   @Test

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -142,6 +142,11 @@
     </dependency>
 
     <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-authentication</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -24,6 +24,7 @@ import static io.camunda.zeebe.gateway.rest.validator.ResourceRequestValidator.v
 import static io.camunda.zeebe.gateway.rest.validator.SignalRequestValidator.validateSignalBroadcastRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateAssignmentRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateUpdateRequest;
+import static io.camunda.zeebe.gateway.rest.validator.UserValidator.validateUserCreateRequest;
 
 import io.camunda.service.AuthorizationServices.PatchAuthorizationRequest;
 import io.camunda.service.DocumentServices.DocumentCreateRequest;
@@ -37,6 +38,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
+import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.security.auth.Authentication.Builder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
@@ -60,6 +62,7 @@ import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserWithPasswordRequest;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionAction;
@@ -254,6 +257,18 @@ public class RequestMapper {
     return getResult(
         validationResponse,
         () -> new DocumentCreateRequest(documentId, storeId, inputStream, internalMetadata));
+  }
+
+  public static Either<ProblemDetail, CreateUserRequest> toCreateUserRequest(
+      final UserWithPasswordRequest request) {
+    return getResult(
+        validateUserCreateRequest(request),
+        () ->
+            new CreateUserRequest(
+                request.getUsername(),
+                request.getName(),
+                request.getEmail(),
+                request.getPassword()));
   }
 
   public static <BrokerResponseT> CompletableFuture<ResponseEntity<Object>> executeServiceMethod(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -44,12 +44,6 @@ public class UserController {
   private CompletableFuture<ResponseEntity<Object>> createUser(final CreateUserRequest request) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
-            userServices
-                .withAuthentication(RequestMapper.getAuthentication())
-                .createUser(
-                    request.username(),
-                    request.name(),
-                    request.email(),
-                    passwordEncoder.encode(request.password())));
+            userServices.withAuthentication(RequestMapper.getAuthentication()).createUser(request));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import io.camunda.service.UserServices;
+import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserWithPasswordRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
@@ -35,15 +37,19 @@ public class UserController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createUser(
       @RequestBody final UserWithPasswordRequest userWithPasswordDto) {
+    return RequestMapper.toCreateUserRequest(userWithPasswordDto)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
+  }
 
+  private CompletableFuture<ResponseEntity<Object>> createUser(final CreateUserRequest request) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userServices
                 .withAuthentication(RequestMapper.getAuthentication())
                 .createUser(
-                    userWithPasswordDto.getUsername(),
-                    userWithPasswordDto.getName(),
-                    userWithPasswordDto.getEmail(),
-                    passwordEncoder.encode(userWithPasswordDto.getPassword())));
+                    request.username(),
+                    request.name(),
+                    request.email(),
+                    passwordEncoder.encode(request.password())));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -28,4 +28,5 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_INVALID_TENANT =
       "Expected to handle request %s with tenant identifier '%s', but %s";
   public static final String ERROR_MESSAGE_ONLY_ONE_FIELD = "Only one of %s is allowed";
+  public static final String ERROR_MESSAGE_INVALID_EMAIL = "The provided email '%s' is not valid";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/UserValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_EMAIL;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.createProblemDetail;
+
+import io.camunda.zeebe.gateway.protocol.rest.UserWithPasswordRequest;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.apache.commons.validator.routines.EmailValidator;
+import org.springframework.http.ProblemDetail;
+
+public final class UserValidator {
+
+  public static Optional<ProblemDetail> validateUserCreateRequest(
+      final UserWithPasswordRequest request) {
+    final List<String> violations = new ArrayList<>();
+
+    if (request.getUsername() == null || request.getUsername().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("username"));
+    }
+    if (request.getName() == null || request.getName().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+    }
+
+    if (request.getPassword() == null || request.getPassword().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("password"));
+    }
+    if (request.getEmail() == null || request.getEmail().isBlank()) {
+      violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("email"));
+    } else if (!EmailValidator.getInstance().isValid(request.getEmail())) {
+      violations.add(ERROR_MESSAGE_INVALID_EMAIL.formatted(request.getEmail()));
+    }
+
+    return createProblemDetail(violations);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.service.CamundaServiceException;
 import io.camunda.service.UserServices;
+import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.gateway.protocol.rest.UserWithPasswordRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
@@ -52,18 +53,16 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void createUserShouldReturnNoContent() {
     // given
-    final UserWithPasswordRequest dto = validRequest();
+    final var dto = validCreateUserRequest();
 
     final var userRecord =
         new UserRecord()
-            .setUsername(dto.getUsername())
-            .setName(dto.getName())
-            .setEmail(dto.getEmail())
-            .setPassword(dto.getPassword());
+            .setUsername(dto.username())
+            .setName(dto.name())
+            .setEmail(dto.email())
+            .setPassword(dto.password());
 
-    when(userServices.createUser(
-            dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword()))
-        .thenReturn(CompletableFuture.completedFuture(userRecord));
+    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
 
     // when
     webClient
@@ -77,8 +76,7 @@ public class UserControllerTest extends RestControllerTest {
         .isNoContent();
 
     // then
-    verify(userServices, times(1))
-        .createUser(dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword());
+    verify(userServices, times(1)).createUser(dto);
   }
 
   @Test
@@ -86,10 +84,9 @@ public class UserControllerTest extends RestControllerTest {
     // given
     final String message = "message";
 
-    final UserWithPasswordRequest dto = validRequest();
+    final var dto = validCreateUserRequest();
 
-    when(userServices.createUser(
-            dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword()))
+    when(userServices.createUser(dto))
         .thenThrow(new CamundaServiceException(RejectionType.ALREADY_EXISTS.name()));
 
     final var expectedBody = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, message);
@@ -114,7 +111,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithMissingUsername() {
     // given
-    final var request = validRequest().username(null);
+    final var request = validUserWithPasswordRequest().username(null);
 
     // when then
     assertRequestRejectedExceptionally(
@@ -134,7 +131,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithBlankUsername() {
     // given
-    final var request = validRequest().username("");
+    final var request = validUserWithPasswordRequest().username("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -154,7 +151,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithEmptyName() {
     // given
-    final var request = validRequest().name(null);
+    final var request = validUserWithPasswordRequest().name(null);
 
     // when then
     assertRequestRejectedExceptionally(
@@ -174,7 +171,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithBlankName() {
     // given
-    final var request = validRequest().name("");
+    final var request = validUserWithPasswordRequest().name("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -194,7 +191,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithEmptyPassword() {
     // given
-    final var request = validRequest().password(null);
+    final var request = validUserWithPasswordRequest().password(null);
 
     // when then
     assertRequestRejectedExceptionally(
@@ -214,7 +211,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithBlankPassword() {
     // given
-    final var request = validRequest().password("");
+    final var request = validUserWithPasswordRequest().password("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -234,7 +231,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithEmptyEmail() {
     // given
-    final var request = validRequest().email(null);
+    final var request = validUserWithPasswordRequest().email(null);
 
     // when then
     assertRequestRejectedExceptionally(
@@ -254,7 +251,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void shouldRejectUserCreationWithBlankEmail() {
     // given
-    final var request = validRequest().email("");
+    final var request = validUserWithPasswordRequest().email("");
 
     // when then
     assertRequestRejectedExceptionally(
@@ -275,7 +272,7 @@ public class UserControllerTest extends RestControllerTest {
   void shouldRejectUserCreationWithInvalidEmail() {
     // given
     final var email = "invalid@email.reject";
-    final var request = validRequest().email(email);
+    final var request = validUserWithPasswordRequest().email(email);
 
     // when then
     assertRequestRejectedExceptionally(
@@ -292,7 +289,11 @@ public class UserControllerTest extends RestControllerTest {
     verifyNoInteractions(userServices);
   }
 
-  private UserWithPasswordRequest validRequest() {
+  private CreateUserRequest validCreateUserRequest() {
+    return new CreateUserRequest("foo", "Foo Bar", "bar@baz.com", "zabraboof");
+  }
+
+  private UserWithPasswordRequest validUserWithPasswordRequest() {
     return new UserWithPasswordRequest()
         .username("foo")
         .name("Foo Bar")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import io.camunda.service.CamundaServiceException;
@@ -34,6 +35,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @WebMvcTest(UserController.class)
 public class UserControllerTest extends RestControllerTest {
+
+  private static final String USER_BASE_URL = "/v2/users";
 
   @MockBean private UserServices userServices;
   @MockBean private PasswordEncoder passwordEncoder;
@@ -69,7 +72,7 @@ public class UserControllerTest extends RestControllerTest {
     // when
     webClient
         .post()
-        .uri("/v2/users")
+        .uri(USER_BASE_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto)
@@ -99,12 +102,12 @@ public class UserControllerTest extends RestControllerTest {
     final var expectedBody = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, message);
     expectedBody.setTitle("Bad Request");
     expectedBody.setDetail(RejectionType.ALREADY_EXISTS.name());
-    expectedBody.setInstance(URI.create("/v2/users"));
+    expectedBody.setInstance(URI.create(USER_BASE_URL));
 
     // when then
     webClient
         .post()
-        .uri("/v2/users")
+        .uri(USER_BASE_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(dto)
@@ -113,5 +116,209 @@ public class UserControllerTest extends RestControllerTest {
         .isBadRequest()
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithMissingUsername() {
+    // given
+    final var request = validRequest().username(null);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No username provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithBlankUsername() {
+    // given
+    final var request = validRequest().username("");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No username provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithEmptyName() {
+    // given
+    final var request = validRequest().name(null);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No name provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithBlankName() {
+    // given
+    final var request = validRequest().name("");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No name provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithEmptyPassword() {
+    // given
+    final var request = validRequest().password(null);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No password provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithBlankPassword() {
+    // given
+    final var request = validRequest().password("");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No password provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithEmptyEmail() {
+    // given
+    final var request = validRequest().email(null);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No email provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithBlankEmail() {
+    // given
+    final var request = validRequest().email("");
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "No email provided.",
+          "instance": "%s"
+        }"""
+            .formatted(USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  @Test
+  void shouldRejectUserCreationWithInvalidEmail() {
+    // given
+    final var email = "invalid@email.reject";
+    final var request = validRequest().email(email);
+
+    // when then
+    assertRequestRejectedExceptionally(
+        request,
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "INVALID_ARGUMENT",
+          "detail": "The provided email '%s' is not valid.",
+          "instance": "%s"
+        }"""
+            .formatted(email, USER_BASE_URL));
+    verifyNoInteractions(userServices);
+  }
+
+  private UserWithPasswordRequest validRequest() {
+    return new UserWithPasswordRequest()
+        .username("foo")
+        .name("Foo Bar")
+        .email("bar@baz.com")
+        .password("zabraboof");
+  }
+
+  private void assertRequestRejectedExceptionally(
+      final UserWithPasswordRequest request, final String expectedError) {
+    webClient
+        .post()
+        .uri(USER_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(expectedError);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -48,7 +48,7 @@ public class UserControllerTest extends RestControllerTest {
 
   @Test
   void createUserShouldReturnNoContent() {
-
+    // given
     final UserWithPasswordRequest dto = new UserWithPasswordRequest();
     dto.setUsername("demo");
     dto.setPassword("password");
@@ -66,6 +66,7 @@ public class UserControllerTest extends RestControllerTest {
             dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword()))
         .thenReturn(CompletableFuture.completedFuture(userRecord));
 
+    // when
     webClient
         .post()
         .uri("/v2/users")
@@ -76,12 +77,14 @@ public class UserControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
+    // then
     verify(userServices, times(1))
         .createUser(dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword());
   }
 
   @Test
   void createUserThrowsExceptionWhenServiceThrowsException() {
+    // given
     final String message = "message";
 
     final UserWithPasswordRequest dto = new UserWithPasswordRequest();
@@ -98,6 +101,7 @@ public class UserControllerTest extends RestControllerTest {
     expectedBody.setDetail(RejectionType.ALREADY_EXISTS.name());
     expectedBody.setInstance(URI.create("/v2/users"));
 
+    // when then
     webClient
         .post()
         .uri("/v2/users")

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -52,11 +52,7 @@ public class UserControllerTest extends RestControllerTest {
   @Test
   void createUserShouldReturnNoContent() {
     // given
-    final UserWithPasswordRequest dto = new UserWithPasswordRequest();
-    dto.setUsername("demo");
-    dto.setPassword("password");
-    dto.setName("Demo");
-    dto.setEmail("demo@e.c");
+    final UserWithPasswordRequest dto = validRequest();
 
     final var userRecord =
         new UserRecord()
@@ -90,10 +86,7 @@ public class UserControllerTest extends RestControllerTest {
     // given
     final String message = "message";
 
-    final UserWithPasswordRequest dto = new UserWithPasswordRequest();
-    dto.setUsername("demo");
-    dto.setEmail("demo@e.c");
-    dto.setPassword("password");
+    final UserWithPasswordRequest dto = validRequest();
 
     when(userServices.createUser(
             dto.getUsername(), dto.getName(), dto.getEmail(), dto.getPassword()))


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds a validation and mapping from the UserWithPasswordRequest DTO to an internal object (CreateUserRequest). When we have a CreateUserRequest the request is validated and we can assume all fields are correct.

The validation is quite straightforward. It checks for all fields that they are not empty or blank. Email validation is
a bit more tricky. It's always hard to determine if an email is valid or not. Instead of coming up with something myself
I used Apache's commons-validator. This has a built-in email validator. I did have to pull in a new dependency for this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21672 
