### PR TITLE
ci: Reduce maven's memory use when building optimize-backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
     if: needs.detect-changes.outputs.optimize-backend-changes == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       LIMITS_CPU: 4
     steps:

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -405,6 +405,16 @@
 
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.13.0</version>
+        <configuration>
+          <meminitial>128m</meminitial>
+          <maxmem>256m</maxmem>
+        </configuration>
+      </plugin>
+
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <executions>

--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -409,6 +409,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
+          <fork>false</fork>
           <meminitial>128m</meminitial>
           <maxmem>256m</maxmem>
         </configuration>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Increase the build timeout to 15 minutes, set a cap on the memory used by `optimize-backend`, and do not allow forking on the same module

The goal is to reduce memory use as that module has been the one that has been failing on timeouts

These changes have had >10 successful CI runs. Most of them complete in a couple of minutes, some a little less than 10, and rarely over 10 minutes

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
