### PR TITLE
Migrate intermediate signal catch events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -58,7 +58,7 @@ public final class ProcessInstanceMigrationPreconditions {
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =
-      EnumSet.of(BpmnEventType.MESSAGE, BpmnEventType.TIMER);
+      EnumSet.of(BpmnEventType.MESSAGE, BpmnEventType.TIMER, BpmnEventType.SIGNAL);
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to migrate process instance but no process instance found with key '%d'";


### PR DESCRIPTION
#### This PR is created on top of https://github.com/camunda/camunda/pull/21932. Please review that PR first.

## Description

It should be possible to migrate signal intermediate catch events.

Signal intermediate catch events can be migrated by providing a mapping instruction. Only active signal intermediate catch events can be migrated.

<img width="428" alt="Screenshot 2024-09-03 at 12 39 40" src="https://github.com/user-attachments/assets/2fd10239-8548-4bbc-bcbc-8c95aac9e3b3">

## Related issues

closes #21863 
