### PR TITLE
Prevent multiple message correlations within the same processId

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -100,6 +100,9 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     brokerProperties.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
     brokerProperties.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
 
+    brokerProperties.getExperimental().getConsistencyChecks().setEnableForeignKeyChecks(true);
+    brokerProperties.getExperimental().getConsistencyChecks().setEnablePreconditions(true);
+
     operateProperties = new OperateProperties();
     tasklistProperties = new TasklistProperties();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -40,7 +40,7 @@ public final class MessageCorrelateBehavior {
     this.commandSender = commandSender;
   }
 
-  public Subscriptions correlateToMessageStartEvents(
+  public void correlateToMessageStartEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
     startEventSubscriptionState.visitSubscriptionsByMessageName(
         messageData.tenantId(),
@@ -69,11 +69,9 @@ public final class MessageCorrelateBehavior {
             correlatingSubscriptions.add(subscriptionRecord);
           }
         });
-
-    return correlatingSubscriptions;
   }
 
-  public Subscriptions correlateToMessageEvents(
+  public void correlateToMessageEvents(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
 
     messageSubscriptionState.visitSubscriptions(
@@ -103,12 +101,11 @@ public final class MessageCorrelateBehavior {
 
           return true;
         });
-    return correlatingSubscriptions;
   }
 
-  public boolean sendCorrelateCommands(
+  public void sendCorrelateCommands(
       final MessageData messageData, final Subscriptions correlatingSubscriptions) {
-    return correlatingSubscriptions.visitSubscriptions(
+    correlatingSubscriptions.visitSubscriptions(
         subscription ->
             commandSender.correlateProcessMessageSubscription(
                 subscription.getProcessInstanceKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -99,21 +99,26 @@ public final class MessageCorrelateBehavior {
                 correlatingSubscription);
 
             correlatingSubscriptions.add(correlatingSubscription);
-
-            commandSender.correlateProcessMessageSubscription(
-                correlatingSubscription.getProcessInstanceKey(),
-                correlatingSubscription.getElementInstanceKey(),
-                correlatingSubscription.getBpmnProcessIdBuffer(),
-                messageData.messageName(),
-                messageData.messageKey(),
-                messageData.variables(),
-                messageData.correlationKey(),
-                messageData.tenantId());
           }
 
           return true;
         });
     return correlatingSubscriptions;
+  }
+
+  public boolean sendCorrelateCommands(
+      final MessageData messageData, final Subscriptions correlatingSubscriptions) {
+    return correlatingSubscriptions.visitSubscriptions(
+        subscription ->
+            commandSender.correlateProcessMessageSubscription(
+                subscription.getProcessInstanceKey(),
+                subscription.getElementInstanceKey(),
+                subscription.getBpmnProcessId(),
+                messageData.messageName(),
+                messageData.messageKey(),
+                messageData.variables(),
+                messageData.correlationKey(),
+                messageData.tenantId()));
   }
 
   public record MessageData(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -40,9 +40,8 @@ public final class MessageCorrelateBehavior {
     this.commandSender = commandSender;
   }
 
-  public Subscriptions correlateToMessageStartEvents(final MessageData messageData) {
-    final var correlatingSubscriptions = new Subscriptions();
-
+  public Subscriptions correlateToMessageStartEvents(
+      final MessageData messageData, final Subscriptions correlatingSubscriptions) {
     startEventSubscriptionState.visitSubscriptionsByMessageName(
         messageData.tenantId(),
         messageData.messageName(),
@@ -74,8 +73,8 @@ public final class MessageCorrelateBehavior {
     return correlatingSubscriptions;
   }
 
-  public Subscriptions correlateToMessageEvents(final MessageData messageData) {
-    final var correlatingSubscriptions = new Subscriptions();
+  public Subscriptions correlateToMessageEvents(
+      final MessageData messageData, final Subscriptions correlatingSubscriptions) {
 
     messageSubscriptionState.visitSubscriptions(
         messageData.tenantId(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -126,15 +126,20 @@ public final class MessageCorrelationCorrelateProcessor
                 messageCorrelationRecord.getTenantId()),
             correlatingSubscriptions);
 
-    if (!correlatedSubscriptions.isEmpty()) {
-      final var subscription = correlatedSubscriptions.peek();
-      messageCorrelationRecord.setProcessInstanceKey(subscription.getProcessInstanceKey());
+    correlatedSubscriptions
+        .getFirstMessageStartEventSubscription()
+        .ifPresent(
+            subscription -> {
+              messageCorrelationRecord.setProcessInstanceKey(subscription.getProcessInstanceKey());
 
-      stateWriter.appendFollowUpEvent(
-          messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
-      responseWriter.writeEventOnCommand(
-          messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord, command);
-    }
+              stateWriter.appendFollowUpEvent(
+                  messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
+              responseWriter.writeEventOnCommand(
+                  messageKey,
+                  MessageCorrelationIntent.CORRELATED,
+                  messageCorrelationRecord,
+                  command);
+            });
   }
 
   private void correlateToMessageEventSubscriptions(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -122,7 +122,8 @@ public final class MessageCorrelationCorrelateProcessor
                 messageCorrelationRecord.getNameBuffer(),
                 messageCorrelationRecord.getCorrelationKeyBuffer(),
                 messageCorrelationRecord.getVariablesBuffer(),
-                messageCorrelationRecord.getTenantId()));
+                messageCorrelationRecord.getTenantId()),
+            correlatingSubscriptions);
     correlatingSubscriptions.addAll(correlatedSubscriptions);
 
     if (!correlatedSubscriptions.isEmpty()) {
@@ -140,13 +141,13 @@ public final class MessageCorrelationCorrelateProcessor
       final MessageCorrelationRecord messageCorrelationRecord,
       final long messageKey,
       final Subscriptions correlatingSubscriptions) {
-    correlatingSubscriptions.addAll(
-        correlateBehavior.correlateToMessageEvents(
-            new MessageData(
-                messageKey,
-                messageCorrelationRecord.getNameBuffer(),
-                messageCorrelationRecord.getCorrelationKeyBuffer(),
-                messageCorrelationRecord.getVariablesBuffer(),
-                messageCorrelationRecord.getTenantId())));
+    correlateBehavior.correlateToMessageEvents(
+        new MessageData(
+            messageKey,
+            messageCorrelationRecord.getNameBuffer(),
+            messageCorrelationRecord.getCorrelationKeyBuffer(),
+            messageCorrelationRecord.getVariablesBuffer(),
+            messageCorrelationRecord.getTenantId()),
+        correlatingSubscriptions);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -95,8 +95,8 @@ public final class MessageCorrelationCorrelateProcessor
         messageKey, MessageCorrelationIntent.CORRELATING, messageCorrelationRecord);
 
     final var correlatingSubscriptions = new Subscriptions();
-    correlateToMessageStartEventSubscriptions(command, messageKey, correlatingSubscriptions);
     correlateToMessageEventSubscriptions(command.getValue(), messageKey, correlatingSubscriptions);
+    correlateToMessageStartEventSubscriptions(command, messageKey, correlatingSubscriptions);
 
     if (correlatingSubscriptions.isEmpty()) {
       final var errorMessage =
@@ -124,7 +124,6 @@ public final class MessageCorrelationCorrelateProcessor
                 messageCorrelationRecord.getVariablesBuffer(),
                 messageCorrelationRecord.getTenantId()),
             correlatingSubscriptions);
-    correlatingSubscriptions.addAll(correlatedSubscriptions);
 
     if (!correlatedSubscriptions.isEmpty()) {
       final var subscription = correlatedSubscriptions.peek();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -97,6 +97,7 @@ public final class MessageCorrelationCorrelateProcessor
     final var correlatingSubscriptions = new Subscriptions();
     correlateToMessageEventSubscriptions(command.getValue(), messageKey, correlatingSubscriptions);
     correlateToMessageStartEventSubscriptions(command, messageKey, correlatingSubscriptions);
+    sendCorrelateCommands(messageKey, messageRecord, correlatingSubscriptions);
 
     if (correlatingSubscriptions.isEmpty()) {
       final var errorMessage =
@@ -148,5 +149,17 @@ public final class MessageCorrelationCorrelateProcessor
             messageCorrelationRecord.getVariablesBuffer(),
             messageCorrelationRecord.getTenantId()),
         correlatingSubscriptions);
+  }
+
+  private void sendCorrelateCommands(
+      final long messageKey, final MessageRecord message, final Subscriptions subscriptions) {
+    correlateBehavior.sendCorrelateCommands(
+        new MessageData(
+            messageKey,
+            message.getNameBuffer(),
+            message.getCorrelationKeyBuffer(),
+            message.getVariablesBuffer(),
+            message.getTenantId()),
+        subscriptions);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -114,6 +114,7 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
     final var correlatingSubscriptions = new Subscriptions();
     correlateToSubscriptions(messageKey, messageRecord, correlatingSubscriptions);
     correlateToMessageStartEvents(messageRecord, correlatingSubscriptions);
+    sendCorrelateCommands(messageKey, messageRecord, correlatingSubscriptions);
 
     if (messageRecord.getTimeToLive() <= 0L) {
       // avoid that the message can be correlated again by writing the EXPIRED event as a follow-up
@@ -143,5 +144,17 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
             messageRecord.getVariablesBuffer(),
             messageRecord.getTenantId()),
         correlatingSubscriptions);
+  }
+
+  private void sendCorrelateCommands(
+      final long messageKey, final MessageRecord message, final Subscriptions subscriptions) {
+    correlateBehavior.sendCorrelateCommands(
+        new MessageData(
+            messageKey,
+            message.getNameBuffer(),
+            message.getCorrelationKeyBuffer(),
+            message.getVariablesBuffer(),
+            message.getTenantId()),
+        subscriptions);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRe
 import io.camunda.zeebe.util.collection.Reusable;
 import io.camunda.zeebe.util.collection.ReusableObjectList;
 import java.util.Optional;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -73,10 +72,6 @@ public final class Subscriptions {
     return subscriptions.size() <= 0;
   }
 
-  public Subscription peek() {
-    return subscriptions.peek();
-  }
-
   public Optional<Subscription> getFirstMessageStartEventSubscription() {
     for (final Subscription subscription : subscriptions) {
       if (subscription.isStartEventSubscription) {
@@ -84,12 +79,6 @@ public final class Subscriptions {
       }
     }
     return Optional.empty();
-  }
-
-  public void visitBpmnProcessIds(final Consumer<DirectBuffer> bpmnProcessIdConsumer) {
-    for (final Subscription subscription : subscriptions) {
-      bpmnProcessIdConsumer.accept(subscription.getBpmnProcessId());
-    }
   }
 
   public boolean visitSubscriptions(final SubscriptionVisitor subscriptionConsumer) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubs
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.util.collection.Reusable;
 import io.camunda.zeebe.util.collection.ReusableObjectList;
+import java.util.Optional;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.agrona.ExpandableArrayBuffer;
@@ -74,6 +75,15 @@ public final class Subscriptions {
 
   public Subscription peek() {
     return subscriptions.peek();
+  }
+
+  public Optional<Subscription> getFirstMessageStartEventSubscription() {
+    for (final Subscription subscription : subscriptions) {
+      if (subscription.isStartEventSubscription) {
+        return Optional.of(subscription);
+      }
+    }
+    return Optional.empty();
   }
 
   public void visitBpmnProcessIds(final Consumer<DirectBuffer> bpmnProcessIdConsumer) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -1021,6 +1021,11 @@ public final class MessageCorrelationTest {
         .withVariable("key", correlationKey)
         .create();
 
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withMessageName(messageName)
+        .withCorrelationKey(correlationKey)
+        .await();
+
     // when
     engine
         .message()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationTest.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -87,6 +89,18 @@ public final class MessageCorrelationTest {
           .endEvent("msg2End")
           .moveToActivity("task")
           .endEvent("taskEnd")
+          .done();
+
+  private static final BpmnModelInstance MSG_START_AND_INTERMEDIATE_CATCH_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent("msgStart")
+          .message("message")
+          .endEvent()
+          .moveToProcess(PROCESS_ID)
+          .startEvent()
+          .intermediateCatchEvent("msgCatch")
+          .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+          .endEvent()
           .done();
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
@@ -993,6 +1007,44 @@ public final class MessageCorrelationTest {
     // then
     final var variable = RecordingExporter.variableRecords().withName("x").getFirst();
     Assertions.assertThat(variable.getValue()).hasValue("3");
+  }
+
+  @Test
+  public void shouldNotCorrelateToMessageStartAndIntermediateCatchWithSameProcessId() {
+    // given
+    engine.deployment().withXmlResource(MSG_START_AND_INTERMEDIATE_CATCH_PROCESS).deploy();
+    final var messageName = "message";
+    final var correlationKey = "correlationKey";
+    engine
+        .processInstance()
+        .ofBpmnProcessId(PROCESS_ID)
+        .withVariable("key", correlationKey)
+        .create();
+
+    // when
+    engine
+        .message()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .withTimeToLive(0)
+        .publish();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
+                .withMessageName(messageName)
+                .withCorrelationKey(correlationKey)
+                .limit(1)
+                .exists())
+        .isTrue();
+    assertThat(
+            RecordingExporter.records()
+                .limit(record -> record.getIntent() == MessageIntent.EXPIRED)
+                .messageStartEventSubscriptionRecords()
+                .withMessageName(messageName)
+                .withIntent(MessageStartEventSubscriptionIntent.CORRELATED)
+                .exists())
+        .isFalse();
   }
 
   private List<Record<ProcessMessageSubscriptionRecordValue>> awaitMessagesCorrelated(

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -50,6 +50,9 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     config.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
     config.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
 
+    config.getExperimental().getConsistencyChecks().setEnableForeignKeyChecks(true);
+    config.getExperimental().getConsistencyChecks().setEnablePreconditions(true);
+
     //noinspection resource
     withBean("config", config, BrokerBasedProperties.class).withAdditionalProfile(Profile.BROKER);
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This bug was introduced in #20265

Generally when you publish a message it'll only correlate with 1 subscription within a process instance. If you have an intermediate message catch event which subscribes to the same message as a message start event, the expectation is that the intermediate catch event correlates, and the message start event subscription doesn't. So no new process instance would be created. This was broken. Because of a refactoring the behavior changed and we would correlate with both the intermediate event, as well as the start event. This would result in failures in the consistency checks.

This PR fixes that bug.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21989
