### PR TITLE
test: remove auth initialization of request executor

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/test/it/extension/EmbeddedOptimizeExtension.java
@@ -143,13 +143,6 @@ public class EmbeddedOptimizeExtension
   public void setupOptimize() {
     try {
       objectMapper = getBean(ObjectMapper.class);
-      requestExecutor =
-          new OptimizeRequestExecutor(
-                  DEFAULT_USERNAME,
-                  DEFAULT_PASSWORD,
-                  IntegrationTestConfigurationUtil.getEmbeddedOptimizeRestApiEndpoint(
-                      applicationContext))
-              .initAuthCookie();
       if (isResetImportOnStart()) {
         resetPositionBasedImportStartIndexes();
         setResetImportOnStart(true);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This logic was broken in a recent jetty upgrade. I think we do not even need the request executor in C8 anyway, so opted to remove the origin of the error

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
