### PR TITLE
fix: skip initialization of partition ring until topology is initialized

### DIFF
--- a/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
@@ -25,6 +25,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   StubbedTopologyManager(final int partitionsCount) {
     clusterState = new BrokerClusterStateImpl();
+    clusterState.setClusterSize(1);
     clusterState.addBrokerIfAbsent(0);
     clusterState.setBrokerAddressIfPresent(0, "localhost:26501");
     for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerClusterState.java
@@ -17,6 +17,8 @@ public interface BrokerClusterState {
   int NODE_ID_NULL = UNKNOWN_NODE_ID - 1;
   int PARTITION_ID_NULL = NODE_ID_NULL - 1;
 
+  boolean isInitialized();
+
   int getClusterSize();
 
   int getPartitionsCount();

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClusterStateImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerClusterStateImpl.java
@@ -182,6 +182,11 @@ public final class BrokerClusterStateImpl implements BrokerClusterState {
   }
 
   @Override
+  public boolean isInitialized() {
+    return clusterSize != UNINITIALIZED_CLUSTER_SIZE;
+  }
+
+  @Override
   public int getClusterSize() {
     return clusterSize;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -165,7 +165,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     // GatewayClusterTopologyService.Listener. BrokerInfo contains the static clusterSize which is
     // the initial clusterSize. However, we still have to initialize it because it should have the
     // correct value even when the dynamic ClusterTopology is disabled.
-    if (topology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
+    if (!topology.isInitialized()) {
       topology.setClusterSize(distributedBrokerInfo.getClusterSize());
       topology.setPartitionsCount(distributedBrokerInfo.getPartitionsCount());
       topology.setReplicationFactor(distributedBrokerInfo.getReplicationFactor());

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -31,7 +31,8 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   public int determinePartition(final BrokerTopologyManager topologyManager) {
     final BrokerClusterState topology = topologyManager.getTopology();
 
-    if (topology == null) {
+    if (topology == null
+        || topology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
       return BrokerClusterState.PARTITION_ID_NULL;
     }
 
@@ -87,6 +88,12 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   }
 
   private record PartitionRing(int[] partitions) {
+    PartitionRing {
+      if (partitions.length == 0) {
+        throw new IllegalArgumentException("Partitions must not be empty");
+      }
+    }
+
     static PartitionRing all(final int partitionCount) {
       final var partitions = new int[partitionCount];
       for (int i = 0; i < partitionCount; i++) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -31,8 +31,7 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
   public int determinePartition(final BrokerTopologyManager topologyManager) {
     final BrokerClusterState topology = topologyManager.getTopology();
 
-    if (topology == null
-        || topology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
+    if (topology == null || !topology.isInitialized()) {
       return BrokerClusterState.PARTITION_ID_NULL;
     }
 

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -28,6 +28,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
     if (leaderId != BrokerClusterState.NODE_ID_NULL) {
       topology.addBrokerIfAbsent(leaderId);
       topology.setPartitionLeader(id, leaderId, 1);
+      topology.setClusterSize(topology.getBrokers().size());
     }
 
     topology.addPartitionIfAbsent(id);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -143,6 +143,11 @@ public class TopologyControllerTest extends RestControllerTest {
   private record TestBrokerClusterState(String version) implements BrokerClusterState {
 
     @Override
+    public boolean isInitialized() {
+      return true;
+    }
+
+    @Override
     public int getClusterSize() {
       return 3;
     }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -27,6 +27,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   StubbedTopologyManager(final int partitionsCount) {
     clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new BrokerClusterStateImpl();
+    clusterState.setClusterSize(1);
     clusterState.addBrokerIfAbsent(0);
     clusterState.setBrokerAddressIfPresent(0, "localhost:26501");
     for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -72,6 +72,11 @@ final class PublishMessageDispatchStrategyTest {
   private record TestBrokerClusterState(int partitionCount) implements BrokerClusterState {
 
     @Override
+    public boolean isInitialized() {
+      return true;
+    }
+
+    @Override
     public int getClusterSize() {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
This fixes a bug where the partition ring was incorrectly initialized from the topology. Checking for `null` is not enough, we must also account for the situation where cluster topology is available but not yet initialized with cluster size and partition count.

Without this fix, we'd initialize with partition count 0 and then never update it again, eventually causing `ArithmeticException: / by zero` when trying to look up a partition that wasn't known before.

Observed here: https://console.cloud.google.com/errors/detail/CIONl6PFkr2UsQE;service=zeebe;version=ck-platform-benchmark;filter=%5B%5D;time=P7D;locations=global?project=zeebe-io