### PR TITLE
feat: validate correct usage of attributes 'bindingType' + 'versionTag'

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeBindingTypeValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeBindingTypeValidator.java
@@ -46,6 +46,13 @@ public class ZeebeBindingTypeValidator<T extends ModelElementInstance>
   @Override
   public void validate(final T element, final ValidationResultCollector validationResultCollector) {
     final String bindingType = element.getAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE);
+    final String versionTag = element.getAttributeValue(ZeebeConstants.ATTRIBUTE_VERSION_TAG);
+    checkValidBindingTypeValue(validationResultCollector, bindingType);
+    checkValidBindingTypeAndVersionTag(validationResultCollector, bindingType, versionTag);
+  }
+
+  private static void checkValidBindingTypeValue(
+      final ValidationResultCollector validationResultCollector, final String bindingType) {
     if (bindingType != null && !ALLOWED_BINDING_TYPES.contains(bindingType)) {
       final String message =
           String.format(
@@ -53,5 +60,32 @@ public class ZeebeBindingTypeValidator<T extends ModelElementInstance>
               ZeebeConstants.ATTRIBUTE_BINDING_TYPE, String.join(", ", ALLOWED_BINDING_TYPES));
       validationResultCollector.addError(0, message);
     }
+  }
+
+  private static void checkValidBindingTypeAndVersionTag(
+      final ValidationResultCollector validationResultCollector,
+      final String bindingType,
+      final String versionTag) {
+    if (ZeebeBindingType.versionTag.name().equals(bindingType) && isBlank(versionTag)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Attribute '%s' must be present and not empty if '%s' is '%s'",
+              ZeebeConstants.ATTRIBUTE_VERSION_TAG,
+              ZeebeConstants.ATTRIBUTE_BINDING_TYPE,
+              ZeebeBindingType.versionTag));
+    } else if (!ZeebeBindingType.versionTag.name().equals(bindingType) && !isBlank(versionTag)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "Attribute '%s' may only be used if '%s' is '%s'",
+              ZeebeConstants.ATTRIBUTE_VERSION_TAG,
+              ZeebeConstants.ATTRIBUTE_BINDING_TYPE,
+              ZeebeBindingType.versionTag));
+    }
+  }
+
+  private static boolean isBlank(final String value) {
+    return value == null || value.trim().isEmpty();
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
@@ -22,10 +22,16 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class BusinessRuleTaskValidatorTest {
 
@@ -86,6 +92,47 @@ class BusinessRuleTaskValidatorTest {
         ExpectedValidationResult.expect(
             ZeebeCalledDecision.class,
             "Attribute 'bindingType' must be one of: deployment, latest, versionTag"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " "})
+  @NullSource
+  void emptyVersionTagForBindingTypeVersionTag(final String versionTag) {
+    // when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeCalledDecisionId("decisionId")
+                    .zeebeBindingType(ZeebeBindingType.versionTag)
+                    .zeebeVersionTag(versionTag)
+                    .zeebeResultVariable("result"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            ZeebeCalledDecision.class,
+            "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = ZeebeBindingType.class, names = "versionTag", mode = Mode.EXCLUDE)
+  void notEmptyVersionTagForWrongBindingType(final ZeebeBindingType bindingType) {
+    // when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeCalledDecisionId("decisionId")
+                    .zeebeBindingType(bindingType)
+                    .zeebeVersionTag("v1.0")
+                    .zeebeResultVariable("result"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            ZeebeCalledDecision.class,
+            "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import org.junit.runners.Parameterized.Parameters;
 
@@ -58,6 +59,82 @@ public class ZeebeCallActivityTest extends AbstractZeebeValidationTest {
             expect(
                 ZeebeCalledElement.class,
                 "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call", c -> c.zeebeProcessId("x").zeebeBindingType(ZeebeBindingType.versionTag))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call",
+                c ->
+                    c.zeebeProcessId("x")
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTag(""))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call",
+                c ->
+                    c.zeebeProcessId("x")
+                        .zeebeBindingType(ZeebeBindingType.versionTag)
+                        .zeebeVersionTag(" "))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call",
+                c ->
+                    c.zeebeProcessId("x")
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call",
+                c ->
+                    c.zeebeProcessId("x")
+                        .zeebeBindingType(ZeebeBindingType.latest)
+                        .zeebeVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
@@ -21,6 +21,7 @@ import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import java.util.Arrays;
@@ -367,6 +368,84 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
                 ZeebeFormDefinition.class,
                 "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId").zeebeFormBindingType(ZeebeBindingType.versionTag))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.versionTag)
+                        .zeebeFormVersionTag(""))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.versionTag)
+                        .zeebeFormVersionTag(" "))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.deployment)
+                        .zeebeFormVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.latest)
+                        .zeebeFormVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
+      },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////////// Native user tasks ////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -661,7 +740,91 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
             expect(
                 ZeebeFormDefinition.class,
                 "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
-      }
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.versionTag))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.versionTag)
+                        .zeebeFormVersionTag(""))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.versionTag)
+                        .zeebeFormVersionTag(" "))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' must be present and not empty if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.deployment)
+                        .zeebeFormVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .zeebeFormBindingType(ZeebeBindingType.latest)
+                        .zeebeFormVersionTag("v1.0"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'versionTag' may only be used if 'bindingType' is 'versionTag'"))
+      },
     };
   }
 }


### PR DESCRIPTION
## Description
Validates the correct usage of the attributes `bindingType` and `versionTag` for the extension elements `ZeebeCalledElement`, `ZeebeCalledDecision` and `ZeebeFormDefinition`.

## Related issues
closes #21161