### PR TITLE
Make ALREADY_EXISTS errors return a 409 Conflict

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -38,9 +38,9 @@ public class RestErrorMapper {
           case NOT_FOUND:
             yield RestErrorMapper.createProblemDetail(HttpStatus.NOT_FOUND, message, title);
           case INVALID_STATE:
+          case ALREADY_EXISTS:
             yield RestErrorMapper.createProblemDetail(HttpStatus.CONFLICT, message, title);
           case INVALID_ARGUMENT:
-          case ALREADY_EXISTS:
             yield RestErrorMapper.createProblemDetail(HttpStatus.BAD_REQUEST, message, title);
           default:
             {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in [Slack](https://camunda.slack.com/archives/C06UKS51QV9/p1724920818935409)

The definition of a 409 Conflict is:
This response is sent when a request conflicts with the current state of the server.

When you try to create and it already exists that is a conflict with the current state of the server. Therefore, this
code is more accurate than the generic 400 Bad Request.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

N/A
