### PR TITLE
Allow instantiating exporter configuration with list fields/members

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfiguration.java
@@ -12,8 +12,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.util.ReflectUtil;
+import java.util.List;
 import java.util.Map;
 
 public record ExporterConfiguration(String id, Map<String, Object> arguments)
@@ -24,6 +26,9 @@ public record ExporterConfiguration(String id, Map<String, Object> arguments)
   // instantiated (the last declared one), using the last matching value.
   private static final ObjectMapper MAPPER =
       JsonMapper.builder()
+          .addModule(
+              new SimpleModule()
+                  .addDeserializer(List.class, new ExporterConfigurationListDeserializer<>()))
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
           .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_VALUES)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.context;
+
+import com.fasterxml.jackson.databind.BeanProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.deser.std.StdDelegatingDeserializer;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+import com.fasterxml.jackson.databind.util.StdConverter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+/**
+ * Delegating deserializer which converts a {@link Map} with all numeric keys into a list, where the
+ * keys are the indices of the items in the list. This allows converting Spring's default {@link
+ * java.util.LinkedHashMap} lists back into lists.
+ *
+ * <p>NOTE: this class expects the keys to start from 0 and increase by one in sequence, with no
+ * gaps. This mirrors the Spring behavior which does not allow specifying gaps in list fields.
+ *
+ * <p>You can then configure this via Spring properties, e.g. {@code
+ * camunda.broker.myConfiguration.myListProperty[0] = foo}
+ */
+final class ExporterConfigurationListDeserializer<E> extends StdDelegatingDeserializer<List<E>> {
+
+  public ExporterConfigurationListDeserializer() {
+    super(new MapListConverter<>());
+  }
+
+  @Override
+  public JsonDeserializer<?> createContextual(
+      final DeserializationContext ctxt, final BeanProperty property) throws JsonMappingException {
+    return new StdDelegatingDeserializer<List<E>>(
+            new MapListConverter<>(property.getType().getContentType()))
+        .createContextual(ctxt, property);
+  }
+
+  private static final class MapListConverter<E> extends StdConverter<Map<String, E>, List<E>> {
+
+    private final JavaType contentType;
+
+    public MapListConverter() {
+      this(TypeFactory.defaultInstance().constructType(Object.class));
+    }
+
+    public MapListConverter(final JavaType contentType) {
+      this.contentType = contentType;
+    }
+
+    @Override
+    public List<E> convert(final Map<String, E> value) {
+      final ArrayList<E> list = new ArrayList<>(value.size());
+
+      // sort the keys so we can access them in ascending order, avoiding index out of bounds due to
+      // random access order of the map keys
+      final var keys = new TreeSet<>(value.keySet());
+      for (final var key : keys) {
+        setListValue(value, key, list);
+      }
+
+      return list;
+    }
+
+    @Override
+    public JavaType getInputType(final TypeFactory typeFactory) {
+      return super.getInputType(typeFactory).withContentType(contentType);
+    }
+
+    @Override
+    public JavaType getOutputType(final TypeFactory typeFactory) {
+      return super.getOutputType(typeFactory).withContentType(contentType);
+    }
+
+    private <E> void setListValue(
+        final Map<String, E> value, final String key, final ArrayList<E> list) {
+      final int index;
+      try {
+        index = Integer.parseInt(key);
+      } catch (final NumberFormatException e) {
+        throw new IllegalArgumentException(
+            "Failed to convert a map of integer to list; at least one key is not a number: [%s]"
+                .formatted(key),
+            e);
+      }
+
+      try {
+        list.add(index, value.get(key));
+      } catch (final IndexOutOfBoundsException e) {
+        throw new IndexOutOfBoundsException(
+            """
+            Failed to convert map of integers to list; tried to insert at [%d], but highest \
+            index is [%d]. Check your configuration for errors when setting the index."""
+                .formatted(index, list.size() - 1));
+      }
+    }
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationListDeserializer.java
@@ -81,7 +81,7 @@ final class ExporterConfigurationListDeserializer<E> extends StdDelegatingDeseri
       return super.getOutputType(typeFactory).withContentType(contentType);
     }
 
-    private <E> void setListValue(
+    private void setListValue(
         final Map<String, E> value, final String key, final ArrayList<E> list) {
       final int index;
       try {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterConfigurationTest.java
@@ -8,7 +8,10 @@
 package io.camunda.zeebe.broker.exporter.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -62,7 +65,74 @@ final class ExporterConfigurationTest {
     assertThat(instance).isEqualTo(expected);
   }
 
+  @RegressionTest("https://github.com/camunda/camunda/issues/4552")
+  void shouldInstantiateMapOfIntegersAsList() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "configs", Map.of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1)));
+    final var expected = new ListConfig(List.of(new Config(0), new Config(1)));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(ListConfig.class);
+
+    // then
+    assertThat(instance).isEqualTo(expected);
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/4552")
+  void shouldInstantiateMapOfIntegersAsListNested() {
+    // given
+    final var serializedConfigs =
+        Map.<String, Object>of("0", Map.of("numberofshards", 0), "1", Map.of("numberofshards", 1));
+    final var args =
+        Map.<String, Object>of("list", Map.of("0", Map.of("configs", serializedConfigs)));
+    final var expected =
+        new NestedListConfig(List.of(new ListConfig(List.of(new Config(0), new Config(1)))));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when
+    final var instance = config.instantiate(NestedListConfig.class);
+
+    // then
+    assertThat(instance).isEqualTo(expected);
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/4552")
+  void shouldNotInstantiateSparseList() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "configs", Map.of("1", Map.of("numberofshards", 0), "2", Map.of("numberofshards", 1)));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(ListConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/4552")
+  void shouldNotInstantiateNonIntegerList() {
+    // given
+    final var args =
+        Map.<String, Object>of(
+            "configs",
+            Map.of("foo", Map.of("numberofshards", 0), "bar", Map.of("numberofshards", 1)));
+    final var config = new ExporterConfiguration("id", args);
+
+    // when - then
+    assertThatCode(() -> config.instantiate(ListConfig.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasRootCauseInstanceOf(NumberFormatException.class);
+  }
+
   private record Config(int numberOfShards) {}
 
   private record ContainerConfig(Config nested) {}
+
+  private record ListConfig(List<Config> configs) {}
+
+  private record NestedListConfig(List<ListConfig> list) {}
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterConfigInstantiationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterConfigInstantiationIT.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter;
+
+import io.camunda.zeebe.it.exporter.util.TestExporter;
+import io.camunda.zeebe.it.exporter.util.TestExporterConfig;
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.zeebe.containers.ZeebeContainer;
+import java.io.IOException;
+import java.nio.file.Path;
+import net.bytebuddy.ByteBuddy;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * The following needs to be a container test because it's the only way to test configuration via
+ * environment variables in an isolated way at the moment.
+ */
+@Testcontainers
+final class ExporterConfigInstantiationIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExporterConfigInstantiationIT.class);
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/4552")
+  void shouldDeserializeListConfiguration(final @TempDir Path tempDir) throws IOException {
+    // given
+    final var exporterJar =
+        new ByteBuddy()
+            .rebase(TestExporter.class)
+            .name("com.acme.Exporter")
+            .make()
+            .include(new ByteBuddy().rebase(TestExporterConfig.class).make())
+            .toJar(tempDir.resolve("exporter.jar").toFile())
+            .toPath();
+    final var broker =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withCopyFileToContainer(MountableFile.forHostPath(exporterJar), "/exporter.jar")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_TEST_CLASSNAME", "com.acme.Exporter")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_TEST_JARPATH", "/exporter.jar")
+            .withEnv("ZEEBE_BROKER_EXPORTERS_TEST_ARGS_STRINGS_0", "foo")
+            .withLogConsumer(new Slf4jLogConsumer(LOGGER));
+
+    // when - then - the broker will fail to start if the strings were not properly parsed, as per
+    // the TestExporter validation in its configure method
+    try (broker) {
+      broker.start();
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterSerializationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterSerializationTest.java
@@ -11,27 +11,44 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.zeebe.it.clustering.ClusteringRule;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.WorkloadGenerator;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public final class ExporterSerializationTest {
+@ZeebeIntegration
+@AutoCloseResources
+final class ExporterSerializationTest {
   private static final ObjectMapper MAPPER =
       new ObjectMapper().registerModule(new ZeebeProtocolModule());
-  @Rule public ClusteringRule clusteringRule = new ClusteringRule(1, 1, 1);
+
+  @TestZeebe
+  private final TestStandaloneBroker broker =
+      new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = broker.newClientBuilder().build();
+  }
 
   @Test
-  public void shouldDeserializeExportedRecords() throws IOException {
+  void shouldDeserializeExportedRecords() throws IOException {
     // given
     RecordingExporter.setMaximumWaitTime(2_000);
-    WorkloadGenerator.performSampleWorkload(clusteringRule.getClient());
+    WorkloadGenerator.performSampleWorkload(client);
     final var exportedRecords = RecordingExporter.records().collect(Collectors.toList());
     final var jsonRecords = exportedRecords.stream().map(Record::toJson).toList();
     final var jsonString = "[" + String.join(",", jsonRecords) + "]";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/util/TestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/util/TestExporter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter.util;
+
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.protocol.record.Record;
+
+/**
+ * A test exporter used by {@link io.camunda.zeebe.it.exporter.ExporterConfigInstantiationIT}. It
+ * needs to be a top level class since we'll be rebasing (i.e. merging) with a dynamically created
+ * implementation class before packaging it as a JAR, along with its companion class {@link
+ * TestExporterConfig}.
+ *
+ * <p>Doing this allows us to define an implementation of a fully standalone exporter that can be
+ * packaged dynamically during a test into a JAR, and injected into a container.
+ */
+public class TestExporter implements Exporter {
+
+  @Override
+  public void configure(final Context context) throws Exception {
+    final var config = context.getConfiguration().instantiate(TestExporterConfig.class);
+    if (config.strings().isEmpty()) {
+      throw new IllegalStateException("Need to specify some strings");
+    }
+  }
+
+  @Override
+  public void export(final Record<?> record) {}
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/util/TestExporterConfig.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/util/TestExporterConfig.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter.util;
+
+import java.util.List;
+
+/**
+ * @see TestExporter
+ */
+public record TestExporterConfig(List<String> strings) {}


### PR DESCRIPTION
## Description

This PR allows usage of `List` as a member/field type for exporter configuration classes instantiated through `Configuration#instantiate` for exporters.

The idea behind it is that, since you explicitly set the type of the field to `List`, you expect to always get one. What's happening until now is that, with Spring Boot, the exporter arguments are being parsed as all `LinkedHashMap`. When configuring for a list, e.g.

```
zeebe.broker.exporters.test.args.myList[0]=foo
zeebe.broker.exporters.test.args.myList[1]=bar
```

What happens is you get a `LinkedHashMap` where the keys are strings and the values `Object`, but the keys are essentially "0", "1", etc.

Since we use a specific `ObjectMapper` to inflate the exporter arguments into a specific configuration class, we can configure it to deserialize list fields by expecting maps of integer keys. This is easily done via a delegating de-serializer with a `Converter`. It's transparent to everyone, and will not breaking existing deployments, as it was simply not possible to have `List` fields in the past.

> [!Note]
> This does not support other list-like types. I assume it can be extended to support it.
> Additionally, I'm fully aware a better solution would be to delegate the property binding to Spring instead of Jackson, but I still can't figure out how to do that =/

The solution itself is not a lot of code, but most of the PR ended up being regression tests :) Additionally I migrated a class to junit 5/our new test infrastructure because I thought I was going to extend it, but in the end did not; since we do want to move away from the `ClusteringRule`, I figured I might as well keep the commit anyway.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #4552 
