### PR TITLE
Benchmark: Allow to publish message from worker

### DIFF
--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -32,8 +32,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Worker extends App {
-  private static final Logger THROTTLED_LOGGER =
-      new ThrottledLogger(LoggerFactory.getLogger(Worker.class), Duration.ofSeconds(5));
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(Worker.class);
+  private static final Logger THROTTLED_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(5));
   private final AppCfg appCfg;
   private final WorkerCfg workerCfg;
 
@@ -86,11 +87,13 @@ public class Worker extends App {
       final BlockingQueue<Future<?>> requestFutures) {
     return (jobClient, job) -> {
       if (workerCfg.isSendMessage()) {
+        final String messageName = workerCfg.getMessageName();
         final Object correlationKey = job.getVariable(workerCfg.getCorrelationKeyVariableName());
 
+        LOGGER.debug("Publish message '{}' with correlation key '{}'", messageName, correlationKey);
         client
             .newPublishMessageCommand()
-            .messageName(workerCfg.getMessageName())
+            .messageName(messageName)
             .correlationKey(correlationKey.toString())
             .send();
       }

--- a/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
+++ b/zeebe/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
@@ -28,6 +28,9 @@ public class WorkerCfg {
   private String payloadPath;
   private boolean isStreamEnabled;
   private Duration timeout;
+  private boolean sendMessage = false;
+  private String messageName = "defaultMessage";
+  private String correlationKeyVariableName = "correlationKey-var";
 
   public String getJobType() {
     return jobType;
@@ -99,5 +102,29 @@ public class WorkerCfg {
 
   public void setTimeout(final Duration timeout) {
     this.timeout = timeout;
+  }
+
+  public boolean isSendMessage() {
+    return sendMessage;
+  }
+
+  public void setSendMessage(final boolean sendMessage) {
+    this.sendMessage = sendMessage;
+  }
+
+  public String getMessageName() {
+    return messageName;
+  }
+
+  public void setMessageName(final String messageName) {
+    this.messageName = messageName;
+  }
+
+  public String getCorrelationKeyVariableName() {
+    return correlationKeyVariableName;
+  }
+
+  public void setCorrelationKeyVariableName(final String correlationKeyVariableName) {
+    this.correlationKeyVariableName = correlationKeyVariableName;
   }
 }

--- a/zeebe/benchmarks/project/src/main/resources/application.conf
+++ b/zeebe/benchmarks/project/src/main/resources/application.conf
@@ -31,5 +31,8 @@ app {
     # if 0, timeout defaults to completionDelay * 6
     timeout = 0
     # timeout = 1800ms
+    sendMessage = false
+    messageName = "messageName"
+    correlationKeyVariableName = "correlationKey-var"
   }
 }

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -128,17 +128,23 @@
     <bpmn:subProcess id="Activity_02tn153" name="Fraud Claim Investigation">
       <bpmn:incoming>Flow_06bdzt7</bpmn:incoming>
       <bpmn:outgoing>Flow_1jy0gq5</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=disputeDetails.disputePositions" inputElement="disputePosition" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
       <bpmn:startEvent id="Event_1tf9brs" name="fraud claim investigation started">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=1" target="vendor_claim_frequency" />
+            <zeebe:output source="=1" target="customer_claim_frequency" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
         <bpmn:outgoing>Flow_16in312</bpmn:outgoing>
       </bpmn:startEvent>
       <bpmn:subProcess id="Activity_03cktkd" name="Vendor fraud claim validation">
         <bpmn:incoming>Flow_16in312</bpmn:incoming>
         <bpmn:outgoing>Flow_1y2i3of</bpmn:outgoing>
-        <bpmn:multiInstanceLoopCharacteristics>
-          <bpmn:extensionElements>
-            <zeebe:loopCharacteristics inputCollection="=disputeDetails.disputePositions" inputElement="disputePosition" />
-          </bpmn:extensionElements>
-        </bpmn:multiInstanceLoopCharacteristics>
         <bpmn:startEvent id="Event_0vl38e2" name="vendor fraud claim validation required">
           <bpmn:extensionElements>
             <zeebe:ioMapping>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -60,6 +60,11 @@
       <bpmn:incoming>Flow_15wpx65</bpmn:incoming>
       <bpmn:outgoing>Flow_06bdzt7</bpmn:outgoing>
       <bpmn:startEvent id="Event_1g0dyzc" name="documents required">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:output source="=disputeDetails.disputeId + customerId" target="correlationKey" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
         <bpmn:outgoing>Flow_0x32zsz</bpmn:outgoing>
       </bpmn:startEvent>
       <bpmn:sendTask id="Activity_0f196ti" name="Request documents from customer">
@@ -135,6 +140,11 @@
           </bpmn:extensionElements>
         </bpmn:multiInstanceLoopCharacteristics>
         <bpmn:startEvent id="Event_0vl38e2" name="vendor fraud claim validation required">
+          <bpmn:extensionElements>
+            <zeebe:ioMapping>
+              <zeebe:output source="=customerId + disputePosition.name" target="correlationKey" />
+            </zeebe:ioMapping>
+          </bpmn:extensionElements>
           <bpmn:outgoing>Flow_1gq2wqo</bpmn:outgoing>
         </bpmn:startEvent>
         <bpmn:eventBasedGateway id="Gateway_1p7bkh1">
@@ -287,18 +297,18 @@
   </bpmn:process>
   <bpmn:message id="Message_2hpi0qp" name="dispute_process_receive_documents">
     <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="=disputeDetails.disputeId + customerId" />
+      <zeebe:subscription correlationKey="=correlationKey" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:escalation id="Escalation_37d5bgh" name="Fraud claim investigation failed" escalationCode="fraud_claim_investigation_failed" />
   <bpmn:message id="Message_3mips66" name="dispute_process_refund_approved">
     <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="=customerId + disputePosition.name" />
+      <zeebe:subscription correlationKey="=correlationKey" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:message id="Message_2mocgcd" name="dispute_process_refund_declined">
     <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="=customerId + disputeDetails.name" />
+      <zeebe:subscription correlationKey="=correlationKey" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -62,7 +62,7 @@
       <bpmn:startEvent id="Event_1g0dyzc" name="documents required">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
-            <zeebe:output source="=disputeDetails.disputeId + customerId" target="correlationKey" />
+            <zeebe:output source="=string(disputeDetails.disputeId) + &#34;-&#34; + string(customerId)" target="correlationKey" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>
         <bpmn:outgoing>Flow_0x32zsz</bpmn:outgoing>
@@ -142,7 +142,7 @@
         <bpmn:startEvent id="Event_0vl38e2" name="vendor fraud claim validation required">
           <bpmn:extensionElements>
             <zeebe:ioMapping>
-              <zeebe:output source="=customerId + disputePosition.name" target="correlationKey" />
+              <zeebe:output source="=string(customerId) + &#34;-&#34; + disputePosition.name" target="correlationKey" />
             </zeebe:ioMapping>
           </bpmn:extensionElements>
           <bpmn:outgoing>Flow_1gq2wqo</bpmn:outgoing>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/decide_on_fraud_case.form
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/decide_on_fraud_case.form
@@ -1,0 +1,136 @@
+{
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.5.0",
+  "exporter": {
+    "name": "Camunda Web Modeler",
+    "version": "538c0e4"
+  },
+  "schemaVersion": 16,
+  "id": "decide-on-fraud-case-000115q",
+  "components": [
+    {
+      "text": "# Analyst - Decide on Fraud Case\nPlease decide on the following fraud case.",
+      "label": "Text view",
+      "type": "text",
+      "layout": {
+        "row": "Row_1bultam",
+        "columns": null
+      },
+      "id": "Field_1hp8d5s"
+    },
+    {
+      "label": "Dispute amount",
+      "type": "number",
+      "layout": {
+        "row": "Row_0gs6t3m",
+        "columns": null
+      },
+      "id": "Field_1by37ei",
+      "key": "disputeDetails.disputeAmount.amount",
+      "appearance": {
+        "suffixAdorner": "=disputeDetails.disputeAmount.currency"
+      }
+    },
+    {
+      "components": [
+        {
+          "label": "Customer message",
+          "type": "textarea",
+          "layout": {
+            "row": "Row_0kkr9o4",
+            "columns": null
+          },
+          "id": "Field_1lmc52h",
+          "key": "customerProofText"
+        },
+        {
+          "label": "Image view",
+          "type": "image",
+          "layout": {
+            "row": "Row_05t7ams",
+            "columns": null
+          },
+          "id": "Field_1ogl5iz",
+          "source": "=customerProofImage.dataUri"
+        }
+      ],
+      "showOutline": true,
+      "label": "Customer proof",
+      "type": "group",
+      "layout": {
+        "row": "Row_1gvmq2w",
+        "columns": null
+      },
+      "id": "Field_1num67s"
+    },
+    {
+      "components": [
+        {
+          "label": "Vendor message",
+          "type": "textarea",
+          "layout": {
+            "row": "Row_1b21vc9",
+            "columns": null
+          },
+          "id": "Field_1e24ode",
+          "key": "vendorProofText"
+        },
+        {
+          "label": "Image view",
+          "type": "image",
+          "layout": {
+            "row": "Row_0ob9o1k",
+            "columns": null
+          },
+          "id": "Field_110zfe4",
+          "source": "=vendorProofImage.dataUri"
+        }
+      ],
+      "showOutline": true,
+      "label": "Vendor proof",
+      "type": "group",
+      "layout": {
+        "row": "Row_1gvmq2w",
+        "columns": null
+      },
+      "id": "Field_09va0x3"
+    },
+    {
+      "text": "No fraud rating determined!",
+      "label": "Text view",
+      "type": "text",
+      "layout": {
+        "row": "Row_1owqk58",
+        "columns": null
+      },
+      "id": "Field_00fsuxy",
+      "conditional": {
+        "hide": "=isHighFraudRatingConfidence\n!= null"
+      }
+    },
+    {
+      "text": "=\"Fraud rating confidence: \" + if isHighFraudRatingConfidence then \"high\" else \"low\"",
+      "label": "Text view",
+      "type": "text",
+      "layout": {
+        "row": "Row_1e46ual",
+        "columns": null
+      },
+      "id": "Field_0qsjtyu",
+      "conditional": {
+        "hide": "=isHighFraudRatingConfidence\n= null"
+      }
+    },
+    {
+      "label": "Check if customer should receive refund",
+      "type": "checkbox",
+      "layout": {
+        "row": "Row_1c4vufk",
+        "columns": null
+      },
+      "id": "Field_1yxztfu",
+      "key": "isRefund"
+    }
+  ],
+  "type": "default"
+}

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="Definitions_17ojz6y" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0" camunda:diagramRelationId="c00115a7-7647-4f2f-9032-8b2a2efe752d">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="Definitions_17ojz6y" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0" camunda:diagramRelationId="c00115a7-7647-4f2f-9032-8b2a2efe752d">
   <decision id="determine-fraud-rating-1dmmwcu" name="Determine fraud rating confidence">
     <decisionTable id="DecisionTable_1xgcg4h" hitPolicy="COLLECT">
-      <input id="InputClause_1abpx7l" label="1-year customer claim frequency">
+      <input id="InputClause_1abpx7l" label="1-year customer claim frequency" biodi:width="192">
         <inputExpression id="LiteralExpression_0ftj8n5" typeRef="number">
           <text>customer_claim_frequency</text>
         </inputExpression>
@@ -14,7 +14,7 @@
       </input>
       <input id="InputClause_16ezqsg" label="dispute amount">
         <inputExpression id="LiteralExpression_1ihjohf" typeRef="number">
-          <text>disputeDetails.disputeAmount.amount</text>
+          <text>disputePosition.amount</text>
         </inputExpression>
       </input>
       <output id="Output_1" label="fraud rating score" name="fraud_rating_score" typeRef="number" />

--- a/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
+++ b/zeebe/benchmarks/project/src/test/java/io/camunda/zeebe/config/ConfigTest.java
@@ -63,6 +63,9 @@ public class ConfigTest {
     assertThat(workerCfg.getPayloadPath()).isEqualTo("bpmn/big_payload.json");
     assertThat(workerCfg.isStreamEnabled()).isTrue();
     assertThat(workerCfg.getTimeout()).hasSeconds(0);
+    assertThat(workerCfg.getMessageName()).isEqualTo("messageName");
+    assertThat(workerCfg.isSendMessage()).isFalse();
+    assertThat(workerCfg.getCorrelationKeyVariableName()).isEqualTo("correlationKey-var");
   }
 
   @Test
@@ -112,5 +115,8 @@ public class ConfigTest {
     assertThat(workerCfg.getPayloadPath()).isEqualTo("bpmn/big_payload.json");
     assertThat(workerCfg.isStreamEnabled()).isTrue();
     assertThat(workerCfg.getTimeout()).hasSeconds(0);
+    assertThat(workerCfg.getMessageName()).isEqualTo("msg");
+    assertThat(workerCfg.isSendMessage()).isTrue();
+    assertThat(workerCfg.getCorrelationKeyVariableName()).isEqualTo("var");
   }
 }

--- a/zeebe/benchmarks/project/src/test/resources/different-application.conf
+++ b/zeebe/benchmarks/project/src/test/resources/different-application.conf
@@ -31,5 +31,8 @@ app {
     # if 0, timeout defaults to completionDelay * 6
     timeout = 0
     # timeout = 1800ms
+    sendMessage = true
+    messageName = "msg"
+    correlationKeyVariableName = "var"
   }
 }


### PR DESCRIPTION
## Problem Description

In our realistic benchmarks we need to complete receive tasks and message catch events, with messages that have a special correlation key, based on PI payload.

Before these catch events, a normal send task exists to symbolically send a message to a different system and after that, we want to receive as message again.

We can mimic this with a worker completing the send task and also publish a message
for the follow-up receive task.

The correlation key must be unique and match to the process instance otherwise
it will not delivered, we need to get the correlation key out of the PI payload
which we get in the SendWorker for example.

![2024-09-04_15-47](https://github.com/user-attachments/assets/7b2edaa1-bd63-456e-a96a-b7fbdcdb8213)
![2024-09-04_15-48](https://github.com/user-attachments/assets/0d54d24f-c2c1-458c-a1d6-a08b47e24189)


## Changes

This PR adds a new feature to the worker application to send messages during the job completion. For the to published message, a name, and a variable name can be specified. The variable name is used to resolve the correlation key, which should be part of the job payload.

### Related changes

Adjusted the process model to make the correlation key calculation key simpler, so only one variable needs to be specified in the worker config. CorrelationKey is pre-calculated in the model as own variable.

Remodeled the process model a bit, in a sense that the multi-instance has now moved to the expanded sub-process, including the DMN. As the fraud detection needs to be done per vendor, and in the payload we have different vendors (per dispute item). This allows furthermore us to go the happy path in the model more easily.

![2024-09-04_16-02](https://github.com/user-attachments/assets/1f91c215-3d9f-4e90-944e-b53f7945a239)


### Other changes

 * Add some more logging in the worker to observe the message publishing
 * Add the missing user task form, that is used by the realistic process model
 * 

<!-- Describe the goal and purpose of this PR. -->

## Example

I have executed the changes in a benchmark to verify everything works as expected. The worker config can look like this:

```yaml
    #### - here we need to send a message from the worker -
  dispute-process-request-proof-from-vendor:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 3
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "dispute_process_request_proof_from_vendor"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.dispute-request-documents.message enables sending a message from a worker
    message:
      name: "dispute_process_refund_approved"
      correlationVariable : "correlationKey"
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi
```

Deploying such allows us to run a more realistic benchmark.

<details><summary>Complete values file</summary>

```yaml

# Default values for Zeebe Benchmark Helm chart.
# This is a YAML-formatted file.
# Declare variables to be passed into your templates.

# The values file follows helm best practices https://helm.sh/docs/chart_best_practices/values/
#
# This means:
#   * Variable names should begin with a lowercase letter, and words should be separated with camelcase.
#   * Every defined property in values.yaml should be documented. The documentation string should begin with the name of the property that it describes, and then give at least a one-sentence description
#
# Furthermore, we try to apply the following pattern: # [VarName] [conjunction] [definition]
#
# VarName:
#
#  * In the documentation the variable name is started with a big letter, similar to kubernetes resource documentation.
#  * If the variable is part of a subsection/object we use a json path expression (to make it more clear where the variable belongs to).
#    The root (chart name) is omitted (e.g. zeebe). This is useful for using --set in helm.
#
# Conjunction:
#   * [defines] for mandatory configuration
#   * [can be used] for optional configuration
#   * [if true] for toggles
#   * [configuration] for section/group of variables

# Global configuration for variables which can be accessed by all sub charts
global:
  # Disable global ingress
  ingress:
    enabled: false
  # Image configuration to be used in each sub chart
  image:
    # Image.repository defines the repository from which to fetch the docker images
    repository: "gcr.io/zeebe-io"
    # Image.tag defines the tag / version which should be used in the chart
    tag: SNAPSHOT
    # Image.pullPolicy defines the image pull policy which should be used https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
    pullPolicy: Always
  # Disable Identity completely; both this flag and `camunda-platform.identity.enabled` are required.
  identity:
    auth:
      enabled: false

# DEPRECATED worker configuration for the to be deployed worker application
worker:
  # Worker.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
  replicas: 0 # disabled per default as it is deprecated
  # Worker.benchmark.capacity defines how many jobs the worker should activate and work on
  capacity: 60

# Workers configuration for the to be deployed worker application
#        => New way to deploy workers <=
workers:
  # Workers.benchmark defines the configuration for the default benchmark worker
  # See below if you want additional workers
  dispute-request-documents:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 1
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "dispute_request_documents"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi

  #####
  extract-data-from-document:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 1
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "extract_data_from_document"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi


    ##### - seems to be referenced twice
    #### - here we need to send a message from the worker -
  dispute-process-request-proof-from-vendor:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 3
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "dispute_process_request_proof_from_vendor"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.dispute-request-documents.message enables sending a message from a worker
    message:
      name: "dispute_process_refund_approved"
      correlationVariable : "correlationKey"
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi

  #####
  refunding:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 3
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "refunding"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi

    #####
  dispute-successful:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 1
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "dispute_successful"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi

    #####
  customer-notification:
    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
    replicas: 1
    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
    capacity: 60
    # Workers.benchmark.jobType defines the job type which should be used by the worker
    jobType: "customer_notification"
    # Workers.benchmark.payloadPath defines the path (inside the worker app) to the payload resource
    # that should be used to complete the corresponding jobs
    payloadPath: "bpmn/emptyPayload.json"
    # Workers.benchmark.payloadPath defines the delay of the worker before completing a job
    completionDelay: 300ms
    message:
      name: "dispute_process_receive_documents"
      correlationVariable: "correlationKey"
    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
    logLevel: "INFO"
    # Workers.benchmark.resources defines the resources for the benchmark worker
    resources:
      limits:
        cpu: 500m
        memory: 256Mi
      requests:
        cpu: 500m
        memory: 256Mi




  # Workers.benchmark defines the configuration for the default benchmark worker
  # Adding more and different worker can be done via adding a new map like:
  #  benchmark-2:
  #    # Workers.benchmark.replicas defines how many replicas of the benchmark worker should be deployed
  #    replicas: 3
  #    # Workers.benchmark.capacity defines how many jobs the worker should activate and work on
  #    capacity: 60
  #    # Workers.benchmark.jobType defines the job type which should be used by the worker
  #    jobType: "benchmark-2-task"
  #    # Workers.benchmark.logLevel defines the logging level for the benchmark worker
  #    logLevel: "WARN"
  #    # Workers.benchmark.resources defines the resources for the benchmark worker
  #    resources:
  #      limits:
  #        cpu: 500m
  #        memory: 256Mi
  #      requests:
  #        cpu: 500m
  #        memory: 256Mi

# Starter configuration for the to be deployed starter application
starter:
  # Starter.replicas defines how many replicas of the application should be deployed
  replicas: 1
  # Starter.rate defines with which rate process instances should be created by the starter
  rate: 1
  # Starter.logLevel defines the logging level for the benchmark starter
  logLevel: "INFO"
  # Starter.processId defines the process ID, that should be used for creating new process instances
  processId: "bankDisputeHandling"
  # Starter.payloadPath defines the path (inside the starter app) to the payload resource
  # that should be used to create the corresponding process instance
  payloadPath: "bpmn/realistic/realisticPayload.json"
  # Starter.bpmnXmlPath defines the path (inside the starter app) to the main bpmn XML resource that should be deployed
  bpmnXmlPath: "bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn"
  # Starter.extraBpmnModels can be used to specify paths (inside the starter app) to extra resources that should be deployed
  extraResources: ["bpmn/realistic/refundingProcess.bpmn", "bpmn/realistic/determineFraudRatingConfidence.dmn"]
  # Starter.businessKey can be used to specify a businessKey variable, inside a unique identifier is stored for
  # each created process instance
  businessKey: "customerId"

# Publisher configuration for the to be deployed publisher application
publisher:
  # Publisher.replicas defines how many replicas of the application should be deployed
  replicas: 0
  # Publisher.rate defines with which rate message should be published
  rate: 25

# Timer configuration for the to be deployed timer application
timer:
  # Timer.replicas defines how many replicas of the application should be deployed
  replicas: 0
  # Timer.rate defines with which rate process instances with timers should be created
  rate: 25

# LeaderBalancing configuration for the auto rebalancing feature, which allows to rebalance periodically the zeebe cluster
# For more details see https://docs.camunda.io/docs/self-managed/zeebe-deployment/operations/rebalancing/
leaderBalancing:
  # LeaderBalancing.enabled if true, enables the auto leader rebalancing
  enabled: true
  # LeaderBalancing.schedule defines the schedule of the auto leader rebalancing feature.
  schedule: "*/15 * * * *"

# Zeebe configuration to configure Zeebe and Gateway
zeebe:
  # Zeebe.config can be used to configure Zeebe Broker and Gateway additional without the need of overwriting all
  # environment variables from the dependency chart.
  # Allows to set configurations via --set, like --set zeebe.config.zeebe.broker.cluster.replicationFactor=3
  config:
    zeebe.gateway.monitoring.enabled: "true"
    zeebe.gateway.threads.managementThreads: "1"
    zeebe.broker.experimental.consistencyChecks.enablePreconditions: "true"
    zeebe.broker.experimental.consistencyChecks.enableForeignKeyChecks: "true"
    zeebe.broker.executionMetricsExporterEnabled: "true"
    zeebe.broker.data.diskUsageCommandWatermark: "0.8"
    zeebe.broker.data.diskUsageReplicationWatermark: "0.9"
    # Configure index suffix with hour pattern, so we create every hour a new index
    # such that ILM can clean it up quickly
    zeebe.broker.exporters.elasticsearch.args.index.indexSuffixDatePattern: "yyyy-MM-dd_HH"
    # Configure a rate limit for all writes, so that we can visualize flow control metrics.
    zeebe.broker.flowControl.write.enabled: "true"
    zeebe.broker.flowControl.write.limit: 4000
  # Zeebe.profiling configuration for pyroscope profiling
  profiling:
    # Zeebe.profiling.enabled if true, enables the pyroscope profiling
    enabled: false

camunda-platform:
  enabled: true
  global:
    image:
      tag: SNAPSHOT
      pullPolicy: Always

  zeebe:
    # Image configuration to configure the zeebe image specifics
    image:
      # Image.repository defines which image repository to use
      repository: camunda/zeebe
      tag: SNAPSHOT
    # ClusterSize defines the amount of brokers (=replicas), which are deployed via helm
    clusterSize: "3"
    # PartitionCount defines how many zeebe partitions are set up in the cluster
    partitionCount: "3"
    # ReplicationFactor defines how each partition is replicated, the value defines the number of nodes
    replicationFactor: "3"

    # CpuThreadCount defines how many threads can be used for the processing on each broker pod
    cpuThreadCount: 3
    # IoThreadCount defines how many threads can be used for the exporting on each broker pod
    ioThreadCount: 3

    # ContainerSecurityContext defines the security options the Zeebe broker container should be run with
    containerSecurityContext:
      ## @param securityContext.allowPrivilegeEscalation
      allowPrivilegeEscalation: true
      ## @param securityContext.privileged
      privileged: true
      ## @param securityContext.readOnlyRootFilesystem
      readOnlyRootFilesystem: true
      ## @param securityContext.runAsUser
      runAsUser: 1000
      capabilities:
        add: [ "NET_ADMIN" ]

    # JavaOpts can be used to set java options for the zeebe brokers
    javaOpts: >-
      -XX:MaxRAMPercentage=25.0
      -XX:+ExitOnOutOfMemoryError
      -XX:+HeapDumpOnOutOfMemoryError
      -XX:HeapDumpPath=/usr/local/zeebe/data
      -XX:ErrorFile=/usr/local/zeebe/data/zeebe_error%p.log
      -Xlog:gc*:file=/usr/local/zeebe/data/gc.log:time:filecount=7,filesize=8M

    # Zeebe config
    extraVolumes:
      - name: benchmark-config
        configMap:
          name: benchmark-config
          defaultMode: 0754
      - name: pyroscope
        emptyDir: {}

    extraVolumeMounts:
      - name: benchmark-config
        mountPath: /usr/local/zeebe/config/benchmark-config.yaml
        subPath: benchmark-config.yaml
      - name: pyroscope
        mountPath: /pyroscope

    extraInitContainers:
      - name: pyroscope
        image: alpine
        command: ['wget', 'https://github.com/pyroscope-io/pyroscope-java/releases/latest/download/pyroscope.jar', '-O', '/pyroscope/pyroscope.jar']
        volumeMounts:
          - name: pyroscope
            mountPath: /pyroscope
        # We have to configure the security context to not run as Root
        securityContext:
          ## @param securityContext.allowPrivilegeEscalation
          allowPrivilegeEscalation: false
          ## @param securityContext.privileged
          privileged: false
          ## @param securityContext.readOnlyRootFilesystem
          readOnlyRootFilesystem: true
          ## @param securityContext.runAsUser
          runAsUser: 1000

    # Retention can be used to define the data in Elasticsearch (ILM).
    retention:
      ## @param zeebe.retention.enabled if true, the ILM Policy is created and applied to the index templates.
      enabled: true
      ## @param zeebe.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
      minimumAge: 10m # set it to a higher value if we run with operate, so operate has enough time to consume the data

    # Environment variables
    env:
      - name: K8S_NAMESPACE
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      - name: K8S_NAME
        valueFrom:
          fieldRef:
            fieldPath: metadata.name
      # Enable JSON logging for google cloud stackdriver
      - name: ZEEBE_LOG_APPENDER
        value: Stackdriver
      - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
        value: zeebe
      - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      - name: ATOMIX_LOG_LEVEL
        value: INFO
      - name: ZEEBE_LOG_LEVEL
        value: DEBUG
      - name: PYROSCOPE_SERVER_ADDRESS
        value: "http://pyroscope.pyroscope.svc.cluster.local:4040"
      - name: PYROSCOPE_APPLICATION_NAME
        value: "io.camunda.zeebe.broker"
      - name: PYROSCOPE_LOG_LEVEL
        value: "debug"
      - name: PYROSCOPE_FORMAT
        value: "jfr"
      - name: PYROSCOPE_PROFILER_EVENT
        value: "cpu"
      - name: PYROSCOPE_PROFILER_ALLOC
        value: "0"
      - name: PYROSCOPE_PROFILER_LOCK
        value: "0"
      - name: PYROSCOPE_LABELS
        value: "namespace=$(K8S_NAMESPACE), pod=$(K8S_NAME)"
      # To be able to load a separate/additional configuration
      # See https://github.com/camunda/camunda-platform-helm/issues/2197
      - name: SPRING_CONFIG_ADDITIONALLOCATION
        value: "/usr/local/zeebe/config/benchmark-config.yaml"
      - name: JAVA_OPTS
        valueFrom:
          configMapKeyRef:
            name: zeebe-config
            key: java-opts
            optional: true

    # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limitsS
    resources:
      limits:
        cpu: 1350m
        memory: 4Gi
      requests:
        cpu: 1350m
        memory: 4Gi

    nodeSelector:
      cloud.google.com/gke-nodepool: n2-standard-2

    # PvcAccessModes can be used to configure the persistent volume claim access mode https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
    pvcAccessMode: [ "ReadWriteOnce" ]
    # PvcSize defines the persistent volume claim size, which is used by each broker pod https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims
    pvcSize: 32Gi
    # PvcStorageClassName can be used to set the storage class name which should be used by the persistent volume claim. It is recommended to use a storage class, which is backed with a SSD.
    pvcStorageClassName: ssd

  zeebeGateway:
    # Replicas defines how many standalone gateways are deployed
    replicas: 2

    # Image configuration to configure the zeebe-gateway image specifics
    image:
      # Image.repository defines which image repository to use
      repository: camunda/zeebe
      tag: SNAPSHOT
    # LogLevel defines the log level which is used by the gateway
    logLevel: debug

    extraVolumes:
      - name: benchmark-config
        configMap:
          name: benchmark-config
          defaultMode: 0754
      - name: pyroscope
        emptyDir: {}

    extraVolumeMounts:
      - name: pyroscope
        mountPath: /pyroscope
      - name: benchmark-config
        mountPath: /usr/local/zeebe/config/benchmark-config.yaml
        subPath: benchmark-config.yaml

    extraInitContainers:
      - name: pyroscope
        image: alpine
        command: ['wget', 'https://github.com/pyroscope-io/pyroscope-java/releases/latest/download/pyroscope.jar', '-O', '/pyroscope/pyroscope.jar']
        volumeMounts:
          - name: pyroscope
            mountPath: /pyroscope
        securityContext:
          ## @param zeebe.containerSecurityContext.allowPrivilegeEscalation
          allowPrivilegeEscalation: false
          ## @param zeebe.containerSecurityContext.privileged
          privileged: false
          ## @param zeebe.containerSecurityContext.readOnlyRootFilesystem
          readOnlyRootFilesystem: true
          ## @param zeebe.containerSecurityContext.runAsUser
          runAsUser: 1000

    # Env can be used to set extra environment variables in each gateway container
    env:
      - name: ZEEBE_LOG_APPENDER
        value: Stackdriver
      - name: ZEEBE_LOG_STACKDRIVER_SERVICENAME
        value: zeebe
      - name: ZEEBE_LOG_STACKDRIVER_SERVICEVERSION
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace
      - name: ATOMIX_LOG_LEVEL
        value: INFO
      - name: ZEEBE_LOG_LEVEL
        value: DEBUG
      - name: PYROSCOPE_SERVER_ADDRESS
        value: "http://pyroscope.pyroscope.svc.cluster.local:4040"
      - name: PYROSCOPE_APPLICATION_NAME
        value: "io.camunda.zeebe.gateway"
      - name: PYROSCOPE_LOG_LEVEL
        value: "debug"
      - name: PYROSCOPE_FORMAT
        value: "jfr"
      - name: PYROSCOPE_PROFILER_EVENT
        value: "cpu"
      - name: PYROSCOPE_PROFILER_ALLOC
        value: "0"
      - name: PYROSCOPE_PROFILER_LOCK
        value: "0"
      - name: PYROSCOPE_LABELS
        value: "namespace=$(K8S_NAMESPACE), pod=$(K8S_NAME)"
      # To be able to load a separate/additional configuration
      # See https://github.com/camunda/camunda-platform-helm/issues/2197
      - name: SPRING_CONFIG_ADDITIONALLOCATION
        value: "/usr/local/zeebe/config/benchmark-config.yaml"
      - name: JAVA_OPTS
        valueFrom:
          configMapKeyRef:
            name: zeebe-config
            key: java-opts
            optional: true

    # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
    resources:
      limits:
        cpu: 450m
        memory: 1Gi
      requests:
        cpu: 450m
        memory: 1Gi

  operate:
    enabled: false
    image:
      tag: SNAPSHOT
    # Resources configuration to set request and limit configuration for the container https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits
    resources:
      requests:
        cpu: 600m
        memory: 400Mi
      limits:
        cpu: 2000m
        memory: 2Gi

    # Retention can be used to define the data in Elasticsearch (ILM).
    retention:
      ## @param operate.retention.enabled if true, the ILM Policy is created and applied to the index templates.
      enabled: true
      ## @param operate.retention.minimumAge defines how old the data must be, before the data is deleted as a duration.
      minimumAge: 30m # there is no need to keep data longer for our benchmarks, otherwise we will fill up ES pretty quick

    env:
      - name: OPERATE_LOG_APPENDER
        value: Stackdriver
      - name: OPERATE_LOG_STACKDRIVER_SERVICENAME
        value: operate
      - name: OPERATE_LOG_STACKDRIVER_SERVICEVERSION
        valueFrom:
          fieldRef:
            fieldPath: metadata.namespace  

    logging:
      level:
        io.camunda.operate: INFO

  tasklist:
    enabled: false

  identity:
    enabled: false

  identityKeycloak:
    enabled: false

  optimize:
    enabled: false

  connectors:
    enabled: false
  
  webModeler:
    enabled: false
  
  postgresql:
    enabled: false

  # ELASTIC
  elasticsearch:
    enabled: true
    imageTag: 8.9.2

    master:
      fullnameOverride: elastic
      nameOverride: elastic
      # Number of master-elegible replicas to deploy
      replicaCount: 3
      pdb:
        minAvailable: 2
      # Elasticsearch master-eligible node heap size.
      # Will be converted to -Xms3g
      heapSize: 3g
      # The resources configurations for elasticsearch containers
      resources:
        requests:
          cpu: 1
          memory: 3Gi
        limits:
          cpu: 2
          memory: 6Gi
      persistence:
        # Persistent Volume Storage Class
        storageClass: "ssd"
        # Persistent Volume Size
        size: 16Gi
        # Persistent Volume Access Modes
        accessModes: [ "ReadWriteOnce" ]

  # Change these settings to configure a different way to collect metrics
  prometheusServiceMonitor:
    enabled: true
    labels:
      release: monitoring
    scrapeInterval: 30s

prometheus-elasticsearch-exporter:
  es:
    ## Address (host and port) of the Elasticsearch node we should connect to.
    ## This could be a local node (localhost:9200, for instance), or the address
    ## of a remote Elasticsearch server. When basic auth is needed,
    ## specify as: <proto>://<user>:<password>@<host>:<port>. e.g., http://admin:pass@localhost:9200.
    ##
    uri: "http://{{ .Release.Name }}-elasticsearch:9200"
  serviceMonitor:
    ## If true, a ServiceMonitor CRD is created for a prometheus operator
    ## https://github.com/coreos/prometheus-operator
    ##
    enabled: true
    # Labels used by the service monitor, specific to our prometheus installation
    labels:
      release: monitoring
```
</details>


![2024-09-04_13-41](https://github.com/user-attachments/assets/b9c3300d-9731-4ca5-b620-4233603b4a51)
![2024-09-04_13-42](https://github.com/user-attachments/assets/4a785e24-8da9-443e-92ca-4ed46d67578a)
![2024-09-04_13-42_1](https://github.com/user-attachments/assets/7d586b20-7a59-4b70-9c65-e1be079ae801)

## Related issues

related https://github.com/camunda/camunda/issues/21472

