### PR TITLE
feat: Update pin clock REST endpoint to use `PUT` method

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
@@ -63,8 +63,8 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
   @Override
   public ZeebeFuture<PinClockResponse> send() {
     final HttpZeebeFuture<PinClockResponse> result = new HttpZeebeFuture<>();
-    httpClient.post(
-        "/administration/clock/pin", jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    httpClient.put(
+        "/administration/clock", jsonMapper.toJson(request), httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -122,6 +122,14 @@ public final class HttpClient implements AutoCloseable {
     sendRequest(Method.POST, path, body, requestConfig, responseType, transformer, result);
   }
 
+  public <RespT> void put(
+      final String path,
+      final String body,
+      final RequestConfig requestConfig,
+      final HttpZeebeFuture<RespT> result) {
+    sendRequest(Method.PUT, path, body, requestConfig, Void.class, r -> null, result);
+  }
+
   public <RespT> void patch(
       final String path,
       final String body,

--- a/clients/java/src/test/java/io/camunda/zeebe/client/clock/PinClockTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/clock/PinClockTest.java
@@ -39,7 +39,7 @@ public final class PinClockTest extends ClientRestTest {
 
     // then
     assertThat(RestGatewayService.getLastRequest())
-        .hasMethod(RequestMethod.POST)
+        .hasMethod(RequestMethod.PUT)
         .hasUrl(RestGatewayPaths.getClockPinUrl())
         .extractingBody(ClockPinRequest.class)
         .isEqualTo(new ClockPinRequest().timestamp(timestamp));
@@ -55,7 +55,7 @@ public final class PinClockTest extends ClientRestTest {
 
     // then
     assertThat(RestGatewayService.getLastRequest())
-        .hasMethod(RequestMethod.POST)
+        .hasMethod(RequestMethod.PUT)
         .hasUrl(RestGatewayPaths.getClockPinUrl())
         .extractingBody(ClockPinRequest.class)
         .isEqualTo(new ClockPinRequest().timestamp(instant.toEpochMilli()));

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
@@ -29,7 +29,7 @@ public class RestGatewayPaths {
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
   private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/message/correlation";
-  private static final String URL_CLOCK_PIN = REST_API_PATH + "/administration/clock/pin";
+  private static final String URL_CLOCK_PIN = REST_API_PATH + "/administration/clock";
   private static final String URL_CLOCK_RESET = REST_API_PATH + "/administration/clock/reset";
   private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -579,11 +579,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
 
-  /administration/clock/pin:
-    post:
+  /administration/clock:
+    put:
       tags:
-        - Administration
-        - Clock control
+        - Clock
       summary: Pin the Zeebe engine’s internal clock to a specific time (experimental)
       description: |
         Set a precise, static time for the Zeebe engine’s internal clock. When the clock is pinned,
@@ -618,8 +617,7 @@ paths:
   /administration/clock/reset:
     post:
       tags:
-        - Administration
-        - Clock control
+        - Clock
       summary: Reset the Zeebe engine’s internal clock to the system time (experimental)
       description: |
         Resets the Zeebe engine’s internal clock to the current system time,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
@@ -16,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -30,8 +31,8 @@ public class AdministrationController {
     this.clockServices = clockServices;
   }
 
-  @PostMapping(
-      path = "/clock/pin",
+  @PutMapping(
+      path = "/clock",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> pinClock(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
@@ -30,8 +30,8 @@ import org.springframework.http.ProblemDetail;
 @WebMvcTest(AdministrationController.class)
 public class AdministrationControllerTest extends RestControllerTest {
 
-  private static final String PIN_CLOCK_URL = "/v2/administration/clock/pin";
-  private static final String RESET_CLOCK_URL = "/v2/administration/clock/reset";
+  private static final String CLOCK_URL = "/v2/administration/clock";
+  private static final String RESET_CLOCK_URL = CLOCK_URL.concat("/reset");
 
   @MockBean private ClockServices clockServices;
 
@@ -52,8 +52,8 @@ public class AdministrationControllerTest extends RestControllerTest {
 
     // when - then
     webClient
-        .post()
-        .uri(PIN_CLOCK_URL)
+        .put()
+        .uri(CLOCK_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)
@@ -71,13 +71,13 @@ public class AdministrationControllerTest extends RestControllerTest {
 
     final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
     expectedBody.setTitle(INVALID_ARGUMENT.name());
-    expectedBody.setInstance(URI.create(PIN_CLOCK_URL));
+    expectedBody.setInstance(URI.create(CLOCK_URL));
     expectedBody.setDetail("No timestamp provided.");
 
     // when - then
     webClient
-        .post()
-        .uri(PIN_CLOCK_URL)
+        .put()
+        .uri(CLOCK_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)


### PR DESCRIPTION
## Description

This PR updates the `pin clock` REST endpoint. The primary change is switching the HTTP method from `POST` to `PUT` to better align with our API's best practices regarding idempotent actions.

### Changes:
- The `pin` endpoint has been moved from `POST /v2/administration/clock/pin` to `PUT /v2/administration/clock`.
- The request body format remains unchanged, still requiring a `timestamp` to set the clock.
- Adjusted relevant Open-API definition and tests to reflect these changes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21823 
