### PR TITLE
fix: Disable graphql introspection in Tasklist

### DIFF
--- a/dist/src/main/resources/application-tasklist.properties
+++ b/dist/src/main/resources/application-tasklist.properties
@@ -31,3 +31,7 @@ camunda.identity.type=AUTH0
 camunda.identity.baseUrl=${camunda.tasklist.identity.baseUrl:${CAMUNDA_TASKLIST_IDENTITY_BASEURL:}}
 camunda.identity.issuer=${camunda.tasklist.identity.issuerUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL:}}
 camunda.identity.issuerBackendUrl=${camunda.tasklist.identity.issuerBackendUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL:}}
+
+#---
+spring.config.activate.on-profile=dev
+camunda.tasklist.graphql-introspection-enabled=true

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -246,6 +246,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.graphql-java</groupId>
+      <artifactId>graphql-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/IntrospectionDisabledIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/IntrospectionDisabledIT.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.graphql;
+
+import com.graphql.spring.boot.test.GraphQLTestTemplate;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import org.assertj.core.api.Condition;
+import org.assertj.core.data.Index;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class IntrospectionDisabledIT extends TasklistIntegrationTest {
+
+  @Autowired private GraphQLTestTemplate graphQLTestTemplate;
+
+  @Test
+  void schemaIntrospectionShouldBeDisabled() throws Exception {
+    // given
+    final String schemaIntrospectionQuery = "{ __schema { types { name } } }";
+
+    // when
+    final var response = graphQLTestTemplate.postMultipart(schemaIntrospectionQuery, "{}");
+
+    // then
+    response
+        .assertThatListOfErrors()
+        .has(
+            new Condition<>(e -> "GraphQL introspection is disabled".equals(e.getMessage()), null),
+            Index.atIndex(0));
+    response.assertThatDataField().isNull();
+  }
+
+  @Test
+  void typeIntrospectionShouldBeDisabled() throws Exception {
+    // given
+    final String typeIntrospectionQuery = "{ __type(name: \"Query\") { name fields { name } } }";
+
+    // when
+    final var response = graphQLTestTemplate.postMultipart(typeIntrospectionQuery, "{}");
+
+    // then
+    response
+        .assertThatListOfErrors()
+        .has(
+            new Condition<>(e -> "GraphQL introspection is disabled".equals(e.getMessage()), null),
+            Index.atIndex(0));
+    response.assertThatDataField().isNull();
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/IntrospectionEnabledIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/IntrospectionEnabledIT.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.graphql;
+
+import com.graphql.spring.boot.test.GraphQLTestTemplate;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import io.camunda.tasklist.util.TestApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(
+    classes = TestApplication.class,
+    properties = {TasklistProperties.PREFIX + ".graphql-introspection-enabled = true"},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class IntrospectionEnabledIT extends TasklistIntegrationTest {
+
+  @Autowired private GraphQLTestTemplate graphQLTestTemplate;
+
+  @Test
+  void schemaIntrospectionShouldBeEnabled() throws Exception {
+    // given
+    final String schemaIntrospectionQuery = "{ __schema { types { name } } }";
+
+    // when
+    final var response = graphQLTestTemplate.postMultipart(schemaIntrospectionQuery, "{}");
+
+    // then
+    response.assertThatNoErrorsArePresent();
+    response.assertThatDataField().isNotNull();
+  }
+
+  @Test
+  void typeIntrospectionShouldBeEnabled() throws Exception {
+    // given
+    final String typeIntrospectionQuery = "{ __type(name: \"Query\") { name fields { name } } }";
+
+    // when
+    final var response = graphQLTestTemplate.postMultipart(typeIntrospectionQuery, "{}");
+
+    // then
+    response.assertThatNoErrorsArePresent();
+    response.assertThatDataField().isNotNull();
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/DisableIntrospectionInstrumentation.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/DisableIntrospectionInstrumentation.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.graphql;
+
+import graphql.ExecutionResult;
+import graphql.execution.ExecutionContext;
+import graphql.execution.instrumentation.InstrumentationContext;
+import graphql.execution.instrumentation.InstrumentationState;
+import graphql.execution.instrumentation.SimplePerformantInstrumentation;
+import graphql.execution.instrumentation.parameters.InstrumentationExecuteOperationParameters;
+import graphql.language.OperationDefinition;
+import graphql.language.OperationDefinition.Operation;
+
+public class DisableIntrospectionInstrumentation extends SimplePerformantInstrumentation {
+
+  @Override
+  public InstrumentationContext<ExecutionResult> beginExecuteOperation(
+      final InstrumentationExecuteOperationParameters parameters,
+      final InstrumentationState state) {
+    final ExecutionContext executionContext = parameters.getExecutionContext();
+    final OperationDefinition operationDefinition = executionContext.getOperationDefinition();
+    if (operationDefinition != null && operationDefinition.getOperation() == Operation.QUERY) {
+      if (executionContext.getExecutionInput() != null
+          && isIntrospectionQuery(executionContext.getExecutionInput().getQuery())) {
+        throw new UnsupportedOperationException("GraphQL introspection is disabled");
+      }
+    }
+    return super.beginExecuteOperation(parameters, state);
+  }
+
+  private boolean isIntrospectionQuery(final String query) {
+    return query != null && query.contains("__schema") || query.contains("__type");
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/TasklistGraphQLConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/TasklistGraphQLConfiguration.java
@@ -9,8 +9,10 @@ package io.camunda.tasklist.webapp.graphql;
 
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.execution.instrumentation.Instrumentation;
 import graphql.kickstart.execution.config.ObjectMapperProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,5 +26,14 @@ public class TasklistGraphQLConfiguration {
     injectableValues.addValue(ObjectMapper.class, objectMapper);
     objectMapper.setInjectableValues(injectableValues);
     return () -> objectMapper;
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      value = "camunda.tasklist.graphql-introspection-enabled",
+      havingValue = "false",
+      matchIfMissing = true)
+  public Instrumentation disableIntrospectionInstrumentation() {
+    return new DisableIntrospectionInstrumentation();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Since the replacement of `graphql-java-tools` use by `graphql-java-annotations`, we cannot use anymore `graphql.tools.introspection-enabled` property to disable graphql introspection.

In this PR, I use [Instrumentation](https://www.graphql-java.com/documentation/instrumentation/) to catch and forbid introspection queries if `camunda.tasklist.graphql-introspection-enabled` is not set to `true`

`camunda.tasklist.graphql-introspection-enabled` is set to `true` in `dev` spring profile

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20672
