### PR TITLE
Generate operations for scale request to add new partitions

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -42,6 +42,24 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
+  record ClusterScaleRequest(
+      Optional<Integer> newClusterSize,
+      Optional<Integer> newPartitionCount,
+      Optional<Integer> newReplicationFactor,
+      boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
+  record ClusterPatchRequest(
+      Set<MemberId> membersToAdd,
+      Set<MemberId> membersToRemove,
+      Optional<Integer> newPartitionCount,
+      Optional<Integer> newReplicationFactor,
+      boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
+  record ForceRemoveBrokersRequest(Set<MemberId> membersToRemove, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record ExporterDisableRequest(String exporterId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+public final class ClusterPatchRequestTransformer implements ConfigurationChangeRequest {
+
+  private final Set<MemberId> membersToAdd;
+  private final Set<MemberId> membersToRemove;
+  private final Optional<Integer> newPartitionCount;
+  private final Optional<Integer> newReplicationFactor;
+
+  public ClusterPatchRequestTransformer(
+      final Set<MemberId> membersToAdd,
+      final Set<MemberId> membersToRemove,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor) {
+    this.membersToAdd = membersToAdd;
+    this.membersToRemove = membersToRemove;
+    this.newPartitionCount = newPartitionCount;
+    this.newReplicationFactor = newReplicationFactor;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    // if membersToAdd and membersToRemove have common items, reject the request
+    if (membersToAdd.stream().anyMatch(membersToRemove::contains)) {
+      return Either.left(
+          new ClusterConfigurationRequestFailedException.InvalidRequest(
+              new IllegalArgumentException(
+                  "Cannot add and remove the same member in the same request")));
+    }
+
+    final var newSetOfMembers = new HashSet<>(clusterConfiguration.members().keySet());
+    newSetOfMembers.addAll(membersToAdd);
+    newSetOfMembers.removeAll(membersToRemove);
+
+    return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+        .operations(clusterConfiguration);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformer.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public final class ClusterScaleRequestTransformer implements ConfigurationChangeRequest {
+
+  private final Optional<Integer> newClusterSize;
+  private final Optional<Integer> newPartitionCount;
+  private final Optional<Integer> newReplicationFactor;
+
+  public ClusterScaleRequestTransformer(
+      final Optional<Integer> newClusterSize,
+      final Optional<Integer> newPartitionCount,
+      final Optional<Integer> newReplicationFactor) {
+    this.newClusterSize = newClusterSize;
+    this.newPartitionCount = newPartitionCount;
+    this.newReplicationFactor = newReplicationFactor;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    if (newClusterSize.isEmpty() && newPartitionCount.isEmpty() && newReplicationFactor.isEmpty()) {
+      // Nothing to change
+      return Either.right(List.of());
+    }
+
+    // replicationFactor and partitionCount is validated in the delegated transformer.
+
+    final var newSetOfMembers =
+        IntStream.range(0, newClusterSize.orElse(clusterConfiguration.members().size()))
+            .mapToObj(i -> MemberId.from(String.valueOf(i)))
+            .collect(Collectors.toSet());
+    return new ScaleRequestTransformer(newSetOfMembers, newReplicationFactor, newPartitionCount)
+        .operations(clusterConfiguration);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public final class ForceRemoveBrokersRequestTransformer implements ConfigurationChangeRequest {
+
+  private final Set<MemberId> membersToRemove;
+  private final MemberId coordinator;
+
+  public ForceRemoveBrokersRequestTransformer(
+      final Set<MemberId> membersToRemove, final MemberId coordinator) {
+    this.membersToRemove = membersToRemove;
+    this.coordinator = coordinator;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    final var membersToRetain = new HashSet<>(clusterConfiguration.members().keySet());
+    membersToRetain.removeAll(membersToRemove);
+
+    return new ForceScaleDownRequestTransformer(membersToRetain, coordinator)
+        .operations(clusterConfiguration);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersRequestTransformer.java
@@ -36,4 +36,9 @@ public final class ForceRemoveBrokersRequestTransformer implements Configuration
     return new ForceScaleDownRequestTransformer(membersToRetain, coordinator)
         .operations(clusterConfiguration);
   }
+
+  @Override
+  public boolean isForced() {
+    return true;
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -22,24 +23,32 @@ import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-/** Reassign all partitions to the given members based on round-robin strategy. */
+/**
+ * Add new partitions and reassign all partitions to the given members based on round-robin
+ * strategy.
+ */
 public class PartitionReassignRequestTransformer implements ConfigurationChangeRequest {
   final Set<MemberId> members;
   private final Optional<Integer> newReplicationFactor;
+  private final Optional<Integer> newPartitionCount;
 
   public PartitionReassignRequestTransformer(
-      final Set<MemberId> members, final Optional<Integer> newReplicationFactor) {
+      final Set<MemberId> members,
+      final Optional<Integer> newReplicationFactor,
+      final Optional<Integer> newPartitionCount) {
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
+    this.newPartitionCount = newPartitionCount;
   }
 
   public PartitionReassignRequestTransformer(final Set<MemberId> members) {
-    this(members, Optional.empty());
+    this(members, Optional.empty(), Optional.empty());
   }
 
   @Override
@@ -59,30 +68,42 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     return newReplicationFactor.orElse(clusterConfiguration.minReplicationFactor());
   }
 
+  private int getPartitionCount(final ClusterConfiguration clusterConfiguration) {
+    return newPartitionCount.orElse(clusterConfiguration.partitionCount());
+  }
+
   private Either<Exception, List<ClusterConfigurationChangeOperation>>
       generatePartitionDistributionOperations(
-          final ClusterConfiguration currentTopology, final Set<MemberId> brokers) {
+          final ClusterConfiguration currentConfiguration, final Set<MemberId> brokers) {
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
 
     final var oldDistribution =
-        ConfigurationUtil.getPartitionDistributionFrom(currentTopology, "temp");
-    final int replicationFactor = getReplicationFactor(currentTopology);
+        ConfigurationUtil.getPartitionDistributionFrom(currentConfiguration, "temp");
 
+    final int partitionCount = getPartitionCount(currentConfiguration);
+    if (partitionCount < currentConfiguration.partitionCount()) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "New partition count [%d] must be greater than or equal to the current partition count [%d]",
+                  partitionCount, currentConfiguration.partitionCount())));
+    }
+
+    final int replicationFactor = getReplicationFactor(currentConfiguration);
     if (replicationFactor <= 0) {
       return Either.left(
-          new ClusterConfigurationRequestFailedException.InvalidRequest(
+          new InvalidRequest(
               String.format("Replication factor [%d] must be greater than 0", replicationFactor)));
     }
 
     if (brokers.size() < replicationFactor) {
       return Either.left(
-          new ClusterConfigurationRequestFailedException.InvalidRequest(
+          new InvalidRequest(
               String.format(
                   "Number of brokers [%d] is less than the replication factor [%d]",
                   brokers.size(), replicationFactor)));
     }
 
-    final var partitionCount = currentTopology.partitionCount();
     final var sortedPartitions =
         IntStream.rangeClosed(1, partitionCount)
             .mapToObj(i -> PartitionId.from("temp", i))
@@ -94,17 +115,41 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var newDistribution =
         roundRobinDistributor.distributePartitions(brokers, sortedPartitions, replicationFactor);
 
-    for (final PartitionMetadata newMetadata : newDistribution) {
-      final var oldMetadata =
-          oldDistribution.stream()
-              .filter(old -> old.id().id().equals(newMetadata.id().id()))
-              .findFirst()
-              .orElseThrow();
-
-      operations.addAll(movePartition(oldMetadata, newMetadata));
+    // Can bootstrap partitions only in the sorted order
+    final var sortedPartitionMetadata =
+        newDistribution.stream().sorted(Comparator.comparingInt(p -> p.id().id())).toList();
+    for (final PartitionMetadata newMetadata : sortedPartitionMetadata) {
+      oldDistribution.stream()
+          .filter(old -> old.id().id().equals(newMetadata.id().id()))
+          .findFirst()
+          .ifPresentOrElse(
+              oldMetadata -> operations.addAll(movePartition(oldMetadata, newMetadata)),
+              () -> operations.addAll(addPartition(newMetadata)));
     }
 
     return Either.right(operations);
+  }
+
+  private List<ClusterConfigurationChangeOperation> addPartition(
+      final PartitionMetadata newMetadata) {
+    final Integer partitionId = newMetadata.id().id();
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+
+    // Bootstrap the partition in the primary
+    final var primary =
+        newMetadata.getPrimary().orElse(newMetadata.members().stream().findAny().orElseThrow());
+    operations.add(
+        new PartitionBootstrapOperation(primary, partitionId, newMetadata.getPriority(primary)));
+
+    // Join each remaining members to the partition
+    for (final MemberId member : newMetadata.members()) {
+      if (!member.equals(primary)) {
+        operations.add(
+            new PartitionJoinOperation(member, partitionId, newMetadata.getPriority(member)));
+      }
+    }
+
+    return operations;
   }
 
   private List<ClusterConfigurationChangeOperation> movePartition(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -22,6 +22,7 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
 
   private final Set<MemberId> members;
   private final Optional<Integer> newReplicationFactor;
+  private final Optional<Integer> newPartitionCount;
   private final ArrayList<ClusterConfigurationChangeOperation> generatedOperations =
       new ArrayList<>();
 
@@ -31,8 +32,16 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
 
   public ScaleRequestTransformer(
       final Set<MemberId> members, final Optional<Integer> newReplicationFactor) {
+    this(members, newReplicationFactor, Optional.empty());
+  }
+
+  public ScaleRequestTransformer(
+      final Set<MemberId> members,
+      final Optional<Integer> newReplicationFactor,
+      final Optional<Integer> newPartitionCount) {
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
+    this.newPartitionCount = newPartitionCount;
   }
 
   @Override
@@ -48,7 +57,7 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
         .flatMap(
             ignore ->
                 new PartitionReassignRequestTransformer(
-                        members, newReplicationFactor, Optional.empty())
+                        members, newReplicationFactor, newPartitionCount)
                     .operations(clusterConfiguration))
         .map(this::addToOperations)
         // then remove members that are not part of the new configuration

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformer.java
@@ -47,7 +47,8 @@ public class ScaleRequestTransformer implements ConfigurationChangeRequest {
         // then reassign partitions
         .flatMap(
             ignore ->
-                new PartitionReassignRequestTransformer(members, newReplicationFactor)
+                new PartitionReassignRequestTransformer(
+                        members, newReplicationFactor, Optional.empty())
                     .operations(clusterConfiguration))
         .map(this::addToOperations)
         // then remove members that are not part of the new configuration

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -254,9 +254,10 @@ final class ClusterConfigurationManagementApiTest {
 
     // then
     assertThat(changeStatus.plannedChanges())
-        .containsExactly(
-            new MemberJoinOperation(id1),
-            new PartitionJoinOperation(id1, 2, 2),
+        .hasSize(4)
+        .startsWith(new MemberJoinOperation(id1))
+        .contains(new PartitionJoinOperation(id1, 2, 2))
+        .containsSequence(
             new PartitionJoinOperation(id1, 1, 1),
             new PartitionReconfigurePriorityOperation(id0, 1, 2));
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class ClusterPatchRequestTransformerTest {
+
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
+  private final MemberId id3 = MemberId.from("3");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Test
+  void shouldRejectIfSameMembersAreAddedAndRemoved() {
+    // given
+    final var patchRequest =
+        new ClusterPatchRequest(
+            Set.of(id0, id2), Set.of(id0, id1), Optional.empty(), Optional.empty(), false);
+
+    // when
+    final var result =
+        new ClusterPatchRequestTransformer(
+                patchRequest.membersToAdd(),
+                patchRequest.membersToRemove(),
+                patchRequest.newPartitionCount(),
+                patchRequest.newReplicationFactor())
+            .operations(ClusterConfiguration.init());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldRejectWhenScalingDownPartitions() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final var patchRequest =
+        new ClusterPatchRequest(Set.of(), Set.of(), Optional.of(1), Optional.empty(), false);
+    final var result =
+        new ClusterPatchRequestTransformer(
+                patchRequest.membersToAdd(),
+                patchRequest.membersToRemove(),
+                patchRequest.newPartitionCount(),
+                patchRequest.newReplicationFactor())
+            .operations(ClusterConfiguration.init());
+
+    // then
+    assertThat(result).isLeft().left().isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldScaleUpBrokersWhenPartitionUnchanged() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)));
+
+    // when
+    final var patchRequest =
+        new ClusterPatchRequest(Set.of(id2), Set.of(), Optional.empty(), Optional.empty(), false);
+    final var expectedDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(Set.of(id0, id1, id2), getSortedPartitionIds(2), 2);
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        2, getClusterMembers(3), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  @Test
+  void shouldScaleDownBrokersWhenPartitionUnchanged() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final var patchRequest =
+        new ClusterPatchRequest(Set.of(), Set.of(id1), Optional.empty(), Optional.empty(), false);
+
+    final var expectedDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(Set.of(id0), getSortedPartitionIds(2), 1);
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        2, Set.of(id0), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  @Test
+  void shouldAddAndRemoveBrokersWhenPartitionsUnchanged() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final var patchRequest =
+        new ClusterPatchRequest(
+            Set.of(id2), Set.of(id1), Optional.empty(), Optional.empty(), false);
+
+    final var expectedDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(Set.of(id0, id2), getSortedPartitionIds(2), 1);
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        2, Set.of(id0, id2), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  @Test
+  void shouldAddAndRemoveBrokersAndAddPartitions() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final int newPartitionCount = 4;
+    final var patchRequest =
+        new ClusterPatchRequest(
+            Set.of(id2), Set.of(id1), Optional.of(newPartitionCount), Optional.empty(), false);
+
+    final var expectedDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(Set.of(id0, id2), getSortedPartitionIds(newPartitionCount), 1);
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        newPartitionCount, Set.of(id0, id2), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  @Test
+  void shouldAddAndRemoveBrokersAndAddPartitionsAndChangeReplicationFactor() {
+    // given
+    final var currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final int newPartitionCount = 4;
+    final var patchRequest =
+        new ClusterPatchRequest(
+            Set.of(id2), Set.of(id1), Optional.of(newPartitionCount), Optional.of(2), false);
+
+    final var expectedDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(Set.of(id0, id2), getSortedPartitionIds(newPartitionCount), 2);
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        newPartitionCount, Set.of(id0, id2), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  private void applyRequestAndVerifyResultingTopology(
+      final int partitionCount,
+      final Set<MemberId> expectedMembers,
+      final ClusterPatchRequest patchRequest,
+      final ClusterConfiguration oldClusterTopology,
+      final Set<PartitionMetadata> expectedNewDistribution) {
+
+    // when
+    final var result =
+        new ClusterPatchRequestTransformer(
+                patchRequest.membersToAdd(),
+                patchRequest.membersToRemove(),
+                patchRequest.newPartitionCount(),
+                patchRequest.newReplicationFactor())
+            .operations(oldClusterTopology);
+    assertThat(result).isRight();
+    final var operations = result.get();
+
+    // apply operations to generate new topology
+    final ClusterConfiguration newTopology =
+        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+
+    // then
+    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    Assertions.assertThat(newDistribution)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(expectedNewDistribution);
+    Assertions.assertThat(newTopology.members().keySet())
+        .describedAs("Expected cluster members")
+        .containsExactlyInAnyOrderElementsOf(expectedMembers);
+    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+  }
+
+  private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(id -> PartitionId.from("temp", id))
+        .collect(Collectors.toList());
+  }
+
+  private Set<MemberId> getClusterMembers(final int newClusterSize) {
+    return IntStream.range(0, newClusterSize)
+        .mapToObj(Integer::toString)
+        .map(MemberId::from)
+        .collect(Collectors.toSet());
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterScaleRequestTransformerTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+import org.assertj.core.api.Assertions;
+
+final class ClusterScaleRequestTransformerTest {
+
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
+  private final MemberId id3 = MemberId.from("3");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Property(tries = 10)
+  void shouldScaleBrokersWhenPartitionsUnchanged(
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 1, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 1, max = 100) final int newClusterSize) {
+    shouldScaleBrokersAndPartitionsByCount(
+        partitionCount,
+        Optional.empty(),
+        1,
+        Optional.empty(),
+        oldClusterSize,
+        Optional.of(newClusterSize));
+  }
+
+  @Property(tries = 10)
+  void shouldScalePartitionsWhenClusterSizeUnchanged(
+      @ForAll @IntRange(min = 3, max = 100) final int clusterSize,
+      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+    shouldScaleBrokersAndPartitionsByCount(
+        oldPartitionCount,
+        Optional.of(newPartitionCount),
+        3,
+        Optional.empty(),
+        clusterSize,
+        Optional.empty());
+  }
+
+  @Property(tries = 10)
+  void shouldChangeReplicationFactorWhenClusterSizeAndPartitionsUnchanged(
+      @ForAll @IntRange(min = 5, max = 10) final int clusterSize,
+      @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
+      @ForAll @IntRange(min = 1, max = 5) final int oldReplicationFactor,
+      @ForAll @IntRange(min = 1, max = 5) final int newReplicationFactor) {
+    shouldScaleBrokersAndPartitionsByCount(
+        partitionCount,
+        Optional.empty(),
+        oldReplicationFactor,
+        Optional.of(newReplicationFactor),
+        clusterSize,
+        Optional.empty());
+  }
+
+  @Property(tries = 10)
+  void shouldScaleBrokersAndPartitions(
+      @ForAll @IntRange(min = 3, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 3, max = 100) final int newClusterSize,
+      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount) {
+    shouldScaleBrokersAndPartitionsByCount(
+        oldPartitionCount,
+        Optional.of(newPartitionCount),
+        3,
+        Optional.empty(),
+        oldClusterSize,
+        Optional.of(newClusterSize));
+  }
+
+  @Property(tries = 10)
+  void shouldScaleBrokersAndPartitionsAndChangeReplicationFactor(
+      @ForAll @IntRange(min = 5, max = 100) final int oldClusterSize,
+      @ForAll @IntRange(min = 5, max = 100) final int newClusterSize,
+      @ForAll @IntRange(min = 1, max = 10) final int oldPartitionCount,
+      @ForAll @IntRange(min = 10, max = 20) final int newPartitionCount,
+      @ForAll @IntRange(min = 1, max = 5) final int oldReplicationFactor,
+      @ForAll @IntRange(min = 1, max = 5) final int newReplicationFactor) {
+    shouldScaleBrokersAndPartitionsByCount(
+        oldPartitionCount,
+        Optional.of(newPartitionCount),
+        oldReplicationFactor,
+        Optional.of(newReplicationFactor),
+        oldClusterSize,
+        Optional.of(newClusterSize));
+  }
+
+  void shouldScaleBrokersAndPartitionsByCount(
+      final int oldPartitionCount,
+      final Optional<Integer> newPartitionCount,
+      final int oldReplicationFactor,
+      final Optional<Integer> newReplicationFactor,
+      final int oldClusterSize,
+      final Optional<Integer> newClusterSize) {
+    // given
+    final var expectedNewDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getClusterMembers(newClusterSize.orElse(oldClusterSize)),
+                getSortedPartitionIds(newPartitionCount.orElse(oldPartitionCount)),
+                newReplicationFactor.orElse(oldReplicationFactor));
+
+    final var oldDistribution =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getClusterMembers(oldClusterSize),
+                getSortedPartitionIds(oldPartitionCount),
+                oldReplicationFactor);
+    ClusterConfiguration oldClusterTopology =
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
+    for (final MemberId member : getClusterMembers(oldClusterSize)) {
+      if (!oldClusterTopology.hasMember(member)) {
+        oldClusterTopology =
+            oldClusterTopology.addMember(member, MemberState.initializeAsActive(Map.of()));
+      }
+    }
+
+    // when
+    final var patchRequest =
+        new ClusterScaleRequest(newClusterSize, newPartitionCount, newReplicationFactor, false);
+
+    applyRequestAndVerifyResultingTopology(
+        newPartitionCount.orElse(oldPartitionCount),
+        getClusterMembers(newClusterSize.orElse(oldClusterSize)),
+        patchRequest,
+        oldClusterTopology,
+        expectedNewDistribution);
+  }
+
+  private void applyRequestAndVerifyResultingTopology(
+      final int partitionCount,
+      final Set<MemberId> expectedMembers,
+      final ClusterScaleRequest patchRequest,
+      final ClusterConfiguration oldClusterTopology,
+      final Set<PartitionMetadata> expectedNewDistribution) {
+
+    // when
+    final var result =
+        new ClusterScaleRequestTransformer(
+                patchRequest.newClusterSize(),
+                patchRequest.newPartitionCount(),
+                patchRequest.newReplicationFactor())
+            .operations(oldClusterTopology);
+    assertThat(result).isRight();
+    final var operations = result.get();
+
+    // apply operations to generate new topology
+    final ClusterConfiguration newTopology =
+        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+
+    // then
+    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    Assertions.assertThat(newDistribution)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(expectedNewDistribution);
+    Assertions.assertThat(newTopology.members().keySet())
+        .describedAs("Expected cluster members")
+        .containsExactlyInAnyOrderElementsOf(expectedMembers);
+    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+  }
+
+  private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+    return IntStream.rangeClosed(1, partitionCount)
+        .mapToObj(id -> PartitionId.from("temp", id))
+        .collect(Collectors.toList());
+  }
+
+  private Set<MemberId> getClusterMembers(final int newClusterSize) {
+    return IntStream.range(0, newClusterSize)
+        .mapToObj(Integer::toString)
+        .map(MemberId::from)
+        .collect(Collectors.toSet());
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceRemoveBrokersTransformerTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import java.util.Map;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class ForceRemoveBrokersTransformerTest {
+
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
+  private final MemberId id3 = MemberId.from("3");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Test
+  void shouldForceRemoveBrokers() {
+    // given
+    final ClusterConfiguration currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .addMember(id2, MemberState.initializeAsActive(Map.of()))
+            .addMember(id3, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
+
+    // when
+    final var patchRequest = new ForceRemoveBrokersRequest(Set.of(id1, id3), false);
+
+    // remove members 1 and 3
+    final var expectedTopology =
+        currentTopology.updateMember(id1, ignore -> null).updateMember(id3, ignore -> null);
+    final var expectedDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(expectedTopology, "temp");
+
+    // then
+    applyRequestAndVerifyResultingTopology(
+        2, Set.of(id0, id2), patchRequest, currentTopology, expectedDistribution);
+  }
+
+  private void applyRequestAndVerifyResultingTopology(
+      final int partitionCount,
+      final Set<MemberId> expectedMembers,
+      final ForceRemoveBrokersRequest patchRequest,
+      final ClusterConfiguration oldClusterTopology,
+      final Set<PartitionMetadata> expectedNewDistribution) {
+
+    // when
+    final var result =
+        new ForceRemoveBrokersRequestTransformer(patchRequest.membersToRemove(), id0)
+            .operations(oldClusterTopology);
+    assertThat(result).isRight();
+    final var operations = result.get();
+
+    // apply operations to generate new topology
+    final ClusterConfiguration newTopology =
+        TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
+
+    // then
+    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
+    Assertions.assertThat(newDistribution)
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(expectedNewDistribution);
+    Assertions.assertThat(newTopology.members().keySet())
+        .describedAs("Expected cluster members")
+        .containsExactlyInAnyOrderElementsOf(expectedMembers);
+    Assertions.assertThat(newTopology.partitionCount()).isEqualTo(partitionCount);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
@@ -33,7 +33,7 @@ final class TestTopologyChangeSimulator {
       final var applier = topologyChangeSimulator.getApplier(operation);
       final var init = applier.init(newTopology);
       if (init.isLeft()) {
-        fail("Failed to init operation ", init.getLeft());
+        fail("Failed to init operation '%s' : '%s'", operation, init.getLeft());
       }
       newTopology = init.get().apply(newTopology);
       newTopology = newTopology.advanceConfigurationChange(applier.apply().join());


### PR DESCRIPTION
## Description

This PR 
* Defines three for patching the cluster configuration. 
    * The two requests for scaling allows to 
        * scale brokers by either providing the new clusterSize or providing a list of broker ids to add or remove. 
        * Scale partitions by providing a new partition count
        * Change replication factor
        * It is possible to change multiple parameters at the same time. For example, add partitions and brokers in the same request.
   * A new force remove brokers request allows to specify set of the brokers to remove, instead of the members to retain.  
   * These requests can eventually replace the existing `ScaleRequest`. But we keep it for backwards compatibility.
* Added the request transformer to generate operations.

This PR do not add the request handling on the coordinator. This will be done in a follow up PR to reduce the size of this PR. 

## Related issues

related #21482 
