### PR TITLE
fix: do not break raft thread on late commit notification

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -112,7 +112,12 @@ public final class LogStreamImpl implements LogStream, CommitListener {
 
   @Override
   public void onCommit() {
-    ensureOpen();
+    if (closed) {
+      // This can be called by the raft thread after we've already closed the log stream.
+      // We can just ignore it in that case. Using `ensureOpen` would throw an exception that would
+      // break the raft thread.
+      return;
+    }
     recordAwaiters.forEach(LogRecordAwaiter::onRecordAvailable);
   }
 


### PR DESCRIPTION
Commit listeners are not allowed to throw, otherwise the raft partition would handle this by going inactive.

Because the notification can be delivered late by the raft thread, after the logstream is already closed, we must simply ignore it instead of throwing.

closes https://github.com/camunda/camunda/issues/20903
closes https://github.com/camunda/camunda/issues/21469