### PR TITLE
refactor: user query from indexes

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -34,8 +34,8 @@ public class CamundaUserDetailsService implements UserDetailsService {
         .map(
             candidate ->
                 User.builder()
-                    .username(candidate.value().username())
-                    .password(candidate.value().password())
+                    .username(candidate.username())
+                    .password(candidate.password())
                     .build())
         .orElseThrow(() -> new UsernameNotFoundException(username));
   }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.service.UserServices;
 import io.camunda.service.entities.UserEntity;
-import io.camunda.service.entities.UserEntity.User;
 import io.camunda.service.search.query.SearchQueryResult;
 import java.util.Collections;
 import java.util.List;
@@ -44,7 +43,7 @@ public class CamundaUserDetailsServiceTest {
     when(userService.search(any()))
         .thenReturn(
             new SearchQueryResult<>(
-                1, List.of(new UserEntity(new User(TEST_USER_ID, "", "", "password1"))), null));
+                1, List.of(new UserEntity(1L, TEST_USER_ID, "", "", "password1")), null));
     // when
     final UserDetails user = userDetailsService.loadUserByUsername(TEST_USER_ID);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -19,7 +19,6 @@ import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.application.sources.DefaultObjectMapperConfiguration;
 import io.camunda.service.UserServices;
 import io.camunda.service.entities.UserEntity;
