### PR TITLE
feat: optionally ordered command distribution

### DIFF
--- a/zeebe/docs/generalized_distribution.md
+++ b/zeebe/docs/generalized_distribution.md
@@ -121,7 +121,7 @@ void distributeInOrder() {
 
 Command distributions submitted with the same queue will be distributed in the order they were submitted.
 The queue is maintained per receiving partition.
-This way we can ensure that all partitions process distributed commands in the correct order, while preventing that partial unavailbility, for example just one partition not processing, does not block progress for other partitions.
+This way we can ensure that all partitions process distributed commands in the correct order, while preventing that partial unavailability, for example just one partition not processing, does not block progress for other partitions.
 
 It is the caller's responsibility to ensure that the queue id is unique.
 Using different queue ids per partition or conversely maintaining order across partitions is not supported.

--- a/zeebe/docs/generalized_distribution.md
+++ b/zeebe/docs/generalized_distribution.md
@@ -82,11 +82,6 @@ The value of the partition id depends on the `CommandDistributionIntent`:
 This property is optional (empty string indicates no queue id). It is set on the `ENQUEUED` and `STARTED` intents.
 If it is set, the next property `queueInsertionKey` must be set as well.
 
-#### Queue insertion key
-
-This property is optional (-1 indicates no queue insertion key) unless the `queueId` is set. It is set on the `ENQUEUED` and `STARTED` intents.
-This indicates the position in the queue where this command is inserted.
-
 #### Value type
 
 The value is part of the record so we know what type of record we are distributing. We need this in
@@ -119,7 +114,7 @@ void distributeInOrder() {
 }
 ```
 
-Command distributions submitted with the same queue will be distributed in the order they were submitted.
+Command distributions submitted with the same queue will be distributed in the natural sort order of their distribution key.
 The queue is maintained per receiving partition.
 This way we can ensure that all partitions process distributed commands in the correct order, while preventing that partial unavailability, for example just one partition not processing, does not block progress for other partitions.
 

--- a/zeebe/docs/generalized_distribution.md
+++ b/zeebe/docs/generalized_distribution.md
@@ -19,7 +19,7 @@ distributing a command to other partitions.
 
 ## How do we distribute commands?
 
-On a high-level we use commands and event to distribute commands. The image below provides a nice
+On a high-level we use commands and events to distribute commands. The image below provides a nice
 overview of the flow of commands and events that are written during distribution.
 
 Note that `CommandDistribution` records only exist on the partition that initiated the distribution.
@@ -66,7 +66,7 @@ metadata and raw record value are removed from the state.
 The diagram shows the flow of commands and events. What it doesn't highlight is the record that
 belongs to these.
 
-The `CommandDistributionRecord` is relatively simple. It contains 4 properties which are required to
+The `CommandDistributionRecord` is relatively simple. It contains 6 properties which are required to
 distribute a command successfully.
 
 #### Partition id
@@ -74,8 +74,18 @@ distribute a command successfully.
 The value of the partition id depends on the `CommandDistributionIntent`:
 
 - `STARTED` and `FINISHED`: The partition id is equal to the distributing partition
-- `DISTRIBUTING`, `ACKNOWLEDGE` and `ACKNOWLEDGED`: The partition id is equal to the partition that
+- `ENQUEUED`, `DISTRIBUTING`, `ACKNOWLEDGE` and `ACKNOWLEDGED`: The partition id is equal to the partition that
   the command is distributed to.
+
+#### Queue id
+
+This property is optional (empty string indicates no queue id). It is set on the `ENQUEUED` and `STARTED` intents.
+If it is set, the next property `queueInsertionKey` must be set as well.
+
+#### Queue insertion key
+
+This property is optional (-1 indicates no queue insertion key) unless the `queueId` is set. It is set on the `ENQUEUED` and `STARTED` intents.
+This indicates the position in the queue where this command is inserted.
 
 #### Value type
 
@@ -91,6 +101,30 @@ distribute the command with.
 
 The command value is the record which is getting distributed. This contains the actual data required
 by the processor on the other partition.
+
+### Ordered distribution
+
+In some cases we need to distribute commands in a specific order. For this we have the option to specify a queue id.
+
+```java
+void distributeInOrder() {
+  commandDistributionBehavior
+    .withKey(firstDistributionKey)
+    .inQueue("my-queue")
+    .distribute(firstCommand);
+  commandDistributionBehavior
+    .withKey(secondDistributionKey)
+    .inQueue("my-queue")
+    .distribute(secondCommand);
+}
+```
+
+Command distributions submitted with the same queue will be distributed in the order they were submitted.
+The queue is maintained per receiving partition.
+This way we can ensure that all partitions process distributed commands in the correct order, while preventing that partial unavailbility, for example just one partition not processing, does not block progress for other partitions.
+
+It is the caller's responsibility to ensure that the queue id is unique.
+Using different queue ids per partition or conversely maintaining order across partitions is not supported.
 
 ### Redistributing
 

--- a/zeebe/docs/generalized_distribution.md
+++ b/zeebe/docs/generalized_distribution.md
@@ -66,8 +66,7 @@ metadata and raw record value are removed from the state.
 The diagram shows the flow of commands and events. What it doesn't highlight is the record that
 belongs to these.
 
-The `CommandDistributionRecord` is relatively simple. It contains 6 properties which are required to
-distribute a command successfully.
+The `CommandDistributionRecord` is relatively simple. It contains the following properties:
 
 #### Partition id
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -114,7 +114,6 @@ public final class EngineProcessors {
 
     final var commandDistributionBehavior =
         new CommandDistributionBehavior(
-            processingState.getKeyGenerator(),
             processingState.getDistributionState(),
             writers,
             typedRecordProcessorContext.getPartitionId(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -114,6 +114,8 @@ public final class EngineProcessors {
 
     final var commandDistributionBehavior =
         new CommandDistributionBehavior(
+            processingState.getKeyGenerator(),
+            processingState.getDistributionState(),
             writers,
             typedRecordProcessorContext.getPartitionId(),
             routingInfo,
@@ -191,6 +193,7 @@ public final class EngineProcessors {
         processingState,
         commandDistributionBehavior);
     addCommandDistributionProcessors(
+        commandDistributionBehavior,
         typedRecordProcessors,
         writers,
         processingState,
@@ -399,6 +402,7 @@ public final class EngineProcessors {
   }
 
   private static void addCommandDistributionProcessors(
+      final CommandDistributionBehavior commandDistributionBehavior,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final ProcessingState processingState,
@@ -412,7 +416,7 @@ public final class EngineProcessors {
 
     final var commandDistributionAcknowledgeProcessor =
         new CommandDistributionAcknowledgeProcessor(
-            processingState.getDistributionState(), writers);
+            commandDistributionBehavior, processingState.getDistributionState(), writers);
     typedRecordProcessors.onCommand(
         ValueType.COMMAND_DISTRIBUTION,
         CommandDistributionIntent.ACKNOWLEDGE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -55,7 +55,7 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
       responseWriter.writeEventOnCommand(eventKey, resultIntent, clockRecord, command);
     }
 
-    commandDistributionBehavior.distributeCommand(eventKey, command);
+    commandDistributionBehavior.withKey(eventKey).distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -179,7 +179,7 @@ public final class DeploymentCreateProcessor
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
     stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 
-    distributionBehavior.distributeCommand(key, command);
+    distributionBehavior.withKey(key).distribute(command);
   }
 
   private void processDistributedRecord(final TypedRecord<DeploymentRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -194,6 +194,21 @@ public final class CommandDistributionBehavior {
             .setQueueInsertionKey(newInsertion));
   }
 
+  /**
+   * If the given distribution was part of a queue, the next distribution from the queue is started.
+   */
+  void distributeNextInQueue(final long finishedDistributionKey, final int partition) {
+    distributionState
+        .queueForDistribution(finishedDistributionKey)
+        .flatMap(queue -> distributionState.nextQueuedDistributionKey(queue, partition))
+        .ifPresent(
+            nextDistributionKey ->
+                startDistributing(
+                    partition,
+                    distributionState.getCommandDistributionRecord(nextDistributionKey, partition),
+                    nextDistributionKey));
+  }
+
   private void startDistributing(
       final int partition,
       final CommandDistributionRecord distributionRecord,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -151,7 +151,7 @@ public final class CommandDistributionBehavior {
 
     final var otherQueuedDistributions =
         distributionQueue
-            .flatMap(queue -> distributionState.nextQueuedDistributionKey(queue, partition))
+            .flatMap(queue -> distributionState.getNextQueuedDistributionKey(queue, partition))
             .filter(nextDistributionKey -> nextDistributionKey != distributionKey);
 
     if (otherQueuedDistributions.isEmpty()) {
@@ -179,8 +179,8 @@ public final class CommandDistributionBehavior {
    */
   void distributeNextInQueue(final long finishedDistributionKey, final int partition) {
     distributionState
-        .queueForDistribution(finishedDistributionKey)
-        .flatMap(queue -> distributionState.nextQueuedDistributionKey(queue, partition))
+        .getQueueIdForDistribution(finishedDistributionKey)
+        .flatMap(queue -> distributionState.getNextQueuedDistributionKey(queue, partition))
         .ifPresent(
             nextDistributionKey ->
                 startDistributing(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCreateProcessor.java
@@ -68,7 +68,7 @@ public class AuthorizationCreateProcessor
     final var key = keyGenerator.nextKey();
 
     stateWriter.appendFollowUpEvent(key, AuthorizationIntent.CREATED, authorizationToCreate);
-    distributionBehavior.distributeCommand(key, command);
+    distributionBehavior.withKey(key).distribute(command);
     responseWriter.writeEventOnCommand(
         key, AuthorizationIntent.CREATED, authorizationToCreate, command);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -64,7 +64,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -541,12 +540,13 @@ public class ProcessInstanceMigrationMigrateProcessor
       commandWriter.appendFollowUpCommand(
           distributionKey, MessageSubscriptionIntent.MIGRATE, messageSubscription);
     } else {
-      commandDistributionBehavior.distributeCommand(
-          distributionKey,
-          ValueType.MESSAGE_SUBSCRIPTION,
-          MessageSubscriptionIntent.MIGRATE,
-          messageSubscription,
-          Set.of(processMessageSubscriptionRecord.getSubscriptionPartitionId()));
+      commandDistributionBehavior
+          .withKey(distributionKey)
+          .forPartition(processMessageSubscriptionRecord.getSubscriptionPartitionId())
+          .distribute(
+              ValueType.MESSAGE_SUBSCRIPTION,
+              MessageSubscriptionIntent.MIGRATE,
+              messageSubscription);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -103,7 +103,7 @@ public class ResourceDeletionDeleteProcessor
     tryDeleteResources(command);
 
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
-    commandDistributionBehavior.distributeCommand(eventKey, command);
+    commandDistributionBehavior.withKey(eventKey).distribute(command);
     responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -89,8 +89,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
             activateElement(subscriptionRecord, signalRecord.getVariablesBuffer());
           }
         });
-
-    commandDistributionBehavior.distributeCommand(eventKey, command);
+    commandDistributionBehavior.withKey(eventKey).distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -68,7 +68,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
     responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
 
-    distributionBehavior.distributeCommand(key, command);
+    distributionBehavior.withKey(key).distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -64,7 +64,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(key, UserIntent.UPDATED, updatedUser);
     responseWriter.writeEventOnCommand(key, UserIntent.UPDATED, updatedUser, command);
 
-    distributionBehavior.distributeCommand(key, command);
+    distributionBehavior.withKey(key).distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
@@ -23,6 +23,12 @@ public final class CommandDistributionAcknowledgedApplier
 
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
-    distributionState.removePendingDistribution(key, value.getPartitionId());
+    final var partitionId = value.getPartitionId();
+
+    distributionState
+        .queueForDistribution(key)
+        .ifPresent(queue -> distributionState.popQueuedDistribution(queue, partitionId));
+
+    distributionState.removePendingDistribution(key, partitionId);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
@@ -26,7 +26,7 @@ public final class CommandDistributionAcknowledgedApplier
     final var partitionId = value.getPartitionId();
 
     distributionState
-        .queueForDistribution(key)
+        .getQueueIdForDistribution(key)
         .ifPresent(queue -> distributionState.popQueuedDistribution(queue, partitionId));
 
     distributionState.removePendingDistribution(key, partitionId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionAcknowledgedApplier.java
@@ -27,7 +27,7 @@ public final class CommandDistributionAcknowledgedApplier
 
     distributionState
         .getQueueIdForDistribution(key)
-        .ifPresent(queue -> distributionState.popQueuedDistribution(queue, partitionId));
+        .ifPresent(queue -> distributionState.removeQueuedDistribution(queue, partitionId, key));
 
     distributionState.removePendingDistribution(key, partitionId);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
@@ -23,6 +23,7 @@ public class CommandDistributionEnqueuedApplier
 
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    distributionState.enqueueCommandDistribution(
+        value.getQueueId(), value.getQueueInsertionKey(), key, value.getPartitionId());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
@@ -23,7 +23,6 @@ public class CommandDistributionEnqueuedApplier
 
   @Override
   public void applyState(final long key, final CommandDistributionRecord value) {
-    distributionState.enqueueCommandDistribution(
-        value.getQueueId(), value.getQueueInsertionKey(), key, value.getPartitionId());
+    distributionState.enqueueCommandDistribution(value.getQueueId(), key, value.getPartitionId());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionEnqueuedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public class CommandDistributionEnqueuedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+
+  private final MutableDistributionState distributionState;
+
+  public CommandDistributionEnqueuedApplier(final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -413,6 +413,9 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.FINISHED,
         new CommandDistributionFinishedApplier(distributionState));
+    register(
+        CommandDistributionIntent.ENQUEUED,
+        new CommandDistributionEnqueuedApplier(distributionState));
   }
 
   private void registerAuthorizationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -217,7 +217,7 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
-  public Optional<Long> nextQueuedDistributionKey(final String queue, final int partition) {
+  public Optional<Long> getNextQueuedDistributionKey(final String queue, final int partition) {
     queueId.wrapString(queue);
     partitionKey.wrapInt(partition);
     final var nextDistributionKey = new MutableReference<Long>(null);
@@ -231,7 +231,7 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
-  public Optional<String> queueForDistribution(final long distributionKey) {
+  public Optional<String> getQueueIdForDistribution(final long distributionKey) {
     this.distributionKey.wrapLong(distributionKey);
 
     return Optional.ofNullable(commandDistributionRecordColumnFamily.get(this.distributionKey))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -18,11 +18,12 @@ import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistribut
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Optional;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public class PersistedCommandDistribution extends UnpackedObject implements DbValue {
 
-  private final StringProperty queueProperty = new StringProperty("queue", "");
+  private final StringProperty queueIdProperty = new StringProperty("queueId", "");
   private final EnumProperty<ValueType> valueTypeProperty =
       new EnumProperty<>("valueType", ValueType.class);
   private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
@@ -31,7 +32,7 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
 
   public PersistedCommandDistribution() {
     super(4);
-    declareProperty(queueProperty)
+    declareProperty(queueIdProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(commandValueProperty);
@@ -40,9 +41,9 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
   public PersistedCommandDistribution wrap(
       final CommandDistributionRecord commandDistributionRecord) {
     if (commandDistributionRecord.getQueueId() != null) {
-      queueProperty.setValue(commandDistributionRecord.getQueueId());
+      queueIdProperty.setValue(commandDistributionRecord.getQueueId());
     } else {
-      queueProperty.reset();
+      queueIdProperty.reset();
     }
     valueTypeProperty.setValue(commandDistributionRecord.getValueType());
     intentProperty.setValue(commandDistributionRecord.getIntent().value());
@@ -57,9 +58,9 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
     return this;
   }
 
-  public String getQueue() {
-    final var value = BufferUtil.bufferAsString(queueProperty.getValue());
-    return value.isEmpty() ? null : value;
+  public Optional<String> getQueueId() {
+    final var value = BufferUtil.bufferAsString(queueIdProperty.getValue());
+    return value.isEmpty() ? Optional.empty() : Optional.of(value);
   }
 
   public ValueType getValueType() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import java.util.Optional;
 
 public interface DistributionState {
 
@@ -50,6 +51,22 @@ public interface DistributionState {
    * @param visitor Each pending distribution is visited by this visitor
    */
   void foreachPendingDistribution(PendingDistributionVisitor visitor);
+
+  /**
+   * Returns the distribution key at the head of the queue for the given partition.
+   *
+   * @param queue the queue to look up
+   * @param partition the partition id within the queue
+   * @return the distribution key at the head of the queues or an empty optional if there is no
+   *     queued distribution for that queue and partition.
+   */
+  Optional<Long> nextQueuedDistributionKey(String queue, int partition);
+
+  /**
+   * Returns the queue for the given distribution or an empty optional if this distribution was not
+   * queued.
+   */
+  Optional<String> queueForDistribution(long distributionKey);
 
   /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
   @FunctionalInterface

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -60,13 +60,13 @@ public interface DistributionState {
    * @return the distribution key at the head of the queues or an empty optional if there is no
    *     queued distribution for that queue and partition.
    */
-  Optional<Long> nextQueuedDistributionKey(String queue, int partition);
+  Optional<Long> getNextQueuedDistributionKey(String queue, int partition);
 
   /**
    * Returns the queue for the given distribution or an empty optional if this distribution was not
    * queued.
    */
-  Optional<String> queueForDistribution(long distributionKey);
+  Optional<String> getQueueIdForDistribution(long distributionKey);
 
   /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
   @FunctionalInterface

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -43,4 +43,21 @@ public interface MutableDistributionState extends DistributionState {
    * @param partition the partition of the pending distribution that will be removed
    */
   void removePendingDistribution(final long distributionKey, final int partition);
+
+  /**
+   * Adds a distribution to the given queue for the given partition,
+   *
+   * @param queue the queue to which the distribution should be added
+   * @param insertionKey typically a newly generated key. Determines the queue position.
+   * @param distributionKey the key of the distribution
+   * @param partition the partition for which the distribution is queued
+   */
+  void enqueueCommandDistribution(
+      final String queue, final long insertionKey, final long distributionKey, final int partition);
+
+  /**
+   * Removes the first queued distribution from the given queue or does nothing if the queue is
+   * empty
+   */
+  void popQueuedDistribution(String queue, int partitionId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -48,16 +48,12 @@ public interface MutableDistributionState extends DistributionState {
    * Adds a distribution to the given queue for the given partition,
    *
    * @param queue the queue to which the distribution should be added
-   * @param insertionKey typically a newly generated key. Determines the queue position.
    * @param distributionKey the key of the distribution
    * @param partition the partition for which the distribution is queued
    */
   void enqueueCommandDistribution(
-      final String queue, final long insertionKey, final long distributionKey, final int partition);
+      final String queue, final long distributionKey, final int partition);
 
-  /**
-   * Removes the first queued distribution from the given queue or does nothing if the queue is
-   * empty
-   */
-  void popQueuedDistribution(String queue, int partitionId);
+  /** Removes the queued distribution from the queue */
+  void removeQueuedDistribution(String queue, int partitionId, long distributionKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -91,7 +91,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to all partitions
-    behavior.distributeCommand(key, command);
+    behavior.withKey(key).distribute(command);
 
     // then no command distribution is started
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords()).isEmpty();
@@ -114,7 +114,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to all partitions
-    behavior.distributeCommand(key, command);
+    behavior.withKey(key).distribute(command);
 
     // then command distribution is started on partition 1 and distributing to all other partitions
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
@@ -151,7 +151,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to partitions 1 and 3
-    behavior.distributeCommand(key, command, Set.of(1, 3));
+    behavior.withKey(key).forPartitions(Set.of(1, 3)).distribute(command);
 
     // then command distribution is started on partition 2 and distributing to all other partitions
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Optional;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
@@ -53,7 +52,6 @@ import org.junit.jupiter.api.Test;
  */
 class CommandDistributionBehaviorTest {
 
-  private KeyGenerator mockKeyGenerator;
   private DistributionState mockDistributionState;
   private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
@@ -66,7 +64,6 @@ class CommandDistributionBehaviorTest {
 
   @BeforeEach
   void setUp() {
-    mockKeyGenerator = mock(KeyGenerator.class);
     mockDistributionState = mock(DistributionState.class);
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
@@ -85,7 +82,6 @@ class CommandDistributionBehaviorTest {
     // given 1 partition
     final var behavior =
         new CommandDistributionBehavior(
-            mockKeyGenerator,
             mockDistributionState,
             writers,
             1,
@@ -108,7 +104,6 @@ class CommandDistributionBehaviorTest {
     // given 3 partitions and behavior on partition 1
     final var behavior =
         new CommandDistributionBehavior(
-            mockKeyGenerator,
             mockDistributionState,
             writers,
             1,
@@ -145,7 +140,6 @@ class CommandDistributionBehaviorTest {
     // given 4 partitions and behavior on partition 2
     final var behavior =
         new CommandDistributionBehavior(
-            mockKeyGenerator,
             mockDistributionState,
             writers,
             2,
@@ -182,7 +176,6 @@ class CommandDistributionBehaviorTest {
     // given 3 partitions and behavior on partition 1
     final var behavior =
         new CommandDistributionBehavior(
-            mockKeyGenerator,
             mockDistributionState,
             writers,
             1,
@@ -217,7 +210,6 @@ class CommandDistributionBehaviorTest {
     // given 3 partitions and behavior on partition 1
     final var behavior =
         new CommandDistributionBehavior(
-            mockKeyGenerator,
             mockDistributionState,
             writers,
             1,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -229,9 +229,9 @@ class CommandDistributionBehaviorTest {
 
     // when adding two distributions to the same queue
     behavior.withKey(firstKey).inQueue("test-queue").distribute(command);
-    when(mockDistributionState.nextQueuedDistributionKey("test-queue", 2))
+    when(mockDistributionState.getNextQueuedDistributionKey("test-queue", 2))
         .thenReturn(Optional.of(firstKey));
-    when(mockDistributionState.nextQueuedDistributionKey("test-queue", 3))
+    when(mockDistributionState.getNextQueuedDistributionKey("test-queue", 3))
         .thenReturn(Optional.of(firstKey));
     behavior.withKey(secondKey).inQueue("test-queue").distribute(command);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +51,8 @@ import org.junit.jupiter.api.Test;
  */
 class CommandDistributionBehaviorTest {
 
+  private KeyGenerator mockKeyGenerator;
+  private DistributionState mockDistributionState;
   private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
   private InterPartitionCommandSender mockInterpartitionCommandSender;
   private Writers writers;
@@ -60,6 +64,8 @@ class CommandDistributionBehaviorTest {
 
   @BeforeEach
   void setUp() {
+    mockKeyGenerator = mock(KeyGenerator.class);
+    mockDistributionState = mock(DistributionState.class);
     fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
     writers = new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
@@ -77,7 +83,12 @@ class CommandDistributionBehaviorTest {
     // given 1 partition
     final var behavior =
         new CommandDistributionBehavior(
-            writers, 1, RoutingInfo.forStaticPartitions(1), mockInterpartitionCommandSender);
+            mockKeyGenerator,
+            mockDistributionState,
+            writers,
+            1,
+            RoutingInfo.forStaticPartitions(1),
+            mockInterpartitionCommandSender);
 
     // when distributing to all partitions
     behavior.distributeCommand(key, command);
@@ -95,7 +106,12 @@ class CommandDistributionBehaviorTest {
     // given 3 partitions and behavior on partition 1
     final var behavior =
         new CommandDistributionBehavior(
-            writers, 1, RoutingInfo.forStaticPartitions(3), mockInterpartitionCommandSender);
+            mockKeyGenerator,
+            mockDistributionState,
+            writers,
+            1,
+            RoutingInfo.forStaticPartitions(3),
+            mockInterpartitionCommandSender);
 
     // when distributing to all partitions
     behavior.distributeCommand(key, command);
@@ -127,7 +143,12 @@ class CommandDistributionBehaviorTest {
     // given 4 partitions and behavior on partition 2
     final var behavior =
         new CommandDistributionBehavior(
-            writers, 2, RoutingInfo.forStaticPartitions(4), mockInterpartitionCommandSender);
+            mockKeyGenerator,
+            mockDistributionState,
+            writers,
+            2,
+            RoutingInfo.forStaticPartitions(4),
+            mockInterpartitionCommandSender);
 
     // when distributing to partitions 1 and 3
     behavior.distributeCommand(key, command, Set.of(1, 3));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -38,6 +39,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
 import java.time.InstantSource;
@@ -61,6 +63,8 @@ public final class MessageStreamProcessorTest {
   @Before
   public void setup() {
     mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
+    final var mockKeyGenerator = mock(KeyGenerator.class);
+    final var mockDistributionState = mock(DistributionState.class);
     final var mockProcessingResultBuilder = mock(ProcessingResultBuilder.class);
     final var mockEventAppliers = mock(EventAppliers.class);
     final var writers = new Writers(() -> mockProcessingResultBuilder, mockEventAppliers);
@@ -70,7 +74,12 @@ public final class MessageStreamProcessorTest {
     spyCommandDistributionBehavior =
         spy(
             new CommandDistributionBehavior(
-                writers, 1, RoutingInfo.forStaticPartitions(1), mockInterpartitionCommandSender));
+                mockKeyGenerator,
+                mockDistributionState,
+                writers,
+                1,
+                RoutingInfo.forStaticPartitions(1),
+                mockInterpartitionCommandSender));
 
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -74,7 +74,6 @@ public final class MessageStreamProcessorTest {
     spyCommandDistributionBehavior =
         spy(
             new CommandDistributionBehavior(
-                mockKeyGenerator,
                 mockDistributionState,
                 writers,
                 1,

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -25,9 +25,6 @@
             "queueId": {
               "type": "keyword"
             },
-            "queueInsertionKey": {
-              "type": "long"
-            },
             "valueType": {
               "type": "keyword"
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -22,6 +22,12 @@
             "partitionId": {
               "type": "integer"
             },
+            "queueId": {
+              "type": "keyword"
+            },
+            "queueInsertionKey": {
+              "type": "long"
+            },
             "valueType": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -25,9 +25,6 @@
             "queueId": {
               "type": "keyword"
             },
-            "queueInsertionKey": {
-              "type": "long"
-            },
             "valueType": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-command-distribution-template.json
@@ -22,6 +22,12 @@
             "partitionId": {
               "type": "integer"
             },
+            "queueId": {
+              "type": "keyword"
+            },
+            "queueInsertionKey": {
+              "type": "long"
+            },
             "valueType": {
               "type": "keyword"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.protocol.impl.record.value.distribution;
 
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
-import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
@@ -56,7 +55,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   */
   private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
   private final StringProperty queueIdProperty = new StringProperty("queueId", "");
-  private final LongProperty queueInsertionKeyProperty = new LongProperty("queueInsertionKey", -1);
   private final EnumProperty<ValueType> valueTypeProperty =
       new EnumProperty<>("valueType", ValueType.class, ValueType.NULL_VAL);
   private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
@@ -66,10 +64,9 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
   public CommandDistributionRecord() {
-    super(6);
+    super(5);
     declareProperty(partitionIdProperty)
         .declareProperty(queueIdProperty)
-        .declareProperty(queueInsertionKeyProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(commandValueProperty);
@@ -78,7 +75,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   public CommandDistributionRecord wrap(final CommandDistributionRecord other) {
     setPartitionId(other.getPartitionId())
         .setQueueId(other.getQueueId())
-        .setQueueInsertionKey(other.getQueueInsertionKey())
         .setValueType(other.getValueType())
         .setIntent(other.getIntent())
         .setCommandValue(other.getCommandValue());
@@ -94,11 +90,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
   public String getQueueId() {
     final var value = BufferUtil.bufferAsString(queueIdProperty.getValue());
     return value.isEmpty() ? null : value;
-  }
-
-  @Override
-  public long getQueueInsertionKey() {
-    return queueInsertionKeyProperty.getValue();
   }
 
   @Override
@@ -174,11 +165,6 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
 
   public CommandDistributionRecord setValueType(final ValueType valueType) {
     valueTypeProperty.setValue(valueType);
-    return this;
-  }
-
-  public CommandDistributionRecord setQueueInsertionKey(final long queueInsertionKey) {
-    queueInsertionKeyProperty.setValue(queueInsertionKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2112,6 +2112,8 @@ final class JsonSerializableToJsonTest {
 
               return new CommandDistributionRecord()
                   .setPartitionId(1)
+                  .setQueueId("totally-random-queue-id")
+                  .setQueueInsertionKey(11)
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
                   .setCommandValue(deploymentRecord);
@@ -2119,8 +2121,8 @@ final class JsonSerializableToJsonTest {
         """
         {
           "partitionId": 1,
-          "queueId": null,
-          "queueInsertionKey": -1,
+          "queueId": "totally-random-queue-id",
+          "queueInsertionKey": 11,
           "valueType": "DEPLOYMENT",
           "intent": "CREATE",
           "commandValue": {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2119,6 +2119,8 @@ final class JsonSerializableToJsonTest {
         """
         {
           "partitionId": 1,
+          "queueId": null,
+          "queueInsertionKey": -1,
           "valueType": "DEPLOYMENT",
           "intent": "CREATE",
           "commandValue": {
@@ -2156,6 +2158,8 @@ final class JsonSerializableToJsonTest {
         """
         {
           "partitionId": 1,
+          "queueId": null,
+          "queueInsertionKey": -1,
           "valueType": "NULL_VAL",
           "intent": "UNKNOWN",
           "commandValue": null

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2113,7 +2113,6 @@ final class JsonSerializableToJsonTest {
               return new CommandDistributionRecord()
                   .setPartitionId(1)
                   .setQueueId("totally-random-queue-id")
-                  .setQueueInsertionKey(11)
                   .setValueType(ValueType.DEPLOYMENT)
                   .setIntent(DeploymentIntent.CREATE)
                   .setCommandValue(deploymentRecord);
@@ -2122,7 +2121,6 @@ final class JsonSerializableToJsonTest {
         {
           "partitionId": 1,
           "queueId": "totally-random-queue-id",
-          "queueInsertionKey": 11,
           "valueType": "DEPLOYMENT",
           "intent": "CREATE",
           "commandValue": {
@@ -2161,7 +2159,6 @@ final class JsonSerializableToJsonTest {
         {
           "partitionId": 1,
           "queueId": null,
-          "queueInsertionKey": -1,
           "valueType": "NULL_VAL",
           "intent": "UNKNOWN",
           "commandValue": null

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -241,7 +241,6 @@ public final class ProtocolFactory {
           return ImmutableCommandDistributionRecordValue.builder()
               .withPartitionId(random.nextInt())
               .withQueueId(random.nextObject(String.class))
-              .withQueueInsertionKey(random.nextLong())
               .withValueType(valueType)
               .withIntent(random.nextObject(typeInfo.getIntentClass()))
               .withCommandValue(generateObject(typeInfo.getValueClass()))

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/ProtocolFactory.java
@@ -240,6 +240,8 @@ public final class ProtocolFactory {
           final var typeInfo = ValueTypeMapping.get(valueType);
           return ImmutableCommandDistributionRecordValue.builder()
               .withPartitionId(random.nextInt())
+              .withQueueId(random.nextObject(String.class))
+              .withQueueInsertionKey(random.nextLong())
               .withValueType(valueType)
               .withIntent(random.nextObject(typeInfo.getIntentClass()))
               .withCommandValue(generateObject(typeInfo.getValueClass()))

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -192,7 +192,9 @@ public enum ZbColumnFamilies implements EnumValue {
   AUTHORIZATION_KEY_BY_RESOURCE_ID_AND_OWNER_KEY(94),
   OWNER_TYPE_BY_OWNER_KEY(95),
 
-  ROUTING(96);
+  ROUTING(96),
+
+  QUEUED_DISTRIBUTION(97);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -20,7 +20,8 @@ public enum CommandDistributionIntent implements Intent {
   DISTRIBUTING(1),
   ACKNOWLEDGE(2),
   ACKNOWLEDGED(3),
-  FINISHED(4);
+  FINISHED(4),
+  ENQUEUED(5);
 
   private final short value;
 
@@ -40,6 +41,7 @@ public enum CommandDistributionIntent implements Intent {
       case DISTRIBUTING:
       case ACKNOWLEDGED:
       case FINISHED:
+      case ENQUEUED:
         return true;
       default:
         return false;
@@ -58,6 +60,8 @@ public enum CommandDistributionIntent implements Intent {
         return ACKNOWLEDGED;
       case 4:
         return FINISHED;
+      case 5:
+        return ENQUEUED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
@@ -36,11 +36,6 @@ public interface CommandDistributionRecordValue extends RecordValue {
   String getQueueId();
 
   /**
-   * @return the key used for ordering within the queue.
-   */
-  long getQueueInsertionKey();
-
-  /**
    * @return the wrapped record value type
    */
   ValueType getValueType();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CommandDistributionRecordValue.java
@@ -31,6 +31,16 @@ public interface CommandDistributionRecordValue extends RecordValue {
   int getPartitionId();
 
   /**
+   * @return the queue id for this distribution or null if the queue id is not set.
+   */
+  String getQueueId();
+
+  /**
+   * @return the key used for ordering within the queue.
+   */
+  long getQueueInsertionKey();
+
+  /**
    * @return the wrapped record value type
    */
   ValueType getValueType();

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -824,7 +824,7 @@ public class CompactRecordLogger {
     final var targetPartitionWord =
         switch (intent) {
           case STARTED, FINISHED -> "on";
-          case DISTRIBUTING -> "to";
+          case DISTRIBUTING, ENQUEUED -> "to";
           case ACKNOWLEDGE, ACKNOWLEDGED -> "for";
         };
 


### PR DESCRIPTION
Introduces the option to specify a string `queueId`. All distributions submitted with the same `queueId` will be distributed in submit order, per partition.

This is implemented storing the `queueId`  for each distribution key as part of the `PersistedCommandDistribution` and adding a new column family to store the queue.

Whenever a new distribution is enqueued, we check if it is now at the head of the queue and trigger distribution in that case.
When processing the acknowledgement, we look up the queue id, remove the head of the queue and trigger distribution of the new head of the queue.

This process ensures that unordered command distribution is not affected at all and that the implementation of `CommandRedistributor` does not need to change at all because we move queued distributions into pending one by one, as they are acknowledged.

I've decided to use string `queueId`s because it makes it easier to generate unique, semantic queue ids.

Tests are minimal because there's no good way to test the `CommandDistributionBehavior` as long as there are no processors making use of ordered distribution yet.

Closes https://github.com/camunda/camunda/issues/21447