### PR TITLE
docs: Deprecate GO

### DIFF
--- a/clients/go/README.md
+++ b/clients/go/README.md
@@ -1,6 +1,25 @@
 # Zeebe Go Client
 
-## Development
+> [!WARNING]
+> The Zeebe Go Client will be officially deprecated with 8.6 release as part of our efforts to streamline the Camunda 8 API experience. This client will not get released with Camunda 8.6, thus no longer receive new features and will be transitioned to a community-maintained status.
+
+### Why This Change?
+
+The decision to deprecate the Go Client aligns with our broader API strategy and resource allocation priorities. The Go Client has seen limited adoption. Moving forward, we are focusing our efforts on the Camunda 8 REST API, which offers a unified, more widely-supported approach for interacting with Zeebe and other Camunda services.
+
+### What Does This Mean for Users?
+
+* No New Features or Updates: Starting with Camunda 8.6, the Go Client will no longer receive new features, updates, or official support from Camunda.
+* The official Go client and zbctl will only remain available and maintained for supported minor versions up to Camunda 8.5.
+* Community Maintenance: The Go Client will be moved to [Camunda Community Hub](https://github.com/camunda-community-hub) and can be maintained by the community. We encourage contributions from users who wish to continue using and improving this client.
+* Transition to REST API: We recommend users transition to the Camunda 8 REST API for all future development. The REST API provides comprehensive functionality and is supported by tools such as cURL, Postman, and OpenAPI.
+
+### Future Considerations
+
+We value feedback from our community. Based on user input, we may explore developing a new client for the Camunda 8 REST API, based on a different technology that aligns with our strategic goals and internal expertise.
+For more information on the deprecation and our API strategy, please refer to the official [Camunda blog](https://camunda.com/blog/).
+
+# Development
 
 If we had a gateway-protocol change we need to make sure that we regenerate the protobuf file, which is used by the go client.
 In order to do this please follow [this guide](../../gateway-protocol-impl/README.md).


### PR DESCRIPTION
## Description
Inform users about GO Client deprecation and move to the community hub. This will be supported with a [blogpost communication](https://docs.google.com/document/d/12i2yQSPnjOB4l1qxO5-no9qGDWlHc3BKvyc5WdD97tU/edit).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
