### PR TITLE
Migrate signal boundary event subscriptions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.state.immutable.TimerInstanceState;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
+import io.camunda.zeebe.engine.state.signal.SignalSubscription;
 import io.camunda.zeebe.model.bpmn.util.time.Timer;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
@@ -393,17 +394,23 @@ public final class CatchEventBehavior {
         subscriptionKey, SignalSubscriptionIntent.CREATED, signalSubscription);
   }
 
-  private void unsubscribeFromSignalEvents(
-      final long elementInstanceKey, final Predicate<DirectBuffer> elementIdFilter) {
+  public void unsubscribeFromSignalEventsBySubscriptionFilter(
+      final long elementInstanceKey, final Predicate<SignalSubscription> signalSubscriptionFilter) {
     signalSubscriptionState.visitByElementInstanceKey(
         elementInstanceKey,
         subscription -> {
-          final var elementId = subscription.getRecord().getCatchEventIdBuffer();
-          if (elementIdFilter.test(elementId)) {
+          if (signalSubscriptionFilter.test(subscription)) {
             stateWriter.appendFollowUpEvent(
                 subscription.getKey(), SignalSubscriptionIntent.DELETED, subscription.getRecord());
           }
         });
+  }
+
+  public void unsubscribeFromSignalEvents(
+      final long elementInstanceKey, final Predicate<DirectBuffer> elementIdFilter) {
+    unsubscribeFromSignalEventsBySubscriptionFilter(
+        elementInstanceKey,
+        signal -> elementIdFilter.test(signal.getRecord().getCatchEventIdBuffer()));
   }
 
   public void unsubscribeFromTimerEventsByInstanceFilter(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -336,6 +336,7 @@ public final class EventAppliers implements EventApplier {
     register(
         SignalSubscriptionIntent.DELETED,
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
+    register(SignalSubscriptionIntent.MIGRATED, NOOP_EVENT_APPLIER);
     register(SignalIntent.BROADCASTED, NOOP_EVENT_APPLIER);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -125,7 +125,7 @@ public final class EventAppliers implements EventApplier {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
-    register(TimerIntent.MIGRATED, new TimerMigrationApplier(state.getTimerState()));
+    register(TimerIntent.MIGRATED, new TimerInstanceMigratedApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableProcessingState state) {
@@ -338,7 +338,7 @@ public final class EventAppliers implements EventApplier {
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
     register(
         SignalSubscriptionIntent.MIGRATED,
-        new SignalSubscriptionMigrationApplier(state.getSignalSubscriptionState()));
+        new SignalSubscriptionMigratedApplier(state.getSignalSubscriptionState()));
     register(SignalIntent.BROADCASTED, NOOP_EVENT_APPLIER);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -336,7 +336,9 @@ public final class EventAppliers implements EventApplier {
     register(
         SignalSubscriptionIntent.DELETED,
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
-    register(SignalSubscriptionIntent.MIGRATED, NOOP_EVENT_APPLIER);
+    register(
+        SignalSubscriptionIntent.MIGRATED,
+        new SignalSubscriptionMigrationApplier(state.getSignalSubscriptionState()));
     register(SignalIntent.BROADCASTED, NOOP_EVENT_APPLIER);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SignalSubscriptionMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SignalSubscriptionMigratedApplier.java
@@ -12,12 +12,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 
-public class SignalSubscriptionMigrationApplier
+public class SignalSubscriptionMigratedApplier
     implements TypedEventApplier<SignalSubscriptionIntent, SignalSubscriptionRecord> {
 
   private final MutableSignalSubscriptionState signalSubscriptionState;
 
-  public SignalSubscriptionMigrationApplier(
+  public SignalSubscriptionMigratedApplier(
       final MutableSignalSubscriptionState signalSubscriptionState) {
     this.signalSubscriptionState = signalSubscriptionState;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SignalSubscriptionMigrationApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/SignalSubscriptionMigrationApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableSignalSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+
+public class SignalSubscriptionMigrationApplier
+    implements TypedEventApplier<SignalSubscriptionIntent, SignalSubscriptionRecord> {
+
+  private final MutableSignalSubscriptionState signalSubscriptionState;
+
+  public SignalSubscriptionMigrationApplier(
+      final MutableSignalSubscriptionState signalSubscriptionState) {
+    this.signalSubscriptionState = signalSubscriptionState;
+  }
+
+  @Override
+  public void applyState(final long key, final SignalSubscriptionRecord value) {
+    signalSubscriptionState.put(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerInstanceMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerInstanceMigratedApplier.java
@@ -13,11 +13,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 
-public class TimerMigrationApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+public class TimerInstanceMigratedApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
 
   private final MutableTimerInstanceState timerInstanceState;
 
-  public TimerMigrationApplier(final MutableTimerInstanceState timerInstanceState) {
+  public TimerInstanceMigratedApplier(final MutableTimerInstanceState timerInstanceState) {
     this.timerInstanceState = timerInstanceState;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
@@ -480,7 +480,7 @@ public class MigrateProcessInstanceRejectionTest {
 
   @Test
   public void
-      shouldRejectCommandWhenTheMigratedProcessInstanceContainsATaskSubscribedToABoundaryEvent() {
+      shouldRejectCommandWhenTheMigratedProcessInstanceHasATaskSubscribedToAnErrorBoundaryEvent() {
     // given
     final var deployment =
         ENGINE
@@ -744,7 +744,7 @@ public class MigrateProcessInstanceRejectionTest {
 
   @Test
   public void
-      shouldRejectCommandWhenTheTargetProcessDefinitionContainsATaskSubscribedToABoundaryEvent() {
+      shouldRejectCommandWhenTheTargetProcessDefinitionHasATaskSubscribedToAnErrorBoundaryEvent() {
     // given
     final var deployment =
         ENGINE

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
@@ -489,8 +489,8 @@ public class MigrateProcessInstanceRejectionTest {
                 Bpmn.createExecutableProcess("process")
                     .startEvent("start")
                     .serviceTask("A", t -> t.zeebeJobType("A"))
-                    .boundaryEvent("boundary")
-                    .signal("signal")
+                    .boundaryEvent("boundaryEvent")
+                    .error("ERROR")
                     .endEvent()
                     .moveToActivity("A")
                     .endEvent("end")
@@ -505,8 +505,8 @@ public class MigrateProcessInstanceRejectionTest {
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
 
-    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
-        .withSignalName("signal")
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("A")
         .await();
 
     final long targetProcessDefinitionKey =
@@ -532,7 +532,7 @@ public class MigrateProcessInstanceRejectionTest {
         .hasRejectionReason(
             """
                 Expected to migrate process instance '%s' \
-                but active element with id 'A' has one or more boundary events of types 'SIGNAL'. \
+                but active element with id 'A' has one or more boundary events of types 'ERROR'. \
                 Migrating active elements with boundary events of these types is not possible yet."""
                 .formatted(processInstanceKey))
         .hasKey(processInstanceKey);
@@ -760,7 +760,7 @@ public class MigrateProcessInstanceRejectionTest {
                     .startEvent()
                     .serviceTask("A", t -> t.zeebeJobType("A"))
                     .boundaryEvent("boundary")
-                    .signal("signal")
+                    .error("ERROR")
                     .endEvent()
                     .moveToActivity("A")
                     .endEvent("end")
@@ -796,7 +796,7 @@ public class MigrateProcessInstanceRejectionTest {
         .hasRejectionReason(
             """
             Expected to migrate process instance '%s' \
-            but target element with id 'A' has one or more boundary events of types 'SIGNAL'. \
+            but target element with id 'A' has one or more boundary events of types 'ERROR'. \
             Migrating target elements with boundary events of these types is not possible yet."""
                 .formatted(processInstanceKey))
         .hasKey(processInstanceKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSignalSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateSignalSubscriptionTest.java
@@ -1,0 +1,543 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.SignalSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.groups.Tuple;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateSignalSubscriptionTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteSignalMigratedEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceSignalName = helper.getSignalName();
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .signal(sourceSignalName)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary2")
+                    .signal("signal2")
+                    .endEvent("target_process_signal_end")
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.MIGRATED)
+                .withSignalName(sourceSignalName)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary2");
+
+    engine.signal().withSignalName(sourceSignalName).broadcast();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary2")
+        .describedAs("Expect that the signal name is not changed")
+        .hasSignalName(sourceSignalName);
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("target_process_signal_end")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateMultipleSignalBoundaryEvents() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceSignalName1 = helper.getSignalName();
+    final String sourceSignalName2 = helper.getSignalName() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .signal(sourceSignalName1)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .boundaryEvent("boundary2")
+                    .signal(sourceSignalName2)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary3")
+                    .signal("signal3")
+                    .endEvent("target_process_signal_end1")
+                    .moveToActivity("B")
+                    .boundaryEvent("boundary4")
+                    .signal("signal4")
+                    .endEvent("target_process_signal_end2")
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName1)
+        .await();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName2)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary3")
+        .addMappingInstruction("boundary2", "boundary4")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.MIGRATED)
+                .withProcessDefinitionKey(targetProcessDefinitionKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            SignalSubscriptionRecordValue::getBpmnProcessId,
+            SignalSubscriptionRecordValue::getCatchEventId,
+            SignalSubscriptionRecordValue::getSignalName)
+        .describedAs("Expect that the signal boundary events are migrated")
+        .containsExactly(
+            Tuple.tuple(targetProcessId, "boundary3", sourceSignalName1),
+            Tuple.tuple(targetProcessId, "boundary4", sourceSignalName2));
+
+    // only one signal event is broadcasted because signal events are interrupting
+    // broadcasting signal for sourceSignalName2 will have no affect
+    engine.signal().withSignalName(sourceSignalName1).broadcast();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary3")
+        .describedAs("Expect that the signal name is not changed")
+        .hasSignalName(sourceSignalName1);
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("target_process_signal_end1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .skip(1)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary4")
+        .describedAs("Expect that the signal name is not changed")
+        .hasSignalName(sourceSignalName2);
+  }
+
+  @Test
+  public void shouldMigrateOneOfMultipleSignalBoundaryEventsAndDelete() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceSignalName1 = helper.getSignalName();
+    final String sourceSignalName2 = helper.getSignalName() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .signal(sourceSignalName1)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .boundaryEvent("boundary2")
+                    .signal(sourceSignalName2)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary3")
+                    .signal("signal3")
+                    .endEvent("target_process_signal_end")
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName1)
+        .await();
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName2)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary3")
+        .migrate();
+
+    // then
+    // assert that the first boundary event is migrated
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.MIGRATED)
+                .withSignalName(sourceSignalName1)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary3");
+
+    // assert that the second signal event is deleted
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withBpmnProcessId(processId)
+                .withCatchEventId("boundary2")
+                .getFirst())
+        .describedAs("Expect that the second signal boundary event is deleted")
+        .isNotNull();
+
+    engine.signal().withSignalName(sourceSignalName1).broadcast();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .skip(1)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary3")
+        .describedAs("Expect that the signal name is not changed")
+        .hasSignalName(sourceSignalName1);
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("target_process_signal_end")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateOneOfMultipleSignalBoundaryEventsAndCreate() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceSignalName = helper.getSignalName();
+    final String targetSignalName = helper.getSignalName() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .signal(sourceSignalName)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary2")
+                    .signal("signal2")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .boundaryEvent("boundary3")
+                    .signal(targetSignalName)
+                    .endEvent("target_process_signal_end")
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    // assert that the first boundary event is migrated
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.MIGRATED)
+                .withSignalName(sourceSignalName)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the catch event id is updated")
+        .hasCatchEventId("boundary2");
+
+    // assert that the second signal event is created
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+                .skip(1)
+                .getFirst()
+                .getValue())
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasCatchEventId("boundary3")
+        .hasSignalName(targetSignalName);
+
+    engine.signal().withSignalName(targetSignalName).broadcast();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withSignalName(targetSignalName)
+                .getFirst()
+                .getValue())
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasCatchEventId("boundary3");
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("target_process_signal_end")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldResubscribeToSignalEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceSignalName = helper.getSignalName();
+    final String targetSignalName = helper.getSignalName() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .signal(sourceSignalName)
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary2")
+                    .signal(targetSignalName)
+                    .endEvent("target_process_signal_end")
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withSignalName(sourceSignalName)
+        .withCatchEventId("boundary1")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withBpmnProcessId(processId)
+                .withCatchEventId("boundary1")
+                .withSignalName(sourceSignalName)
+                .getFirst())
+        .describedAs("Expect that the signal boundary event in the source is deleted")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+                .withSignalName(targetSignalName)
+                .withCatchEventId("boundary2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the signal boundary event in the target is created")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId);
+
+    engine.signal().withSignalName(targetSignalName).broadcast();
+
+    Assertions.assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withSignalName(targetSignalName)
+                .withCatchEventId("boundary2")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expect that the signal boundary event in the target is deleted after signal broadcast")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId);
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("target_process_signal_end")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isNotNull();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
@@ -17,7 +17,8 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum SignalSubscriptionIntent implements Intent {
   CREATED((short) 0),
-  DELETED((short) 1);
+  DELETED((short) 1),
+  MIGRATED((short) 2);
 
   private final short value;
 
@@ -41,6 +42,8 @@ public enum SignalSubscriptionIntent implements Intent {
         return CREATED;
       case 1:
         return DELETED;
+      case 2:
+        return MIGRATED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

It should be possible to migrate signal boundary event subscriptions, similar to migrating a timers, by providing a mapping instructions for the related signal catch event.

Consider the following example, where an active user task is subscribed to a signal boundary event (interrupting). When migrating the process instance, mapping instructions are provided for both the user task and the signal boundary event. After the instance is migrated, the user task is now subscribed to the attached signal boundary event (non-interrupting).

<img width="389" alt="Screenshot 2024-09-03 at 12 33 12" src="https://github.com/user-attachments/assets/175bba04-7c03-44ed-b307-5b25a211faa0">

We will introduce a new `Signal:MIGRATED` intent to represent the subscription migration.

Subscriptions to signal boundary events for which no mapping instructions are provided will not be migrated. Similar to these cases for timers, we can unsubscribe and subscribe to these catch events.

## Related issues

closes #21862 
