### PR TITLE
feat: add routing info to cluster endpoint response

### DIFF
--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -93,6 +93,55 @@ schemas:
         $ref: "components.yaml#/schemas/CompletedChange"
       pendingChange:
         $ref: "components.yaml#/schemas/TopologyChange"
+      routing:
+        $ref: "components.yaml#/schemas/RoutingState"
+
+  RoutingState:
+    description: The routing state, i.e. where requests are sent to and how messages are correlated
+    type: object
+    required:
+      - version
+      - activePartitions
+      - messageCorrelation
+    properties:
+      version:
+        type: integer
+        format: int64
+        description: The version of the routing state
+        example: 1
+      activePartitions:
+        type: array
+        description: The list of active partitions that accept round-robin requests
+        example: [1, 2, 3]
+        items:
+          type: integer
+          format: int32
+      messageCorrelation:
+        $ref: "components.yaml#/schemas/MessageCorrelation"
+
+
+  MessageCorrelation:
+    description: The message correlation strategy
+    oneOf:
+      - $ref: "components.yaml#/schemas/MessageCorrelationHashMod"
+    discriminator:
+      propertyName: strategy
+      mapping:
+        HashMod: "components.yaml#/schemas/MessageCorrelationHashMod"
+
+  MessageCorrelationHashMod:
+    type: object
+    required:
+      - strategy
+      - partitionCount
+    properties:
+      strategy:
+        type: string
+      partitionCount:
+        type: integer
+        format: int32
+        description: The number of partitions
+        example: 3
 
   CompletedChange:
     type: object

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -20,7 +20,11 @@ import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
 final class ClusterEndpointResponseIT {
-  @TestZeebe static TestStandaloneBroker broker = new TestStandaloneBroker();
+  @TestZeebe
+  static TestStandaloneBroker broker =
+      new TestStandaloneBroker()
+          .withBrokerConfig(
+              cfg -> cfg.getExperimental().getFeatures().setEnablePartitionScaling(true));
 
   @Test
   void shouldMatchExpectedSerialization() throws IOException, InterruptedException {
@@ -30,30 +34,39 @@ final class ClusterEndpointResponseIT {
       final var response = httpClient.send(request, BodyHandlers.ofString());
       assertEquality(
           response.body(),
+          // language=JSON
           """
-                        {
-                          "version": 1,
-                          "brokers": [
-                            {
-                              "id": 0,
-                              "state": "ACTIVE",
-                              "version": 0,
-                              "lastUpdatedAt": "0000-01-01T00:00:00Z",
-                              "partitions": [
-                                {
-                                  "id": 1,
-                                  "state": "ACTIVE",
-                                  "priority": 1,
-                                  "config":{
-                                     "exporting": {
-                                        "exporters": []
-                                     }
-                                  }
-                                }
-                              ]
-                            }
-                          ]
-                        }""");
+          {
+            "version": 1,
+            "brokers": [
+              {
+                "id": 0,
+                "state": "ACTIVE",
+                "version": 0,
+                "lastUpdatedAt": "0000-01-01T00:00:00Z",
+                "partitions": [
+                  {
+                    "id": 1,
+                    "state": "ACTIVE",
+                    "priority": 1,
+                    "config":{
+                       "exporting": {
+                          "exporters": []
+                       }
+                    }
+                  }
+                ]
+              }
+            ],
+            "routing": {
+              "version": 1,
+              "activePartitions": [1],
+              "messageCorrelation": {
+                "strategy": "HashMod",
+                "partitionCount": 1
+              }
+            }
+          }""");
     }
   }
 }


### PR DESCRIPTION
This extends the OpenAPI spec with the new routing state and defines the necessary mapping.

closes https://github.com/camunda/camunda/issues/21920