### PR TITLE
Partition manager can bootstrap new partitions

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -270,7 +270,8 @@ final class ClusterApiUtils {
       case JOINING -> PartitionStateCode.JOINING;
       case ACTIVE -> PartitionStateCode.ACTIVE;
       case LEAVING -> PartitionStateCode.LEAVING;
-      case UNKNOWN -> PartitionStateCode.UNKNOWN;
+      // TODO: Define state code for BootStrapping
+      case BOOTSTRAPPING, UNKNOWN -> PartitionStateCode.UNKNOWN;
     };
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcessShutdownException;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthStatus;
@@ -326,6 +327,13 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
               });
         });
     return result;
+  }
+
+  @Override
+  public ActorFuture<Void> bootstrap(
+      final int partitionId, final int priority, final DynamicPartitionConfig partitionConfig) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException("Not yet implemented"));
   }
 
   @Override

--- a/zeebe/dynamic-config/pom.xml
+++ b/zeebe/dynamic-config/pom.xml
@@ -64,6 +64,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -82,6 +83,12 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               enableExporterOperation.memberId(),
               enableExporterOperation.exporterId(),
               enableExporterOperation.initializeFrom(),
+              partitionChangeExecutor);
+      case final PartitionBootstrapOperation bootstrapOperation ->
+          new PartitionBootstrapApplier(
+              bootstrapOperation.partitionId(),
+              bootstrapOperation.priority(),
+              bootstrapOperation.memberId(),
               partitionChangeExecutor);
       case null, default -> new FailingApplier(operation);
     };

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -30,6 +30,12 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   }
 
   @Override
