### PR TITLE
feat: partition scoped metric registrity

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.ExporterDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.InterPartitionCommandServiceStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStoragePartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.LogStreamPartitionTransitionStep;
+import io.camunda.zeebe.broker.system.partitions.impl.steps.MetricsStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.MigrationTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.QueryServicePartitionTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.RockDbMetricExporterPartitionStartupStep;
@@ -73,6 +74,7 @@ public final class ZeebePartitionFactory {
 
   private static final List<PartitionTransitionStep> TRANSITION_STEPS =
       List.of(
+          new MetricsStep(),
           new LogStoragePartitionTransitionStep(),
           new LogStreamPartitionTransitionStep(),
           new ZeebeDbPartitionTransitionStep(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -47,6 +47,8 @@ import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -102,7 +104,8 @@ public class PartitionStartupAndTransitionContextImpl
   private BackupStore backupStore;
   private AdminApiRequestHandler adminApiService;
   private PartitionAdminAccess adminAccess;
-  private final MeterRegistry meterRegistry;
+  private final MeterRegistry brokerMeterRegistry;
+  private MeterRegistry partitionMeterRegistry;
   private ControllableStreamClock clock;
 
   public PartitionStartupAndTransitionContextImpl(
@@ -124,7 +127,7 @@ public class PartitionStartupAndTransitionContextImpl
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final AtomixServerTransport gatewayBrokerTransport,
       final TopologyManager topologyManager,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry brokerMeterRegistry) {
     this.nodeId = nodeId;
     this.partitionCount = partitionCount;
     this.clusterCommunicationService = clusterCommunicationService;
@@ -145,7 +148,8 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
-    this.meterRegistry = meterRegistry;
+    this.brokerMeterRegistry = new CompositeMeterRegistry().add(brokerMeterRegistry);
+    this.brokerMeterRegistry.config().commonTags(Tags.of("partition", String.valueOf(partitionId)));
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -357,8 +361,18 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public MeterRegistry getMeterRegistry() {
-    return meterRegistry;
+  public MeterRegistry getBrokerMeterRegistry() {
+    return brokerMeterRegistry;
+  }
+
+  @Override
+  public MeterRegistry getPartitionMeterRegistry() {
+    return partitionMeterRegistry;
+  }
+
+  @Override
+  public void setPartitionMeterRegistry(final MeterRegistry partitionMeterRegistry) {
+    this.partitionMeterRegistry = partitionMeterRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -127,5 +127,9 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   void setBackupStore(BackupStore backupStore);
 
-  MeterRegistry getMeterRegistry();
+  MeterRegistry getBrokerMeterRegistry();
+
+  MeterRegistry getPartitionMeterRegistry();
+
+  void setPartitionMeterRegistry(MeterRegistry partitionMeterRegistry);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -124,7 +124,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
-            .meterRegistry(context.getBrokerMeterRegistry());
+            .meterRegistry(context.getPartitionMeterRegistry());
 
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -124,7 +124,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
             .positionsToSkipFilter(exporterFilter)
-            .meterRegistry(context.getMeterRegistry());
+            .meterRegistry(context.getBrokerMeterRegistry());
 
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MetricsStep.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl.steps;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
+
+public final class MetricsStep implements PartitionTransitionStep {
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var partitionMeterRegistry = (CompositeMeterRegistry) context.getPartitionMeterRegistry();
+    final var brokerMeterRegistry = context.getBrokerMeterRegistry();
+    if (partitionMeterRegistry != null) {
+      // Clear all meters from the partition registry. Their values are invalid after the
+      // transition.
+      partitionMeterRegistry.clear();
+      // Remove the backing broker registry from the partition registry so that we can close the
+      // partition registry without closing the broker registry.
+      // This also increases reliability in case something holds on to the partition registry
+      // because any new meters will no longer be forwarded to the broker registry.
+      partitionMeterRegistry.remove(brokerMeterRegistry);
+      partitionMeterRegistry.close();
+      context.setPartitionMeterRegistry(null);
+    }
+    return context.getConcurrencyControl().createCompletedFuture();
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    final var brokerRegistry = context.getBrokerMeterRegistry();
+
+    // Create a new registry that already has the partition tag defined.
+    final var partitionRegistry = new CompositeMeterRegistry();
+    partitionRegistry
+        .config()
+        .commonTags(Tags.of("partition", Integer.toString(context.getPartitionId())));
+    // Wrap over the broker registry so that all meters are forwarded to the broker registry.
+    partitionRegistry.add(brokerRegistry);
+
+    context.setPartitionMeterRegistry(partitionRegistry);
+    return context.getConcurrencyControl().createCompletedFuture();
+  }
+
+  @Override
+  public String getName() {
+    return "Metrics";
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -151,7 +151,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 
     return StreamProcessor.builder()
-        .meterRegistry(context.getBrokerMeterRegistry())
+        .meterRegistry(context.getPartitionMeterRegistry())
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -151,7 +151,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 
     return StreamProcessor.builder()
-        .meterRegistry(context.getMeterRegistry())
+        .meterRegistry(context.getBrokerMeterRegistry())
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -39,7 +39,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
-import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
@@ -75,10 +74,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private CheckpointRecordsProcessor checkpointRecordsProcessor;
   private BackupStore backupStore;
   private DynamicPartitionConfig partitionConfig;
-  private CommandApiService commandApiService;
-  private MeterRegistry meterRegistry;
   private ControllableStreamClock clock;
-  private ClusterContext clusterContext;
 
   @Override
   public int getPartitionId() {
@@ -312,9 +308,17 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   }
 
   @Override
-  public MeterRegistry getMeterRegistry() {
-    return meterRegistry;
+  public MeterRegistry getBrokerMeterRegistry() {
+    return null;
   }
+
+  @Override
+  public MeterRegistry getPartitionMeterRegistry() {
+    return null;
+  }
+
+  @Override
+  public void setPartitionMeterRegistry(final MeterRegistry partitionMeterRegistry) {}
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {
     this.gatewayBrokerTransport = gatewayBrokerTransport;
@@ -368,7 +372,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
 
   @Override
   public CommandApiService getCommandApiService() {
-    return commandApiService;
+    return null;
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -44,9 +44,8 @@ class ElasticsearchClient implements AutoCloseable {
   private final TemplateReader templateReader;
   private final RecordIndexRouter indexRouter;
   private final BulkIndexRequest bulkIndexRequest;
-  private final MeterRegistry meterRegistry;
 
-  private ElasticsearchMetrics metrics;
+  private final ElasticsearchMetrics metrics;
 
   /**
    * Sample to measure the flush latency of the current bulk request.
@@ -64,8 +63,7 @@ class ElasticsearchClient implements AutoCloseable {
         RestClientFactory.of(configuration),
         new RecordIndexRouter(configuration.index),
         new TemplateReader(configuration),
-        null,
-        meterRegistry);
+        new ElasticsearchMetrics(meterRegistry));
   }
 
   ElasticsearchClient(
@@ -74,15 +72,13 @@ class ElasticsearchClient implements AutoCloseable {
       final RestClient client,
       final RecordIndexRouter indexRouter,
       final TemplateReader templateReader,
-      final ElasticsearchMetrics metrics,
-      final MeterRegistry meterRegistry) {
+      final ElasticsearchMetrics metrics) {
     this.configuration = configuration;
     this.bulkIndexRequest = bulkIndexRequest;
     this.client = client;
     this.indexRouter = indexRouter;
     this.templateReader = templateReader;
     this.metrics = metrics;
-    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -91,10 +87,6 @@ class ElasticsearchClient implements AutoCloseable {
   }
 
   public void index(final Record<?> record, final RecordSequence recordSequence) {
-    if (metrics == null) {
-      metrics = new ElasticsearchMetrics(record.getPartitionId(), meterRegistry);
-    }
-
     if (bulkIndexRequest.isEmpty()) {
       flushLatencyMeasurement = metrics.startFlushLatencyMeasurement();
     }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -17,9 +17,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class ElasticsearchMetrics {
   private static final String NAMESPACE = "zeebe.elasticsearch.exporter";
-  private static final String PARTITION_LABEL = "partition";
 
-  private final String partitionIdLabel;
   private final MeterRegistry meterRegistry;
   private final AtomicInteger bulkMemorySize = new AtomicInteger(0);
   private final Timer flushDuration;
@@ -27,19 +25,16 @@ public class ElasticsearchMetrics {
   private final Counter failedFlush;
   private final Timer flushLatency;
 
-  public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
-    partitionIdLabel = String.valueOf(partitionId);
+  public ElasticsearchMetrics(final MeterRegistry registry) {
     meterRegistry = registry;
 
     Gauge.builder(meterName("bulk.memory.size"), bulkMemorySize, AtomicInteger::get)
-        .tags(PARTITION_LABEL, partitionIdLabel)
         .description("Exporter bulk memory size")
         .register(meterRegistry);
 
     flushDuration =
         Timer.builder(meterName("flush.duration.seconds"))
             .description("Flush duration of bulk exporters in seconds")
-            .tags(PARTITION_LABEL, partitionIdLabel)
             .publishPercentileHistogram()
             .minimumExpectedValue(Duration.ofMillis(10))
             .register(meterRegistry);
@@ -47,21 +42,18 @@ public class ElasticsearchMetrics {
     bulkSize =
         DistributionSummary.builder(meterName("bulk.size"))
             .description("Exporter bulk size")
-            .tags(PARTITION_LABEL, partitionIdLabel)
             .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
             .register(meterRegistry);
 
     failedFlush =
         Counter.builder(meterName("failed.flush"))
             .description("Number of failed flush operations")
-            .tags(PARTITION_LABEL, partitionIdLabel)
             .register(meterRegistry);
 
     flushLatency =
         Timer.builder(meterName("flush.latency"))
             .description(
                 "Time of how long a export buffer is open and collects new records before flushing, meaning latency until the next flush is done.")
-            .tags(PARTITION_LABEL, partitionIdLabel)
             .publishPercentileHistogram()
             .register(meterRegistry);
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -71,8 +71,7 @@ final class ElasticsearchClientIT {
             RestClientFactory.of(config),
             indexRouter,
             templateReader,
-            null,
-            new SimpleMeterRegistry());
+            new ElasticsearchMetrics(new SimpleMeterRegistry()));
   }
 
   @AfterEach

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -65,8 +65,7 @@ final class ElasticsearchClientTest {
           restClient,
           indexRouter,
           templateReader,
-          null,
-          new SimpleMeterRegistry());
+          new ElasticsearchMetrics(new SimpleMeterRegistry()));
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -49,9 +49,8 @@ public class OpensearchClient implements AutoCloseable {
   private final TemplateReader templateReader;
   private final RecordIndexRouter indexRouter;
   private final BulkIndexRequest bulkIndexRequest;
-  private final MeterRegistry meterRegistry;
 
-  private OpensearchMetrics metrics;
+  private final OpensearchMetrics metrics;
 
   OpensearchClient(
       final OpensearchExporterConfiguration configuration, final MeterRegistry meterRegistry) {
@@ -61,8 +60,7 @@ public class OpensearchClient implements AutoCloseable {
         RestClientFactory.of(configuration),
         new RecordIndexRouter(configuration.index),
         new TemplateReader(configuration.index),
-        null,
-        meterRegistry);
+        new OpensearchMetrics(meterRegistry));
   }
 
   OpensearchClient(
@@ -71,15 +69,13 @@ public class OpensearchClient implements AutoCloseable {
       final RestClient client,
       final RecordIndexRouter indexRouter,
       final TemplateReader templateReader,
-      final OpensearchMetrics metrics,
-      final MeterRegistry meterRegistry) {
+      final OpensearchMetrics metrics) {
     this.configuration = configuration;
     this.bulkIndexRequest = bulkIndexRequest;
     this.client = client;
     this.indexRouter = indexRouter;
     this.templateReader = templateReader;
     this.metrics = metrics;
-    this.meterRegistry = meterRegistry;
   }
 
   @Override
@@ -88,10 +84,6 @@ public class OpensearchClient implements AutoCloseable {
   }
 
   public void index(final Record<?> record, final RecordSequence recordSequence) {
-    if (metrics == null) {
-      metrics = new OpensearchMetrics(record.getPartitionId(), meterRegistry);
-    }
-
     final BulkIndexAction action =
         new BulkIndexAction(
             indexRouter.indexFor(record),

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchMetrics.java
@@ -18,21 +18,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class OpensearchMetrics {
   private static final String NAMESPACE = "zeebe.opensearch.exporter";
-  private static final String PARTITION_LABEL = "partition";
 
-  private final String partitionIdLabel;
   private final MeterRegistry meterRegistry;
   private final AtomicInteger bulkMemorySize = new AtomicInteger(0);
 
-  public OpensearchMetrics(final int partitionId, final MeterRegistry meterRegistry) {
-    partitionIdLabel = String.valueOf(partitionId);
+  public OpensearchMetrics(final MeterRegistry meterRegistry) {
     this.meterRegistry = meterRegistry;
   }
 
   public ResourceSample measureFlushDuration() {
     return Timer.resource(meterRegistry, meterName("flush.duration.seconds"))
         .description("Flush duration of bulk exporters in seconds")
-        .tag(PARTITION_LABEL, partitionIdLabel)
         .publishPercentileHistogram()
         .minimumExpectedValue(Duration.ofMillis(10));
   }
@@ -40,7 +36,6 @@ public class OpensearchMetrics {
   public void recordBulkSize(final int bulkSize) {
     DistributionSummary.builder(meterName("bulk.size"))
         .description("Exporter bulk size")
-        .tags(PARTITION_LABEL, partitionIdLabel)
         .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
         .register(meterRegistry)
         .record(bulkSize);
@@ -48,7 +43,6 @@ public class OpensearchMetrics {
 
   public void recordBulkMemorySize(final int bulkMemorySize) {
     Gauge.builder(meterName("bulk.memory.size"), this.bulkMemorySize, AtomicInteger::get)
-        .tags(PARTITION_LABEL, partitionIdLabel)
         .description("Exporter bulk memory size")
         .register(meterRegistry);
 
@@ -58,7 +52,6 @@ public class OpensearchMetrics {
   public void recordFailedFlush() {
     Counter.builder(meterName("failed.flush"))
         .description("Number of failed flush operations")
-        .tags(PARTITION_LABEL, partitionIdLabel)
         .register(meterRegistry)
         .increment();
   }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -60,8 +60,7 @@ final class OpensearchClientIT {
             RestClientFactory.of(config, true),
             indexRouter,
             templateReader,
-            new OpensearchMetrics(PARTITION_ID, new SimpleMeterRegistry()),
-            new SimpleMeterRegistry());
+            new OpensearchMetrics(new SimpleMeterRegistry()));
   }
 
   @AfterEach
@@ -152,8 +151,7 @@ final class OpensearchClientIT {
             RestClientFactory.of(config, true),
             indexRouter,
             templateReader,
-            new OpensearchMetrics(PARTITION_ID, new SimpleMeterRegistry()),
-            new SimpleMeterRegistry());
+            new OpensearchMetrics(new SimpleMeterRegistry()));
     authenticatedClient.putComponentTemplate();
 
     // then

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
@@ -62,8 +62,7 @@ final class OpensearchClientTest {
           restClient,
           indexRouter,
           templateReader,
-          new OpensearchMetrics(PARTITION_ID, new SimpleMeterRegistry()),
-          new SimpleMeterRegistry());
+          new OpensearchMetrics(new SimpleMeterRegistry()));
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -166,9 +166,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       final var startRecoveryTimer = metrics.startRecoveryTimer();
       final long snapshotPosition = recoverFromSnapshot();
 
-      scheduledTaskMetrics =
-          ScheduledTaskMetrics.of(
-              streamProcessorContext.getMeterRegistry(), streamProcessorContext.getPartitionId());
+      scheduledTaskMetrics = ScheduledTaskMetrics.of(streamProcessorContext.getMeterRegistry());
       processorActorService =
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase,
@@ -287,7 +285,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void tearDown() {
-    scheduledTaskMetrics.close();
     processorActorService.close();
     asyncScheduleService.close();
     streamProcessorContext.getLogStreamReader().close();

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -405,7 +405,7 @@ class ProcessingScheduleServiceTest {
                 commandCache,
                 actorScheduler.getClock(),
                 Duration.ofSeconds(1),
-                ScheduledTaskMetrics.of(registry, 1)));
+                ScheduledTaskMetrics.of(registry)));
 
     // when
     actorScheduler.submitActor(scheduleService);
@@ -413,20 +413,8 @@ class ProcessingScheduleServiceTest {
 
     // then
     assertThat(registry.getMeters()).isNotEmpty();
-    assertThat(
-            registry
-                .get("zeebe.processing.scheduling.tasks")
-                .tags("partition", "1")
-                .gauge()
-                .value())
-        .isEqualTo(0);
-    assertThat(
-            registry
-                .get("zeebe.processing.scheduling.delay")
-                .tags("partition", "1")
-                .timer()
-                .count())
-        .isEqualTo(0);
+    assertThat(registry.get("zeebe.processing.scheduling.tasks").gauge().value()).isEqualTo(0);
+    assertThat(registry.get("zeebe.processing.scheduling.delay").timer().count()).isEqualTo(0);
   }
 
   @Test
@@ -442,7 +430,7 @@ class ProcessingScheduleServiceTest {
                 commandCache,
                 actorScheduler.getClock(),
                 Duration.ofSeconds(1),
-                ScheduledTaskMetrics.of(registry, 1)));
+                ScheduledTaskMetrics.of(registry)));
     actorScheduler.submitActor(scheduleService);
     actorScheduler.workUntilDone();
 
@@ -467,7 +455,7 @@ class ProcessingScheduleServiceTest {
                 commandCache,
                 actorScheduler.getClock(),
                 Duration.ofSeconds(1),
-                ScheduledTaskMetrics.of(registry, 1)));
+                ScheduledTaskMetrics.of(registry)));
     actorScheduler.submitActor(scheduleService);
     actorScheduler.workUntilDone();
 


### PR DESCRIPTION
This solves three problems:
1. How to remove meters when partitions are removed
2. How to reset meters when partitions change roles
3. How to set the partition id label for every meter

We do this by creating a new registry on every partition transition.
This allows us to define common labels (i.e. partition id) and to remove all meters specific to that partition and role.

The partition registry is wrapped over the general broker registry such that all meters are forwarded to the correct
backend automatically.

This happens to close https://github.com/camunda/camunda/issues/22017 which I only discovered while testing this PR.