### PR TITLE
Tasklist process search should return latest versions only

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -37,10 +37,10 @@ import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.Filter;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
-import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
-import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
-import org.elasticsearch.search.aggregations.metrics.ParsedTopHits;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
+import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -352,19 +352,18 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     return composite.getBuckets().stream()
         .flatMap(
             bucket ->
-                ((ParsedLongTerms)
-                        bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
+                ((ParsedTerms) bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
                     .getBuckets().stream()
                         .flatMap(
                             versionBucket -> {
                               final var startedByFormDocs =
-                                  ((ParsedFilter)
+                                  ((Filter)
                                           versionBucket
                                               .getAggregations()
                                               .get(STARTED_BY_FORM_FILTERED_DOCS))
                                       .getAggregations();
                               return Arrays.stream(
-                                  ((ParsedTopHits) startedByFormDocs.get(TOP_HITS_AGG_NAME))
+                                  ((TopHits) startedByFormDocs.get(TOP_HITS_AGG_NAME))
                                       .getHits()
                                       .getHits());
                             }))
@@ -375,13 +374,12 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     return composite.getBuckets().stream()
         .flatMap(
             bucket ->
-                ((ParsedLongTerms)
-                        bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
+                ((ParsedTerms) bucket.getAggregations().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
                     .getBuckets().stream()
                         .flatMap(
                             versionBucket ->
                                 Arrays.stream(
-                                    ((ParsedTopHits)
+                                    ((TopHits)
                                             versionBucket.getAggregations().get(TOP_HITS_AGG_NAME))
                                         .getHits()
                                         .getHits())))

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -20,19 +20,27 @@ import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
 import io.camunda.tasklist.util.ElasticsearchUtil;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.BucketOrder;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.composite.TermsValuesSourceBuilder;
-import org.elasticsearch.search.aggregations.metrics.TopHits;
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilter;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedLongTerms;
+import org.elasticsearch.search.aggregations.metrics.ParsedTopHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -51,6 +59,8 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   private static final String TOP_HITS_AGG_NAME = "top_hit_doc";
   private static final String DEFINITION_ID_TERMS_SOURCE_NAME = "group_by_definition_id";
   private static final String TENANT_ID_TERMS_SOURCE_NAME = "group_by_tenant_id";
+  private static final String MAX_VERSION_DOCUMENTS_AGG_NAME = "max_version_docs";
+  private static final String STARTED_BY_FORM_FILTERED_DOCS = "started_by_form_docs";
 
   @Autowired private ProcessIndex processIndex;
 
@@ -62,7 +72,8 @@ public class ProcessStoreElasticSearch implements ProcessStore {
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  public ProcessEntity getProcessByProcessDefinitionKey(String processDefinitionKey) {
+  @Override
+  public ProcessEntity getProcessByProcessDefinitionKey(final String processDefinitionKey) {
     final QueryBuilder qb = QueryBuilders.termQuery(ProcessIndex.KEY, processDefinitionKey);
 
     final SearchRequest searchRequest =
@@ -83,17 +94,20 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Process with key %s not found", processDefinitionKey));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(e);
     }
   }
 
   /** Gets the process by id. */
-  public ProcessEntity getProcessByBpmnProcessId(String bpmnProcessId) {
+  @Override
+  public ProcessEntity getProcessByBpmnProcessId(final String bpmnProcessId) {
     return getProcessByBpmnProcessId(bpmnProcessId, null);
   }
 
-  public ProcessEntity getProcessByBpmnProcessId(String bpmnProcessId, final String tenantId) {
+  @Override
+  public ProcessEntity getProcessByBpmnProcessId(
+      final String bpmnProcessId, final String tenantId) {
     final QueryBuilder qb;
     if (tasklistProperties.getMultiTenancy().isEnabled() && StringUtils.isNotBlank(tenantId)) {
       qb =
@@ -122,14 +136,15 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", bpmnProcessId));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
     }
   }
 
-  public ProcessEntity getProcess(String processId) {
+  @Override
+  public ProcessEntity getProcess(final String processId) {
     final SearchRequest searchRequest =
         new SearchRequest(processIndex.getAlias())
             .source(
@@ -147,17 +162,14 @@ public class ProcessStoreElasticSearch implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", processId));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
     }
   }
 
-  private ProcessEntity fromSearchHit(String processString) {
-    return ElasticsearchUtil.fromSearchHit(processString, objectMapper, ProcessEntity.class);
-  }
-
+  @Override
   public List<ProcessEntity> getProcesses(
       final List<String> processDefinitions, final String tenantId, final Boolean isStartedByForm) {
     final QueryBuilder qb;
@@ -190,13 +202,13 @@ public class ProcessStoreElasticSearch implements ProcessStore {
               .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""));
     }
 
-    QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
-    finalQuery = enhanceQueryByIsStartedByForm(finalQuery, isStartedByForm);
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery);
+    final QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery, isStartedByForm);
   }
 
+  @Override
   public List<ProcessEntity> getProcesses(
-      String search,
+      final String search,
       final List<String> processDefinitions,
       final String tenantId,
       final Boolean isStartedByForm) {
@@ -205,150 +217,35 @@ public class ProcessStoreElasticSearch implements ProcessStore {
       return getProcesses(processDefinitions, tenantId, isStartedByForm);
     }
 
-    final QueryBuilder qb;
     final String regexSearch = String.format(".*%s.*", search);
+    BoolQueryBuilder qb =
+        QueryBuilders.boolQuery()
+            .should(QueryBuilders.termQuery(ProcessIndex.ID, search))
+            .should(
+                QueryBuilders.regexpQuery(ProcessIndex.NAME, regexSearch)
+                    .caseInsensitive(CASE_INSENSITIVE))
+            .should(
+                QueryBuilders.regexpQuery(ProcessIndex.PROCESS_DEFINITION_ID, regexSearch)
+                    .caseInsensitive(CASE_INSENSITIVE))
+            .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
+            .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""))
+            .minimumShouldMatch(1);
 
     if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()) {
-
-      if (processDefinitions.size() == 0) {
+      if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }
-
-      if (processDefinitions.contains(IdentityProperties.ALL_RESOURCES)) {
+      if (!processDefinitions.contains(IdentityProperties.ALL_RESOURCES)) {
         qb =
-            QueryBuilders.boolQuery()
-                .should(QueryBuilders.termQuery(ProcessIndex.ID, search))
-                .should(
-                    QueryBuilders.regexpQuery(ProcessIndex.NAME, regexSearch)
-                        .caseInsensitive(CASE_INSENSITIVE))
-                .should(
-                    QueryBuilders.regexpQuery(ProcessIndex.PROCESS_DEFINITION_ID, regexSearch)
-                        .caseInsensitive(CASE_INSENSITIVE))
-                .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
-                .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""))
-                .minimumShouldMatch(1);
-      } else {
-        qb =
-            QueryBuilders.boolQuery()
-                .should(QueryBuilders.termQuery(ProcessIndex.ID, search))
-                .should(
-                    QueryBuilders.regexpQuery(ProcessIndex.NAME, regexSearch)
-                        .caseInsensitive(CASE_INSENSITIVE))
-                .should(
-                    QueryBuilders.regexpQuery(ProcessIndex.PROCESS_DEFINITION_ID, regexSearch)
-                        .caseInsensitive(CASE_INSENSITIVE))
-                .must(
-                    QueryBuilders.termsQuery(
-                        ProcessIndex.PROCESS_DEFINITION_ID, processDefinitions))
-                .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
-                .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""))
-                .minimumShouldMatch(1);
+            qb.must(
+                QueryBuilders.termsQuery(ProcessIndex.PROCESS_DEFINITION_ID, processDefinitions));
       }
-
-    } else {
-      qb =
-          QueryBuilders.boolQuery()
-              .should(QueryBuilders.termQuery(ProcessIndex.ID, search))
-              .should(
-                  QueryBuilders.regexpQuery(ProcessIndex.NAME, regexSearch)
-                      .caseInsensitive(CASE_INSENSITIVE))
-              .should(
-                  QueryBuilders.regexpQuery(ProcessIndex.PROCESS_DEFINITION_ID, regexSearch)
-                      .caseInsensitive(CASE_INSENSITIVE))
-              .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
-              .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""))
-              .minimumShouldMatch(1);
     }
