### PR TITLE
feat: allow message and timer boundary event migration in UI

### DIFF
--- a/operate/client/e2e-playwright/pages/ProcessInstance.ts
+++ b/operate/client/e2e-playwright/pages/ProcessInstance.ts
@@ -29,6 +29,7 @@ export class ProcessInstance {
   readonly executionCountToggleOn: Locator;
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
+  readonly metadataModal: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -55,6 +56,7 @@ export class ProcessInstance {
       /^hide execution count$/i,
     );
     this.listenersTabButton = page.getByTestId('listeners-tab-button');
+    this.metadataModal = this.page.getByRole('dialog', {name: /metadata/i});
   }
 
   getEditVariableFieldSelector(variableName: string) {

--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -79,4 +79,10 @@ export class Processes {
       .nth(index)
       .locator('label');
   };
+
+  getNthProcessInstanceLink = (index: number) => {
+    return this.processInstancesTable
+      .getByRole('link', {name: /view instance/i})
+      .nth(index);
+  };
 }

--- a/operate/client/e2e-playwright/pages/components/Diagram.ts
+++ b/operate/client/e2e-playwright/pages/components/Diagram.ts
@@ -50,6 +50,12 @@ export class Diagram {
       .filter({hasText: new RegExp(`^${flowNodeName}$`, 'i')});
   }
 
