### PR TITLE
ci: Reducing number of threads in unit tests for optimize to improve stability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
         uses: ./.github/actions/run-maven
         with:
           parameters: -f optimize/pom.xml test -Dskip.fe.build -Dskip.docker
-          threads: 1C
+          threads: .5C
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Reduce the number of threads for Optimize to `.5`, as suggested here https://github.com/camunda/camunda/issues/21722#issuecomment-2321261490

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/21722
