### PR TITLE
fix: stop zeebe task completion variables from being serialized

### DIFF
--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.zeebeimport.v860.processors.common;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.entities.TaskVariableEntity;
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.zeebeimport.v860.record.Intent;
 import io.camunda.zeebe.protocol.record.Record;
@@ -44,8 +45,7 @@ public class UserTaskRecordToVariableEntityMapper {
         try {
           varValue = objectMapper.writeValueAsString(varMap.getValue());
         } catch (final JsonProcessingException e) {
-          LOGGER.error("Failed to parse variable %s".formatted(varMap), e);
-          throw new RuntimeException(e);
+          throw new TasklistRuntimeException("Failed to parse variable %s".formatted(varMap), e);
         }
         final TaskVariableEntity variableEntity = new TaskVariableEntity();
         variableEntity.setId(

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.zeebeimport.v860.processors.common;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.entities.TaskVariableEntity;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.zeebeimport.v860.record.Intent;
@@ -28,7 +30,10 @@ public class UserTaskRecordToVariableEntityMapper {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record) {
+  @Autowired private ObjectMapper objectMapper;
+
+  public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record)
+      throws JsonProcessingException {
     final List<TaskVariableEntity> variables = new ArrayList<>();
 
     if (record.getIntent().equals(Intent.COMPLETED)) {
@@ -36,15 +41,13 @@ public class UserTaskRecordToVariableEntityMapper {
 
       final Map<String, Object> variablesMap = recordValue.getVariables();
       for (final Map.Entry<String, Object> varMap : variablesMap.entrySet()) {
-        final String varValue = String.valueOf(varMap.getValue());
-
+        final String varValue = objectMapper.writeValueAsString(varMap.getValue());
         final TaskVariableEntity variableEntity = new TaskVariableEntity();
         variableEntity.setId(
             TaskVariableEntity.getIdBy(
                 String.valueOf(recordValue.getUserTaskKey()), varMap.getKey()));
         variableEntity.setName(varMap.getKey());
         variableEntity.setTaskId(String.valueOf(recordValue.getUserTaskKey()));
-        variableEntity.setValue(String.valueOf(varMap.getValue()));
         variableEntity.setPartitionId(record.getPartitionId());
         variableEntity.setTenantId(recordValue.getTenantId());
         variableEntity.setFullValue(varValue);

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToVariableEntityMapper.java
@@ -32,8 +32,7 @@ public class UserTaskRecordToVariableEntityMapper {
 
   @Autowired private ObjectMapper objectMapper;
 
-  public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record)
-      throws JsonProcessingException {
+  public List<TaskVariableEntity> mapVariables(final Record<UserTaskRecordValue> record) {
     final List<TaskVariableEntity> variables = new ArrayList<>();
 
     if (record.getIntent().equals(Intent.COMPLETED)) {
@@ -41,7 +40,13 @@ public class UserTaskRecordToVariableEntityMapper {
 
       final Map<String, Object> variablesMap = recordValue.getVariables();
       for (final Map.Entry<String, Object> varMap : variablesMap.entrySet()) {
-        final String varValue = objectMapper.writeValueAsString(varMap.getValue());
+        final String varValue;
+        try {
+          varValue = objectMapper.writeValueAsString(varMap.getValue());
+        } catch (final JsonProcessingException e) {
+          LOGGER.error("Failed to parse variable %s".formatted(varMap), e);
+          throw new RuntimeException(e);
+        }
         final TaskVariableEntity variableEntity = new TaskVariableEntity();
         variableEntity.setId(
             TaskVariableEntity.getIdBy(

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -23,7 +23,6 @@ import io.camunda.tasklist.zeebeimport.v860.processors.common.UserTaskRecordToTa
 import io.camunda.tasklist.zeebeimport.v860.processors.common.UserTaskRecordToVariableEntityMapper;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
-import jakarta.json.Json;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -112,12 +111,12 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
           TaskVariableTemplate.VALUE,
           "null".equals(variable.getValue())
               ? "null"
-              : objectMapper.writeValueAsString(Json.createValue(variable.getValue())));
+              : objectMapper.writeValueAsString(variable.getValue()));
       updateFields.put(
           TaskVariableTemplate.FULL_VALUE,
           "null".equals(variable.getFullValue())
               ? "null"
-              : objectMapper.writeValueAsString(Json.createValue(variable.getFullValue())));
+              : objectMapper.writeValueAsString(variable.getFullValue()));
       updateFields.put(TaskVariableTemplate.IS_PREVIEW, variable.getIsPreview());
 
       return new UpdateRequest()

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -9,7 +9,6 @@ package io.camunda.tasklist.zeebeimport.v860.processors.es;
 
 import static io.camunda.tasklist.util.ElasticsearchUtil.UPDATE_RETRY_COUNT;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.entities.TaskEntity;
@@ -69,12 +68,8 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
       bulkRequest.add(persistUserTaskToListView(taskEntity.get(), record));
       // Variables
       if (!record.getValue().getVariables().isEmpty()) {
-        final List<TaskVariableEntity> variables;
-        try {
-          variables = userTaskRecordToVariableEntityMapper.mapVariables(record);
-        } catch (final JsonProcessingException e) {
-          throw new RuntimeException(e);
-        }
+        final List<TaskVariableEntity> variables =
+            userTaskRecordToVariableEntityMapper.mapVariables(record);
         for (final TaskVariableEntity variable : variables) {
           bulkRequest.add(getVariableQuery(variable));
         }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -9,7 +9,6 @@ package io.camunda.tasklist.zeebeimport.v860.processors.os;
 
 import static io.camunda.tasklist.util.OpenSearchUtil.UPDATE_RETRY_COUNT;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
@@ -69,12 +68,8 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
     }
 
     if (!record.getValue().getVariables().isEmpty()) {
-      final List<TaskVariableEntity> variables;
-      try {
-        variables = userTaskRecordToVariableEntityMapper.mapVariables(record);
-      } catch (final JsonProcessingException e) {
-        throw new RuntimeException(e);
-      }
+      final List<TaskVariableEntity> variables =
+          userTaskRecordToVariableEntityMapper.mapVariables(record);
       for (final TaskVariableEntity variable : variables) {
         operations.add(getVariableQuery(variable));
       }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -24,7 +24,6 @@ import io.camunda.tasklist.zeebeimport.v860.processors.common.UserTaskRecordToTa
 import io.camunda.tasklist.zeebeimport.v860.processors.common.UserTaskRecordToVariableEntityMapper;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
-import jakarta.json.Json;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -102,12 +101,12 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
           TaskVariableTemplate.VALUE,
           "null".equals(variable.getValue())
               ? "null"
-              : objectMapper.writeValueAsString(Json.createValue(variable.getValue())));
+              : objectMapper.writeValueAsString(variable.getValue()));
       updateFields.put(
           TaskVariableTemplate.FULL_VALUE,
           "null".equals(variable.getFullValue())
               ? "null"
-              : objectMapper.writeValueAsString(Json.createValue(variable.getFullValue())));
+              : objectMapper.writeValueAsString(variable.getFullValue()));
       updateFields.put(TaskVariableTemplate.IS_PREVIEW, variable.getIsPreview());
 
       return new BulkOperation.Builder()

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.zeebeimport.v860.processors.os;
 
 import static io.camunda.tasklist.util.OpenSearchUtil.UPDATE_RETRY_COUNT;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.CommonUtils;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
@@ -68,8 +69,12 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
     }
 
     if (!record.getValue().getVariables().isEmpty()) {
-      final List<TaskVariableEntity> variables =
-          userTaskRecordToVariableEntityMapper.mapVariables(record);
+      final List<TaskVariableEntity> variables;
+      try {
+        variables = userTaskRecordToVariableEntityMapper.mapVariables(record);
+      } catch (final JsonProcessingException e) {
+        throw new RuntimeException(e);
+      }
       for (final TaskVariableEntity variable : variables) {
         operations.add(getVariableQuery(variable));
       }

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -473,6 +473,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/TaskIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/TaskIT.java
@@ -1262,7 +1262,7 @@ public class TaskIT extends TasklistZeebeIntegrationTest {
           .extractingListContent(objectMapper, VariableSearchResponse.class)
           .extracting("name", "value")
           .containsExactlyInAnyOrder(
-              tuple("varA", "value Var A"), tuple("varB", "123"), tuple("varC", "123"));
+              tuple("varA", "\"value Var A\""), tuple("varB", "123"), tuple("varC", "123"));
     }
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -41,12 +41,14 @@ import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
 import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -1398,6 +1400,14 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
               tuple("var_2", "222222", "222222", false),
               tuple("var_a", "225", "225", false),
               tuple("var_b", "779", "779", false));
+
+      Awaitility.await("tasklist-list-view has imported the data")
+          .timeout(Duration.ofSeconds(20))
+          .untilAsserted(
+              () -> {
+                listViewStore.getVariablesByVariableName("var_1");
+                assertThat(listViewStore.getVariablesByVariableName("var_1")).isNotEmpty();
+              });
 
       // Assert the Task Variables were persisted in the tasklist-list-view
       assertThat(listViewStore.getVariablesByVariableName("var_a").get(0).equals("225"));

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1405,7 +1405,6 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
           .timeout(Duration.ofSeconds(20))
           .untilAsserted(
               () -> {
-                listViewStore.getVariablesByVariableName("var_1");
                 assertThat(listViewStore.getVariablesByVariableName("var_1")).isNotEmpty();
               });
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -1404,9 +1404,7 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       Awaitility.await("tasklist-list-view has imported the data")
           .timeout(Duration.ofSeconds(20))
           .untilAsserted(
-              () -> {
-                assertThat(listViewStore.getVariablesByVariableName("var_1")).isNotEmpty();
-              });
+              () -> assertThat(listViewStore.getVariablesByVariableName("var_1")).isNotEmpty());
 
       // Assert the Task Variables were persisted in the tasklist-list-view
       assertThat(listViewStore.getVariablesByVariableName("var_a").get(0).equals("225"));


### PR DESCRIPTION
## Description

Address tasklist issue mentioned [here](https://camunda.slack.com/archives/C046XS3GGCR/p1724945281241419?thread_ts=1724936257.713079&cid=C046XS3GGCR): Completed Zeebe User Task form variables were being flushed as serialized JSON values in ES/OS.