+  public ActorFuture<Void> bootstrap(
+      final int partitionId, final int priority, final DynamicPartitionConfig partitionConfig) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
   public ActorFuture<Void> reconfigurePriority(final int partitionId, final int newPriority) {
     return CompletableActorFuture.completed(null);
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+public class PartitionBootstrapApplier implements MemberOperationApplier {
+
+  private final int partitionId;
+  private final int priority;
+  private final MemberId memberId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+  private DynamicPartitionConfig partitionConfig;
+
+  public PartitionBootstrapApplier(
+      final int partitionId,
+      final int priority,
+      final MemberId memberId,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.priority = priority;
+    this.memberId = memberId;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
+      final ClusterConfiguration currentClusterConfiguration) {
+
+    final boolean localMemberIsActive =
+        currentClusterConfiguration.hasMember(memberId)
+            && currentClusterConfiguration.getMember(memberId).state() == State.ACTIVE;
+    if (!localMemberIsActive) {
+      return Either.left(
+          new IllegalStateException(
+              "Expected to bootstrap partition, but the member '{}' is not active"
+                  .formatted(memberId)));
+    }
+
+    if (isPartitionAlreadyBootstrapping(currentClusterConfiguration)) {
+      return Either.right(UnaryOperator.identity());
+    }
+
+    if (partitionExists(currentClusterConfiguration)) {
+      return Either.left(
+          new IllegalStateException(
+              "Failed to bootstrap partition '{}'. Partition already exists in the cluster"
+                  .formatted(partitionId)));
+    }
+
+    if (!isPartitionIdContiguous(currentClusterConfiguration, partitionId)) {
+      return Either.left(
+          new IllegalStateException(
+              "Failed to bootstrap partition '{}'. Partition ID is not contiguous"
+                  .formatted(partitionId)));
+    }
+
+    // Let's assume Partition 1 always exists
+    partitionConfig =
+        currentClusterConfiguration.members().values().stream()
+            .flatMap(m -> m.partitions().entrySet().stream().filter(p -> p.getKey() == 1))
+            .findFirst()
+            .get()
+            .getValue()
+            .config();
+    return Either.right(
+        memberState ->
+            memberState.addPartition(
+                partitionId, PartitionState.bootstrapping(priority, partitionConfig)));
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
+    final CompletableActorFuture<UnaryOperator<MemberState>> result =
+        new CompletableActorFuture<>();
+
+    partitionChangeExecutor
+        .bootstrap(partitionId, priority, partitionConfig)
+        .onComplete(
+            (ignore, error) -> {
+              if (error == null) {
+                result.complete(
+                    memberState ->
+                        memberState.updatePartition(partitionId, PartitionState::toActive));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+
+  // For now, we only allow adding new partitions with continuous IDs. In theory, it should not
+  // matter. But there might be legacy code where we assume this, such as message routing.
+  private boolean isPartitionIdContiguous(
+      final ClusterConfiguration currentClusterConfiguration, final int partitionId) {
+    final var lastPartitionId =
+        currentClusterConfiguration.members().values().stream()
+            .flatMap(m -> m.partitions().keySet().stream())
+            .max(Integer::compareTo)
+            .orElse(0);
+    return partitionId == lastPartitionId + 1;
+  }
+
+  private boolean isPartitionAlreadyBootstrapping(
+      final ClusterConfiguration currentClusterConfiguration) {
+    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    return member.hasPartition(partitionId)
+        && member.getPartition(partitionId).state() == PartitionState.State.BOOTSTRAPPING;
+  }
+
+  private boolean partitionExists(final ClusterConfiguration currentClusterConfiguration) {
+    return currentClusterConfiguration.members().values().stream()
+        .anyMatch(memberState -> memberState.hasPartition(partitionId));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -48,8 +48,8 @@ public interface PartitionChangeExecutor {
 
   /**
    * The implementation of this method must bootstrap the partition with a single replica. The
-   * implementation must be idempotent. * If the node restarts after this method was called, but
-   * before marking the operation as * completed, it will be retried after the restart.
+   * implementation must be idempotent. If the node restarts after this method was called, but
+   * before marking the operation as completed, it will be retried after the restart.
    *
    * @param partitionId id of the partition
    * @param priority priority of the member in the partition used for Raft's priority election

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -47,6 +47,19 @@ public interface PartitionChangeExecutor {
   ActorFuture<Void> leave(int partitionId);
 
   /**
+   * The implementation of this method must bootstrap the partition with a single replica. The
+   * implementation must be idempotent. * If the node restarts after this method was called, but
+   * before marking the operation as * completed, it will be retried after the restart.
+   *
+   * @param partitionId id of the partition
+   * @param priority priority of the member in the partition used for Raft's priority election
+   * @param partitionConfig the configuration of the partition
+   * @return a future that completes when the partition is bootstrapped
+   */
+  ActorFuture<Void> bootstrap(
+      int partitionId, int priority, DynamicPartitionConfig partitionConfig);
+
+  /**
    * Updates the priority of the member used for raft priority election for the given partition.
    *
    * @param partitionId id of the partition

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -421,6 +421,7 @@ public class ProtoBufSerializer
           builder.setPartitionBootstrap(
               Topology.PartitionBootstrapOperation.newBuilder()
                   .setPartitionId(bootstrapOperation.partitionId())
+                  .setPriority(bootstrapOperation.priority())
                   .build());
       default ->
           throw new IllegalArgumentException(
@@ -571,7 +572,8 @@ public class ProtoBufSerializer
     } else if (topologyChangeOperation.hasPartitionBootstrap()) {
       return new PartitionBootstrapOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),
-          topologyChangeOperation.getPartitionBootstrap().getPartitionId());
+          topologyChangeOperation.getPartitionBootstrap().getPartitionId(),
+          topologyChangeOperation.getPartitionBootstrap().getPriority());
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -306,6 +306,8 @@ public class ProtoBufSerializer
       case JOINING -> MemberState.State.JOINING;
       case LEAVING -> MemberState.State.LEAVING;
       case LEFT -> MemberState.State.LEFT;
+      case BOOTSTRAPPING ->
+          throw new IllegalStateException("Member cannot be in BOOTSTRAPPING state");
     };
   }
 
@@ -315,6 +317,7 @@ public class ProtoBufSerializer
       case ACTIVE -> PartitionState.State.ACTIVE;
       case JOINING -> PartitionState.State.JOINING;
       case LEAVING -> PartitionState.State.LEAVING;
+      case BOOTSTRAPPING -> PartitionState.State.BOOTSTRAPPING;
     };
   }
 
@@ -324,6 +327,7 @@ public class ProtoBufSerializer
       case ACTIVE -> Topology.State.ACTIVE;
       case JOINING -> Topology.State.JOINING;
       case LEAVING -> Topology.State.LEAVING;
+      case BOOTSTRAPPING -> Topology.State.BOOTSTRAPPING;
     };
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -115,7 +115,7 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param memberId the member id of the member that will apply this operation
      * @param partitionId id of the partition to bootstrap
      */
-    record PartitionBootstrapOperation(MemberId memberId, int partitionId)
+    record PartitionBootstrapOperation(MemberId memberId, int partitionId, int priority)
         implements PartitionChangeOperation {}
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -44,6 +44,7 @@ public record PartitionState(State state, int priority, DynamicPartitionConfig c
     UNKNOWN,
     JOINING,
     ACTIVE,
-    LEAVING
+    LEAVING,
+    BOOTSTRAPPING
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -20,6 +20,11 @@ public record PartitionState(State state, int priority, DynamicPartitionConfig c
     return new PartitionState(State.JOINING, priority, partitionConfig);
   }
 
+  public static PartitionState bootstrapping(
+      final int priority, final DynamicPartitionConfig partitionConfig) {
+    return new PartitionState(State.BOOTSTRAPPING, priority, partitionConfig);
+  }
+
   public PartitionState toActive() {
     if (state == State.LEAVING) {
       throw new IllegalStateException(

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -145,6 +145,7 @@ enum State {
   ACTIVE = 2;
   LEAVING = 3;
   LEFT = 4;
+  BOOTSTRAPPING = 5;
 }
 
 enum ChangeStatus {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -129,6 +129,7 @@ message PartitionEnableExporterOperation {
 
 message PartitionBootstrapOperation {
   int32 partitionId = 1;
+  int32 priority = 2;
 }
 
 message MemberJoinOperation {}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplierTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
+import io.camunda.zeebe.dynamic.config.PartitionStateAssert;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class PartitionBootstrapApplierTest {
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+  private final int partitionId = 2;
+  private final int priority = 1;
+  private final MemberId localMemberId = MemberId.from("1");
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+
+  @Nested
+  final class Init {
+
+    final ClusterConfiguration initialConfiguration =
+        ClusterConfiguration.init()
+            .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
+            .updateMember(
+                localMemberId,
+                m -> m.addPartition(1, PartitionState.active(priority, partitionConfig)));
+
+    @Test
+    void shouldRejectIfPartitionAlreadyExistsInOtherMembers() {
+      // given
+      final var otherMemberId = MemberId.from("2");
+      final var configurationWithActivePartition =
+          initialConfiguration
+              .addMember(otherMemberId, MemberState.initializeAsActive(Map.of()))
+              .updateMember(
+                  otherMemberId,
+                  m ->
+                      m.addPartition(
+                          partitionId, PartitionState.active(priority, partitionConfig)));
+
+      // when
+      final var result =
+          new PartitionBootstrapApplier(
+                  partitionId, priority, localMemberId, partitionChangeExecutor)
+              .init(configurationWithActivePartition);
+
+      // then
+      EitherAssert.assertThat(result).isLeft().left().isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectIfPartitionIdIsNotContiguous() {
+      // when
+      final var result =
+          new PartitionBootstrapApplier(
+                  partitionId + 1, priority, localMemberId, partitionChangeExecutor)
+              .init(initialConfiguration);
+
+      // then
+      EitherAssert.assertThat(result).isLeft().left().isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldRejectIfLocalMemberIsNotActive() {
+      // given
+      final var configurationWithInactiveMember = ClusterConfiguration.init();
+
+      // when
+      final var result =
+          new PartitionBootstrapApplier(
+                  partitionId, priority, localMemberId, partitionChangeExecutor)
+              .init(configurationWithInactiveMember);
+
+      // then
+      EitherAssert.assertThat(result).isLeft().left().isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void shouldNotRejectBootstrapIfPartitionIsAlreadyBootstrappingInLocalMember() {
+      // given
+      final var topologyWithPartitionBootstrapping =
+          initialConfiguration.updateMember(
+              localMemberId,
+              m ->
+                  m.addPartition(
+                      partitionId, PartitionState.bootstrapping(partitionId, partitionConfig)));
+
+      // when
+      final var result =
+          new PartitionBootstrapApplier(
+                  partitionId, priority, localMemberId, partitionChangeExecutor)
+              .init(topologyWithPartitionBootstrapping);
+
+      // then
+      EitherAssert.assertThat(result).isRight();
+      assertThat(result.get().apply(topologyWithPartitionBootstrapping))
+          .describedAs("No change to the topology")
+          .isEqualTo(topologyWithPartitionBootstrapping);
+    }
+
+    @Test
+    void shouldUpdatePartitionStateToBootstrapping() {
+      // when
+      final var result =
+          new PartitionBootstrapApplier(
+                  partitionId, priority, localMemberId, partitionChangeExecutor)
+              .init(initialConfiguration);
+
+      // then
+      EitherAssert.assertThat(result).isRight();
+      ClusterConfigurationAssert.assertThatClusterTopology(result.get().apply(initialConfiguration))
+          .describedAs("Partition added at state bootstrapping")
+          .member(localMemberId)
+          .hasPartitionSatisfying(
+              partitionId,
+              state ->
+                  PartitionStateAssert.assertThat(state)
+                      .hasConfig(partitionConfig)
+                      .hasState(State.BOOTSTRAPPING)
+                      .hasPriority(priority));
+    }
+  }
+
+  @Nested
+  final class Apply {
+    private PartitionBootstrapApplier partitionBootstrapApplier;
+    private ClusterConfiguration operationInitialized;
+
+    @BeforeEach
+    void init() {
+      final var initialTopology =
+          ClusterConfiguration.init()
+              .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
+              .updateMember(
+                  localMemberId,
+                  m -> m.addPartition(1, PartitionState.active(priority, partitionConfig)));
+
+      // when
+      partitionBootstrapApplier =
+          new PartitionBootstrapApplier(
+              partitionId, priority, localMemberId, partitionChangeExecutor);
+      operationInitialized =
+          partitionBootstrapApplier.init(initialTopology).get().apply(initialTopology);
+    }
+
+    @Test
+    void shouldFailFutureIfBootstrappingFailed() {
+      // given
+      when(partitionChangeExecutor.bootstrap(partitionId, priority, partitionConfig))
+          .thenReturn(CompletableActorFuture.completedExceptionally(new RuntimeException("FAIL")));
+
+      // when
+      final var result = partitionBootstrapApplier.apply();
+
+      // then
+      assertThat(result).failsWithin(Duration.ofMillis(100));
+    }
+
+    @Test
+    void shouldUpdateStateToActive() {
+      // given
+      when(partitionChangeExecutor.bootstrap(partitionId, priority, partitionConfig))
+          .thenReturn(CompletableActorFuture.completed(null));
+
+      // when
+      final var result = partitionBootstrapApplier.apply();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ofMillis(100));
+      ClusterConfigurationAssert.assertThatClusterTopology(
+              result.join().apply(operationInitialized))
+          .member(localMemberId)
+          .hasPartitionSatisfying(
+              partitionId,
+              state ->
+                  PartitionStateAssert.assertThat(state)
+                      .hasConfig(partitionConfig)
+                      .hasState(State.ACTIVE)
+                      .hasPriority(priority));
+    }
+  }
+}


### PR DESCRIPTION
## Description

* Added applier for PartitionBootstrapOperation
* PartitionManager can start new partitions as a single replica raft-group. 

## Related issues

closes #21479 
