### PR TITLE
fix: decouple template deletion from index name

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/es/SchemaUpgradeClient.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/es/SchemaUpgradeClient.java
@@ -232,12 +232,17 @@ public class SchemaUpgradeClient {
   public void deleteTemplateIfExists(final String indexTemplateName) {
     if (indexTemplateExists(indexTemplateName)) {
       try {
+        log.debug("Deleting index template [{}]", indexTemplateName);
         elasticsearchClient.deleteIndexTemplateByIndexTemplateName(indexTemplateName);
       } catch (Exception e) {
         String errorMessage =
             String.format("Could not delete index template [%s]!", indexTemplateName);
         throw new UpgradeRuntimeException(errorMessage, e);
       }
+    } else {
+      log.debug(
+          "Index template [{}] does not exist and will therefore not be deleted.",
+          indexTemplateName);
     }
   }
 

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/steps/schema/DeleteIndexTemplateIfExistsStep.java
@@ -44,11 +44,12 @@ public class DeleteIndexTemplateIfExistsStep extends UpgradeStep {
 
   @Override
   public void execute(final SchemaUpgradeClient schemaUpgradeClient) {
-    final String indexAlias =
-        schemaUpgradeClient.getIndexNameService().getOptimizeIndexAliasForIndex(templateName);
-    schemaUpgradeClient.getAliasMap(indexAlias).keySet().stream()
-        .filter(templateName -> templateName.contains(this.templateName))
-        .forEach(schemaUpgradeClient::deleteTemplateIfExists);
+    final String fullTemplateName =
+        schemaUpgradeClient
+            .getIndexNameService()
+            .getOptimizeIndexOrTemplateNameForAliasAndVersionWithPrefix(
+                templateName, String.valueOf(templateVersion));
+    schemaUpgradeClient.deleteTemplateIfExists(fullTemplateName);
   }
 
   public String getVersionedTemplateNameWithTemplateSuffix() {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/OptimizeIndexNameService.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/OptimizeIndexNameService.java
@@ -111,6 +111,13 @@ public class OptimizeIndexNameService implements ConfigurationReloadable {
     return indexAlias + versionSuffix;
   }
 
+  public String getOptimizeIndexOrTemplateNameForAliasAndVersionWithPrefix(
+      final String indexOrTemplateNameWithoutPrefix, final String version) {
+    return getOptimizeIndexAliasForIndexNameAndPrefix(
+        getOptimizeIndexOrTemplateNameForAliasAndVersion(indexOrTemplateNameWithoutPrefix, version),
+        indexPrefix);
+  }
+
   public static String getOptimizeIndexAliasForIndexNameAndPrefix(
       final String indexName, final String indexPrefix) {
     String original = indexName;


### PR DESCRIPTION
## Description

Extracting the potential fix for template deletion into a separate PR to confirm our suspicion that the [migration](https://github.com/camunda/camunda/pull/21852) and [upgrade](https://github.com/camunda/camunda/pull/21796) tests pull the latest snapshot instead of using the changes on their respective branches.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
