### PR TITLE
Add support to text/xml response contentType in REST client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
@@ -70,8 +70,9 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       entityConsumer = new JsonApiEntityConsumer<>(json, type, false);
     } else {
       final boolean isResponse =
-          SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType));
-      entityConsumer = new RawApiEntityConsumer(isResponse);
+          String.class.equals(type)
+              && SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType));
+      entityConsumer = new RawApiEntityConsumer<>(isResponse);
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
@@ -74,7 +74,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       responseType = ResponseType.JSON_PROBLEM;
     } else {
       responseType =
-          SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(contentType::isSameMimeType)
+          SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType))
               ? ResponseType.TEXT
               : ResponseType.UNKNOWN;
       nonJsonBody = new byte[1024];

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
@@ -71,7 +71,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
     if (ContentType.APPLICATION_JSON.isSameMimeType(contentType)) {
       responseType = ResponseType.JSON;
     } else if (ContentType.APPLICATION_PROBLEM_JSON.isSameMimeType(contentType)) {
-      responseType = ResponseType.JSON_PROBLEM;
+      responseType = ResponseType.PROBLEM_JSON;
     } else {
       responseType =
           SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType))
@@ -118,7 +118,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
     final int offset = bufferedBytes;
     bufferedBytes += src.remaining();
 
-    if (responseType == ResponseType.TEXT || responseType == ResponseType.UNKNOWN) {
+    if (!responseType.isJson()) {
       consumeNonJsonBody(src, offset);
     } else {
       consumeJsonBody(src, endOfStream);
@@ -167,10 +167,20 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
     }
   }
 
