### PR TITLE
fix: check for isEmbeddedForm to handle customFormKey user tasks

### DIFF
--- a/tasklist/client/src/Tasks/Task/index.tsx
+++ b/tasklist/client/src/Tasks/Task/index.tsx
@@ -156,7 +156,7 @@ const Task: React.FC = observer(() => {
   }
 
   const isDeployedForm = typeof formId === 'string';
-  const isEmbeddedForm = typeof formKey === 'string' && !isDeployedForm;
+  const isEmbeddedForm = typeof formKey === 'string' && task.isFormEmbedded;
   if (isEmbeddedForm || isDeployedForm) {
     return (
       <FormJS

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -30,6 +30,7 @@ import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.xcontent.XContentType;
@@ -46,6 +47,8 @@ public class JobZeebeRecordProcessorElasticSearch {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorElasticSearch.class);
+
+  private final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -117,7 +120,8 @@ public class JobZeebeRecordProcessorElasticSearch {
               entity.setIsFormEmbedded(false);
             },
             () -> {
-              entity.setIsFormEmbedded(formKey != null ? true : null);
+              entity.setIsFormEmbedded(
+                  formKey != null && EMBEDDED_FORMS_PATTERN.matcher(formKey).matches());
               entity.setFormVersion(null);
               entity.setFormId(null);
             });

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -48,7 +48,7 @@ public class JobZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorElasticSearch.class);
 
-  private final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
+  private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -47,7 +47,7 @@ public class JobZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorOpenSearch.class);
 
-  private final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
+  private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
@@ -45,6 +46,8 @@ public class JobZeebeRecordProcessorOpenSearch {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorOpenSearch.class);
+
+  private final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -111,7 +114,8 @@ public class JobZeebeRecordProcessorOpenSearch {
               entity.setIsFormEmbedded(false);
             },
             () -> {
-              entity.setIsFormEmbedded(true);
+              entity.setIsFormEmbedded(
+                  formKey != null && EMBEDDED_FORMS_PATTERN.matcher(formKey).matches());
               entity.setFormVersion(null);
               entity.setFormId(null);
             });

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportIT.java
@@ -10,12 +10,15 @@ package io.camunda.tasklist.zeebeimport;
 import static io.camunda.tasklist.util.TestCheck.PROCESS_IS_DEPLOYED_CHECK;
 import static io.camunda.tasklist.util.TestCheck.TASK_IS_CREATED_BY_FLOW_NODE_BPMN_ID_CHECK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.graphql.spring.boot.test.GraphQLResponse;
+import io.camunda.tasklist.entities.TaskEntity;
 import io.camunda.tasklist.entities.TaskState;
+import io.camunda.tasklist.store.TaskStore;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.util.TestCheck;
 import java.io.IOException;
@@ -34,6 +37,8 @@ public class ZeebeImportIT extends TasklistZeebeIntegrationTest {
   private TestCheck processIsDeployedCheck;
 
   @Autowired private RecordsReaderHolder recordsReaderHolder;
+
+  @Autowired private TaskStore taskStore;
 
   @Test
   public void shouldImportAllTasks() throws IOException {
@@ -69,7 +74,91 @@ public class ZeebeImportIT extends TasklistZeebeIntegrationTest {
     }
   }
 
-  protected void processAllRecordsAndWait(TestCheck testCheck, Object... arguments) {
+  @Test
+  public void shouldImportUserTaskWithCustomFormKey() {
+    final String bpmnProcessId = "testProcess";
+    final String flowNodeBpmnId = "taskA";
+
+    final String taskId =
+        tester
+            .createAndDeploySimpleProcess(
+                bpmnProcessId, flowNodeBpmnId, t -> t.zeebeFormKey("customFormKey"))
+            .waitUntil()
+            .processIsDeployed()
+            .startProcessInstance(bpmnProcessId)
+            .then()
+            .taskIsCreated(flowNodeBpmnId)
+            .getTaskId();
+
+    final TaskEntity task = taskStore.getTask(taskId);
+    assertNotNull(task);
+    assertNull(task.getFormId());
+    assertEquals("customFormKey", task.getFormKey());
+    assertFalse(task.getIsFormEmbedded());
+  }
+
+  @Test
+  public void shouldImportUserTaskWithEmbeddedForm() {
+    final String embeddedFormPrefix = "camunda-forms:bpmn:";
+    final String bpmnProcessId = "testProcess";
+    final String flowNodeBpmnId = "taskA";
+    final String embeddedForm =
+        """
+                            {
+                              "components": [
+                                {
+                                  "label": "Field 1",
+                                  "type": "textfield",
+                                  "layout": {
+                                    "row": "Row_15ghdy6",
+                                    "columns": null
+                                  },
+                                  "id": "Field_0ibsmz4",
+                                  "key": "field_1lfayry"
+                                },
+                                {
+                                  "label": "Field 2",
+                                  "type": "textfield",
+                                  "layout": {
+                                    "row": "Row_1klibf9",
+                                    "columns": null
+                                  },
+                                  "id": "Field_0msuoi3",
+                                  "key": "field_1prtdvl"
+                                }
+                              ],
+                              "type": "default",
+                              "id": "Field1",
+                              "executionPlatform": "Camunda Cloud",
+                              "executionPlatformVersion": "8.6.0",
+                              "exporter": {
+                                "name": "Camunda Modeler",
+                                "version": "5.10.0"
+                              },
+                              "schemaVersion": 8
+                            }""";
+
+    final String taskId =
+        tester
+            .createAndDeploySimpleProcess(
+                bpmnProcessId,
+                flowNodeBpmnId,
+                t -> t.zeebeUserTaskForm("embeddedForm", embeddedForm))
+            .waitUntil()
+            .processIsDeployed()
+            .startProcessInstance(bpmnProcessId)
+            .then()
+            .taskIsCreated(flowNodeBpmnId)
+            .getTaskId();
+
+    final TaskEntity task = taskStore.getTask(taskId);
+    assertNotNull(task);
+    assertNull(task.getFormId());
+    assertEquals(embeddedFormPrefix + "embeddedForm", task.getFormKey());
+    assertTrue(task.getIsFormEmbedded());
+  }
+
+  protected void processAllRecordsAndWait(final TestCheck testCheck, final Object... arguments) {
     databaseTestExtension.processRecordsAndWaitFor(
         recordsReaderHolder.getAllRecordsReaders(), testCheck, null, arguments);
   }


### PR DESCRIPTION
## Description
Adjust the condition to set the `isFormEmbedded` flag for User Tasks to match the pattern set by Zeebe for such forms `^camunda-forms:bpmn:.*` .

closes #21811 
