### PR TITLE
docs: bring up downstream changes found in C8 REST API's generated docs

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -618,10 +618,10 @@ paths:
     post:
       tags:
         - Clock
-      summary: Reset the Zeebe engine’s internal clock to the system time (experimental)
+      summary: Reset internal clock (experimental)
       description: |
-        Resets the Zeebe engine’s internal clock to the current system time,
-        enabling it to tick in real-time. This operation is useful for returning the clock to
+        Resets the Zeebe engine’s internal clock to the current system time, enabling it to tick in real-time. 
+        This operation is useful for returning the clock to
         normal behavior after it has been pinned to a specific time.
 
         :::note
@@ -629,7 +629,7 @@ paths:
         :::
       responses:
         "204":
-          description: The clock was successfully reset to the system time
+          description: The clock was successfully reset to the system time.
         "500":
           description: An internal error occurred while processing the request.
           content:
@@ -842,8 +842,8 @@ paths:
     patch:
       tags:
         - Authorization
-      summary: Patch an authorization
-      description: Manage the permissions assigned to the authorization
+      summary: Patch authorization
+      description: Manage the permissions assigned to the authorization.
       operationId: patchAuthorization
       parameters:
         - name: ownerKey
@@ -1285,7 +1285,8 @@ paths:
         - Resources
       summary: Deploy resources
       description: |
-        Deploys one or more resources (e.g. processes, decision models, or forms). This is an atomic call, i.e. either all resources are deployed or none of them are.
+        Deploys one or more resources (e.g. processes, decision models, or forms). 
+        This is an atomic call, i.e. either all resources are deployed or none of them are.
       requestBody:
         required: true
         content:


### PR DESCRIPTION
(Note that this is different from #22037, another recent PR which brought up different downstream changes.)

## Description

This PR addresses a few small C8 REST API spec issues, which were identified in https://github.com/camunda/camunda-docs/pull/4256. 

See that PR for original conversation on these changes. 

