### PR TITLE
deps: revert jetty upgrade to unblock Optimize CI

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -12,7 +12,7 @@
   <name>Optimize Backend</name>
 
   <properties>
-    <jetty.version>12.0.13</jetty.version>
+    <jetty.version>12.0.12</jetty.version>
     <jersey.version>3.1.3</jersey.version>
     <spring.security.version>6.3.3</spring.security.version>
     <nimbus.jose.jwt.version>9.40</nimbus.jose.jwt.version>


### PR DESCRIPTION
## Description

A jetty upgrade broke all Zeebe IT for Optimize. While we look into what changes are required to upgrade without CI failures, lets revert this dependency change to unblock Optimize CI in the meantime with the aim to add it back in once a solution is found.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
