### PR TITLE
feat: Implement `reset` Clock REST endpoint

### DIFF
--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -12,6 +12,7 @@ import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockPinRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockResetRequest;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import java.util.concurrent.CompletableFuture;
 
@@ -32,5 +33,9 @@ public final class ClockServices extends ApiServices<ClockServices> {
 
   public CompletableFuture<ClockRecord> pinClock(final long pinnedEpoch) {
     return sendBrokerRequest(new BrokerClockPinRequest(pinnedEpoch));
+  }
+
+  public CompletableFuture<ClockRecord> resetClock() {
+    return sendBrokerRequest(new BrokerClockResetRequest());
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -615,6 +615,29 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+  /administration/clock/reset:
+    post:
+      tags:
+        - Administration
+        - Clock control
+      summary: Reset the Zeebe engine’s internal clock to the system time (experimental)
+      description: |
+        Resets the Zeebe engine’s internal clock to the current system time,
+        enabling it to tick in real-time. This operation is useful for returning the clock to
+        normal behavior after it has been pinned to a specific time.
+
+        :::note
+        This endpoint is experimental and may undergo changes or improvements in future releases.
+        :::
+      responses:
+        "204":
+          description: The clock was successfully reset to the system time
+        "500":
+          description: An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
   /process-instances/search:
     post:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
@@ -41,6 +41,15 @@ public class AdministrationController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::pinClock);
   }
 
+  @PostMapping(
+      path = "/clock/reset",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> resetClock() {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () -> clockServices.withAuthentication(RequestMapper.getAuthentication()).resetClock());
+  }
+
   private CompletableFuture<ResponseEntity<Object>> pinClock(final long pinnedEpoch) {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
@@ -31,6 +31,7 @@ import org.springframework.http.ProblemDetail;
 public class AdministrationControllerTest extends RestControllerTest {
 
   private static final String PIN_CLOCK_URL = "/v2/administration/clock/pin";
+  private static final String RESET_CLOCK_URL = "/v2/administration/clock/reset";
 
   @MockBean private ClockServices clockServices;
 
@@ -85,5 +86,24 @@ public class AdministrationControllerTest extends RestControllerTest {
         .isBadRequest()
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
+  }
+
+  @Test
+  void restClockShouldReturnNoContent() {
+    // given
+    when(clockServices.resetClock())
+        .thenReturn(CompletableFuture.completedFuture(new ClockRecord()));
+
+    // when - then
+    webClient
+        .post()
+        .uri(RESET_CLOCK_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(clockServices).resetClock();
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerClockResetRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerClockResetRequest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerClockResetRequest extends BrokerExecuteCommand<ClockRecord> {
+
+  private final ClockRecord requestDto = new ClockRecord();
+
+  public BrokerClockResetRequest() {
+    super(ValueType.CLOCK, ClockIntent.RESET);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ClockRecord toResponseDto(final DirectBuffer buffer) {
+    final ClockRecord responseDto = new ClockRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}


### PR DESCRIPTION
## Description

This pull request implements the REST API endpoint for resetting the Zeebe clock to the system time, as part of the remaining scope for the Control Zeebe Clock epic.

### Changes:
- **Gateway:**
  - Added `BrokerClockResetRequest` to handle reset clock requests.
- **Services:**
  - Extended the `ClockServices` class with a `resetClock` method to send `BrokerClockResetRequest`.
- **Gateway-Rest:**
  - Updated the `AdministrationController` to include the [`POST /v2/administration/clock/reset`](https://docs.google.com/document/d/1rS989EESojWRrCMLH7Nscy1UppbgOanvzVeOljCc_iA/edit#bookmark=id.dwwd3qik0c2w) REST endpoint.

### Notes:
- The endpoint is designed to be straightforward, with no parameters required for the reset operation.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21646 
