### PR TITLE
ci: use infra self-hosted runners for tasklist-ci-test-reusable.yml workflow

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -40,12 +40,13 @@ env:
 jobs:
   integration-tests:
     name: Test
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false
       matrix:
         database: [ elasticsearch, opensearch ]
+
         include:
           - database: elasticsearch
             testProfile: docker-es


### PR DESCRIPTION
## Description

This PR introduces the use of `gcp-perf-core-*` runner type for the `tasklist-ci-test-reusable.yml` workflow. I chose a runner with the same amount of resources as the zeebe runners.

The test job for `opensearch` database fails, but this seems to have been the case recently for the [main](https://github.com/camunda/camunda/actions/runs/10846939310/job/30100950233) branch as well, with the same error.

<img width="1324" alt="image" src="https://github.com/user-attachments/assets/c95be74a-c575-41ec-bc64-0df6addeb6d3">

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
