### PR TITLE
ci: use infra self-hosted runners for zeebe-snyk.yml workflow

### DIFF
--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -83,7 +83,7 @@ jobs:
   scan:
     name: Snyk Scan
     # Run on self-hosted to make building Zeebe much faster
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-8-default
     permissions:
       security-events: write # required to upload SARIF files
     steps:


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

This PR introduces the use of `gcp-perf-core-*` runner type for the `zeebe-snyk.yml` workflow.

This new type of runner uses the same C2D machine series as the Zeebe runners, in order to benefit from its HPC capabilities to distribute and parralelize the Zeebe distribution build (via Maven).

I did some quick tests to get an idea of the performance depending on the runner size (same cache level for all, i.e. no Maven cache):
- `gcp-perf-core-4-default` -> [8m13s](https://github.com/camunda/camunda/actions/runs/10813657247/job/29998193639)
- `gcp-perf-core-8-default` -> [6m12s](https://github.com/camunda/camunda/actions/runs/10813696270)
- `gcp-perf-core-16-default` -> [6m35s](https://github.com/camunda/camunda/actions/runs/10813563408/job/29998557805)

A conservative choice would be `gcp-perf-core-8-default` but `gcp-perf-core-4-default` seems reasonable too. I would say it's up to @camunda/monorepo-ci-dri to make a final decision.

Also, I manually triggered the [zeebe-snyk.yml](https://github.com/camunda/camunda/actions/workflows/zeebe-snyk.yml) workflow with the current self-hosted runner (zeebe) and the new runners (infra) multiple times, using different level of cache, to get a meaningful comparison and ensure no regression.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
