### PR TITLE
[Backport stable/operate-8.5] fix: Operate OpenSearch AWS config can't be disabled

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -138,7 +138,7 @@ public class OpensearchConnector {
   public OpenSearchAsyncClient createAsyncOsClient(OpensearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsAsyncClient(osConfig);
     }
     final HttpHost host = getHttpHost(osConfig);
@@ -187,7 +187,11 @@ public class OpensearchConnector {
     return openSearchAsyncClient;
   }
 
-  private boolean isAws() {
+  private boolean hasAwsCredentials() {
+    if (!operateProperties.getOpensearch().isAwsEnabled()) {
+      LOGGER.info("AWS Credentials are disabled. Using basic auth.");
+      return false;
+    }
     final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
     try {
       credentialsProvider.resolveCredentials();
@@ -201,7 +205,7 @@ public class OpensearchConnector {
 
   public OpenSearchClient createOsClient(OpensearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsClient(osConfig);
     }
     final HttpHost host = getHttpHost(osConfig);

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -239,7 +239,7 @@ public class OpensearchConnector {
     if (!checkHealth(openSearchClient)) {
       LOGGER.warn("OpenSearch cluster is not accessible");
     } else {
-      LOGGER.debug("Elasticsearch connection was successfully created.");
+      LOGGER.debug("OpenSearch connection was successfully created.");
     }
     return openSearchClient;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -52,6 +52,8 @@ public class OpensearchProperties {
 
   private int bulkRequestMaxSizeInBytes = BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT;
 
+  private boolean awsEnabled = false;
+
   @NestedConfigurationProperty private SslProperties ssl;
 
   public String getClusterName() {
@@ -166,6 +168,15 @@ public class OpensearchProperties {
 
   public void setConnectTimeout(final Integer connectTimeout) {
     this.connectTimeout = connectTimeout;
+  }
+
+  public boolean isAwsEnabled() {
+    return awsEnabled;
+  }
+
+  public OpensearchProperties setAwsEnabled(final boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
+    return this;
   }
 
   public SslProperties getSsl() {

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.connect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.OperateOpensearchProperties;
+import io.camunda.operate.property.OperateProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.aws.AwsSdk2Transport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchConnectorTest {
+
+  private static final String AWS_REGION = "eu-west-1";
+  private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAcessKey";
+  private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  private final OperateOpensearchProperties opensearchProperties =
+      new OperateOpensearchProperties();
+
+  private final OperateProperties operateProperties = new OperateProperties();
+
+  private OpensearchConnector opensearchConnector;
+
+  @BeforeEach
+  public void setup() {
+    operateProperties.setOpensearch(opensearchProperties);
+    opensearchConnector = new OpensearchConnector(operateProperties, objectMapper);
+  }
+
+  @Test
+  public void asyncHasAwsEnabledAndAwsCredentialsSetAndShouldUseAwsCredentials() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    opensearchProperties.setAwsEnabled(true);
+
+    final OpenSearchAsyncClient client =
+        opensearchConnector.createAsyncOsClient(opensearchProperties);
+
+    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void asyncHasAwsCredentialsButShouldUseBasicAuth() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    // awsEnabled not set -> should default to false
+    final OpensearchConnector spyConnector = spy(opensearchConnector);
+    doReturn(true).when(spyConnector).checkHealth(any(OpenSearchAsyncClient.class));
+
+    final OpenSearchAsyncClient client = spyConnector.createAsyncOsClient(opensearchProperties);
+
+    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void syncHasAwsEnabledAndAwsCredentialsSetAndShouldUseAwsCredentials() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    opensearchProperties.setAwsEnabled(true);
+
+    final OpenSearchClient client = opensearchConnector.createOsClient(opensearchProperties);
+
+    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void syncHasAwsCredentialsButShouldUseBasicAuth() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    // awsEnabled not set -> should default to false
+    final OpensearchConnector spyConnector = spy(opensearchConnector);
+    doReturn(true).when(spyConnector).checkHealth(any(OpenSearchClient.class));
+
+    final OpenSearchClient client = spyConnector.createOsClient(opensearchProperties);
+
+    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+  }
+}


### PR DESCRIPTION
# Description
Backport of #21481 to `stable/operate-8.5`.

relates to camunda/camunda#20939
original author: @kristinkomschow