### PR TITLE
fix: Include sortValues property in items for Listeners paginated query

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.elasticsearch;
+package io.camunda.operate.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -118,9 +118,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     assertEquals("12", resultListeners1.get(2).getListenerKey());
 
     // next page - test searchAfter
-    final Object[] sortValuesFromLastInResultOfPage = resultListeners1.get(2).getSortValues();
-    final SortValuesWrapper[] sortValuesAfter =
-        SortValuesWrapper.createFrom(sortValuesFromLastInResultOfPage, objectMapper);
+    final SortValuesWrapper[] sortValuesAfter = resultListeners1.get(2).getSortValues();
     final ListenerRequestDto request2 =
         new ListenerRequestDto()
             .setPageSize(3)
@@ -136,9 +134,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     assertEquals("31", resultListeners2.get(1).getListenerKey());
 
     // test searchBefore (from last result)
-    final Object[] sortValuesFromLastResult = resultListeners2.get(1).getSortValues();
-    final SortValuesWrapper[] sortValuesBefore =
-        SortValuesWrapper.createFrom(sortValuesFromLastResult, objectMapper);
+    final SortValuesWrapper[] sortValuesBefore = resultListeners2.get(1).getSortValues();
     final ListenerRequestDto request3 =
         new ListenerRequestDto()
             .setPageSize(3)

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -62,6 +62,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.RawTaskStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -107,7 +108,7 @@ public abstract class ElasticsearchUtil {
           esClient.submitReindexTask(reindexRequest, RequestOptions.DEFAULT).getTask();
       LOGGER.debug("Reindexing started for index {}. Task id: {}", sourceIndexName, taskId);
       reindexFuture.complete(taskId);
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       reindexFuture.completeExceptionally(ex);
     }
     return reindexFuture.thenCompose(
@@ -148,7 +149,7 @@ public abstract class ElasticsearchUtil {
       final String taskId = (String) bodyMap.get("task");
       LOGGER.debug("Deletion started for index {}. Task id {}", sourceIndexName, taskId);
       deleteRequestFuture.complete(taskId);
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       deleteRequestFuture.completeExceptionally(ex);
     }
     return deleteRequestFuture.thenCompose(
@@ -156,11 +157,11 @@ public abstract class ElasticsearchUtil {
   }
 
   private static CompletableFuture<Long> checkTaskResult(
-      ThreadPoolTaskScheduler executor,
-      String taskId,
-      String sourceIndexName,
-      String operation,
-      RestHighLevelClient esClient) {
+      final ThreadPoolTaskScheduler executor,
+      final String taskId,
+      final String sourceIndexName,
+      final String operation,
+      final RestHighLevelClient esClient) {
 
     final CompletableFuture<Long> checkTaskResult = new CompletableFuture<>();
 
@@ -191,7 +192,7 @@ public abstract class ElasticsearchUtil {
                 executor.schedule(
                     this, Date.from(Instant.now().plusMillis(idleStrategy.idleTime())));
               }
-            } catch (Exception e) {
+            } catch (final Exception e) {
               checkTaskResult.completeExceptionally(e);
             }
           }
@@ -201,7 +202,7 @@ public abstract class ElasticsearchUtil {
   }
 
   private static long getTotalAffectedFromTask(
-      String sourceIndexName, String operation, RawTaskStatus status) {
+      final String sourceIndexName, final String operation, final RawTaskStatus status) {
     // parse and check task status
     final Map<String, Object> statusMap = status.toMap();
     final long total = (Integer) statusMap.get("total");
@@ -220,19 +221,20 @@ public abstract class ElasticsearchUtil {
     return total;
   }
 
-  public static SearchRequest createSearchRequest(TemplateDescriptor template) {
+  public static SearchRequest createSearchRequest(final TemplateDescriptor template) {
     return createSearchRequest(template, QueryType.ALL);
   }
 
   /* CREATE QUERIES */
 
   public static SearchRequest createSearchRequest(
-      TemplateDescriptor template, QueryType queryType) {
+      final TemplateDescriptor template, final QueryType queryType) {
     final SearchRequest searchRequest = new SearchRequest(whereToSearch(template, queryType));
     return searchRequest;
   }
 
-  private static String whereToSearch(TemplateDescriptor template, QueryType queryType) {
+  private static String whereToSearch(
+      final TemplateDescriptor template, final QueryType queryType) {
     switch (queryType) {
       case ONLY_RUNTIME:
         return template.getFullQualifiedName();
@@ -243,9 +245,9 @@ public abstract class ElasticsearchUtil {
   }
 
   public static QueryBuilder joinWithOr(
-      BoolQueryBuilder boolQueryBuilder, QueryBuilder... queries) {
+      final BoolQueryBuilder boolQueryBuilder, final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
-    for (QueryBuilder query : notNullQueries) {
+    for (final QueryBuilder query : notNullQueries) {
       boolQueryBuilder.should(query);
     }
     return boolQueryBuilder;
@@ -259,7 +261,7 @@ public abstract class ElasticsearchUtil {
    * @param queries
    * @return
    */
-  public static QueryBuilder joinWithOr(QueryBuilder... queries) {
+  public static QueryBuilder joinWithOr(final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
     switch (notNullQueries.size()) {
       case 0:
@@ -268,14 +270,14 @@ public abstract class ElasticsearchUtil {
         return notNullQueries.get(0);
       default:
         final BoolQueryBuilder boolQ = boolQuery();
-        for (QueryBuilder query : notNullQueries) {
+        for (final QueryBuilder query : notNullQueries) {
           boolQ.should(query);
         }
         return boolQ;
     }
   }
 
-  public static QueryBuilder joinWithOr(Collection<QueryBuilder> queries) {
+  public static QueryBuilder joinWithOr(final Collection<QueryBuilder> queries) {
     return joinWithOr(queries.toArray(new QueryBuilder[queries.size()]));
   }
 
@@ -287,7 +289,7 @@ public abstract class ElasticsearchUtil {
    * @param queries
    * @return
    */
-  public static QueryBuilder joinWithAnd(QueryBuilder... queries) {
+  public static QueryBuilder joinWithAnd(final QueryBuilder... queries) {
     final List<QueryBuilder> notNullQueries = throwAwayNullElements(queries);
     switch (notNullQueries.size()) {
       case 0:
@@ -296,7 +298,7 @@ public abstract class ElasticsearchUtil {
         return notNullQueries.get(0);
       default:
         final BoolQueryBuilder boolQ = boolQuery();
-        for (QueryBuilder query : notNullQueries) {
+        for (final QueryBuilder query : notNullQueries) {
           boolQ.must(query);
         }
         return boolQ;
@@ -308,7 +310,9 @@ public abstract class ElasticsearchUtil {
   }
 
   public static void processBulkRequest(
-      RestHighLevelClient esClient, BulkRequest bulkRequest, long maxBulkRequestSizeInBytes)
+      final RestHighLevelClient esClient,
+      final BulkRequest bulkRequest,
+      final long maxBulkRequestSizeInBytes)
       throws PersistenceException {
     processBulkRequest(esClient, bulkRequest, false, maxBulkRequestSizeInBytes);
   }
@@ -316,10 +320,10 @@ public abstract class ElasticsearchUtil {
   /* EXECUTE QUERY */
 
   public static void processBulkRequest(
-      RestHighLevelClient esClient,
-      BulkRequest bulkRequest,
-      boolean refreshImmediately,
-      long maxBulkRequestSizeInBytes)
+      final RestHighLevelClient esClient,
+      final BulkRequest bulkRequest,
+      final boolean refreshImmediately,
+      final long maxBulkRequestSizeInBytes)
       throws PersistenceException {
     if (bulkRequest.estimatedSizeInBytes() > maxBulkRequestSizeInBytes) {
       divideLargeBulkRequestAndProcess(
@@ -379,7 +383,7 @@ public abstract class ElasticsearchUtil {
 
   @SuppressWarnings("checkstyle:NestedIfDepth")
   private static void processLimitedBulkRequest(
-      RestHighLevelClient esClient, BulkRequest bulkRequest, boolean refreshImmediately)
+      final RestHighLevelClient esClient, BulkRequest bulkRequest, final boolean refreshImmediately)
       throws PersistenceException {
     if (bulkRequest.requests().size() > 0) {
       try {
@@ -423,7 +427,7 @@ public abstract class ElasticsearchUtil {
           }
         }
         LOGGER.debug("************* FLUSH BULK FINISH *************");
-      } catch (IOException ex) {
+      } catch (final IOException ex) {
         throw new PersistenceException(
             "Error when processing bulk request against Elasticsearch: " + ex.getMessage(), ex);
       }
@@ -449,35 +453,35 @@ public abstract class ElasticsearchUtil {
 
   /* MAP QUERY RESULTS */
   public static <T> List<T> mapSearchHits(
-      List<HitEntity> hits, ObjectMapper objectMapper, JavaType valueType) {
+      final List<HitEntity> hits, final ObjectMapper objectMapper, final JavaType valueType) {
     return map(hits, h -> fromSearchHit(h.getSourceAsString(), objectMapper, valueType));
   }
 
   public static <T> List<T> mapSearchHits(
-      HitEntity[] searchHits, ObjectMapper objectMapper, Class<T> clazz) {
+      final HitEntity[] searchHits, final ObjectMapper objectMapper, final Class<T> clazz) {
     return map(
         searchHits,
         (searchHit) -> fromSearchHit(searchHit.getSourceAsString(), objectMapper, clazz));
   }
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, Function<SearchHit, T> searchHitMapper) {
+      final SearchHit[] searchHits, final Function<SearchHit, T> searchHitMapper) {
     return map(searchHits, searchHitMapper);
   }
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, ObjectMapper objectMapper, Class<T> clazz) {
+      final SearchHit[] searchHits, final ObjectMapper objectMapper, final Class<T> clazz) {
     return map(
         searchHits,
         (searchHit) -> fromSearchHit(searchHit.getSourceAsString(), objectMapper, clazz));
   }
 
   public static <T> T fromSearchHit(
-      String searchHitString, ObjectMapper objectMapper, Class<T> clazz) {
+      final String searchHitString, final ObjectMapper objectMapper, final Class<T> clazz) {
     final T entity;
     try {
       entity = objectMapper.readValue(searchHitString, clazz);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error(
           String.format(
               "Error while reading entity of type %s from Elasticsearch!", clazz.getName()),
@@ -491,18 +495,18 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> mapSearchHits(
-      SearchHit[] searchHits, ObjectMapper objectMapper, JavaType valueType) {
+      final SearchHit[] searchHits, final ObjectMapper objectMapper, final JavaType valueType) {
     return map(
         searchHits,
         (searchHit) -> fromSearchHit(searchHit.getSourceAsString(), objectMapper, valueType));
   }
 
   public static <T> T fromSearchHit(
-      String searchHitString, ObjectMapper objectMapper, JavaType valueType) {
+      final String searchHitString, final ObjectMapper objectMapper, final JavaType valueType) {
     final T entity;
     try {
       entity = objectMapper.readValue(searchHitString, valueType);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error(
           String.format(
               "Error while reading entity of type %s from Elasticsearch!", valueType.toString()),
@@ -516,34 +520,34 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> scroll(
-      SearchRequest searchRequest,
-      Class<T> clazz,
-      ObjectMapper objectMapper,
-      RestHighLevelClient esClient)
+      final SearchRequest searchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient)
       throws IOException {
     return scroll(searchRequest, clazz, objectMapper, esClient, null, null);
   }
 
   public static <T> List<T> scroll(
-      SearchRequest searchRequest,
-      Class<T> clazz,
-      ObjectMapper objectMapper,
-      RestHighLevelClient esClient,
-      Consumer<SearchHits> searchHitsProcessor,
-      Consumer<Aggregations> aggsProcessor)
+      final SearchRequest searchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final Consumer<Aggregations> aggsProcessor)
       throws IOException {
     return scroll(
         searchRequest, clazz, objectMapper, esClient, null, searchHitsProcessor, aggsProcessor);
   }
 
   public static <T> List<T> scroll(
-      SearchRequest searchRequest,
-      Class<T> clazz,
-      ObjectMapper objectMapper,
-      RestHighLevelClient esClient,
-      Function<SearchHit, T> searchHitMapper,
-      Consumer<SearchHits> searchHitsProcessor,
-      Consumer<Aggregations> aggsProcessor)
+      final SearchRequest searchRequest,
+      final Class<T> clazz,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient,
+      final Function<SearchHit, T> searchHitMapper,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final Consumer<Aggregations> aggsProcessor)
       throws IOException {
 
     searchRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
@@ -585,18 +589,18 @@ public abstract class ElasticsearchUtil {
   }
 
   public static void scroll(
-      SearchRequest searchRequest,
-      Consumer<SearchHits> searchHitsProcessor,
-      RestHighLevelClient esClient)
+      final SearchRequest searchRequest,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final RestHighLevelClient esClient)
       throws IOException {
     scroll(searchRequest, searchHitsProcessor, esClient, SCROLL_KEEP_ALIVE_MS);
   }
 
   public static void scroll(
-      SearchRequest searchRequest,
-      Consumer<SearchHits> searchHitsProcessor,
-      RestHighLevelClient esClient,
-      long scrollKeepAlive)
+      final SearchRequest searchRequest,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final RestHighLevelClient esClient,
+      final long scrollKeepAlive)
       throws IOException {
     final var scrollKeepAliveTimeValue = TimeValue.timeValueMillis(scrollKeepAlive);
 
@@ -626,19 +630,19 @@ public abstract class ElasticsearchUtil {
   }
 
   public static void scrollWith(
-      SearchRequest searchRequest,
-      RestHighLevelClient esClient,
-      Consumer<SearchHits> searchHitsProcessor)
+      final SearchRequest searchRequest,
+      final RestHighLevelClient esClient,
+      final Consumer<SearchHits> searchHitsProcessor)
       throws IOException {
     scrollWith(searchRequest, esClient, searchHitsProcessor, null, null);
   }
 
   public static void scrollWith(
-      SearchRequest searchRequest,
-      RestHighLevelClient esClient,
-      Consumer<SearchHits> searchHitsProcessor,
-      Consumer<Aggregations> aggsProcessor,
-      Consumer<SearchHits> firstResponseConsumer)
+      final SearchRequest searchRequest,
+      final RestHighLevelClient esClient,
+      final Consumer<SearchHits> searchHitsProcessor,
+      final Consumer<Aggregations> aggsProcessor,
+      final Consumer<SearchHits> firstResponseConsumer)
       throws IOException {
 
     searchRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
@@ -673,21 +677,21 @@ public abstract class ElasticsearchUtil {
     clearScroll(scrollId, esClient);
   }
 
-  public static void clearScroll(String scrollId, RestHighLevelClient esClient) {
+  public static void clearScroll(final String scrollId, final RestHighLevelClient esClient) {
     if (scrollId != null) {
       // clear the scroll
       final ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
       clearScrollRequest.addScrollId(scrollId);
       try {
         esClient.clearScroll(clearScrollRequest, RequestOptions.DEFAULT);
-      } catch (Exception e) {
+      } catch (final Exception e) {
         LOGGER.warn("Error occurred when clearing the scroll with id [{}]", scrollId);
       }
     }
   }
 
-  public static List<Long> scrollKeysToList(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static List<Long> scrollKeysToList(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final List<Long> result = new ArrayList<>();
 
     final Consumer<SearchHits> collectIds =
@@ -700,7 +704,8 @@ public abstract class ElasticsearchUtil {
   }
 
   public static <T> List<T> scrollFieldToList(
-      SearchRequest request, String fieldName, RestHighLevelClient esClient) throws IOException {
+      final SearchRequest request, final String fieldName, final RestHighLevelClient esClient)
+      throws IOException {
     final List<T> result = new ArrayList<>();
     final Function<SearchHit, T> searchHitFieldToString =
         (searchHit) -> (T) searchHit.getSourceAsMap().get(fieldName);
@@ -714,8 +719,8 @@ public abstract class ElasticsearchUtil {
     return result;
   }
 
-  public static Set<String> scrollIdsToSet(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static Set<String> scrollIdsToSet(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final Set<String> result = new HashSet<>();
 
     final Consumer<SearchHits> collectIds =
@@ -727,7 +732,7 @@ public abstract class ElasticsearchUtil {
   }
 
   public static Map<String, String> getIndexNames(
-      String aliasName, Collection<String> ids, RestHighLevelClient esClient) {
+      final String aliasName, final Collection<String> ids, final RestHighLevelClient esClient) {
 
     final Map<String, String> indexNames = new HashMap<>();
 
@@ -753,14 +758,16 @@ public abstract class ElasticsearchUtil {
                               return hit.getIndex();
                             })));
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e.getMessage(), e);
     }
     return indexNames;
   }
 
   public static Map<String, String> getIndexNames(
-      AbstractTemplateDescriptor template, Collection<String> ids, RestHighLevelClient esClient) {
+      final AbstractTemplateDescriptor template,
+      final Collection<String> ids,
+      final RestHighLevelClient esClient) {
 
     final Map<String, String> indexNames = new HashMap<>();
 
@@ -786,14 +793,16 @@ public abstract class ElasticsearchUtil {
                               return hit.getIndex();
                             })));
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e.getMessage(), e);
     }
     return indexNames;
   }
 
   public static Map<String, List<String>> getIndexNamesAsList(
-      AbstractTemplateDescriptor template, Collection<String> ids, RestHighLevelClient esClient) {
+      final AbstractTemplateDescriptor template,
+      final Collection<String> ids,
+      final RestHighLevelClient esClient) {
 
     final Map<String, List<String>> indexNames = new ConcurrentHashMap<>();
 
@@ -823,13 +832,13 @@ public abstract class ElasticsearchUtil {
                               return v1;
                             }));
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e.getMessage(), e);
     }
     return indexNames;
   }
 
-  public static RequestOptions requestOptionsFor(int maxSizeInBytes) {
+  public static RequestOptions requestOptionsFor(final int maxSizeInBytes) {
     final RequestOptions.Builder options = RequestOptions.DEFAULT.toBuilder();
     options.setHttpAsyncResponseConsumerFactory(
         new HttpAsyncResponseConsumerFactory.HeapBufferedResponseConsumerFactory(maxSizeInBytes));
@@ -845,16 +854,16 @@ public abstract class ElasticsearchUtil {
     private DelegatingActionListener(
         final CompletableFuture<Response> future, final Executor executor) {
       this.future = future;
-      this.executorDelegate = executor;
+      executorDelegate = executor;
     }
 
     @Override
-    public void onResponse(Response response) {
+    public void onResponse(final Response response) {
       executorDelegate.execute(() -> future.complete(response));
     }
 
     @Override
-    public void onFailure(Exception e) {
+    public void onFailure(final Exception e) {
       executorDelegate.execute(() -> future.completeExceptionally(e));
     }
   }

--- a/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
+++ b/operate/schema/src/main/java/io/camunda/operate/util/ElasticsearchUtil.java
@@ -845,6 +845,14 @@ public abstract class ElasticsearchUtil {
     return options.build();
   }
 
+  public static SortOrder reverseOrder(final SortOrder sortOrder) {
+    if (sortOrder.equals(SortOrder.ASC)) {
+      return SortOrder.DESC;
+    } else {
+      return SortOrder.ASC;
+    }
+  }
+
   private static final class DelegatingActionListener<Response>
       implements ActionListener<Response> {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/DecisionInstanceReader.java
@@ -29,6 +29,7 @@ import static io.camunda.operate.schema.templates.DecisionInstanceTemplate.STATE
 import static io.camunda.operate.util.ElasticsearchUtil.QueryType.ALL;
 import static io.camunda.operate.util.ElasticsearchUtil.createMatchNoneQuery;
 import static io.camunda.operate.util.ElasticsearchUtil.joinWithAnd;
+import static io.camunda.operate.util.ElasticsearchUtil.reverseOrder;
 import static io.camunda.operate.webapp.rest.dto.dmn.list.DecisionInstanceListRequestDto.SORT_BY_PROCESS_INSTANCE_ID;
 import static java.util.stream.Collectors.groupingBy;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
@@ -310,14 +311,6 @@ public class DecisionInstanceReader extends AbstractReader
       return sortBy;
     }
     return null;
-  }
-
-  private SortOrder reverseOrder(final SortOrder sortOrder) {
-    if (sortOrder.equals(SortOrder.ASC)) {
-      return SortOrder.DESC;
-    } else {
-      return SortOrder.ASC;
-    }
   }
 
   private QueryBuilder createRequestQuery(final DecisionInstanceListQueryDto query) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
@@ -134,12 +134,4 @@ public class ElasticsearchListenerReader extends AbstractReader implements Liste
         .sort(SortBuilders.fieldSort(JobTemplate.TIME).order(sortOrder).missing(missing))
         .sort(SortBuilders.fieldSort(JobTemplate.JOB_KEY).order(sortOrder));
   }
-
-  private SortOrder reverseOrder(final SortOrder sortOrder) {
-    if (sortOrder.equals(SortOrder.ASC)) {
-      return SortOrder.DESC;
-    } else {
-      return SortOrder.ASC;
-    }
-  }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.reader.ListenerReader;
 import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import io.camunda.operate.webapp.rest.dto.ListenerResponseDto;
+import io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -88,7 +89,9 @@ public class ElasticsearchListenerReader extends AbstractReader implements Liste
                 final JobEntity entity =
                     fromSearchHit(searchHit.getSourceAsString(), objectMapper, JobEntity.class);
                 final ListenerDto dto = ListenerDto.fromJobEntity(entity);
-                dto.setSortValues(searchHit.getSortValues());
+                final SortValuesWrapper[] sortValues =
+                    SortValuesWrapper.createFrom(searchHit.getSortValues(), objectMapper);
+                dto.setSortValues(sortValues);
                 return dto;
               });
       if (request.getSearchBefore() != null) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ListViewReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ListViewReader.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.webapp.elasticsearch.reader;
 
 import static io.camunda.operate.schema.templates.ListViewTemplate.PARENT_FLOW_NODE_INSTANCE_KEY;
+import static io.camunda.operate.util.ElasticsearchUtil.reverseOrder;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -219,14 +220,6 @@ public class ListViewReader implements io.camunda.operate.webapp.reader.ListView
       return sortBy;
     }
     return null;
-  }
-
-  private SortOrder reverseOrder(final SortOrder sortOrder) {
-    if (sortOrder.equals(SortOrder.ASC)) {
-      return SortOrder.DESC;
-    } else {
-      return SortOrder.ASC;
-    }
   }
 
   private void findCalledProcessInstance(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.reader.ListenerReader;
 import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import io.camunda.operate.webapp.rest.dto.ListenerResponseDto;
+import io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -73,7 +74,9 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
             .map(
                 hit -> {
                   final JobEntity entity = hit.source();
-                  return ListenerDto.fromJobEntity(entity).setSortValues(hit.sort().toArray());
+                  final SortValuesWrapper[] sortValues =
+                      SortValuesWrapper.createFrom(hit.sort().toArray(), objectMapper);
+                  return ListenerDto.fromJobEntity(entity).setSortValues(sortValues);
                 })
             .collect(Collectors.toList());
     if (request.getSearchBefore() != null) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -74,7 +74,7 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
             .map(
                 hit -> {
                   final JobEntity entity = hit.source();
-                  return ListenerDto.fromJobEntity(entity);
+                  return ListenerDto.fromJobEntity(entity).setSortValues(hit.sort().toArray());
                 })
             .collect(Collectors.toUnmodifiableList());
     return new ListenerResponseDto(listenerDtos, totalHitCount);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -16,15 +16,17 @@ import io.camunda.operate.entities.JobEntity;
 import io.camunda.operate.entities.ListenerType;
 import io.camunda.operate.schema.templates.JobTemplate;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.reader.ListenerReader;
 import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import io.camunda.operate.webapp.rest.dto.ListenerResponseDto;
-import io.camunda.operate.webapp.rest.dto.SortingDto;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.search.SearchResult;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
@@ -58,32 +60,59 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
             or(
                 term(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER.name()),
                 term(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER.name())));
-    final var searchRequest =
-        searchRequestBuilder(jobTemplate.getAlias())
-            .query(query)
-            .sort(
-                sortOptions(
-                    request.getSorting().getSortBy(),
-                    getSortOrder(request.getSorting().getSortOrder())));
+
+    final var searchRequestBuilder = searchRequestBuilder(jobTemplate.getAlias()).query(query);
+    applySorting(searchRequestBuilder, request);
+    searchRequestBuilder.size(request.getPageSize());
 
     final SearchResult<JobEntity> searchResult =
-        richOpenSearchClient.doc().search(searchRequest, JobEntity.class);
+        richOpenSearchClient.doc().fixedSearch(searchRequestBuilder.build(), JobEntity.class);
     final Long totalHitCount = searchResult.hits().total().value();
-    final List<ListenerDto> listenerDtos =
+    final List<ListenerDto> listeners =
         searchResult.hits().hits().stream()
             .map(
                 hit -> {
                   final JobEntity entity = hit.source();
                   return ListenerDto.fromJobEntity(entity).setSortValues(hit.sort().toArray());
                 })
-            .collect(Collectors.toUnmodifiableList());
-    return new ListenerResponseDto(listenerDtos, totalHitCount);
+            .collect(Collectors.toList());
+    if (request.getSearchBefore() != null) {
+      Collections.reverse(listeners);
+    }
+    return new ListenerResponseDto(listeners, totalHitCount);
   }
 
-  private SortOrder getSortOrder(final String sortOrder) {
-    if (sortOrder.equals(SortingDto.SORT_ORDER_DESC_VALUE)) {
-      return SortOrder.Desc;
+  private void applySorting(
+      final SearchRequest.Builder searchSourceBuilder, final ListenerRequestDto request) {
+
+    SortOrder sortOrder = SortOrder.Desc;
+
+    if (request.getSorting() != null) {
+      if (request.getSorting().getSortOrder() != null) {
+        sortOrder =
+            "asc".equals(request.getSorting().getSortOrder()) ? SortOrder.Asc : SortOrder.Desc;
+      }
     }
-    return SortOrder.Asc;
+
+    final String missing;
+    Object[] querySearchAfter = null;
+    if (request.getSearchBefore() != null) {
+      sortOrder = reverseOrder(sortOrder);
+      missing = "_last";
+      querySearchAfter = request.getSearchBefore(objectMapper);
+    } else {
+      missing = "_first";
+      if (request.getSearchAfter() != null) {
+        querySearchAfter = request.getSearchAfter(objectMapper);
+      }
+    }
+
+    if (querySearchAfter != null) {
+      searchSourceBuilder.searchAfter(CollectionUtil.toSafeListOfStrings(querySearchAfter));
+    }
+
+    searchSourceBuilder
+        .sort(sortOptions(JobTemplate.TIME, sortOrder, missing))
+        .sort(sortOptions(JobTemplate.JOB_KEY, sortOrder));
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
@@ -13,7 +13,6 @@ import io.camunda.operate.Metrics;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationType;
 import io.camunda.operate.entities.SequenceFlowEntity;
-import io.camunda.operate.schema.templates.JobTemplate;
 import io.camunda.operate.store.SequenceFlowStore;
 import io.camunda.operate.util.rest.ValidLongId;
 import io.camunda.operate.webapp.InternalAPIErrorController;
@@ -210,7 +209,6 @@ public class ProcessInstanceRestService extends InternalAPIErrorController {
       @RequestBody final ListenerRequestDto request) {
     checkIdentityReadPermission(Long.parseLong(processInstanceId));
     processInstanceRequestValidator.validateListenerRequest(request);
-    request.setSorting(new SortingDto().setSortBy(JobTemplate.TIME).setSortOrder("desc"));
     return listenerReader.getListenerExecutions(processInstanceId, request);
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerDto.java
@@ -12,6 +12,7 @@ import io.camunda.operate.entities.ListenerEventType;
 import io.camunda.operate.entities.ListenerState;
 import io.camunda.operate.entities.ListenerType;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.Objects;
 
 public class ListenerDto {
@@ -21,6 +22,8 @@ public class ListenerDto {
   private String jobType;
   private ListenerEventType event;
   private OffsetDateTime time;
+
+  private Object[] sortValues;
 
   public ListenerType getListenerType() {
     return listenerType;
@@ -76,6 +79,15 @@ public class ListenerDto {
     return this;
   }
 
+  public Object[] getSortValues() {
+    return sortValues;
+  }
+
+  public ListenerDto setSortValues(final Object[] sortValues) {
+    this.sortValues = sortValues;
+    return this;
+  }
+
   public static ListenerDto fromJobEntity(final JobEntity jobEntity) {
     return new ListenerDto()
         .setListenerType(ListenerType.fromZeebeJobKind(jobEntity.getJobKind()))
@@ -100,35 +112,34 @@ public class ListenerDto {
       return false;
     }
     final ListenerDto that = (ListenerDto) o;
-    return Objects.equals(listenerType, that.listenerType)
+    return listenerType == that.listenerType
         && Objects.equals(listenerKey, that.listenerKey)
-        && Objects.equals(state, that.state)
+        && state == that.state
         && Objects.equals(jobType, that.jobType)
-        && Objects.equals(event, that.event)
-        && Objects.equals(time, that.time);
+        && event == that.event
+        && Objects.equals(time, that.time)
+        && Arrays.equals(sortValues, that.sortValues);
   }
 
   @Override
   public String toString() {
     return "ListenerDto{"
-        + "listenerType='"
+        + "listenerType="
         + listenerType
-        + '\''
         + ", listenerKey='"
         + listenerKey
         + '\''
-        + ", state='"
+        + ", state="
         + state
-        + '\''
         + ", jobType='"
         + jobType
         + '\''
-        + ", event='"
+        + ", event="
         + event
-        + '\''
-        + ", time='"
+        + ", time="
         + time
-        + '\''
+        + ", sortValues="
+        + Arrays.toString(sortValues)
         + '}';
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerDto.java
@@ -11,6 +11,7 @@ import io.camunda.operate.entities.JobEntity;
 import io.camunda.operate.entities.ListenerEventType;
 import io.camunda.operate.entities.ListenerState;
 import io.camunda.operate.entities.ListenerType;
+import io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper;
 import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Objects;
@@ -23,7 +24,7 @@ public class ListenerDto {
   private ListenerEventType event;
   private OffsetDateTime time;
 
-  private Object[] sortValues;
+  private SortValuesWrapper[] sortValues;
 
   public ListenerType getListenerType() {
     return listenerType;
@@ -79,11 +80,11 @@ public class ListenerDto {
     return this;
   }
 
-  public Object[] getSortValues() {
+  public SortValuesWrapper[] getSortValues() {
     return sortValues;
   }
 
-  public ListenerDto setSortValues(final Object[] sortValues) {
+  public ListenerDto setSortValues(final SortValuesWrapper[] sortValues) {
     this.sortValues = sortValues;
     return this;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
@@ -8,11 +8,15 @@
 package io.camunda.operate.webapp.rest.dto;
 
 import io.camunda.operate.schema.templates.JobTemplate;
+import io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper;
+import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import java.util.Objects;
 import java.util.Set;
 
 public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
   private String flowNodeId;
+
+  public ListenerRequestDto() {}
 
   public String getFlowNodeId() {
     return flowNodeId;
@@ -26,6 +30,22 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
   @Override
   protected Set<String> getValidSortByValues() {
     return Set.of(JobTemplate.TIME);
+  }
+
+  @Override
+  public ListenerRequestDto setSearchAfterOrEqual(final SortValuesWrapper[] searchAfterOrEqual) {
+    if (searchAfterOrEqual != null) {
+      throw new InvalidRequestException("SearchAfterOrEqual is not supported.");
+    }
+    return this;
+  }
+
+  @Override
+  public ListenerRequestDto setSearchBeforeOrEqual(final SortValuesWrapper[] searchBeforeOrEqual) {
+    if (searchBeforeOrEqual != null) {
+      throw new InvalidRequestException("SearchBeforeOrEqual is not supported.");
+    }
+    return this;
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added `sortValues`  to `ListenerDto`s and the necessary logic to the `ListenerReader` classes to allow for pagination via `searchBefore` and `searchAfter`.

Stabilized sorting by using the jobKey as secondary value to sort by if there is no `endTime` set or if listeners have the same `endTime`.

Also did some minor refactoring and moved the listener integration test class to a more appropriate package.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/21540
