### PR TITLE
build: fix fetching the last push commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,7 +509,7 @@ jobs:
       #   - for PRs, we use the last commit of the base
       #   - for merge queues, we use the last commit of the target merge queue
       #   - for a push, we use the last commit before the push
-      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.push.before }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
     if: |
       needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:


### PR DESCRIPTION
## Description

The `protobuf-checks` job does not fetch the right commit to compare against on push event. This is because, contrary to _all_ other webhook payloads for GHA, the push one does not have the `push` prefix. Go figure.