-import io.camunda.service.entities.UserEntity.User;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
@@ -70,8 +69,7 @@ public class BasicAuthIT {
         .thenReturn(
             new SearchQueryResult<>(
                 1,
-                List.of(
-                    new UserEntity(new User(USERNAME, "", "", passwordEncoder.encode(PASSWORD)))),
+                List.of(new UserEntity(1L, USERNAME, "", "", passwordEncoder.encode(PASSWORD))),
                 null));
 
     content =

--- a/service/src/main/java/io/camunda/service/entities/UserEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/UserEntity.java
@@ -10,6 +10,4 @@ package io.camunda.service.entities;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record UserEntity(User value) {
-  public record User(String username, String name, String email, String password) {}
-}
+public record UserEntity(Long key, String username, String name, String email, String password) {}

--- a/service/src/main/java/io/camunda/service/search/filter/UserFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/UserFilter.java
@@ -9,11 +9,18 @@ package io.camunda.service.search.filter;
 
 import io.camunda.util.ObjectBuilder;
 
-public record UserFilter(String username, String name, String email) implements FilterBase {
+public record UserFilter(Long key, String username, String name, String email)
+    implements FilterBase {
   public static final class Builder implements ObjectBuilder<UserFilter> {
+    private Long key;
     private String username;
     private String name;
     private String email;
+
+    public Builder key(final Long value) {
+      key = value;
+      return this;
+    }
 
     public Builder username(final String value) {
       username = value;
@@ -32,7 +39,7 @@ public record UserFilter(String username, String name, String email) implements 
 
     @Override
     public UserFilter build() {
-      return new UserFilter(username, name, email);
+      return new UserFilter(key, username, name, email);
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/search/sort/UserSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/UserSort.java
@@ -26,18 +26,23 @@ public record UserSort(List<FieldSorting> orderings) implements SortOption {
   public static final class Builder extends AbstractBuilder<Builder>
       implements ObjectBuilder<UserSort> {
 
+    public Builder key() {
+      currentOrdering = new FieldSorting("key", null);
+      return this;
+    }
+
     public Builder username() {
-      currentOrdering = new FieldSorting("value.username", null);
+      currentOrdering = new FieldSorting("username", null);
       return this;
     }
 
     public Builder name() {
-      currentOrdering = new FieldSorting("value.name", null);
+      currentOrdering = new FieldSorting("name", null);
       return this;
     }
 
     public Builder email() {
-      currentOrdering = new FieldSorting("value.email", null);
+      currentOrdering = new FieldSorting("email", null);
       return this;
     }
 

--- a/service/src/main/java/io/camunda/service/transformers/filter/UserFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/UserFilterTransformer.java
@@ -20,13 +20,14 @@ public class UserFilterTransformer implements FilterTransformer<UserFilter> {
   public SearchQuery toSearchQuery(final UserFilter filter) {
 
     return and(
-        filter.username() == null ? null : term("value.username", filter.username()),
-        filter.email() == null ? null : term("value.email", filter.email()),
-        filter.name() == null ? null : term("value.name", filter.name()));
+        filter.key() == null ? null : term("key", filter.key()),
+        filter.username() == null ? null : term("username", filter.username()),
+        filter.email() == null ? null : term("email", filter.email()),
+        filter.name() == null ? null : term("name", filter.name()));
   }
 
   @Override
   public List<String> toIndices(final UserFilter filter) {
-    return List.of("zeebe-record-user");
+    return List.of("users");
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/UserFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserFilterTest.java
@@ -53,7 +53,7 @@ public class UserFilterTest {
     assertThat(searchQueryResult.total()).isEqualTo(2);
     assertThat(searchQueryResult.items()).hasSize(2);
     final UserEntity item = searchQueryResult.items().get(0);
-    assertThat(item.value().name()).isEqualTo("name1");
+    assertThat(item.name()).isEqualTo("name1");
   }
 
   @ParameterizedTest
@@ -61,7 +61,7 @@ public class UserFilterTest {
   public void shouldQueryByField(
       final Function<Builder, ObjectBuilder<UserFilter>> fn,
       final String column,
-      final String value) {
+      final Object value) {
     // given
     final var userFilter = FilterBuilders.user(fn);
     final var searchQuery = SearchQueryBuilders.userSearchQuery(q -> q.filter(userFilter));
@@ -78,23 +78,22 @@ public class UserFilterTest {
             SearchTermQuery.class,
             t -> {
               assertThat(t.field()).isEqualTo(column);
-              assertThat(t.value().stringValue()).isEqualTo(value);
+              assertThat(t.value().value()).isEqualTo(value);
             });
   }
 
   public static Stream<Arguments> queryFilterParameters() {
     return Stream.of(
+        Arguments.of((Function<Builder, ObjectBuilder<UserFilter>>) f -> f.key(1L), "key", 1L),
         Arguments.of(
             (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.username("username1"),
-            "value.username",
+            "username",
             "username1"),
         Arguments.of(
-            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.name("name1"),
-            "value.name",
-            "name1"),
+            (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.name("name1"), "name", "name1"),
         Arguments.of(
             (Function<Builder, ObjectBuilder<UserFilter>>) f -> f.email("email1"),
-            "value.email",
+            "email",
             "email1"));
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/UserSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserSearchQueryStub.java
@@ -23,15 +23,11 @@ public class UserSearchQueryStub implements RequestStub<UserEntity> {
         List.of(
             new SearchQueryHit.Builder<UserEntity>()
                 .id("1")
-                .source(
-                    new UserEntity(
-                        new UserEntity.User("username1", "name1", "email1", "password1")))
+                .source(new UserEntity(1L, "username1", "name1", "email1", "password1"))
                 .build(),
             new SearchQueryHit.Builder<UserEntity>()
                 .id("2")
-                .source(
-                    new UserEntity(
-                        new UserEntity.User("username2", "name2", "email2", "password2")))
+                .source(new UserEntity(2L, "username2", "name2", "email2", "password2"))
                 .build());
 
     final SearchQueryResponse<UserEntity> response =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/entities/UserEntity.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/entities/UserEntity.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.entities;
 
 public class UserEntity implements ExporterEntity<UserEntity> {
   private String id;
+  private Long key;
   private String username;
   private String name;
   private String email;
@@ -22,6 +23,15 @@ public class UserEntity implements ExporterEntity<UserEntity> {
   @Override
   public UserEntity setId(final String id) {
     this.id = id;
+    return this;
+  }
+
+  public Long getKey() {
+    return key;
+  }
+
+  public UserEntity setKey(final Long key) {
+    this.key = key;
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserRecordValueExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserRecordValueExportHandler.java
@@ -45,6 +45,7 @@ public class UserRecordValueExportHandler implements ExportHandler<UserEntity, U
   public void updateEntity(final Record<UserRecordValue> record, final UserEntity entity) {
     final UserRecordValue value = record.getValue();
     entity
+        .setKey(value.getUserKey())
         .setUsername(value.getUsername())
         .setName(value.getName())
         .setEmail(value.getEmail())

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1785,6 +1785,9 @@ components:
         id:
           type: "integer"
           format: "int64"
+        key:
+          type: "integer"
+          format: "int64"
         username:
           type: "string"
         name:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -253,8 +253,9 @@ public final class SearchQueryResponseMapper {
   public static Either<ProblemDetail, UserResponse> toUser(final UserEntity user) {
     return Either.right(
         new UserResponse()
-            .username(user.value().username())
-            .email(user.value().email())
-            .name(user.value().name()));
+            .key(user.key())
+            .username(user.username())
+            .email(user.email())
+            .name(user.name()));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserQueryControllerTest.java
@@ -57,9 +57,7 @@ public class UserQueryControllerTest extends RestControllerTest {
   private static final SearchQueryResult<UserEntity> SEARCH_QUERY_RESULT =
       new Builder<UserEntity>()
           .total(1L)
-          .items(
-              List.of(
-                  new UserEntity(new UserEntity.User("username1", "name1", "email1", "password1"))))
+          .items(List.of(new UserEntity(1L, "username1", "name1", "email1", "password1")))
           .sortValues(new Object[] {"v"})
           .build();
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserQueryControllerTest.java
@@ -39,7 +39,8 @@ public class UserQueryControllerTest extends RestControllerTest {
       """
           {
               "items": [
-                 { "username": "username1",
+                 { "key": 1,
+                   "username": "username1",
                    "name": "name1",
                    "email": "email1"
                  }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
With the exporter changes in https://github.com/camunda/camunda/pull/21841 users are now exported to the correct indexes in a structure that is flat. This means that we can update the existing code to use the new indexes and flatter structure.

Along with this, I have also set the user key to be exported on the new entities and added in the required filter/sort/transformer support
