### PR TITLE
fix: make SBE code generation thread safe

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2437,11 +2437,11 @@
             -->
             <execution>
               <id>generate-sbe</id>
-              <!-- not bound by default since it would execute in places where we don't want SBE generation -->
-              <phase>none</phase>
               <goals>
                 <goal>exec</goal>
               </goals>
+              <!-- not bound by default since it would execute in places where we don't want SBE generation -->
+              <phase>none</phase>
               <configuration combine.children="override">
                 <!--
                   we have to use the goal exec with the java executable as otherwise the process
@@ -2458,7 +2458,7 @@
                   <argument>-classpath</argument>
                   <!-- automatically creates the classpath using all project dependencies,
                      also adding the project build directory -->
-                  <classpath/>
+                  <classpath></classpath>
                   <argument>uk.co.real_logic.sbe.SbeTool</argument>
                 </arguments>
                 <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2421,27 +2421,50 @@
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
           <version>${plugin.version.exec}</version>
-          <configuration>
-            <!-- Define system properties in one place, see https://github.com/camunda-zeebe/zeebe/issues/377 -->
-            <systemProperties>
-              <systemProperty>
-                <key>sbe.output.dir</key>
-                <value>${project.build.directory}/generated-sources/sbe</value>
-              </systemProperty>
-              <systemProperty>
-                <key>sbe.java.generate.interfaces</key>
-                <value>true</value>
-              </systemProperty>
-              <systemProperty>
-                <key>sbe.decode.unknown.enum.values</key>
-                <value>true</value>
-              </systemProperty>
-              <systemProperty>
-                <key>sbe.xinclude.aware</key>
-                <value>true</value>
-              </systemProperty>
-            </systemProperties>
-          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>uk.co.real-logic</groupId>
+              <artifactId>sbe-tool</artifactId>
+              <version>${version.sbe}</version>
+            </dependency>
+          </dependencies>
+          <executions>
+            <!--
+              Use exec:exec to generate SBE instead of exec:java, as exec:java does not fork the
+              process, and the SBE tool is not thread safe, i.e. could not be used with a parallel
+              multi-module maven build.
+              See: https://github.com/camunda/camunda/issues/16029
+            -->
+            <execution>
+              <id>generate-sbe</id>
+              <!-- not bound by default since it would execute in places where we don't want SBE generation -->
+              <phase>none</phase>
+              <goals>
+                <goal>exec</goal>
+              </goals>
+              <configuration combine.children="override">
+                <!--
+                  we have to use the goal exec with the java executable as otherwise the process
+                  will not fork, and this can cause thread safety issues in a parallel multi-module
+                  build
+                -->
+                <executable>java</executable>
+                <includePluginDependencies>true</includePluginDependencies>
+                <arguments combine.children="append">
+                  <argument>-Dsbe.output.dir=${project.build.directory}/generated-sources/sbe</argument>
+                  <argument>-Dsbe.java.generate.interfaces=true</argument>
+                  <argument>-Dsbe.decode.unknown.enum.values=true</argument>
+                  <argument>-Dsbe.xinclude.aware=true</argument>
+                  <argument>-classpath</argument>
+                  <!-- automatically creates the classpath using all project dependencies,
+                     also adding the project build directory -->
+                  <classpath/>
+                  <argument>uk.co.real_logic.sbe.SbeTool</argument>
+                </arguments>
+                <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <!-- Resources Plugin -->

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -299,30 +299,16 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <includeProjectDependencies>false</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
-          <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
-          <arguments>
-            <argument>${project.build.resources[0].directory}/snapshot-schema.xml</argument>
-            <argument>${project.build.resources[0].directory}/raft-entry-schema.xml</argument>
-          </arguments>
-          <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-          <!-- system properties defined in zeebe-parent -->
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>uk.co.real-logic</groupId>
-            <artifactId>sbe-tool</artifactId>
-            <version>${version.sbe}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
+            <id>generate-sbe</id>
             <phase>generate-sources</phase>
