### PR TITLE
feat: engine uses dynamic routing info

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
@@ -63,7 +64,7 @@ public final class BpmnProcessors {
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
-      final int partitionsCount,
+      final RoutingInfo routingInfo,
       final InstantSource clock) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         processingState.getProcessMessageSubscriptionState();
@@ -105,7 +106,7 @@ public final class BpmnProcessors {
         bpmnBehaviors,
         commandDistributionBehavior,
         partitionId,
-        partitionsCount);
+        routingInfo);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -247,7 +248,7 @@ public final class BpmnProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
-      final int partitionsCount) {
+      final RoutingInfo routingInfo) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
@@ -257,7 +258,7 @@ public final class BpmnProcessors {
             bpmnBehaviors,
             commandDistributionBehavior,
             partitionId,
-            partitionsCount));
+            routingInfo));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.engine.processing.usertask.UserTaskEventProcessors;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
@@ -72,11 +73,14 @@ public final class EngineProcessors {
       final JobStreamer jobStreamer) {
 
     final var processingState = typedRecordProcessorContext.getProcessingState();
+    final var keyGenerator = processingState.getKeyGenerator();
+    final var routingInfo =
+        RoutingInfo.dynamic(
+            processingState.getRoutingState(), RoutingInfo.forStaticPartitions(partitionsCount));
     final var scheduledTaskStateFactory =
         typedRecordProcessorContext.getScheduledTaskStateFactory();
     final var writers = typedRecordProcessorContext.getWriters();
-    final TypedRecordProcessors typedRecordProcessors =
-        TypedRecordProcessors.processors(processingState.getKeyGenerator(), writers);
+    final var typedRecordProcessors = TypedRecordProcessors.processors(keyGenerator, writers);
 
     typedRecordProcessors.withListener(processingState);
 
@@ -101,7 +105,7 @@ public final class EngineProcessors {
             processingState,
             writers,
             subscriptionCommandSender,
-            partitionsCount,
+            routingInfo,
             timerChecker,
             jobStreamer,
             jobMetrics,
@@ -112,7 +116,7 @@ public final class EngineProcessors {
         new CommandDistributionBehavior(
             writers,
             typedRecordProcessorContext.getPartitionId(),
-            partitionsCount,
+            routingInfo,
             interPartitionCommandSender);
 
     final var deploymentDistributionCommandSender =
@@ -125,7 +129,7 @@ public final class EngineProcessors {
         typedRecordProcessors,
         writers,
         deploymentDistributionCommandSender,
-        processingState.getKeyGenerator(),
+        keyGenerator,
         featureFlags,
         commandDistributionBehavior,
         config,
@@ -153,7 +157,7 @@ public final class EngineProcessors {
             timerChecker,
             commandDistributionBehavior,
             partitionId,
-            partitionsCount,
+            routingInfo,
             clock);
 
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
@@ -197,25 +201,13 @@ public final class EngineProcessors {
         typedRecordProcessors, processingState, bpmnBehaviors, writers);
 
     UserEventProcessors.addUserProcessors(
-        processingState.getKeyGenerator(),
-        typedRecordProcessors,
-        processingState,
-        writers,
-        commandDistributionBehavior);
+        keyGenerator, typedRecordProcessors, processingState, writers, commandDistributionBehavior);
 
     ClockProcessors.addClockProcessors(
-        typedRecordProcessors,
-        writers,
-        processingState.getKeyGenerator(),
-        clock,
-        commandDistributionBehavior);
+        typedRecordProcessors, writers, keyGenerator, clock, commandDistributionBehavior);
 
     AuthorizationEventProcessors.addAuthorizationProcessors(
-        processingState.getKeyGenerator(),
-        typedRecordProcessors,
-        processingState,
-        writers,
-        commandDistributionBehavior);
+        keyGenerator, typedRecordProcessors, processingState, writers, commandDistributionBehavior);
 
     return typedRecordProcessors;
   }
