### PR TITLE
build: compare against proper base sha for all triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,12 @@ jobs:
     timeout-minutes: 10
     needs: [detect-changes]
     runs-on: ubuntu-latest
+    env:
+      # set the comparison based on the type of workflow trigger:
+      #   - for PRs, we use the last commit of the base
+      #   - for merge queues, we use the last commit of the target merge queue
+      #   - for a push, we use the last commit before the push
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
     if: |
       needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:
@@ -532,6 +538,7 @@ jobs:
           push: false
           archive: false
           breaking: true
+          breaking_against: '${{ github.event.repository.clone_url }}#format=git,commit=${{ env.BASE_SHA }}'
       - name: Observe build status
         if: always()
         continue-on-error: true


### PR DESCRIPTION
## Description

This PR fixes the comparison for Protobuf backwards compatibility, specifically for merge groups. Before, it was correctly comparing for PRs and push, but it failed to determine the appropriate base for a merge group.

We did not detect this because the previous PRs had the magic work to skip the check (which I will not repeat here ;)), and the check only runs if you do proto changes.

I detected it on a stable branch where we always run the check: https://github.com/camunda/camunda/actions/runs/10667830725/job/29566213582

And fixed it here: https://github.com/camunda/camunda/pull/21773

This is essentially forward-porting this fix.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #21773
