### PR TITLE
feat: implement has_parent on es and os query transformers

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchConstantScoreQuery;
 import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchIdsQuery;
 import io.camunda.search.clients.query.SearchMatchAllQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
@@ -33,6 +34,7 @@ import io.camunda.search.es.transformers.query.BoolQueryTransformer;
 import io.camunda.search.es.transformers.query.ConstantScoreQueryTransformer;
 import io.camunda.search.es.transformers.query.ExistsQueryTransformer;
 import io.camunda.search.es.transformers.query.HasChildQueryTransformer;
+import io.camunda.search.es.transformers.query.HasParentQueryTransformer;
 import io.camunda.search.es.transformers.query.IdsQueryTransformer;
 import io.camunda.search.es.transformers.query.MatchAllQueryTransformer;
 import io.camunda.search.es.transformers.query.MatchNoneQueryTransformer;
@@ -92,6 +94,7 @@ public final class ElasticsearchTransformers {
     mappers.put(SearchTermQuery.class, new TermQueryTransformer(mappers));
     mappers.put(SearchTermsQuery.class, new TermsQueryTransformer(mappers));
     mappers.put(SearchWildcardQuery.class, new WildcardQueryTransformer(mappers));
+    mappers.put(SearchHasParentQuery.class, new HasParentQueryTransformer(mappers));
 
     // sort
     mappers.put(SearchSortOptions.class, new SortOptionsTransformer(mappers));

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/HasParentQueryTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/HasParentQueryTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.HasParentQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import io.camunda.search.clients.query.SearchHasParentQuery;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public final class HasParentQueryTransformer
+    extends QueryOptionTransformer<SearchHasParentQuery, HasParentQuery> {
+
+  public HasParentQueryTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public HasParentQuery apply(final SearchHasParentQuery value) {
+    final var transformer = getQueryTransformer();
+    final var searchQuery = value.query();
+    final var query = transformer.apply(searchQuery);
+    final var parentType = value.parentType();
+    return QueryBuilders.hasParent().parentType(parentType).query(query).build();
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/HasParentQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/HasParentQueryTransformerTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class HasParentQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchQuery.class);
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.hasParentQuery("fooParentType", SearchQueryBuilders.term("fooField", 123)),
+            "Query: {\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.hasParent()
+                .parentType("fooParentType")
+                .query(SearchQueryBuilders.term("fooField", 123))
+                .build()
+                .toSearchQuery(),
+            "Query: {\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQuery() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasParent().parentType("fooParentType").build())
+        .hasMessageContaining("Expected a non-null query parameter for the hasParent query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQueryFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasParentQuery("fooParentType", null))
+        .hasMessageContaining("Expected a non-null query parameter for the hasParent query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullParentType() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+        () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
+        .hasMessageContaining(
+            "Expected a non-null parentType parameter for the hasParent query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullParentTypeFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+        () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
+        .hasMessageContaining(
+            "Expected a non-null parentType parameter for the hasParent query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/HasParentQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/HasParentQueryTransformerTest.java
@@ -35,7 +35,8 @@ public class HasParentQueryTransformerTest {
   private static Stream<Arguments> provideQueries() {
     return Stream.of(
         Arguments.arguments(
-            SearchQueryBuilders.hasParentQuery("fooParentType", SearchQueryBuilders.term("fooField", 123)),
+            SearchQueryBuilders.hasParentQuery(
+                "fooParentType", SearchQueryBuilders.term("fooField", 123)),
             "Query: {\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"),
         Arguments.arguments(
             SearchQueryBuilders.hasParent()
@@ -86,7 +87,7 @@ public class HasParentQueryTransformerTest {
 
     // when - throw
     assertThatThrownBy(
-        () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
+            () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
         .hasMessageContaining(
             "Expected a non-null parentType parameter for the hasParent query, with query:")
         .hasMessageContaining("field=foo")
@@ -100,7 +101,7 @@ public class HasParentQueryTransformerTest {
 
     // when - throw
     assertThatThrownBy(
-        () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
+            () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
         .hasMessageContaining(
             "Expected a non-null parentType parameter for the hasParent query, with query:")
         .hasMessageContaining("field=foo")

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -14,6 +14,7 @@ import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchConstantScoreQuery;
 import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchIdsQuery;
 import io.camunda.search.clients.query.SearchMatchAllQuery;
 import io.camunda.search.clients.query.SearchMatchNoneQuery;
@@ -33,6 +34,7 @@ import io.camunda.search.os.transformers.query.BoolQueryTransformer;
 import io.camunda.search.os.transformers.query.ConstantScoreQueryTransformer;
 import io.camunda.search.os.transformers.query.ExistsQueryTransformer;
 import io.camunda.search.os.transformers.query.HasChildQueryTransformer;
+import io.camunda.search.os.transformers.query.HasParentQueryTransformer;
 import io.camunda.search.os.transformers.query.IdsQueryTransformer;
 import io.camunda.search.os.transformers.query.MatchAllQueryTransformer;
 import io.camunda.search.os.transformers.query.MatchNoneQueryTransformer;
@@ -93,6 +95,7 @@ public final class OpensearchTransformers {
     mappers.put(SearchTermQuery.class, new TermQueryTransformer(mappers));
     mappers.put(SearchTermsQuery.class, new TermsQueryTransformer(mappers));
     mappers.put(SearchWildcardQuery.class, new WildcardQueryTransformer(mappers));
+    mappers.put(SearchHasParentQuery.class, new HasParentQueryTransformer(mappers));
 
     // sort
     mappers.put(SearchSortOptions.class, new SortOptionsTransformer(mappers));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/HasParentQueryTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/HasParentQueryTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import io.camunda.search.clients.query.SearchHasParentQuery;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import org.opensearch.client.opensearch._types.query_dsl.HasParentQuery;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+
+public final class HasParentQueryTransformer
+    extends QueryOptionTransformer<SearchHasParentQuery, HasParentQuery> {
+
+  public HasParentQueryTransformer(final OpensearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public HasParentQuery apply(final SearchHasParentQuery value) {
+    final var transformer = getQueryTransformer();
+    final var searchQuery = value.query();
+    final var query = transformer.apply(searchQuery);
+    final var parentType = value.parentType();
+    return QueryBuilders.hasParent().parentType(parentType).query(query).build();
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasParentQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasParentQueryTransformerTest.java
@@ -48,7 +48,8 @@ public class HasParentQueryTransformerTest {
   private static Stream<Arguments> provideQueries() {
     return Stream.of(
         Arguments.arguments(
-            SearchQueryBuilders.hasParentQuery("fooParentType", SearchQueryBuilders.term("fooField", 123)),
+            SearchQueryBuilders.hasParentQuery(
+                "fooParentType", SearchQueryBuilders.term("fooField", 123)),
             "{\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"),
         Arguments.arguments(
             SearchQueryBuilders.hasParent()
@@ -61,7 +62,8 @@ public class HasParentQueryTransformerTest {
 
   @ParameterizedTest
   @MethodSource("provideQueries")
-  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) throws IOException {
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery)
+      throws IOException {
     // given
     final var expectedQuery = expectedResultQuery.replace("'", "\"");
 
@@ -99,7 +101,7 @@ public class HasParentQueryTransformerTest {
 
     // when - throw
     assertThatThrownBy(
-        () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
+            () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
         .hasMessageContaining(
             "Expected a non-null parentType parameter for the hasParent query, with query:")
         .hasMessageContaining("field=foo")
@@ -113,7 +115,7 @@ public class HasParentQueryTransformerTest {
 
     // when - throw
     assertThatThrownBy(
-        () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
+            () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
         .hasMessageContaining(
             "Expected a non-null parentType parameter for the hasParent query, with query:")
         .hasMessageContaining("field=foo")

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasParentQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasParentQueryTransformerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class HasParentQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.hasParentQuery("fooParentType", SearchQueryBuilders.term("fooField", 123)),
+            "{\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.hasParent()
+                .parentType("fooParentType")
+                .query(SearchQueryBuilders.term("fooField", 123))
+                .build()
+                .toSearchQuery(),
+            "{\"has_parent\":{\"parent_type\":\"fooParentType\",\"query\":{\"term\":{\"fooField\":{\"value\":123}}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) throws IOException {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQuery() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasParent().parentType("fooParentType").build())
+        .hasMessageContaining("Expected a non-null query parameter for the hasParent query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQueryFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasParentQuery("fooParentType", null))
+        .hasMessageContaining("Expected a non-null query parameter for the hasParent query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullParentType() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+        () -> SearchQueryBuilders.hasParent().query(SearchQueryBuilders.term("foo", 1)).build())
+        .hasMessageContaining(
+            "Expected a non-null parentType parameter for the hasParent query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullParentTypeFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+        () -> SearchQueryBuilders.hasParentQuery(null, SearchQueryBuilders.term("foo", 1)))
+        .hasMessageContaining(
+            "Expected a non-null parentType parameter for the hasParent query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchHasParentQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchHasParentQuery.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.query;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+
+public record SearchHasParentQuery(SearchQuery query, String parentType)
+    implements SearchQueryOption {
+
+  public static final class Builder implements ObjectBuilder<SearchHasParentQuery> {
+
+    private SearchQuery query;
+    private String parentType;
+
+    public Builder query(final SearchQuery value) {
+      query = value;
+      return this;
+    }
+
+    public Builder parentType(final String value) {
+      parentType = value;
+      return this;
+    }
+
+    @Override
+    public SearchHasParentQuery build() {
+      return new SearchHasParentQuery(
+          Objects.requireNonNull(
+              query, "Expected a non-null query parameter for the hasParent query."),
+          Objects.requireNonNull(
+              parentType,
+              () ->
+                  String.format(
+                      "Expected a non-null parentType parameter for the hasParent query, with query: '%s'.",
+                      query)));
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQuery.java
@@ -142,6 +142,16 @@ public final record SearchQuery(SearchQueryOption queryOption) {
       return wildcard(SearchQueryBuilders.wildcard(fn));
     }
 
+    public Builder hasParent(final SearchHasParentQuery query) {
+      queryOption = query;
+      return this;
+    }
+
+    public Builder hasParent(
+        final Function<SearchHasParentQuery.Builder, ObjectBuilder<SearchHasParentQuery>> fn) {
+      return hasParent(SearchQueryBuilders.hasParent(fn));
+    }
+
     @Override
     public SearchQuery build() {
       return new SearchQuery(queryOption);

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -10,6 +10,7 @@ package io.camunda.search.clients.query;
 import static io.camunda.util.CollectionUtil.collectValues;
 import static io.camunda.util.CollectionUtil.withoutNull;
 
+import io.camunda.search.clients.query.SearchHasParentQuery.Builder;
 import io.camunda.search.clients.query.SearchMatchQuery.SearchMatchQueryOperator;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
@@ -297,5 +298,18 @@ public final class SearchQueryBuilders {
 
   public static SearchQuery wildcardQuery(final String field, final String value) {
     return wildcard(q -> q.field(field).value(value)).toSearchQuery();
+  }
+
+  public static SearchHasParentQuery.Builder hasParent() {
+    return new SearchHasParentQuery.Builder();
+  }
+
+  public static SearchHasParentQuery hasParent(
+      final Function<Builder, ObjectBuilder<SearchHasParentQuery>> fn) {
+    return fn.apply(hasParent()).build();
+  }
+
+  public static SearchQuery hasParentQuery(final String parent, final SearchQuery query) {
+    return hasParent(q -> q.parentType(parent).query(query)).toSearchQuery();
   }
 }


### PR DESCRIPTION
## Description

- Added support for `has_parent` query in Elasticsearch and OpenSearch query transformers.
- Implemented `HasParentQueryTransformer` for both Elasticsearch and OpenSearch.
- Introduced a new `SearchHasParentQuery` class for representing `has_parent` queries.
- Extended `SearchQuery` and `SearchQueryBuilders` to support building `has_parent` queries.

This will be use on retrieve tasks by process variables on Search Task by Variable 


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #https://github.com/camunda/camunda/issues/21848