@@ -224,7 +216,7 @@ public final class EngineProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final int partitionsCount,
+      final RoutingInfo routingInfo,
       final DueDateTimerChecker timerChecker,
       final JobStreamer jobStreamer,
       final JobMetrics jobMetrics,
@@ -236,7 +228,7 @@ public final class EngineProcessors {
         jobMetrics,
         decisionBehavior,
         subscriptionCommandSender,
-        partitionsCount,
+        routingInfo,
         timerChecker,
         jobStreamer,
         clock);
@@ -252,7 +244,7 @@ public final class EngineProcessors {
       final DueDateTimerChecker timerChecker,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
-      final int partitionsCount,
+      final RoutingInfo routingInfo,
       final InstantSource clock) {
     return BpmnProcessors.addBpmnStreamProcessor(
         processingState,
@@ -264,7 +256,7 @@ public final class EngineProcessors {
         writers,
         commandDistributionBehavior,
         partitionId,
-        partitionsCount,
+        routingInfo,
         clock);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.processing.variable.VariableStateEvaluationContextLookup;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import java.time.InstantSource;
 
 public final class BpmnBehaviorsImpl implements BpmnBehaviors {
@@ -56,7 +57,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
       final JobMetrics jobMetrics,
       final DecisionBehavior decisionBehavior,
       final SubscriptionCommandSender subscriptionCommandSender,
-      final int partitionsCount,
+      final RoutingInfo routingInfo,
       final DueDateTimerChecker timerChecker,
       final JobStreamer jobStreamer,
       final InstantSource clock) {
@@ -78,7 +79,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             writers.state(),
             writers.sideEffect(),
             timerChecker,
-            partitionsCount,
+            routingInfo,
             clock);
 
     eventTriggerBehavior =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -27,8 +27,8 @@ import io.camunda.zeebe.engine.state.immutable.SignalSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
-import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -48,7 +48,7 @@ public final class CatchEventBehavior {
 
   private final ExpressionProcessor expressionProcessor;
   private final SubscriptionCommandSender subscriptionCommandSender;
-  private final int partitionsCount;
+  private final RoutingInfo routingInfo;
   private final StateWriter stateWriter;
   private final SideEffectWriter sideEffectWriter;
 
@@ -73,13 +73,13 @@ public final class CatchEventBehavior {
       final StateWriter stateWriter,
       final SideEffectWriter sideEffectWriter,
       final DueDateTimerChecker timerChecker,
-      final int partitionsCount,
+      final RoutingInfo routingInfo,
       final InstantSource clock) {
     this.expressionProcessor = expressionProcessor;
     this.subscriptionCommandSender = subscriptionCommandSender;
     this.stateWriter = stateWriter;
     this.sideEffectWriter = sideEffectWriter;
-    this.partitionsCount = partitionsCount;
+    this.routingInfo = routingInfo;
 
     timerInstanceState = processingState.getTimerState();
     processMessageSubscriptionState = processingState.getProcessMessageSubscriptionState();
@@ -294,8 +294,7 @@ public final class CatchEventBehavior {
     final DirectBuffer bpmnProcessId = cloneBuffer(context.getBpmnProcessId());
     final long elementInstanceKey = context.getElementInstanceKey();
 
-    final int subscriptionPartitionId =
-        SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionsCount);
+    final int subscriptionPartitionId = routingInfo.partitionForCorrelationKey(correlationKey);
 
     subscription.setSubscriptionPartitionId(subscriptionPartitionId);
     subscription.setMessageName(messageName);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -25,9 +25,9 @@ public final class DbRoutingState implements MutableRoutingState {
    */
   private static final String CURRENT_KEY = "CURRENT";
 
-  private final ColumnFamily<DbString, RoutingInfo> columnFamily;
+  private final ColumnFamily<DbString, PersistedRoutingInfo> columnFamily;
   private final DbString key = new DbString();
-  private final RoutingInfo currentRoutingInfo = new RoutingInfo();
+  private final PersistedRoutingInfo currentRoutingInfo = new PersistedRoutingInfo();
 
   public DbRoutingState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/PersistedRoutingInfo.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.msgpack.value.IntegerValue;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public class RoutingInfo extends UnpackedObject implements DbValue {
+final class PersistedRoutingInfo extends UnpackedObject implements DbValue {
   private final ArrayProperty<IntegerValue> partitions =
       new ArrayProperty<>("partitions", IntegerValue::new);
   private final EnumProperty<MessageCorrelationStrategy> messageCorrelationStrategy =
@@ -29,7 +29,7 @@ public class RoutingInfo extends UnpackedObject implements DbValue {
   private final IntegerProperty hashModPartitionCount =
       new IntegerProperty("hashModPartitionCount", -1);
 
-  public RoutingInfo() {
+  public PersistedRoutingInfo() {
     super(3);
     declareProperty(partitions)
         .declareProperty(messageCorrelationStrategy)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.routing;
+
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.engine.state.immutable.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
+
+/**
+ * Utility class that holds the current routing information. To be uses everywhere the number of
+ * partitions or message correlation strategy is needed.
+ *
+ * <p>The information always reflects the current persisted routing info from {@link
+ * DbRoutingState}.
+ */
+public interface RoutingInfo {
+  /** Returns the current set of partitions. */
+  Set<Integer> partitions();
+
+  /** Returns the current partition id for the given correlation key. */
+  int partitionForCorrelationKey(final DirectBuffer correlationKey);
+
+  /**
+   * Creates a {@link RoutingInfo} instance for static partitions. This is used when the partitions
+   * are fixed and known at startup. Only relevant for testing.
+   */
+  static RoutingInfo forStaticPartitions(final int partitionCount) {
+    final var partitions =
+        IntStream.rangeClosed(Protocol.START_PARTITION_ID, partitionCount)
+            .boxed()
+            .collect(Collectors.toSet());
+    return new StaticRoutingInfo(partitions, partitionCount);
+  }
+
+  static RoutingInfo dynamic(final RoutingState routingState, final RoutingInfo fallback) {
+    return new DynamicRoutingInfo(routingState, fallback);
+  }
+
+  class StaticRoutingInfo implements RoutingInfo {
+    private final Set<Integer> otherPartitions;
+    private final int partitionCount;
+
+    public StaticRoutingInfo(final Set<Integer> otherPartitions, final int partitionCount) {
+      this.otherPartitions = otherPartitions;
+      this.partitionCount = partitionCount;
+    }
+
+    @Override
+    public Set<Integer> partitions() {
+      return otherPartitions;
+    }
+
+    @Override
+    public int partitionForCorrelationKey(final DirectBuffer correlationKey) {
+      return SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionCount);
+    }
+  }
+
+  /**
+   * Naive implementation that always looks up the routing information from the {@link
+   * RoutingState}. Later on, we might want to cache this information.
+   */
+  class DynamicRoutingInfo implements RoutingInfo {
+    private final RoutingState routingState;
+    private final RoutingInfo fallback;
+
+    public DynamicRoutingInfo(final RoutingState routingState, final RoutingInfo fallback) {
+      this.routingState = routingState;
+      this.fallback = fallback;
+    }
+
+    @Override
+    public Set<Integer> partitions() {
+      if (!routingState.isInitialized()) {
+        return fallback.partitions();
+      }
+      return routingState.partitions();
+    }
+
+    @Override
+    public int partitionForCorrelationKey(final DirectBuffer correlationKey) {
+      if (!routingState.isInitialized()) {
+        return fallback.partitionForCorrelationKey(correlationKey);
+      }
+
+      switch (routingState.messageCorrelation()) {
+        case HashMod(final var partitionCount) -> {
+          return SubscriptionUtil.getSubscriptionPartitionId(correlationKey, partitionCount);
+        }
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
 import io.camunda.zeebe.protocol.Protocol;
@@ -28,7 +29,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
-import java.util.List;
+import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +76,8 @@ class CommandDistributionBehaviorTest {
   void shouldNotDistributeCommandToThisPartition() {
     // given 1 partition
     final var behavior =
-        new CommandDistributionBehavior(writers, 1, 1, mockInterpartitionCommandSender);
+        new CommandDistributionBehavior(
+            writers, 1, RoutingInfo.forStaticPartitions(1), mockInterpartitionCommandSender);
 
     // when distributing to all partitions
     behavior.distributeCommand(key, command);
@@ -92,7 +94,8 @@ class CommandDistributionBehaviorTest {
   void shouldDistributeCommandToAllOtherPartitions() {
     // given 3 partitions and behavior on partition 1
     final var behavior =
-        new CommandDistributionBehavior(writers, 1, 3, mockInterpartitionCommandSender);
+        new CommandDistributionBehavior(
+            writers, 1, RoutingInfo.forStaticPartitions(3), mockInterpartitionCommandSender);
 
     // when distributing to all partitions
     behavior.distributeCommand(key, command);
@@ -122,10 +125,11 @@ class CommandDistributionBehaviorTest {
   void shouldDistributeCommandToSpecificPartitions() {
     // given 4 partitions and behavior on partition 2
     final var behavior =
-        new CommandDistributionBehavior(writers, 2, 4, mockInterpartitionCommandSender);
+        new CommandDistributionBehavior(
+            writers, 2, RoutingInfo.forStaticPartitions(4), mockInterpartitionCommandSender);
 
     // when distributing to partitions 1 and 3
-    behavior.distributeCommand(key, command, List.of(1, 3));
+    behavior.distributeCommand(key, command, Set.of(1, 3));
 
     // then command distribution is started on partition 2 and distributing to all other partitions
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -107,8 +107,9 @@ class CommandDistributionBehaviorTest {
             Record::getIntent,
             r -> r.getValue().getPartitionId(),
             r -> r.getValue().getIntent())
-        .containsExactly(
-            tuple(key, CommandDistributionIntent.STARTED, 1, intent),
+        .hasSize(3)
+        .startsWith(tuple(key, CommandDistributionIntent.STARTED, 1, intent))
+        .contains(
             tuple(key, CommandDistributionIntent.DISTRIBUTING, 2, intent),
             tuple(key, CommandDistributionIntent.DISTRIBUTING, 3, intent));
 
@@ -138,8 +139,9 @@ class CommandDistributionBehaviorTest {
             Record::getIntent,
             r -> r.getValue().getPartitionId(),
             r -> r.getValue().getIntent())
-        .containsExactly(
-            tuple(key, CommandDistributionIntent.STARTED, 2, intent),
+        .hasSize(3)
+        .startsWith(tuple(key, CommandDistributionIntent.STARTED, 2, intent))
+        .contains(
             tuple(key, CommandDistributionIntent.DISTRIBUTING, 1, intent),
             tuple(key, CommandDistributionIntent.DISTRIBUTING, 3, intent));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.util.StreamProcessorRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -67,7 +68,9 @@ public final class MessageStreamProcessorTest {
         spy(new SubscriptionCommandSender(1, mockInterpartitionCommandSender));
     spySubscriptionCommandSender.setWriters(writers);
     spyCommandDistributionBehavior =
-        spy(new CommandDistributionBehavior(writers, 1, 1, mockInterpartitionCommandSender));
+        spy(
+            new CommandDistributionBehavior(
+                writers, 1, RoutingInfo.forStaticPartitions(1), mockInterpartitionCommandSender));
 
     rule.startTypedStreamProcessor(
         (typedRecordProcessors, processingContext) -> {


### PR DESCRIPTION
This replaces all usages of static partition count from the engine. Instead, we now inject `RoutingInfo`.
This new interface is implemented naively at first, by looking up the current routing info from the state or falling back to static partition count. The fallback is needed to not break all engine tests where migrations don't run and `DbRoutingState` is never initialized.
Later on, we might want to optimize the implementation to cache some information and not look up from state every time.
Because caching is difficult to get right (there's no callback to tell us whether the latest state changes were committed or rolled back), I'll leave this for later.

Closes https://github.com/camunda/camunda/issues/21476