### PR TITLE
ci: use infra self-hosted runners for zeebe-ci.yml/property-tests job

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -85,7 +85,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: gcp-perf-core-16-default
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -85,7 +85,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

This PR introduces the use of `gcp-perf-core-8-default` runner type for the `zeebe-ci.yml/property-tests` job, with **half** the [resources](https://github.com/camunda/infra-core/blob/stage/camunda-ci/kustomize/base/github-self-hosted-runners/runnersets/types/c2d/manifests/gcp-perf-core-8.yml#L16-L31) of zeebe [runners](https://github.com/zeebe-io/infra/blob/main/gcp/zeebe-io/zeebe-ci-1/runner-amd64-16.yml#L33-L34) (15cpu + 50Gi).

No particular degradation of correctness or performance was detected:
- `gcp-perf-core-8-default` -> [9m36s](https://github.com/camunda/camunda/actions/runs/10920046230/job/30309118097)
- `gcp-perf-core-16-default` -> [9m11s](https://github.com/camunda/camunda/actions/runs/10919599803/job/30308520581)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