-    QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
-    finalQuery = enhanceQueryByIsStartedByForm(finalQuery, isStartedByForm);
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery);
+    final QueryBuilder finalQuery = enhanceQueryByTenantIdCheck(qb, tenantId);
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(finalQuery, isStartedByForm);
   }
 
-  private QueryBuilder enhanceQueryByTenantIdCheck(QueryBuilder qb, final String tenantId) {
-    if (tasklistProperties.getMultiTenancy().isEnabled() && StringUtils.isNotBlank(tenantId)) {
-      return ElasticsearchUtil.joinWithAnd(
-          QueryBuilders.termQuery(ProcessIndex.TENANT_ID, tenantId), qb);
-    }
-
-    return qb;
-  }
-
-  private QueryBuilder enhanceQueryByIsStartedByForm(
-      QueryBuilder qb, final Boolean isStartedByForm) {
-    // Construct queries to check if FORM_KEY or FORM_ID is not null
-    // This is in order to consider a process as started by form but not public
-    final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery();
-    if (Boolean.TRUE.equals(isStartedByForm)) {
-      final ExistsQueryBuilder formKeyExistsQuery =
-          QueryBuilders.existsQuery(ProcessIndex.FORM_KEY);
-      final ExistsQueryBuilder formIdExistsQuery = QueryBuilders.existsQuery(ProcessIndex.FORM_ID);
-
-      boolQuery.should(formKeyExistsQuery);
-      boolQuery.should(formIdExistsQuery);
-      boolQuery.minimumShouldMatch(1);
-
-      return ElasticsearchUtil.joinWithAnd(boolQuery, qb);
-    }
-    if (Boolean.FALSE.equals(isStartedByForm)) {
-      final BoolQueryBuilder mustNotQuery = QueryBuilders.boolQuery();
-      mustNotQuery.mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_KEY));
-      mustNotQuery.mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_ID));
-
-      boolQuery.must(mustNotQuery);
-      return ElasticsearchUtil.joinWithAnd(boolQuery, qb);
-    }
-    // No filter is applied if isStartedByForm is null
-    return qb;
-  }
-
-  public List<ProcessEntity> getProcessEntityUniqueByProcessDefinitionIdAndTenantId(
-      QueryBuilder qb) {
-    final SearchSourceBuilder sourceBuilder =
-        new SearchSourceBuilder()
-            .query(qb)
-            .size(0) // Set size to 0 to retrieve only aggregation results
-            .aggregation(
-                AggregationBuilders.composite(
-                        BPMN_PROCESS_ID_TENANT_ID_AGG_NAME,
-                        List.of(
-                            new TermsValuesSourceBuilder(DEFINITION_ID_TERMS_SOURCE_NAME)
-                                .field(ProcessIndex.PROCESS_DEFINITION_ID),
-                            new TermsValuesSourceBuilder(TENANT_ID_TERMS_SOURCE_NAME)
-                                .field(ProcessIndex.TENANT_ID)))
-                    .size(ElasticsearchUtil.QUERY_MAX_SIZE)
-                    .subAggregation(
-                        AggregationBuilders.topHits(TOP_HITS_AGG_NAME)
-                            .sort(
-                                SortBuilders.fieldSort(ProcessIndex.VERSION).order(SortOrder.DESC))
-                            .size(1)));
-
-    final SearchRequest searchRequest =
-        new SearchRequest(processIndex.getAlias()).source(sourceBuilder);
-
-    final SearchResponse response;
-    try {
-      response = tenantAwareClient.search(searchRequest);
-
-      final CompositeAggregation compositeAggregation =
-          response.getAggregations().get(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME);
-      final List<ProcessEntity> results = new ArrayList<>();
-      for (final CompositeAggregation.Bucket bucket : compositeAggregation.getBuckets()) {
-        final TopHits topHits = bucket.getAggregations().get(TOP_HITS_AGG_NAME);
-        for (final SearchHit hit : topHits.getHits().getHits()) {
-          final ProcessEntity entity =
-              ElasticsearchUtil.fromSearchHit(
-                  hit.getSourceAsString(), objectMapper, ProcessEntity.class);
-          results.add(entity);
-        }
-      }
-      return results;
-    } catch (IOException e) {
-      final String message =
-          String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
-      throw new TasklistRuntimeException(message, e);
-    }
-  }
-
+  @Override
   public List<ProcessEntity> getProcessesStartedByForm() {
     final QueryBuilder qb;
 
@@ -357,8 +254,137 @@ public class ProcessStoreElasticSearch implements ProcessStore {
             .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
             .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""));
 
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(qb).stream()
-        .filter(ProcessEntity::isStartedByForm)
-        .toList();
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(qb, true).stream().toList();
+  }
+
+  private ProcessEntity fromSearchHit(final String processString) {
+    return ElasticsearchUtil.fromSearchHit(processString, objectMapper, ProcessEntity.class);
+  }
+
+  private QueryBuilder enhanceQueryByTenantIdCheck(final QueryBuilder qb, final String tenantId) {
+    if (tasklistProperties.getMultiTenancy().isEnabled() && StringUtils.isNotBlank(tenantId)) {
+      return ElasticsearchUtil.joinWithAnd(
+          QueryBuilders.termQuery(ProcessIndex.TENANT_ID, tenantId), qb);
+    }
+
+    return qb;
+  }
+
+  public List<ProcessEntity> getProcessEntityUniqueByProcessDefinitionIdAndTenantId(
+      final QueryBuilder qb, final Boolean isStartedByForm) {
+
+    final CompositeAggregationBuilder processDefinitionAndTenantBucket =
+        AggregationBuilders.composite(
+                BPMN_PROCESS_ID_TENANT_ID_AGG_NAME,
+                List.of(
+                    new TermsValuesSourceBuilder(DEFINITION_ID_TERMS_SOURCE_NAME)
+                        .field(ProcessIndex.PROCESS_DEFINITION_ID),
+                    new TermsValuesSourceBuilder(TENANT_ID_TERMS_SOURCE_NAME)
+                        .field(ProcessIndex.TENANT_ID)))
+            .size(ElasticsearchUtil.QUERY_MAX_SIZE);
+
+    final AggregationBuilder maxVersionDocsAggregate =
+        AggregationBuilders.terms(MAX_VERSION_DOCUMENTS_AGG_NAME)
+            .field(ProcessIndex.VERSION)
+            .order(BucketOrder.key(false))
+            .size(1);
+
+    final AggregationBuilder topHitsAggregate =
+        AggregationBuilders.topHits(TOP_HITS_AGG_NAME)
+            .sort(SortBuilders.fieldSort(ProcessIndex.VERSION).order(SortOrder.DESC))
+            .size(1);
+
+    final SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(qb).size(0);
+    if (isStartedByForm == null) {
+      sourceBuilder.aggregation(
+          processDefinitionAndTenantBucket.subAggregation(
+              maxVersionDocsAggregate.subAggregation(topHitsAggregate)));
+    } else {
+      sourceBuilder.aggregation(
+          processDefinitionAndTenantBucket.subAggregation(
+              maxVersionDocsAggregate.subAggregation(
+                  startedByFormAggregateFilter(isStartedByForm).subAggregation(topHitsAggregate))));
+    }
+
+    final SearchRequest searchRequest =
+        new SearchRequest(processIndex.getAlias()).source(sourceBuilder);
+
+    final SearchResponse response;
+    try {
+      response = tenantAwareClient.search(searchRequest);
+      final CompositeAggregation compositeAgg =
+          response.getAggregations().get(BPMN_PROCESS_ID_TENANT_ID_AGG_NAME);
+      final Set<SearchHit> hits =
+          isStartedByForm != null
+              ? getFilteredAggregateSearchHits(compositeAgg)
+              : getAggregateSearchHits(compositeAgg);
+      return hits.stream()
+          .map(
+              hit ->
+                  ElasticsearchUtil.fromSearchHit(
+                      hit.getSourceAsString(), objectMapper, ProcessEntity.class))
+          .toList();
+
+    } catch (final IOException e) {
+      final String message =
+          String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
+      throw new TasklistRuntimeException(message, e);
+    }
+  }
+
+  private FilterAggregationBuilder startedByFormAggregateFilter(final boolean isStartedByForm) {
+    return isStartedByForm
+        ? AggregationBuilders.filter(
+            STARTED_BY_FORM_FILTERED_DOCS,
+            QueryBuilders.boolQuery()
+                .should(QueryBuilders.existsQuery(ProcessIndex.FORM_KEY))
+                .should(QueryBuilders.existsQuery(ProcessIndex.FORM_ID))
+                .minimumShouldMatch(1))
+        : AggregationBuilders.filter(
+            STARTED_BY_FORM_FILTERED_DOCS,
+            QueryBuilders.boolQuery()
+                .mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_KEY))
+                .mustNot(QueryBuilders.existsQuery(ProcessIndex.FORM_ID))
+                .minimumShouldMatch(1));
+  }
+
+  private Set<SearchHit> getFilteredAggregateSearchHits(final CompositeAggregation composite) {
+    return composite.getBuckets().stream()
+        .flatMap(
+            bucket ->
+                ((ParsedLongTerms)
+                        bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
+                    .getBuckets().stream()
+                        .flatMap(
+                            versionBucket -> {
+                              final var startedByFormDocs =
+                                  ((ParsedFilter)
+                                          versionBucket
+                                              .getAggregations()
+                                              .get(STARTED_BY_FORM_FILTERED_DOCS))
+                                      .getAggregations();
+                              return Arrays.stream(
+                                  ((ParsedTopHits) startedByFormDocs.get(TOP_HITS_AGG_NAME))
+                                      .getHits()
+                                      .getHits());
+                            }))
+        .collect(Collectors.toSet());
+  }
+
+  private Set<SearchHit> getAggregateSearchHits(final CompositeAggregation composite) {
+    return composite.getBuckets().stream()
+        .flatMap(
+            bucket ->
+                ((ParsedLongTerms)
+                        bucket.getAggregations().asMap().get(MAX_VERSION_DOCUMENTS_AGG_NAME))
+                    .getBuckets().stream()
+                        .flatMap(
+                            versionBucket ->
+                                Arrays.stream(
+                                    ((ParsedTopHits)
+                                            versionBucket.getAggregations().get(TOP_HITS_AGG_NAME))
+                                        .getHits()
+                                        .getHits())))
+        .collect(Collectors.toSet());
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -175,7 +175,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
     final QueryBuilder qb;
 
     if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()) {
-      if (processDefinitions.size() == 0) {
+      if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }
 
@@ -254,7 +254,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
             .must(QueryBuilders.existsQuery(ProcessIndex.PROCESS_DEFINITION_ID))
             .mustNot(QueryBuilders.termQuery(ProcessIndex.PROCESS_DEFINITION_ID, ""));
 
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(qb, true).stream().toList();
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(qb, true);
   }
 
   private ProcessEntity fromSearchHit(final String processString) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -281,12 +281,22 @@ public class ProcessStoreOpenSearch implements ProcessStore {
     final BoolQuery.Builder query =
         QueryBuilders.bool()
             .should(s -> s.term(t -> t.field(ProcessIndex.ID).value(FieldValue.of(search))))
-            .should(s -> s.regexp(regex -> regex.field(ProcessIndex.NAME).value(regexSearch)))
             .should(
                 s ->
                     s.regexp(
                         regex ->
-                            regex.field(ProcessIndex.PROCESS_DEFINITION_ID).value(regexSearch)))
+                            regex
+                                .field(ProcessIndex.NAME)
+                                .caseInsensitive(CASE_INSENSITIVE)
+                                .value(regexSearch)))
+            .should(
+                s ->
+                    s.regexp(
+                        regex ->
+                            regex
+                                .field(ProcessIndex.PROCESS_DEFINITION_ID)
+                                .caseInsensitive(CASE_INSENSITIVE)
+                                .value(regexSearch)))
             .must(m -> m.exists(e -> e.field(ProcessIndex.PROCESS_DEFINITION_ID)))
             .mustNot(
                 mn ->

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -330,10 +330,8 @@ public class ProcessStoreOpenSearch implements ProcessStore {
                     mn.term(
                         t -> t.field(ProcessIndex.PROCESS_DEFINITION_ID).value(FieldValue.of(""))))
             .build()
-            ._toQuery();
-    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(query, true).stream()
-        .filter(ProcessEntity::isStartedByForm)
-        .toList();
+            .toQuery();
+    return getProcessEntityUniqueByProcessDefinitionIdAndTenantId(query, true);
   }
 
   private Query addFilterOnTenantIdIfRequired(final Query query, final String tenantId) {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/ProcessIdentityIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/ProcessIdentityIT.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.graphql;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.graphql.spring.boot.test.GraphQLResponse;
@@ -65,6 +66,9 @@ public class ProcessIdentityIT extends IdentityTester {
         tester.getAllProcessesWithBearerAuth(query, generateTasklistToken());
     assertTrue(response.isOk());
     assertEquals("3", response.get("$.data.processes.length()"));
-    assertEquals("Simple process", response.get("$.data.processes[0].name"));
+    assertFalse(
+        response
+            .getList("$.data.processes[?(@.name=='Simple process')].name", String.class)
+            .isEmpty());
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/mt/MultiTenancyIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/mt/MultiTenancyIT.java
@@ -85,7 +85,7 @@ public class MultiTenancyIT extends IdentityTester {
         .extractingListContent(objectMapper, ProcessResponse.class)
         .hasSize(2)
         .extracting("id", "tenantId")
-        .containsExactly(tuple(processId1, TENANT_1), tuple(processId2, TENANT_2));
+        .containsExactlyInAnyOrder(tuple(processId1, TENANT_1), tuple(processId2, TENANT_2));
 
     tester.withAuthenticationToken(generateTokenForUser(USER_2));
     final var result2 = mockMvcHelper.doRequest(get(TasklistURIs.PROCESSES_URL_V1));

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -45,6 +45,7 @@ import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.elasticsearch.search.aggregations.bucket.composite.CompositeAggregation;
+import org.elasticsearch.search.aggregations.bucket.terms.ParsedTerms;
 import org.elasticsearch.search.aggregations.metrics.TopHits;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -296,10 +297,18 @@ class ProcessStoreElasticSearchTest {
     final var bucket = mock(CompositeAggregation.Bucket.class);
     when((List<CompositeAggregation.Bucket>) compositeAggregation.getBuckets())
         .thenReturn(List.of(bucket));
+    when(bucket.getAggregations()).thenReturn(aggregations);
+    final var termsBucket = mock(ParsedTerms.ParsedBucket.class);
+    final var maxVersionTerms = mock(ParsedTerms.class);
+    when((List<ParsedTerms.ParsedBucket>) maxVersionTerms.getBuckets())
+        .thenReturn(List.of(termsBucket));
+    when(aggregations.get("max_version_docs")).thenReturn(maxVersionTerms);
+    final var versionBucket = mock(ParsedTerms.ParsedBucket.class);
+    when((List<ParsedTerms.ParsedBucket>) maxVersionTerms.getBuckets())
+        .thenReturn(List.of(versionBucket));
+    when(versionBucket.getAggregations()).thenReturn(aggregations);
     final var topHits = mock(TopHits.class);
-    final var bucketAggregations = mock(Aggregations.class);
-    when(bucket.getAggregations()).thenReturn(bucketAggregations);
-    when(bucketAggregations.get("top_hit_doc")).thenReturn(topHits);
+    when(aggregations.get("top_hit_doc")).thenReturn(topHits);
     final var searchHits = mock(SearchHits.class);
     when(topHits.getHits()).thenReturn(searchHits);
     final var searchHit = mock(SearchHit.class);


### PR DESCRIPTION
## Description
Tasklist process search ES/OS queries were not retrieving latest version of each process document when `startedByForm` parameter was present.

## Related issues

closes #20734 
