### PR TITLE
test: run banning in a separate transaction

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -397,6 +397,10 @@ public final class EngineRule extends ExternalResource {
     environmentRule.pauseProcessing(partitionId);
   }
 
+  public void banInstanceInNewTransaction(final int partitionId, final long processInstanceKey) {
+    environmentRule.banInstanceInNewTransaction(partitionId, processInstanceKey);
+  }
+
   public void resumeProcessing(final int partitionId) {
     environmentRule.resumeProcessing(partitionId);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -114,6 +114,10 @@ public class StreamProcessingComposite implements CommandWriter {
     streams.pauseProcessing(getLogName(partitionId));
   }
 
+  public void banInstanceInNewTransaction(final int partitionId, final long processInstanceKey) {
+    streams.banInstanceInNewTransaction(getLogName(partitionId), partitionId, processInstanceKey);
+  }
+
   public void resumeProcessing(final int partitionId) {
     streams.resumeProcessing(getLogName(partitionId));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -151,6 +151,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
     streamProcessingComposite.pauseProcessing(partitionId);
   }
 
+  public void banInstanceInNewTransaction(final int partitionId, final long processInstanceKey) {
+    streamProcessingComposite.banInstanceInNewTransaction(partitionId, processInstanceKey);
+  }
+
   public void resumeProcessing(final int partitionId) {
     streamProcessingComposite.resumeProcessing(partitionId);
   }


### PR DESCRIPTION
## Description

Fixes the following flaky behavior in the `ResourceDeletionTest`:
- Two threads (engine and test thread) alter the `WriteBatch` of RocksDB concurrently occasionally.
- The `WriteBatch` is not thread-safe, thus both threads might increase the number of entries without respecting the additions of the other.
- Even `Engine::pauseProcessing` doesn't always prevent that further adjustments to RocksDB are made by the engine after it's called. Thus, the test thread and the engine threads can still concurrently alter RocksDB and lead to a wrong number in the WriteBatch

The fix provides the following:
- Use a separate transaction to ban the instance.
- The `WriteBatch` exists per transaction and thus isn't altered concurrently by the test thread and the engine.
- Banning the instance is committed automatically when the outer transaction operation (which we create specifically) ends.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #15388 
