### PR TITLE
feat: Add validation for non-negative value in `pin` clock command

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -166,6 +166,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
@@ -51,9 +51,7 @@ public final class ArgumentUtil {
   }
 
   public static void ensureNotNegative(final String property, final Duration testValue) {
-    if (testValue.isNegative()) {
-      throw new IllegalArgumentException(String.format("%s must be not negative", property));
-    }
+    ensureNotNegative(property, testValue.toMillis());
   }
 
   public static void ensureNotZero(final String property, final Duration testValue) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.impl.command;
 
 import java.time.Duration;
+import java.time.Instant;
 
 public final class ArgumentUtil {
 
@@ -43,6 +44,12 @@ public final class ArgumentUtil {
     }
   }
 
+  public static void ensureNotNegative(final String property, final long testValue) {
+    if (testValue < 0) {
+      throw new IllegalArgumentException(String.format("%s must be not negative", property));
+    }
+  }
+
   public static void ensureNotNegative(final String property, final Duration testValue) {
     if (testValue.isNegative()) {
       throw new IllegalArgumentException(String.format("%s must be not negative", property));
@@ -58,5 +65,13 @@ public final class ArgumentUtil {
   public static void ensurePositive(final String property, final Duration testValue) {
     ensureNotNegative(property, testValue);
     ensureNotZero(property, testValue);
+  }
+
+  public static void ensureNotBefore(
+      final String property, final Instant testValue, final Instant otherInstant) {
+    if (testValue.isBefore(otherInstant)) {
+      throw new IllegalArgumentException(
+          String.format("%s must be equal to or after %s", property, otherInstant));
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
@@ -44,6 +44,7 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
 
   @Override
   public ClockPinCommandStep1 time(final long timestamp) {
+    ArgumentUtil.ensureNotNegative("timestamp", timestamp);
     request.setTimestamp(timestamp);
     return this;
   }
@@ -51,6 +52,7 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
   @Override
   public ClockPinCommandStep1 time(final Instant instant) {
     ArgumentUtil.ensureNotNull("instant", instant);
+    ArgumentUtil.ensureNotBefore("instant", instant, Instant.EPOCH);
     return time(instant.toEpochMilli());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -49,10 +49,8 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
 
   @Override
   public void processNewCommand(final TypedRecord<ClockRecord> command) {
-    final long eventKey = keyGenerator.nextKey();
-    final var clockRecord = command.getValue();
     final var intent = (ClockIntent) command.getIntent();
-    final var resultIntent = followUpIntent(intent);
+    final var clockRecord = command.getValue();
 
     if (intent == ClockIntent.PIN && clockRecord.getTime() < 0) {
       final var rejectionMessage =
@@ -63,6 +61,9 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
           command, RejectionType.INVALID_ARGUMENT, rejectionMessage);
       return;
     }
+
+    final long eventKey = keyGenerator.nextKey();
+    final var resultIntent = followUpIntent(intent);
 
     applyClockModification(eventKey, intent, resultIntent, clockRecord);
     if (command.hasRequestMetadata()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -11,9 +11,11 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.stream.api.SideEffectProducer;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
@@ -28,6 +30,7 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
   private final ControllableStreamClock clock;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final TypedResponseWriter responseWriter;
+  private final TypedRejectionWriter rejectionWriter;
 
   public ClockProcessor(
       final Writers writers,
@@ -38,6 +41,7 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
     responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
     this.clock = clock;
 
     this.commandDistributionBehavior = commandDistributionBehavior;
@@ -49,6 +53,16 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
     final var clockRecord = command.getValue();
     final var intent = (ClockIntent) command.getIntent();
     final var resultIntent = followUpIntent(intent);
+
+    if (intent == ClockIntent.PIN && clockRecord.getTime() < 0) {
+      final var rejectionMessage =
+          "Expected pin time to be not negative but it was %d".formatted(clockRecord.getTime());
+
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, rejectionMessage);
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_ARGUMENT, rejectionMessage);
+      return;
+    }
 
     applyClockModification(eventKey, intent, resultIntent, clockRecord);
     if (command.hasRequestMetadata()) {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -603,7 +603,7 @@ paths:
           description: >
             The clock was successfully pinned to the specified time in epoch milliseconds.
         "400":
-          description: The required timestamp parameter is missing or if a negative timestamp value is provided.
+          description: The required timestamp parameter is missing or it is negative.
           content:
             application/problem+json:
               schema:
@@ -2023,6 +2023,7 @@ components:
           description: The exact time in epoch milliseconds to which the clock should be pinned.
           type: integer
           format: int64
+          minimum: 0
       required:
         - timestamp
     JobActivationRequest:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -603,7 +603,7 @@ paths:
           description: >
             The clock was successfully pinned to the specified time in epoch milliseconds.
         "400":
-          description: The required timestamp parameter is missing.
+          description: The required timestamp parameter is missing or if a negative timestamp value is provided.
           content:
             application/problem+json:
               schema:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AdministrationController.java
@@ -44,8 +44,7 @@ public class AdministrationController {
 
   @PostMapping(
       path = "/clock/reset",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public CompletableFuture<ResponseEntity<Object>> resetClock() {
     return RequestMapper.executeServiceMethodWithNoContentResult(
         () -> clockServices.withAuthentication(RequestMapper.getAuthentication()).resetClock());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
@@ -18,16 +18,18 @@ import org.springframework.http.ProblemDetail;
 public class ClockValidator {
 
   public static Optional<ProblemDetail> validateClockPinRequest(final ClockPinRequest pinRequest) {
+
     return validate(
-        violations -> {
-          final Long timestamp = pinRequest.getTimestamp();
-          if (timestamp == null) {
-            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("timestamp"));
-          } else if (timestamp < 0) {
-            violations.add(
-                ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
-                    "timestamp", timestamp, "not negative"));
-          }
-        });
+        violations ->
+            Optional.ofNullable(pinRequest.getTimestamp())
+                .ifPresentOrElse(
+                    timestamp -> {
+                      if (timestamp < 0) {
+                        violations.add(
+                            ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+                                "timestamp", timestamp, "not negative"));
+                      }
+                    },
+                    () -> violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("timestamp"))));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ClockValidator.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.validator;
 
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.ClockPinRequest;
@@ -19,8 +20,13 @@ public class ClockValidator {
   public static Optional<ProblemDetail> validateClockPinRequest(final ClockPinRequest pinRequest) {
     return validate(
         violations -> {
-          if (pinRequest.getTimestamp() == null) {
+          final Long timestamp = pinRequest.getTimestamp();
+          if (timestamp == null) {
             violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("timestamp"));
+          } else if (timestamp < 0) {
+            violations.add(
+                ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+                    "timestamp", timestamp, "not negative"));
           }
         });
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AdministrationControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
+import static org.junit.jupiter.params.provider.Arguments.of;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,8 +20,12 @@ import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -64,15 +69,23 @@ public class AdministrationControllerTest extends RestControllerTest {
     verify(clockServices).pinClock(timestamp);
   }
 
-  @Test
-  public void pinClockShouldReturnBadRequestIfTimestampIsNotProvided() {
-    // given
-    final var request = new ClockPinRequest();
+  static Stream<Arguments> invalidClockPinRequests() {
+    return Stream.of(
+        of(new ClockPinRequest(), "No timestamp provided."),
+        of(
+            new ClockPinRequest().timestamp(-1L),
+            "The value for timestamp is '-1' but must be not negative."));
+  }
 
+  @ParameterizedTest
+  @MethodSource("invalidClockPinRequests")
+  public void pinClockShouldReturnBadRequestIfInvalidClockPinRequestProvided(
+      final ClockPinRequest invalidRequest, final String expectedError) {
+    // given
     final var expectedBody = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
     expectedBody.setTitle(INVALID_ARGUMENT.name());
     expectedBody.setInstance(URI.create(CLOCK_URL));
-    expectedBody.setDetail("No timestamp provided.");
+    expectedBody.setDetail(expectedError);
 
     // when - then
     webClient
@@ -80,7 +93,7 @@ public class AdministrationControllerTest extends RestControllerTest {
         .uri(CLOCK_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
+        .bodyValue(invalidRequest)
         .exchange()
         .expectStatus()
         .isBadRequest()
@@ -99,7 +112,6 @@ public class AdministrationControllerTest extends RestControllerTest {
         .post()
         .uri(RESET_CLOCK_URL)
         .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isNoContent();


### PR DESCRIPTION
## Description

This PR adds validations for clock pinning commands to ensure the use of valid non-negative time values. Negative timestamps and instants before the Unix epoch (`1970-01-01T00:00:00Z`) will now be rejected in both the REST endpoint and the Zeebe client.

- Validation added in `ClockProcessor` to reject PIN command with negative pin time
- Added validation to `PUT /v2/administration/clock` REST endpoint to accept only non-negative timestamps
- Updated `ClockPinCommandImpl#time(long timestamp)` to ensure non-negative timestamps
- Updated `ClockPinCommandImpl#time(Instant instant)` to ensure that the `Instant` is not before `Instant.EPOCH`


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21964 