+            <configuration>
+              <arguments>
+                <argument>${project.build.resources[0].directory}/snapshot-schema.xml</argument>
+                <argument>${project.build.resources[0].directory}/raft-entry-schema.xml</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -443,29 +443,15 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <includeProjectDependencies>false</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
-          <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
-          <arguments>
-            <argument>${project.build.resources[0].directory}/broker-protocol.xml</argument>
-          </arguments>
-          <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-        </configuration>
-        <!-- system properties defined in zeebe-parent -->
-        <dependencies>
-          <dependency>
-            <groupId>uk.co.real-logic</groupId>
-            <artifactId>sbe-tool</artifactId>
-            <version>${version.sbe}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
+            <id>generate-sbe</id>
             <phase>generate-sources</phase>
+            <configuration>
+              <arguments>
+                <argument>${project.build.resources[0].directory}/broker-protocol.xml</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeebe/journal/pom.xml
+++ b/zeebe/journal/pom.xml
@@ -129,29 +129,15 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <includeProjectDependencies>false</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
-          <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
-          <arguments>
-            <argument>${project.build.resources[0].directory}/journal-schema.xml</argument>
-          </arguments>
-          <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-          <!-- system properties defined in zeebe-parent -->
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>uk.co.real-logic</groupId>
-            <artifactId>sbe-tool</artifactId>
-            <version>${version.sbe}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
+            <id>generate-sbe</id>
             <phase>generate-sources</phase>
+            <configuration>
+              <arguments>
+                <argument>${project.build.resources[0].directory}/journal-schema.xml</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -174,29 +174,16 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <includeProjectDependencies>false</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
-          <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
-          <arguments>
-            <argument>${project.build.outputDirectory}/protocol.xml</argument>
-            <argument>${project.build.outputDirectory}/cluster-management-protocol.xml</argument>
-          </arguments>
-          <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>uk.co.real-logic</groupId>
-            <artifactId>sbe-tool</artifactId>
-            <version>${version.sbe}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
+            <id>generate-sbe</id>
             <phase>generate-sources</phase>
+            <configuration>
+              <arguments>
+                <argument>${project.build.outputDirectory}/protocol.xml</argument>
+                <argument>${project.build.outputDirectory}/cluster-management-protocol.xml</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/zeebe/transport/pom.xml
+++ b/zeebe/transport/pom.xml
@@ -143,28 +143,15 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <configuration>
-          <includeProjectDependencies>false</includeProjectDependencies>
-          <includePluginDependencies>true</includePluginDependencies>
-          <mainClass>uk.co.real_logic.sbe.SbeTool</mainClass>
-          <arguments>
-            <argument>${project.build.outputDirectory}/stream-protocol.xml</argument>
-          </arguments>
-          <workingDirectory>${project.build.directory}/generated-sources</workingDirectory>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>uk.co.real-logic</groupId>
-            <artifactId>sbe-tool</artifactId>
-            <version>${version.sbe}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>java</goal>
-            </goals>
+            <id>generate-sbe</id>
             <phase>generate-sources</phase>
+            <configuration>
+              <arguments>
+                <argument>${project.build.outputDirectory}/stream-protocol.xml</argument>
+              </arguments>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
## Description

The SBE tool used for code generation is not thread safe in itself, as it uses some static/shared properties. This is not an issue with single-threaded Maven builds, but when using a multi-threaded Maven build, with multiple modules, this can cause some builds to fail during code generation.

To avoid this, we change the use of `exec:java` to `exec:exec`, which will call `java` as a separate process. It would be nicer if `exec:java` would allow forking, but it unfortunately does not.

At the same time, this commit centralizes a lot of the SBE settings and makes it easier to add SBE code generation to a sub-module.

One thing to note, the execution to generate SBE is initially not bound to any phase, as the plugin itself is used in other modules. So when you want to add code generation to your module, you have to configure that specific `generate-sbe` execution of the plugin and bind it to a phase.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #16029 
