### PR TITLE
ci: only add issues to zeebe projects if component matches

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -37,7 +37,7 @@ jobs:
           project-url: https://github.com/orgs/camunda/projects/92
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: component/zeebe
-      - id: add-to-zda
+      - id: add-to-zpa
         name: Add to ZPA project
         uses: actions/add-to-project@v1.0.2
         if: ${{ steps.has-project.outputs.result == 'false' }}

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -1,10 +1,10 @@
 name: Assign new issues to the default projects
 on:
   issues:
-    types: [ opened, reopened, transferred ]
+    types: [ opened, reopened, transferred, labeled ]
 jobs:
   add-to-projects:
-    name: Add issue to ZDP/ZPA project if no project set yet
+    name: Add issue to team projects if no project assigned and by corresponding component label
     runs-on: ubuntu-latest
     steps:
       - id: get_project_count
@@ -36,8 +36,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/camunda/projects/92
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: kind/task
-          label-operator: NOT
+          labeled: component/zeebe
       - id: add-to-zda
         name: Add to ZPA project
         uses: actions/add-to-project@v1.0.2
@@ -45,8 +44,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/camunda/projects/29
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
-          labeled: kind/task
-          label-operator: NOT
+          labeled: component/zeebe
       - id: add-to-operate
         name: Add to Operate project
         uses: actions/add-to-project@v1.0.2


### PR DESCRIPTION
## Description

Up until now all non task issues were added to the Zeebe project boards, this was too verbose given the activity of multiple teams on the repo. Now only issues labeled as zeebe will get added, also on changing labels (in case an issue was lacking as label on initial creation).