### PR TITLE
ci: use infra self-hosted runners for ci.yml/java-checks,integration-tests jobs

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -43,7 +43,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=120
+        -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
         EOF
     - name: Cache local Maven repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-8-default
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -196,7 +196,7 @@ jobs:
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -207,21 +207,25 @@ jobs:
             maven-modules: "'qa/integration-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
           - group: modules
             name: "Zeebe Module Integration Tests"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-16-default
           - group: qa-update
             name: "Zeebe QA - Update Tests"
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-8-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

This PR introduces the use of `gcp-perf-core-8-default` and `gcp-perf-core-16-default` for the following jobs:
- `ci.yml/java-checks`
- `ci.yml/integration-tests`

Initial tests resulted in a large number of `java.lang.IllegalStateException: Could not acquire lock(s) within XX seconds` errors, preventing jobs from completing. I had to increase `aether.syncContext.named.time` to `180` in the `setup-maven-cache` composite action to avoid such errors. I noticed that artifact resolution in the `setup-zeebe` action is now faster because self-hosted runners are now collocated with Nexus, which probably explains the problem (somehow more chance of hitting a lock timeout due to artifact being resolved more quickly).

Performance (build time) is of the same order or lower 🚀 .

Before merging:
- [x] Check that https://github.com/camunda/infra-core/pull/8375 is merged
- [x] Remove test [commit](https://github.com/camunda/camunda/pull/22033/commits/c6b438c2bc66e1fbc8427c0951b447cfee998852)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