+  showMetaData() {
+    return this.popover
+      .getByRole('button', {name: /show more metadata/i})
+      .click();
+  }
+
   getExecutionCount(elementId: string) {
     return this.diagram.evaluate(
       (node, {elementId}) => {

--- a/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
@@ -38,6 +38,7 @@ const setup = async () => {
       'orderProcessMigration',
       deploymentsV1[0].process.version,
       10,
+      {key1: 'myFirstCorrelationKey', key2: 'mySecondCorrelationKey'},
     ),
     processV1: deploymentsV1[0].process,
     processV2: deploymentsV2[0].process,

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="Gateway_1" />
     <bpmn:serviceTask id="checkPayment" name="Check payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkPayment" />
       </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:incoming>Flow_18wek8y</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:serviceTask id="shipArticles" name="Ship Articles">
@@ -20,10 +20,10 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_042s0oc">
-      <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_0qko2kt</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="EndEvent_042s0oc" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Gateway_2" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
@@ -44,7 +44,112 @@
     <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_18wek8y" sourceRef="Gateway_1" targetRef="checkPayment" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_18wek8y</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1clcikd</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1lf6gyt</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0vrcdpx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_143wmxd</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0qko2kt" sourceRef="Gateway_2" targetRef="EndEvent_1" />
+    <bpmn:endEvent id="Event_2">
+      <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_3">
+      <bpmn:incoming>Flow_1ym4tee</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_4">
+      <bpmn:incoming>Flow_0b5y250</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="TaskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1clcikd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nr2w41</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskB" name="Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1lf6gyt</bpmn:incoming>
+      <bpmn:outgoing>Flow_1o99cpi</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskC" name="Task C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0vrcdpx</bpmn:incoming>
+      <bpmn:outgoing>Flow_18qdbnx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerInterrupting" name="Timer interrupting" attachedToRef="TaskB">
+      <bpmn:outgoing>Flow_1ym4tee</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_04oq8h5">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+      <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_3mvm2pn" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_2" />
+    <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting" targetRef="Event_3" />
+    <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting" targetRef="Event_4" />
+    <bpmn:sequenceFlow id="Flow_1clcikd" sourceRef="Gateway_1" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_1lf6gyt" sourceRef="Gateway_1" targetRef="TaskB" />
+    <bpmn:sequenceFlow id="Flow_0vrcdpx" sourceRef="Gateway_1" targetRef="TaskC" />
+    <bpmn:sequenceFlow id="Flow_0nr2w41" sourceRef="TaskA" targetRef="Gateway_2" />
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
+      <bpmn:incoming>Flow_0nr2w41</bpmn:incoming>
+      <bpmn:incoming>Flow_1o99cpi</bpmn:incoming>
+      <bpmn:incoming>Flow_18qdbnx</bpmn:incoming>
+      <bpmn:incoming>Flow_1i7pkzb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qko2kt</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1o99cpi" sourceRef="TaskB" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_18qdbnx" sourceRef="TaskC" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_143wmxd" sourceRef="Gateway_1" targetRef="TaskD" />
+    <bpmn:endEvent id="Event_5">
+      <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="TaskD" name="Task D">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_143wmxd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1i7pkzb</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1i7pkzb" sourceRef="TaskD" targetRef="Gateway_2" />
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+      <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting" targetRef="Event_5" />
   </bpmn:process>
+  <bpmn:message id="Message_0so1os3" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1xpzcw8" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key2" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_3mvm2pn" name="Message_2">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key2" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessMigration">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
@@ -54,68 +159,190 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
-        <dc:Bounds x="300" y="98" width="100" height="80" />
+        <dc:Bounds x="440" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
-        <dc:Bounds x="633" y="98" width="100" height="80" />
+        <dc:Bounds x="773" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="792" y="120" width="36" height="36" />
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="609" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="600" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="584" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1p3ovhb_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="305" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1062" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="469" y="113" width="50" height="50" />
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="562" y="485" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="562" y="635" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="562" y="795" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
+        <dc:Bounds x="440" y="370" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
+        <dc:Bounds x="440" y="532" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
+        <dc:Bounds x="440" y="692" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
+        <dc:Bounds x="440" y="852" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1bflyvp_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="945" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="562" y="955" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="492" y="432" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="460" y="85" width="69" height="14" />
+          <dc:Bounds x="442" y="459" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
-        <dc:Bounds x="444" y="260" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
+        <dc:Bounds x="492" y="594" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="417" y="626" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
+        <dc:Bounds x="492" y="754" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="434" y="789" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="492" y="914" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="442" y="949" width="56" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />
-        <di:waypoint x="300" y="138" />
+        <di:waypoint x="305" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="733" y="138" />
-        <di:waypoint x="792" y="138" />
+        <di:waypoint x="873" y="138" />
+        <di:waypoint x="945" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="337.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="400" y="138" />
-        <di:waypoint x="469" y="138" />
+        <di:waypoint x="540" y="138" />
+        <di:waypoint x="609" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="494" y="163" />
-        <di:waypoint x="494" y="260" />
+        <di:waypoint x="634" y="163" />
+        <di:waypoint x="634" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="450" y="188" width="41" height="14" />
+          <dc:Bounds x="590" y="188" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="444" y="300" />
-        <di:waypoint x="350" y="300" />
-        <di:waypoint x="350" y="178" />
+        <di:waypoint x="584" y="300" />
+        <di:waypoint x="490" y="300" />
+        <di:waypoint x="490" y="178" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="519" y="138" />
-        <di:waypoint x="633" y="138" />
+        <di:waypoint x="659" y="138" />
+        <di:waypoint x="773" y="138" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="566" y="117" width="21" height="14" />
+          <dc:Bounds x="706" y="117" width="21" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18wek8y_di" bpmnElement="Flow_18wek8y">
+        <di:waypoint x="355" y="138" />
+        <di:waypoint x="440" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qko2kt_di" bpmnElement="Flow_0qko2kt">
+        <di:waypoint x="995" y="138" />
+        <di:waypoint x="1062" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="510" y="468" />
+        <di:waypoint x="510" y="503" />
+        <di:waypoint x="562" y="503" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="510" y="653" />
+        <di:waypoint x="562" y="653" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
+        <di:waypoint x="510" y="790" />
+        <di:waypoint x="510" y="813" />
+        <di:waypoint x="562" y="813" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="510" y="950" />
+        <di:waypoint x="510" y="973" />
+        <di:waypoint x="562" y="973" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1clcikd_di" bpmnElement="Flow_1clcikd">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="410" />
+        <di:waypoint x="440" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lf6gyt_di" bpmnElement="Flow_1lf6gyt">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="572" />
+        <di:waypoint x="440" y="572" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vrcdpx_di" bpmnElement="Flow_0vrcdpx">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="732" />
+        <di:waypoint x="440" y="732" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_143wmxd_di" bpmnElement="Flow_143wmxd">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="892" />
+        <di:waypoint x="440" y="892" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nr2w41_di" bpmnElement="Flow_0nr2w41">
+        <di:waypoint x="540" y="410" />
+        <di:waypoint x="970" y="410" />
+        <di:waypoint x="970" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o99cpi_di" bpmnElement="Flow_1o99cpi">
+        <di:waypoint x="540" y="572" />
+        <di:waypoint x="970" y="572" />
+        <di:waypoint x="970" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18qdbnx_di" bpmnElement="Flow_18qdbnx">
+        <di:waypoint x="540" y="732" />
+        <di:waypoint x="970" y="732" />
+        <di:waypoint x="970" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i7pkzb_di" bpmnElement="Flow_1i7pkzb">
+        <di:waypoint x="540" y="892" />
+        <di:waypoint x="970" y="892" />
+        <di:waypoint x="970" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="Gateway_1" />
     <bpmn:serviceTask id="checkPayment" name="Check payment">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkPayment" />
       </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:incoming>Flow_0ngsahl</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_042s0oc">
-      <bpmn:incoming>Flow_0zx0zzd</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -44,7 +44,7 @@
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Activity_0ae6k1y" />
-    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="EndEvent_042s0oc" />
+    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Gateway_2" />
     <bpmn:serviceTask id="Activity_0ae6k1y" name="Notify Customer">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="notifyCustomer" />
@@ -52,7 +52,107 @@
       <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
       <bpmn:outgoing>Flow_0zx0zzd</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_2">
+      <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_3">
+      <bpmn:incoming>Flow_1ym4tee</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_4">
+      <bpmn:incoming>Flow_0b5y250</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_5">
+      <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="TaskA" name="Task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05ul9v8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qjjeae</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskB" name="Task B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jjil6z</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vp8yz2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskC" name="Task C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1rzqxuo</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bqerrc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerInterrupting" name="Timer interrupting" attachedToRef="TaskB">
+      <bpmn:outgoing>Flow_1ym4tee</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_04oq8h5">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+      <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_2" />
+    <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting" targetRef="Event_3" />
+    <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting" targetRef="Event_4" />
+    <bpmn:sequenceFlow id="Flow_0ngsahl" sourceRef="Gateway_1" targetRef="checkPayment" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ngsahl</bpmn:outgoing>
+      <bpmn:outgoing>Flow_05ul9v8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0jjil6z</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rzqxuo</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1bdhdkt</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_05ul9v8" sourceRef="Gateway_1" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_0jjil6z" sourceRef="Gateway_1" targetRef="TaskB" />
+    <bpmn:sequenceFlow id="Flow_1rzqxuo" sourceRef="Gateway_1" targetRef="TaskC" />
+    <bpmn:sequenceFlow id="Flow_1xou7mm" sourceRef="Gateway_2" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_1qjjeae" sourceRef="TaskA" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0vp8yz2" sourceRef="TaskB" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0bqerrc" sourceRef="TaskC" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_1bdhdkt" sourceRef="Gateway_1" targetRef="TaskD" />
+    <bpmn:serviceTask id="TaskD" name="Task D">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1bdhdkt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hx3trf</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0hx3trf" sourceRef="TaskD" targetRef="Gateway_2" />
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+      <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting" targetRef="Event_5" />
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>Flow_0zx0zzd</bpmn:incoming>
+      <bpmn:incoming>Flow_1qjjeae</bpmn:incoming>
+      <bpmn:incoming>Flow_0vp8yz2</bpmn:incoming>
+      <bpmn:incoming>Flow_0bqerrc</bpmn:incoming>
+      <bpmn:incoming>Flow_0hx3trf</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xou7mm</bpmn:outgoing>
+    </bpmn:parallelGateway>
   </bpmn:process>
+  <bpmn:message id="Message_0so1os3" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1xpzcw8" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessMigration">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
@@ -61,76 +161,198 @@
           <dc:Bounds x="157" y="156" width="73" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
-        <dc:Bounds x="300" y="98" width="100" height="80" />
+      <bpmndi:BPMNShape id="Gateway_0qdsa34_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="285" y="113" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="882" y="120" width="36" height="36" />
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="400" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="569" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="560" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="544" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
+        <dc:Bounds x="690" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
+        <dc:Bounds x="840" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="522" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="522" y="662" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="522" y="822" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="522" y="982" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
+        <dc:Bounds x="400" y="397" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
+        <dc:Bounds x="400" y="559" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
+        <dc:Bounds x="400" y="719" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
+        <dc:Bounds x="400" y="879" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1062" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="469" y="113" width="50" height="50" />
+      <bpmndi:BPMNShape id="Gateway_1c7u8wl_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="975" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="452" y="459" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="460" y="85" width="69" height="14" />
+          <dc:Bounds x="402" y="486" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
-        <dc:Bounds x="444" y="260" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
+        <dc:Bounds x="452" y="621" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="377" y="653" width="86" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
-        <dc:Bounds x="590" y="98" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
+        <dc:Bounds x="452" y="781" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="394" y="816" width="71" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
-        <dc:Bounds x="740" y="98" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="452" y="941" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="402" y="976" width="56" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />
-        <di:waypoint x="300" y="138" />
+        <di:waypoint x="285" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="400" y="138" />
-        <di:waypoint x="469" y="138" />
+        <di:waypoint x="500" y="138" />
+        <di:waypoint x="569" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="494" y="163" />
-        <di:waypoint x="494" y="260" />
+        <di:waypoint x="594" y="163" />
+        <di:waypoint x="594" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="450" y="188" width="41" height="14" />
+          <dc:Bounds x="550" y="188" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="444" y="300" />
-        <di:waypoint x="350" y="300" />
-        <di:waypoint x="350" y="178" />
+        <di:waypoint x="544" y="300" />
+        <di:waypoint x="450" y="300" />
+        <di:waypoint x="450" y="178" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="519" y="138" />
-        <di:waypoint x="590" y="138" />
+        <di:waypoint x="619" y="138" />
+        <di:waypoint x="690" y="138" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="539" y="117" width="21" height="14" />
+          <dc:Bounds x="639" y="117" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="690" y="138" />
-        <di:waypoint x="740" y="138" />
+        <di:waypoint x="790" y="138" />
+        <di:waypoint x="840" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="337.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zx0zzd_di" bpmnElement="Flow_0zx0zzd">
-        <di:waypoint x="840" y="138" />
-        <di:waypoint x="882" y="138" />
+        <di:waypoint x="940" y="138" />
+        <di:waypoint x="975" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="470" y="495" />
+        <di:waypoint x="470" y="530" />
+        <di:waypoint x="522" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
+        <di:waypoint x="470" y="657" />
+        <di:waypoint x="470" y="680" />
+        <di:waypoint x="522" y="680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
+        <di:waypoint x="470" y="817" />
+        <di:waypoint x="470" y="840" />
+        <di:waypoint x="522" y="840" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="470" y="977" />
+        <di:waypoint x="470" y="1000" />
+        <di:waypoint x="522" y="1000" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ngsahl_di" bpmnElement="Flow_0ngsahl">
+        <di:waypoint x="335" y="138" />
+        <di:waypoint x="400" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05ul9v8_di" bpmnElement="Flow_05ul9v8">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="437" />
+        <di:waypoint x="400" y="437" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jjil6z_di" bpmnElement="Flow_0jjil6z">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="599" />
+        <di:waypoint x="400" y="599" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rzqxuo_di" bpmnElement="Flow_1rzqxuo">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="759" />
+        <di:waypoint x="400" y="759" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bdhdkt_di" bpmnElement="Flow_1bdhdkt">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="919" />
+        <di:waypoint x="400" y="919" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
+        <di:waypoint x="1025" y="138" />
+        <di:waypoint x="1062" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qjjeae_di" bpmnElement="Flow_1qjjeae">
+        <di:waypoint x="500" y="437" />
+        <di:waypoint x="1000" y="437" />
+        <di:waypoint x="1000" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
+        <di:waypoint x="500" y="599" />
+        <di:waypoint x="1000" y="599" />
+        <di:waypoint x="1000" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bqerrc_di" bpmnElement="Flow_0bqerrc">
+        <di:waypoint x="500" y="759" />
+        <di:waypoint x="1000" y="759" />
+        <di:waypoint x="1000" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hx3trf_di" bpmnElement="Flow_0hx3trf">
+        <di:waypoint x="500" y="919" />
+        <di:waypoint x="1000" y="919" />
+        <di:waypoint x="1000" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_2" name="Order received 2">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_2" targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="Gateway_1" />
     <bpmn:serviceTask id="checkPayment2" name="Check payment 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkPayment" />
       </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:incoming>Flow_0s77slh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:endEvent id="EndEvent_042s0oc">
-      <bpmn:incoming>Flow_0hxjz3q</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_1">
+      <bpmn:incoming>Flow_1ibxab9</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -52,7 +52,7 @@
       <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
       <bpmn:outgoing>Flow_0zx0zzd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="checkDeliveryState2" targetRef="EndEvent_042s0oc" />
+    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="checkDeliveryState2" targetRef="Gateway_2" />
     <bpmn:serviceTask id="checkDeliveryState2" name="Check delivery state 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkDelivery" />
@@ -60,97 +60,323 @@
       <bpmn:incoming>Flow_0zx0zzd</bpmn:incoming>
       <bpmn:outgoing>Flow_0hxjz3q</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_2">
+      <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_3">
+      <bpmn:incoming>Flow_1ym4tee</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_4">
+      <bpmn:incoming>Flow_0b5y250</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="TaskA2" name="Task A2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1umsz4s</bpmn:incoming>
+      <bpmn:outgoing>Flow_0o6cwfv</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskB2" name="Task B2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_19twklg</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lyxcbw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="TaskC2" name="Task C2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0fyja5s</bpmn:incoming>
+      <bpmn:outgoing>Flow_159gm2j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_5">
+      <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="TaskD2" name="Task D2">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1478njt</bpmn:incoming>
+      <bpmn:outgoing>Flow_0279afj</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="MessageInterrupting2" name="Message interrupting 2" attachedToRef="TaskA2">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerInterrupting2" name="Timer interrupting 2" attachedToRef="TaskB2">
+      <bpmn:outgoing>Flow_1ym4tee</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_04oq8h5">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="MessageNonInterrupting2" name="Message non-interrupting 2" cancelActivity="false" attachedToRef="TaskC2">
+      <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0ox9bto" messageRef="Message_1xpzcw8" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerNonInterrupting2" name="Timer non-interrupting 2" cancelActivity="false" attachedToRef="TaskD2">
+      <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting2" targetRef="Event_2" />
+    <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting2" targetRef="Event_3" />
+    <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting2" targetRef="Event_4" />
+    <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting2" targetRef="Event_5" />
+    <bpmn:sequenceFlow id="Flow_0s77slh" sourceRef="Gateway_1" targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="Flow_1umsz4s" sourceRef="Gateway_1" targetRef="TaskA2" />
+    <bpmn:sequenceFlow id="Flow_19twklg" sourceRef="Gateway_1" targetRef="TaskB2" />
+    <bpmn:sequenceFlow id="Flow_0fyja5s" sourceRef="Gateway_1" targetRef="TaskC2" />
+    <bpmn:sequenceFlow id="Flow_1478njt" sourceRef="Gateway_1" targetRef="TaskD2" />
+    <bpmn:sequenceFlow id="Flow_1ibxab9" sourceRef="Gateway_2" targetRef="EndEvent_1" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0s77slh</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1umsz4s</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19twklg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0fyja5s</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1478njt</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>Flow_0hxjz3q</bpmn:incoming>
+      <bpmn:incoming>Flow_0o6cwfv</bpmn:incoming>
+      <bpmn:incoming>Flow_0lyxcbw</bpmn:incoming>
+      <bpmn:incoming>Flow_159gm2j</bpmn:incoming>
+      <bpmn:incoming>Flow_0279afj</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ibxab9</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0o6cwfv" sourceRef="TaskA2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0lyxcbw" sourceRef="TaskB2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_159gm2j" sourceRef="TaskC2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0279afj" sourceRef="TaskD2" targetRef="Gateway_2" />
   </bpmn:process>
+  <bpmn:message id="Message_0so1os3" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1xpzcw8" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newOrderProcessMigration">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_2">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="175" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="153" y="156" width="82" height="14" />
+          <dc:Bounds x="158" y="156" width="73" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_176evz4_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="265" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment2">
-        <dc:Bounds x="300" y="98" width="100" height="80" />
+        <dc:Bounds x="360" y="98" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="1032" y="120" width="36" height="36" />
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="529" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="520" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment2">
+        <dc:Bounds x="504" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles2">
+        <dc:Bounds x="650" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="notifyCustomer2">
+        <dc:Bounds x="800" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="checkDeliveryState2">
+        <dc:Bounds x="950" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="482" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="482" y="642" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="482" y="802" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA2">
+        <dc:Bounds x="360" y="377" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB2">
+        <dc:Bounds x="360" y="539" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC2">
+        <dc:Bounds x="360" y="699" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="482" y="962" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD2">
+        <dc:Bounds x="360" y="859" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
+        <dc:Bounds x="1192" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="469" y="113" width="50" height="50" />
+      <bpmndi:BPMNShape id="Gateway_0oxwpws_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="1105" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting2">
+        <dc:Bounds x="412" y="439" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="460" y="85" width="69" height="14" />
+          <dc:Bounds x="358" y="466" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment2">
-        <dc:Bounds x="444" y="260" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting2">
+        <dc:Bounds x="412" y="601" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337" y="633" width="86" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles2">
-        <dc:Bounds x="590" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting2">
+        <dc:Bounds x="412" y="761" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="354" y="796" width="71" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="notifyCustomer2">
-        <dc:Bounds x="740" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="checkDeliveryState2">
-        <dc:Bounds x="890" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting2">
+        <dc:Bounds x="412" y="921" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="358" y="956" width="65" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />
-        <di:waypoint x="300" y="138" />
+        <di:waypoint x="265" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="400" y="138" />
-        <di:waypoint x="469" y="138" />
+        <di:waypoint x="460" y="138" />
+        <di:waypoint x="529" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="494" y="163" />
-        <di:waypoint x="494" y="260" />
+        <di:waypoint x="554" y="163" />
+        <di:waypoint x="554" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="450" y="188" width="41" height="14" />
+          <dc:Bounds x="510" y="188" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="444" y="300" />
-        <di:waypoint x="350" y="300" />
-        <di:waypoint x="350" y="178" />
+        <di:waypoint x="504" y="300" />
+        <di:waypoint x="410" y="300" />
+        <di:waypoint x="410" y="178" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="519" y="138" />
-        <di:waypoint x="590" y="138" />
+        <di:waypoint x="579" y="138" />
+        <di:waypoint x="650" y="138" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="539" y="117" width="21" height="14" />
+          <dc:Bounds x="599" y="117" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="690" y="138" />
-        <di:waypoint x="740" y="138" />
+        <di:waypoint x="750" y="138" />
+        <di:waypoint x="800" y="138" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="337.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zx0zzd_di" bpmnElement="Flow_0zx0zzd">
-        <di:waypoint x="840" y="138" />
-        <di:waypoint x="890" y="138" />
+        <di:waypoint x="900" y="138" />
+        <di:waypoint x="950" y="138" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0hxjz3q_di" bpmnElement="Flow_0hxjz3q">
-        <di:waypoint x="990" y="138" />
-        <di:waypoint x="1032" y="138" />
+        <di:waypoint x="1050" y="138" />
+        <di:waypoint x="1105" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="430" y="475" />
+        <di:waypoint x="430" y="510" />
+        <di:waypoint x="482" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
+        <di:waypoint x="430" y="637" />
+        <di:waypoint x="430" y="660" />
+        <di:waypoint x="482" y="660" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
+        <di:waypoint x="430" y="797" />
+        <di:waypoint x="430" y="820" />
+        <di:waypoint x="482" y="820" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="430" y="957" />
+        <di:waypoint x="430" y="980" />
+        <di:waypoint x="482" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s77slh_di" bpmnElement="Flow_0s77slh">
+        <di:waypoint x="315" y="138" />
+        <di:waypoint x="360" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1umsz4s_di" bpmnElement="Flow_1umsz4s">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="417" />
+        <di:waypoint x="360" y="417" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19twklg_di" bpmnElement="Flow_19twklg">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="579" />
+        <di:waypoint x="360" y="579" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fyja5s_di" bpmnElement="Flow_0fyja5s">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="739" />
+        <di:waypoint x="360" y="739" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1478njt_di" bpmnElement="Flow_1478njt">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="899" />
+        <di:waypoint x="360" y="899" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
+        <di:waypoint x="1155" y="138" />
+        <di:waypoint x="1192" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o6cwfv_di" bpmnElement="Flow_0o6cwfv">
+        <di:waypoint x="460" y="417" />
+        <di:waypoint x="1130" y="417" />
+        <di:waypoint x="1130" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
+        <di:waypoint x="460" y="579" />
+        <di:waypoint x="1130" y="579" />
+        <di:waypoint x="1130" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_159gm2j_di" bpmnElement="Flow_159gm2j">
+        <di:waypoint x="460" y="739" />
+        <di:waypoint x="1130" y="739" />
+        <di:waypoint x="1130" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0279afj_di" bpmnElement="Flow_0279afj">
+        <di:waypoint x="460" y="899" />
+        <di:waypoint x="1130" y="899" />
+        <di:waypoint x="1130" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -27,6 +27,8 @@ import {
   ArrowRight,
   ToggleContainer,
 } from './styled';
+import {hasType} from 'modules/bpmn-js/utils/hasType';
+import {getEventType} from 'modules/bpmn-js/utils/getEventType';
 
 const TOGGLE_LABEL = 'Show only not mapped';
 
@@ -125,6 +127,23 @@ const BottomPanel: React.FC = observer(() => {
               const selectableTargetFlowNodes =
                 processXmlMigrationTargetStore.selectableFlowNodes.filter(
                   (flowNode) => {
+                    /**
+                     * For boundary events allow only target flow nodes with the same event type
+                     */
+                    if (
+                      hasType({
+                        businessObject: sourceFlowNode,
+                        types: ['bpmn:BoundaryEvent'],
+                      })
+                    ) {
+                      return (
+                        getEventType(sourceFlowNode) === getEventType(flowNode)
+                      );
+                    }
+
+                    /**
+                     * For all other flow nodes allow target flow nodes with the same element type
+                     */
                     return sourceFlowNode.$type === flowNode.$type;
                   },
                 );

--- a/operate/client/src/modules/bpmn-js/utils/getFlowElementIds.ts
+++ b/operate/client/src/modules/bpmn-js/utils/getFlowElementIds.ts
@@ -7,6 +7,7 @@
  */
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
 
 const getFlowElementIds = (flowNode?: BusinessObject): string[] => {
   if (flowNode?.flowElements === undefined) {
@@ -14,7 +15,7 @@ const getFlowElementIds = (flowNode?: BusinessObject): string[] => {
   }
 
   return flowNode.flowElements.reduce<string[]>((elementIds, element) => {
-    if (element.$type === 'bpmn:SequenceFlow') {
+    if (hasType({businessObject: element, types: ['bpmn:SequenceFlow']})) {
       return elementIds;
     }
 

--- a/operate/client/src/modules/bpmn-js/utils/hasEventType.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasEventType.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject, EventType} from 'bpmn-js/lib/NavigatedViewer';
+import {getEventType} from './getEventType';
+
+const hasEventType = ({
+  businessObject,
+  types,
+}: {
+  businessObject: BusinessObject;
+  types: EventType[];
+}) => {
+  const eventType = getEventType(businessObject);
+  if (eventType !== undefined && types.includes(eventType)) {
+    return true;
+  }
+};
+export {hasEventType};

--- a/operate/client/src/modules/bpmn-js/utils/hasType.ts
+++ b/operate/client/src/modules/bpmn-js/utils/hasType.ts
@@ -6,14 +6,18 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
-import {hasType} from './hasType';
+import {BusinessObject, ElementType} from 'bpmn-js/lib/NavigatedViewer';
 
-function isSubProcess(businessObject?: BusinessObject) {
-  return (
-    businessObject !== undefined &&
-    hasType({businessObject, types: ['bpmn:SubProcess']})
-  );
-}
+const hasType = ({
+  businessObject,
+  types,
+}: {
+  businessObject: BusinessObject;
+  types: ElementType[];
+}) => {
+  if (types.includes(businessObject.$type)) {
+    return true;
+  }
+};
 
-export {isSubProcess};
+export {hasType};

--- a/operate/client/src/modules/bpmn-js/utils/isEventSubProcess.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isEventSubProcess.ts
@@ -7,10 +7,11 @@
  */
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
 
 const isEventSubProcess = (businessObject: BusinessObject) => {
   return (
-    businessObject.$type === 'bpmn:SubProcess' &&
+    hasType({businessObject, types: ['bpmn:SubProcess']}) &&
     businessObject.triggeredByEvent === true
   );
 };

--- a/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isMoveModificationTarget.ts
@@ -10,6 +10,7 @@ import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import isNil from 'lodash/isNil';
 import {isWithinMultiInstance} from './isWithinMultiInstance';
 import {isAttachedToAnEventBasedGateway} from './isAttachedToAnEventBasedGateway';
+import {hasType} from './hasType';
 
 const isMoveModificationTarget = (
   businessObject: BusinessObject | null | undefined,
@@ -18,8 +19,7 @@ const isMoveModificationTarget = (
     !isNil(businessObject) &&
     !isWithinMultiInstance(businessObject) &&
     !isAttachedToAnEventBasedGateway(businessObject) &&
-    businessObject.$type !== 'bpmn:StartEvent' &&
-    businessObject.$type !== 'bpmn:BoundaryEvent'
+    !hasType({businessObject, types: ['bpmn:StartEvent', 'bpmn:BoundaryEvent']})
   );
 };
 

--- a/operate/client/src/modules/bpmn-js/utils/isProcessEndEvent.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isProcessEndEvent.ts
@@ -7,11 +7,13 @@
  */
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
 
 const isProcessEndEvent = (businessObject: BusinessObject) => {
   return (
-    businessObject.$type === 'bpmn:EndEvent' &&
-    businessObject?.$parent?.$type === 'bpmn:Process'
+    hasType({businessObject, types: ['bpmn:EndEvent']}) &&
+    businessObject?.$parent !== undefined &&
+    hasType({businessObject: businessObject?.$parent, types: ['bpmn:Process']})
   );
 };
 

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
   <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -38,7 +38,7 @@
     </bpmn:sequenceFlow>
     <bpmn:subProcess id="shippingSubProcess" name="Shipping Sub Process">
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
-      <bpmn:outgoing>Flow_14zxms3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1o2at6f</bpmn:outgoing>
       <bpmn:startEvent id="Event_0lv0fih">
         <bpmn:outgoing>Flow_1iyep4f</bpmn:outgoing>
       </bpmn:startEvent>
@@ -52,16 +52,117 @@
       <bpmn:sequenceFlow id="Flow_0n8gs7h" sourceRef="shipArticles" targetRef="Event_0rg692j" />
       <bpmn:sequenceFlow id="Flow_1iyep4f" sourceRef="Event_0lv0fih" targetRef="shipArticles" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_14zxms3" sourceRef="shippingSubProcess" targetRef="confirmDelivery" />
     <bpmn:callActivity id="confirmDelivery" name="Confirm delivery">
       <bpmn:extensionElements>
         <zeebe:calledElement propagateAllChildVariables="false" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_14zxms3</bpmn:incoming>
+      <bpmn:incoming>Flow_0xq0gk6</bpmn:incoming>
       <bpmn:outgoing>Flow_0k3om5o</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0k3om5o" sourceRef="confirmDelivery" targetRef="EndEvent_042s0oc" />
+    <bpmn:parallelGateway id="Gateway_1fr6z3f">
+      <bpmn:incoming>Flow_1o2at6f</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ap3af</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rcqlru</bpmn:outgoing>
+      <bpmn:outgoing>Flow_073q9ji</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ditevp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0xpveg6</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_0wzi4n5">
+      <bpmn:incoming>Flow_1rxumvr</bpmn:incoming>
+      <bpmn:incoming>Flow_1v87lmb</bpmn:incoming>
+      <bpmn:incoming>Flow_1c5723c</bpmn:incoming>
+      <bpmn:incoming>Flow_1l3fmxv</bpmn:incoming>
+      <bpmn:incoming>Flow_0qwbw29</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xq0gk6</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:task id="TaskA" name="Task A">
+      <bpmn:incoming>Flow_19ap3af</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rxumvr</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="TaskB" name="Task B">
+      <bpmn:incoming>Flow_1rcqlru</bpmn:incoming>
+      <bpmn:outgoing>Flow_1v87lmb</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="TaskC" name="Task C">
+      <bpmn:incoming>Flow_073q9ji</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c5723c</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="TaskD" name="Task D">
+      <bpmn:incoming>Flow_0ditevp</bpmn:incoming>
+      <bpmn:outgoing>Flow_1l3fmxv</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="TaskE" name="Task E">
+      <bpmn:incoming>Flow_0xpveg6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qwbw29</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_1q5nldo">
+      <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0c40wzp">
+      <bpmn:incoming>Flow_1ym4tee</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_14gulzq">
+      <bpmn:incoming>Flow_0b5y250</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1ptwud8">
+      <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1xyc01u">
+      <bpmn:incoming>Flow_1iklgns</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0wsooye" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerInterrupting" name="Timer interrupting" attachedToRef="TaskB">
+      <bpmn:outgoing>Flow_1ym4tee</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0x9o3yy">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1H</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="MessageNonInterrupting" name="Message non-interrupting" cancelActivity="false" attachedToRef="TaskC">
+      <bpmn:outgoing>Flow_0b5y250</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0diu924" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+      <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1s178ck">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="EscalationInterrupting" name="Escalation interrupting" attachedToRef="TaskE">
+      <bpmn:outgoing>Flow_1iklgns</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0zv7tml" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_19ap3af" sourceRef="Gateway_1fr6z3f" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_1rcqlru" sourceRef="Gateway_1fr6z3f" targetRef="TaskB" />
+    <bpmn:sequenceFlow id="Flow_073q9ji" sourceRef="Gateway_1fr6z3f" targetRef="TaskC" />
+    <bpmn:sequenceFlow id="Flow_0ditevp" sourceRef="Gateway_1fr6z3f" targetRef="TaskD" />
+    <bpmn:sequenceFlow id="Flow_0xpveg6" sourceRef="Gateway_1fr6z3f" targetRef="TaskE" />
+    <bpmn:sequenceFlow id="Flow_1rxumvr" sourceRef="TaskA" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_1v87lmb" sourceRef="TaskB" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_1c5723c" sourceRef="TaskC" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_1l3fmxv" sourceRef="TaskD" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_0qwbw29" sourceRef="TaskE" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_1q5nldo" />
+    <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting" targetRef="Event_0c40wzp" />
+    <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting" targetRef="Event_14gulzq" />
+    <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting" targetRef="Event_1ptwud8" />
+    <bpmn:sequenceFlow id="Flow_1iklgns" sourceRef="EscalationInterrupting" targetRef="Event_1xyc01u" />
+    <bpmn:sequenceFlow id="Flow_1o2at6f" sourceRef="shippingSubProcess" targetRef="Gateway_1fr6z3f" />
+    <bpmn:sequenceFlow id="Flow_0xq0gk6" sourceRef="Gateway_0wzi4n5" targetRef="confirmDelivery" />
   </bpmn:process>
+  <bpmn:message id="Message_0so1os3" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_0t0vqvi" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
@@ -82,15 +183,56 @@
       <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
         <dc:Bounds x="444" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1o28q8h" bpmnElement="Gateway_1fr6z3f">
+        <dc:Bounds x="1015" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
+        <dc:Bounds x="1315" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1fyji1z" bpmnElement="TaskA">
+        <dc:Bounds x="1150" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0s3dru7" bpmnElement="TaskB">
+        <dc:Bounds x="1150" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0lcbf6w" bpmnElement="TaskC">
+        <dc:Bounds x="1150" y="420" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1yzjxm3" bpmnElement="TaskD">
+        <dc:Bounds x="1150" y="580" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mdt1zr_di" bpmnElement="TaskE">
+        <dc:Bounds x="1150" y="751" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11gdqkh" bpmnElement="Event_1q5nldo">
+        <dc:Bounds x="1272" y="213" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0u9dyqr" bpmnElement="Event_0c40wzp">
+        <dc:Bounds x="1272" y="363" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0i5kuow" bpmnElement="Event_14gulzq">
+        <dc:Bounds x="1272" y="523" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_16zirwb" bpmnElement="Event_1ptwud8">
+        <dc:Bounds x="1272" y="683" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xyc01u_di" bpmnElement="Event_1xyc01u">
+        <dc:Bounds x="1272" y="863" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d5b5q4_di" bpmnElement="confirmDelivery">
+        <dc:Bounds x="1420" y="96" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="1172" y="120" width="36" height="36" />
+        <dc:Bounds x="1582" y="118" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d5b5q4_di" bpmnElement="confirmDelivery">
-        <dc:Bounds x="1020" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zhf45a_di" bpmnElement="shippingSubProcess" isExpanded="true">
         <dc:Bounds x="610" y="38" width="350" height="200" />
@@ -113,6 +255,36 @@
         <di:waypoint x="686" y="138" />
         <di:waypoint x="740" y="138" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_0y1tf9l" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="1202" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1152" y="187" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0yryixh" bpmnElement="TimerInterrupting">
+        <dc:Bounds x="1202" y="322" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1127" y="354" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1fq39db" bpmnElement="MessageNonInterrupting">
+        <dc:Bounds x="1202" y="482" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1144" y="517" width="71" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kb9m92" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="1202" y="642" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1152" y="677" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1me1qfe_di" bpmnElement="EscalationInterrupting">
+        <dc:Bounds x="1192" y="813" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1142" y="847" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />
         <di:waypoint x="300" y="138" />
@@ -149,13 +321,90 @@
           <dc:Bounds x="554" y="117" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14zxms3_di" bpmnElement="Flow_14zxms3">
-        <di:waypoint x="960" y="138" />
-        <di:waypoint x="1020" y="138" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0k3om5o_di" bpmnElement="Flow_0k3om5o">
-        <di:waypoint x="1120" y="138" />
-        <di:waypoint x="1172" y="138" />
+        <di:waypoint x="1520" y="136" />
+        <di:waypoint x="1582" y="136" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_19owe7j" bpmnElement="Flow_19ap3af">
+        <di:waypoint x="1065" y="138" />
+        <di:waypoint x="1150" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_153ae47" bpmnElement="Flow_1rcqlru">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="300" />
+        <di:waypoint x="1150" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0u8cduw" bpmnElement="Flow_073q9ji">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="460" />
+        <di:waypoint x="1150" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1j4dwvf" bpmnElement="Flow_0ditevp">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="620" />
+        <di:waypoint x="1150" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xpveg6_di" bpmnElement="Flow_0xpveg6">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="791" />
+        <di:waypoint x="1150" y="791" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1i35hqz" bpmnElement="Flow_1rxumvr">
+        <di:waypoint x="1250" y="138" />
+        <di:waypoint x="1315" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1r2l6ld" bpmnElement="Flow_1v87lmb">
+        <di:waypoint x="1250" y="300" />
+        <di:waypoint x="1340" y="300" />
+        <di:waypoint x="1340" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1su02u0" bpmnElement="Flow_1c5723c">
+        <di:waypoint x="1250" y="460" />
+        <di:waypoint x="1340" y="460" />
+        <di:waypoint x="1340" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0gq30du" bpmnElement="Flow_1l3fmxv">
+        <di:waypoint x="1250" y="620" />
+        <di:waypoint x="1340" y="620" />
+        <di:waypoint x="1340" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qwbw29_di" bpmnElement="Flow_0qwbw29">
+        <di:waypoint x="1250" y="791" />
+        <di:waypoint x="1340" y="791" />
+        <di:waypoint x="1340" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1up7i5i" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="1220" y="196" />
+        <di:waypoint x="1220" y="231" />
+        <di:waypoint x="1272" y="231" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1bckvue" bpmnElement="Flow_1ym4tee">
+        <di:waypoint x="1220" y="358" />
+        <di:waypoint x="1220" y="381" />
+        <di:waypoint x="1272" y="381" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_19unyuk" bpmnElement="Flow_0b5y250">
+        <di:waypoint x="1220" y="518" />
+        <di:waypoint x="1220" y="541" />
+        <di:waypoint x="1272" y="541" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1e0c2q0" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="1220" y="678" />
+        <di:waypoint x="1220" y="701" />
+        <di:waypoint x="1272" y="701" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iklgns_di" bpmnElement="Flow_1iklgns">
+        <di:waypoint x="1210" y="849" />
+        <di:waypoint x="1210" y="881" />
+        <di:waypoint x="1272" y="881" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o2at6f_di" bpmnElement="Flow_1o2at6f">
+        <di:waypoint x="960" y="138" />
+        <di:waypoint x="1015" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xq0gk6_di" bpmnElement="Flow_0xq0gk6">
+        <di:waypoint x="1365" y="138" />
+        <di:waypoint x="1420" y="138" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
   <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -14,7 +14,7 @@
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_042s0oc">
-      <bpmn:incoming>Flow_0jjk1nl</bpmn:incoming>
+      <bpmn:incoming>Flow_0r0cpho</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -37,8 +37,59 @@
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>Flow_0jjk1nl</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_0jjk1nl" sourceRef="shipArticles" targetRef="EndEvent_042s0oc" />
+    <bpmn:sequenceFlow id="Flow_0jjk1nl" sourceRef="shipArticles" targetRef="Gateway_1fr6z3f" />
+    <bpmn:parallelGateway id="Gateway_1fr6z3f">
+      <bpmn:incoming>Flow_0jjk1nl</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ap3af</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1u8201x</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_0wzi4n5">
+      <bpmn:incoming>Flow_1rxumvr</bpmn:incoming>
+      <bpmn:incoming>Flow_10w6zi2</bpmn:incoming>
+      <bpmn:outgoing>Flow_0r0cpho</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:task id="TaskA" name="Task A">
+      <bpmn:incoming>Flow_19ap3af</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rxumvr</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_1q5nldo">
+      <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0wsooye" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_19ap3af" sourceRef="Gateway_1fr6z3f" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_1rxumvr" sourceRef="TaskA" targetRef="Gateway_0wzi4n5" />
+    <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_1q5nldo" />
+    <bpmn:sequenceFlow id="Flow_0r0cpho" sourceRef="Gateway_0wzi4n5" targetRef="EndEvent_042s0oc" />
+    <bpmn:endEvent id="Event_1ptwud8">
+      <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="TaskD" name="Task D">
+      <bpmn:incoming>Flow_1u8201x</bpmn:incoming>
+      <bpmn:outgoing>Flow_10w6zi2</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
+      <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1s178ck">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting" targetRef="Event_1ptwud8" />
+    <bpmn:sequenceFlow id="Flow_1u8201x" sourceRef="Gateway_1fr6z3f" targetRef="TaskD" />
+    <bpmn:sequenceFlow id="Flow_10w6zi2" sourceRef="TaskD" targetRef="Gateway_0wzi4n5" />
   </bpmn:process>
+  <bpmn:message id="Message_0so1os3" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_0w4i21x" name="Message_1">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key" />
+    </bpmn:extensionElements>
+  </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
@@ -63,9 +114,41 @@
         <dc:Bounds x="630" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="792" y="120" width="36" height="36" />
+        <dc:Bounds x="1182" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1o28q8h" bpmnElement="Gateway_1fr6z3f">
+        <dc:Bounds x="775" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1fyji1z" bpmnElement="TaskA">
+        <dc:Bounds x="910" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
+        <dc:Bounds x="1075" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_11gdqkh" bpmnElement="Event_1q5nldo">
+        <dc:Bounds x="1012" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_16zirwb" bpmnElement="Event_1ptwud8">
+        <dc:Bounds x="1032" y="392" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1yzjxm3" bpmnElement="TaskD">
+        <dc:Bounds x="910" y="289" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0y1tf9l" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="962" y="160" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="912" y="187" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1kb9m92" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="962" y="351" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="912" y="386" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -106,7 +189,39 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0jjk1nl_di" bpmnElement="Flow_0jjk1nl">
         <di:waypoint x="730" y="138" />
-        <di:waypoint x="792" y="138" />
+        <di:waypoint x="775" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1up7i5i" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="980" y="196" />
+        <di:waypoint x="980" y="230" />
+        <di:waypoint x="1012" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0r0cpho_di" bpmnElement="Flow_0r0cpho">
+        <di:waypoint x="1125" y="138" />
+        <di:waypoint x="1182" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_19owe7j" bpmnElement="Flow_19ap3af">
+        <di:waypoint x="825" y="138" />
+        <di:waypoint x="910" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1i35hqz" bpmnElement="Flow_1rxumvr">
+        <di:waypoint x="1010" y="138" />
+        <di:waypoint x="1075" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1e0c2q0" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="980" y="387" />
+        <di:waypoint x="980" y="410" />
+        <di:waypoint x="1032" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1u8201x_di" bpmnElement="Flow_1u8201x">
+        <di:waypoint x="800" y="163" />
+        <di:waypoint x="800" y="329" />
+        <di:waypoint x="910" y="329" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10w6zi2_di" bpmnElement="Flow_10w6zi2">
+        <di:waypoint x="1010" y="329" />
+        <di:waypoint x="1100" y="329" />
+        <di:waypoint x="1100" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
@@ -31,6 +31,10 @@ describe('stores/processXml/processXml.list', () => {
       'shippingSubProcess',
       'shipArticles',
       'confirmDelivery',
+      'MessageInterrupting',
+      'TimerInterrupting',
+      'MessageNonInterrupting',
+      'TimerNonInterrupting',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
@@ -9,6 +9,7 @@
 import {action, makeObservable, override} from 'mobx';
 import {ProcessXmlBase} from './processXml.base';
 import {parseDiagramXML} from 'modules/utils/bpmn';
+import {isMigratableFlowNode} from './utils/isMigratableFlowNode';
 
 class ProcessesXml extends ProcessXmlBase {
   constructor() {
@@ -22,14 +23,7 @@ class ProcessesXml extends ProcessXmlBase {
 
   get selectableFlowNodes() {
     return super.selectableFlowNodes
-      .filter((flowNode) => {
-        return [
-          'bpmn:ServiceTask',
-          'bpmn:UserTask',
-          'bpmn:SubProcess',
-          'bpmn:CallActivity',
-        ].includes(flowNode.$type);
-      })
+      .filter(isMigratableFlowNode)
       .map((flowNode) => {
         return {...flowNode, name: flowNode.name ?? flowNode.id};
       });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
@@ -31,6 +31,10 @@ describe('stores/processXml/processXml.list', () => {
       'shippingSubProcess',
       'shipArticles',
       'confirmDelivery',
+      'MessageInterrupting',
+      'TimerInterrupting',
+      'MessageNonInterrupting',
+      'TimerNonInterrupting',
     ]);
   });
 
@@ -52,6 +56,10 @@ describe('stores/processXml/processXml.list', () => {
       'shippingSubProcess',
       'shipArticles',
       'confirmDelivery',
+      'MessageInterrupting',
+      'TimerInterrupting',
+      'MessageNonInterrupting',
+      'TimerNonInterrupting',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
@@ -8,6 +8,7 @@
 
 import {computed, makeObservable, override} from 'mobx';
 import {ProcessXmlBase} from './processXml.base';
+import {isMigratableFlowNode} from './utils/isMigratableFlowNode';
 
 class ProcessesXml extends ProcessXmlBase {
   constructor() {
@@ -21,14 +22,7 @@ class ProcessesXml extends ProcessXmlBase {
 
   get selectableFlowNodes() {
     return super.selectableFlowNodes
-      .filter((flowNode) => {
-        return [
-          'bpmn:ServiceTask',
-          'bpmn:UserTask',
-          'bpmn:SubProcess',
-          'bpmn:CallActivity',
-        ].includes(flowNode.$type);
-      })
+      .filter(isMigratableFlowNode)
       .map((flowNode) => {
         return {...flowNode, name: flowNode.name ?? flowNode.id};
       });

--- a/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
+++ b/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from 'modules/bpmn-js/utils/hasType';
+
+const isMigratableFlowNode = (businessObject: BusinessObject) => {
+  return hasType({
+    businessObject,
+    types: [
+      'bpmn:ServiceTask',
+      'bpmn:UserTask',
+      'bpmn:SubProcess',
+      'bpmn:CallActivity',
+    ],
+  });
+};
+
+export {isMigratableFlowNode};

--- a/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
+++ b/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
@@ -7,9 +7,26 @@
  */
 
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasEventType} from 'modules/bpmn-js/utils/hasEventType';
 import {hasType} from 'modules/bpmn-js/utils/hasType';
 
 const isMigratableFlowNode = (businessObject: BusinessObject) => {
+  if (
+    /**
+     * Check boundary events
+     */
+    hasType({
+      businessObject,
+      types: ['bpmn:BoundaryEvent'],
+    }) &&
+    hasEventType({
+      businessObject,
+      types: ['bpmn:MessageEventDefinition', 'bpmn:TimerEventDefinition'],
+    })
+  ) {
+    return true;
+  }
+
   return hasType({
     businessObject,
     types: [


### PR DESCRIPTION
## Description

- add hasType and hasEventType helper functions to identify element types
- add reusable element migration check
- allow message and timer boundary event migration in UI
- add/extend unit tests
- extend/add E2E test 

>  Optional: The edge cases limitations ([set 1](https://github.com/camunda/camunda/issues/19640), [set 2](https://github.com/camunda/camunda/issues/20906), [set 3](https://github.com/camunda/camunda/issues/19956)) are validated and not allowed in the frontend

These edge cases will be discussed later. 

This is the first time I tried to attach a bpmn diagram diff (created with the web modeler). It was a bit of effort, but I think it might be beneficial to understand what changed. If we see value in this I will continue to do it.

I also attached some UI screenshots to explain how the code change impacts the UI. Same here: let's keep doing it if we see value.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #19886 
