### PR TITLE
refactor: Refactor ServiceTransformers for safer instantiation

### DIFF
--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.service;
 
+import static java.util.Optional.ofNullable;
+
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
@@ -16,7 +18,6 @@ import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -44,7 +45,7 @@ public abstract class ApiServices<T extends ApiServices<T>> {
     this.brokerClient = brokerClient;
     this.searchClient = searchClient;
     this.authentication = authentication;
-    this.transformers = Objects.requireNonNullElse(transformers, new ServiceTransformers());
+    this.transformers = ofNullable(transformers).orElseGet(ServiceTransformers::newInstance);
   }
 
   public abstract T withAuthentication(final Authentication authentication);

--- a/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
+++ b/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
@@ -32,15 +32,7 @@ import io.camunda.service.search.query.UserQuery;
 import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.query.VariableQuery;
 import io.camunda.service.search.result.QueryResultConfig;
-import io.camunda.service.search.sort.AuthorizationSort;
-import io.camunda.service.search.sort.DecisionDefinitionSort;
-import io.camunda.service.search.sort.DecisionRequirementsSort;
-import io.camunda.service.search.sort.IncidentSort;
-import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOption;
-import io.camunda.service.search.sort.UserSort;
-import io.camunda.service.search.sort.UserTaskSort;
-import io.camunda.service.search.sort.VariableSort;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.filter.AuthenticationTransformer;
 import io.camunda.service.transformers.filter.AuthorizationFilterTransformer;
@@ -64,11 +56,14 @@ import java.util.Map;
 
 public final class ServiceTransformers {
 
-  private final Map<Class<?>, ServiceTransformer<?, ?>> transformers;
+  private final Map<Class<?>, ServiceTransformer<?, ?>> transformers = new HashMap<>();
 
-  public ServiceTransformers() {
-    transformers = new HashMap<>();
-    initializeTransformers(this);
+  private ServiceTransformers() {}
+
+  public static ServiceTransformers newInstance() {
+    final var serviceTransformers = new ServiceTransformers();
+    initializeTransformers(serviceTransformers);
+    return serviceTransformers;
   }
 
   public <F extends FilterBase, S extends SortOption>
@@ -93,29 +88,14 @@ public final class ServiceTransformers {
 
   public static void initializeTransformers(final ServiceTransformers mappers) {
     // query -> request
-    mappers.put(
-        ProcessInstanceQuery.class,
-        new TypedSearchQueryTransformer<ProcessInstanceFilter, ProcessInstanceSort>(mappers));
-    mappers.put(
-        UserTaskQuery.class,
-        new TypedSearchQueryTransformer<UserTaskFilter, UserTaskSort>(mappers));
-    mappers.put(
-        VariableQuery.class,
-        new TypedSearchQueryTransformer<VariableFilter, VariableSort>(mappers));
-    mappers.put(
-        DecisionDefinitionQuery.class,
-        new TypedSearchQueryTransformer<DecisionDefinitionFilter, DecisionDefinitionSort>(mappers));
-    mappers.put(
-        DecisionRequirementsQuery.class,
-        new TypedSearchQueryTransformer<DecisionRequirementsFilter, DecisionRequirementsSort>(
-            mappers));
-    mappers.put(UserQuery.class, new TypedSearchQueryTransformer<UserFilter, UserSort>(mappers));
-    mappers.put(
-        AuthorizationQuery.class,
-        new TypedSearchQueryTransformer<AuthorizationFilter, AuthorizationSort>(mappers));
-    mappers.put(
-        IncidentQuery.class,
-        new TypedSearchQueryTransformer<IncidentFilter, IncidentSort>(mappers));
+    mappers.put(ProcessInstanceQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(UserTaskQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(VariableQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(DecisionDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(DecisionRequirementsQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(UserQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(AuthorizationQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(IncidentQuery.class, new TypedSearchQueryTransformer<>(mappers));
 
     // search query response -> search query result
     mappers.put(SearchQueryResult.class, new SearchQueryResultTransformer());


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR refactors the `ServiceTransformers` class to improve its instantiation pattern and avoid potential issues caused by passing a partially initialized `this` reference during construction.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