-  enum ResponseType {
-    JSON,
-    JSON_PROBLEM,
-    TEXT,
-    UNKNOWN
+  private enum ResponseType {
+    JSON(true),
+    PROBLEM_JSON(true),
+    TEXT(false),
+    UNKNOWN(false);
+
+    private final boolean isJson;
+
+    ResponseType(final boolean isJson) {
+      this.isJson = isJson;
+    }
+
+    public boolean isJson() {
+      return isJson;
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.http;
+
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.async.NonBlockingByteBufferJsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.util.TokenBuffer;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+/**
+ * A generic interface for consuming API entities from an asynchronous data stream. This interface
+ * defines the basic operations required by {@link ApiEntityConsumer} to handle different types of
+ * API responses, including JSON and raw byte data.
+ *
+ * @param <T> the type of the entity expected in the successful response
+ */
+public interface TypedApiEntityConsumer<T> {
+
+  /**
+   * Generates the final content after all data has been consumed.
+   *
+   * @return an {@link ApiEntity} containing the deserialized content, or null if no data was
+   *     consumed
+   */
+  ApiEntity<T> generateContent() throws IOException;
+
+  /**
+   * Consumes data from the provided {@link ByteBuffer}. This method is called as data becomes
+   * available and can be invoked multiple times as more data is streamed.
+   *
+   * @param src the {@link ByteBuffer} containing the data to be consumed
+   * @param endOfStream a flag indicating whether this is the last chunk of data
+   */
+  void consumeData(final ByteBuffer src, final boolean endOfStream) throws IOException;
+
+  /**
+   * Releases any resources associated with this consumer. This method should be called once the
+   * consumer is no longer needed, such as after the response has been fully processed.
+   */
+  void releaseResources();
+
+  /**
+   * Returns the number of bytes currently buffered by this consumer.
+   *
+   * @return the number of buffered bytes
+   */
+  int getBufferedBytes();
+
+  /**
+   * A {@link TypedApiEntityConsumer} implementation for handling JSON data. This consumer uses
+   * Jackson's non-blocking parser to incrementally parse JSON data as it is streamed.
+   */
+  class JsonApiEntityConsumer<T> implements TypedApiEntityConsumer<T> {
+    private final ObjectMapper json;
+    private final Class<T> type;
+    private final NonBlockingByteBufferJsonParser parser;
+    private final TokenBuffer buffer;
+    private final boolean isResponse;
+    private int bufferedBytes;
+
+    public JsonApiEntityConsumer(
+        final ObjectMapper json, final Class<T> type, final boolean isResponse) throws IOException {
+      this.json = json;
+      this.type = type;
+      this.isResponse = isResponse;
+      parser =
+          (NonBlockingByteBufferJsonParser) json.getFactory().createNonBlockingByteBufferParser();
+      buffer = new TokenBuffer(parser, json.getDeserializationContext());
+    }
+
+    @Override
+    public ApiEntity<T> generateContent() throws IOException {
+      buffer.asParserOnFirstToken();
+
+      if (isResponse) {
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
+      }
+
+      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
+    }
+
+    @Override
+    public void consumeData(final ByteBuffer src, final boolean endOfStream) throws IOException {
+      bufferedBytes += src.remaining();
+      parser.feedInput(src);
+      JsonToken jsonToken = parser.nextToken();
+      while (jsonToken != null && jsonToken != JsonToken.NOT_AVAILABLE) {
+        buffer.copyCurrentEvent(parser);
+        jsonToken = parser.nextToken();
+      }
+
+      if (endOfStream) {
+        parser.endOfInput();
+      }
+    }
+
+    @Override
+    public void releaseResources() {
+      try {
+        parser.close();
+      } catch (final Exception e) {
+        // log but otherwise ignore
+      }
+      try {
+        buffer.close();
+      } catch (final IOException e) {
+        // log but otherwise ignore
+      }
+      bufferedBytes = 0;
+    }
+
+    @Override
+    public int getBufferedBytes() {
+      return bufferedBytes;
+    }
+  }
+
+  /**
+   * A {@link TypedApiEntityConsumer} implementation for handling raw data, which could be text or
+   * binary. This consumer accumulates the raw data into a byte array, which can later be converted
+   * to a string or another appropriate type.
+   */
+  class RawApiEntityConsumer<T> implements TypedApiEntityConsumer<T> {
+
+    private final boolean isResponse;
+
+    private byte[] body = new byte[1024];
+
+    private int bufferedBytes;
+
+    public RawApiEntityConsumer(final boolean isResponse) {
+      this.isResponse = isResponse;
+    }
+
+    @Override
+    public ApiEntity<T> generateContent() {
+      if (bufferedBytes == 0) {
+        return null;
+      }
+      if (isResponse) {
+        return (ApiEntity<T>)
+            ApiEntity.of(new String(body, 0, bufferedBytes, StandardCharsets.UTF_8));
+      }
+
+      return ApiEntity.of(ByteBuffer.wrap(body, 0, bufferedBytes));
+    }
+
+    @Override
+    public void consumeData(final ByteBuffer src, final boolean endOfStream) throws IOException {
+      final int offset = bufferedBytes;
+      bufferedBytes += src.remaining();
+      if (body.length < bufferedBytes) {
+        body = Arrays.copyOf(body, body.length + 1024);
+      }
+      src.get(body, offset, src.remaining());
+    }
+
+    @Override
+    public void releaseResources() {
+      bufferedBytes = 0;
+    }
+
+    @Override
+    public int getBufferedBytes() {
+      return bufferedBytes;
+    }
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -164,7 +164,7 @@ public interface TypedApiEntityConsumer<T> {
     }
 
     @Override
-    public void consumeData(final ByteBuffer src, final boolean endOfStream) throws IOException {
+    public void consumeData(final ByteBuffer src, final boolean endOfStream) {
       final int offset = bufferedBytes;
       bufferedBytes += src.remaining();
       if (body.length < bufferedBytes) {

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.impl.http.ApiEntity.Error;
+import io.camunda.zeebe.client.impl.http.ApiEntity.Response;
+import io.camunda.zeebe.client.impl.http.ApiEntity.Unknown;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.apache.hc.core5.http.ContentType;
+import org.junit.jupiter.api.Test;
+
+class ApiEntityConsumerTest {
+
+  @Test
+  void testJsonApiEntityConsumerWithValidJsonResponse() throws IOException {
+    // given
+    final String jsonResponse = "{\"name\":\"test\",\"value\":123}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with the correct content type
+    consumer.streamStart(ContentType.APPLICATION_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Response.class);
+    final TestEntity response = entity.response();
+    assertThat(response).isNotNull();
+    assertThat(response.getName()).isEqualTo("test");
+    assertThat(response.getValue()).isEqualTo(123);
+  }
+
+  @Test
+  void testJsonApiEntityConsumerWithProblemDetailResponse() throws IOException {
+    // given
+    final String problemDetailResponse =
+        "{\"type\":\"about:blank\",\"title\":\"Something went wrong\",\"status\":400,\"detail\":\"Invalid request\",\"instance\":\"/v1/entity/123\"}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(problemDetailResponse.getBytes());
+    final ApiEntityConsumer<ProblemDetail> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), ProblemDetail.class, 2048);
+
+    // when
+    // Start the stream with content type application/problem+json
+    consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<ProblemDetail> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Error.class);
+    final ProblemDetail problemDetail = entity.problem();
+    assertThat(problemDetail).isNotNull();
+    assertThat(problemDetail.getType()).isEqualTo(URI.create("about:blank"));
+    assertThat(problemDetail.getTitle()).isEqualTo("Something went wrong");
+    assertThat(problemDetail.getStatus()).isEqualTo(400);
+    assertThat(problemDetail.getDetail()).isEqualTo("Invalid request");
+    assertThat(problemDetail.getInstance()).isEqualTo(URI.create("/v1/entity/123"));
+  }
+
+  @Test
+  void testRawApiEntityConsumerWithTextXmlResponse() throws IOException {
+    // given
+    final String textXmlResponse = "<xml/>";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(textXmlResponse.getBytes());
+    final ApiEntityConsumer<String> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+
+    // when
+    // Start the stream with a supported text content type (text/xml)
+    consumer.streamStart(ContentType.TEXT_XML);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content (should return the plain text as a string)
+    final ApiEntity<String> entity = consumer.generateContent();
+
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response()).isEqualTo(textXmlResponse);
+  }
+
+  @Test
+  void testRawApiEntityConsumerWithTextXmlResponseContainingUTF8Chars() throws IOException {
+    // given
+    final String textXmlResponse =
+        "<xml>Thís ís á UTF-8 text wíth specíal cháracters: €, ñ, ö, 测试</xml>";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(textXmlResponse.getBytes());
+    final ApiEntityConsumer<String> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+
+    // when
+    // Start the stream with a supported text content type (text/xml)
+    consumer.streamStart(ContentType.TEXT_XML);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content (should return the plain text as a string)
+    final ApiEntity<String> entity = consumer.generateContent();
+
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response()).isEqualTo(textXmlResponse);
+  }
+
+  @Test
+  void testJsonApiEntityConsumerWithPartialData() throws IOException {
+    // given
+    final String part1 = "{\"name\":\"t";
+    final String part2 = "est\",\"value\":123}";
+    final ByteBuffer byteBuffer1 = ByteBuffer.wrap(part1.getBytes(StandardCharsets.UTF_8));
+    final ByteBuffer byteBuffer2 = ByteBuffer.wrap(part2.getBytes(StandardCharsets.UTF_8));
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with a supported content type (application/json)
+    consumer.streamStart(ContentType.APPLICATION_JSON);
+    // Feed the first part of the data
+    consumer.data(byteBuffer1, false);
+    // Feed the second part of the data
+    consumer.data(byteBuffer2, true);
+    // Generate the content (should parse and combine both parts)
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response().getName()).isEqualTo("test");
+    assertThat(entity.response().getValue()).isEqualTo(123);
+  }
+
+  @Test
+  void testRawApiEntityConsumerWithPartialData() throws IOException {
+    // given
+    final String part1 = "<xml>";
+    final String part2 = "</xml>>";
+    final ByteBuffer byteBuffer1 = ByteBuffer.wrap(part1.getBytes());
+    final ByteBuffer byteBuffer2 = ByteBuffer.wrap(part2.getBytes());
+    final ApiEntityConsumer<String> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
+
+    // when
+    // Start the stream with a supported content type (text/xml)
+    consumer.streamStart(ContentType.TEXT_XML);
+    // Feed the first part of the data
+    consumer.data(byteBuffer1, false);
+    // Feed the second part of the data
+    consumer.data(byteBuffer2, true);
+    // Generate the content (should concatenate both parts)
+    final ApiEntity<String> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Response.class);
+    assertThat(entity.response()).isEqualTo(part1 + part2);
+  }
+
+  @Test
+  void testUnknownContentType() throws IOException {
+    // given
+    final String unsupportedData = "<html>";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(unsupportedData.getBytes());
+    final ApiEntityConsumer<ByteBuffer> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), ByteBuffer.class, 2048);
+
+    // when
+    // Start the stream with an unsupported content type
+    consumer.streamStart(ContentType.TEXT_HTML);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content (should return raw data as ByteBuffer)
+    final ApiEntity<ByteBuffer> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Unknown.class);
+    assertThat(StandardCharsets.UTF_8.decode(entity.unknown()).toString())
+        .isEqualTo(unsupportedData);
+  }
+
+  // Test entity class used for JSON serialization/deserialization
+  static class TestEntity {
+    private String name;
+    private int value;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(final String name) {
+      this.name = name;
+    }
+
+    public int getValue() {
+      return value;
+    }
+
+    public void setValue(final int value) {
+      this.value = value;
+    }
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -180,8 +180,8 @@ class ApiEntityConsumerTest {
     // given
     final String unsupportedData = "<html>";
     final ByteBuffer byteBuffer = ByteBuffer.wrap(unsupportedData.getBytes());
-    final ApiEntityConsumer<ByteBuffer> consumer =
-        new ApiEntityConsumer<>(new ObjectMapper(), ByteBuffer.class, 2048);
+    final ApiEntityConsumer<String> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), String.class, 2048);
 
     // when
     // Start the stream with an unsupported content type
@@ -189,7 +189,29 @@ class ApiEntityConsumerTest {
     // Feed the data
     consumer.data(byteBuffer, true);
     // Generate the content (should return raw data as ByteBuffer)
-    final ApiEntity<ByteBuffer> entity = consumer.generateContent();
+    final ApiEntity<String> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Unknown.class);
+    assertThat(StandardCharsets.UTF_8.decode(entity.unknown()).toString())
+        .isEqualTo(unsupportedData);
+  }
+
+  @Test
+  void testUnknownContentTypeWhenExpectedResponseIsNotAString() throws IOException {
+    // given
+    final String unsupportedData = "<unexpected/>";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(unsupportedData.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with a supported content type
+    consumer.streamStart(ContentType.TEXT_XML);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content (should return raw data as ByteBuffer)
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
 
     // then
     assertThat(entity).isInstanceOf(Unknown.class);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Currently the REST client supports only JSON response content types, it does not support endpoints that returns plain text,
for now I added support to `text/xml` mime type but it can be extended to other mime types

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
