### PR TITLE
Rework TreePath Cache

### DIFF
--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -29,8 +29,9 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
-import io.camunda.operate.util.SoftHashMap;
 import io.camunda.operate.zeebe.PartitionHolder;
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceTreePathCache;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -58,8 +59,8 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private final FlowNodeStore flowNodeStore;
   private final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
-  // treePath by flowNodeInstanceKey per partition cache
-  private final Map<Integer, Map<String, String>> partitionToTreePathCache = new HashMap<>();
+  // treePath by flowNodeInstanceKey caches
+  private final FlowNodeInstanceTreePathCache treePathCache;
 
   public FlowNodeInstanceZeebeRecordProcessor(
       final FlowNodeStore flowNodeStore,
@@ -68,13 +69,11 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       final PartitionHolder partitionHolder) {
     this.flowNodeStore = flowNodeStore;
     this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
-    partitionHolder
-        .getPartitionIds()
-        .forEach(
-            partitionId ->
-                partitionToTreePathCache.put(
-                    partitionId,
-                    new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
+    final var flowNodeTreeCacheSize = operateProperties.getImporter().getFlowNodeTreeCacheSize();
+    final var partitionIds = partitionHolder.getPartitionIds();
+    treePathCache =
+        new FlowNodeInstanceTreePathCache(
+            partitionIds, flowNodeTreeCacheSize, flowNodeStore::findParentTreePathFor);
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
@@ -166,6 +165,15 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             || ELEMENT_MIGRATED.name().equals(intent));
   }
 
+  private static FNITreePathCacheCompositeKey toCompositeKey(
+      final Record<?> record, final ProcessInstanceRecordValue recordValue) {
+    return new FNITreePathCacheCompositeKey(
+        record.getPartitionId(),
+        record.getKey(),
+        recordValue.getFlowScopeKey(),
+        recordValue.getProcessInstanceKey());
+  }
+
   private FlowNodeInstanceEntity updateFlowNodeInstance(
       final Record<ProcessInstanceRecordValue> record, FlowNodeInstanceEntity entity) {
     if (entity == null) {
@@ -186,7 +194,8 @@ public class FlowNodeInstanceZeebeRecordProcessor {
 
     if (entity.getTreePath() == null) {
 
-      final String parentTreePath = getParentTreePath(record, recordValue);
+      final String parentTreePath =
+          treePathCache.resolveTreePath(toCompositeKey(record, recordValue));
       entity.setTreePath(
           String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
       entity.setLevel(parentTreePath.split("/").length);
@@ -214,38 +223,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
                 : recordValue.getBpmnElementType().name()));
 
     return entity;
-  }
-
-  private String getParentTreePath(
-      final Record record, final ProcessInstanceRecordValue recordValue) {
-    String parentTreePath;
-    final var partitionTreePathCache = partitionToTreePathCache.get(record.getPartitionId());
-    // if scopeKey differs from processInstanceKey, then it's inner tree level, and we need to
-    // search
-    // for parent 1st
-    if (recordValue.getFlowScopeKey() == recordValue.getProcessInstanceKey()) {
-      parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
-    } else {
-      // find parent flow node instance
-      parentTreePath =
-          partitionTreePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
-      // query from ELS
-      if (parentTreePath == null) {
-        parentTreePath = flowNodeStore.findParentTreePathFor(recordValue.getFlowScopeKey());
-      }
-
-      if (parentTreePath == null) {
-        LOGGER.warn(
-            "Unable to find parent tree path for flow node instance id [{}], parent flow node instance id [{}]",
-            record.getKey(),
-            recordValue.getFlowScopeKey());
-        parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
-      }
-    }
-    partitionTreePathCache.put(
-        ConversionUtils.toStringOrNull(record.getKey()),
-        String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
-    return parentTreePath;
   }
 
   private boolean canOptimizeFlowNodeInstanceIndexing(final FlowNodeInstanceEntity entity) {

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -30,7 +30,7 @@ import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.zeebe.PartitionHolder;
-import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceRecord;
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
 import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceTreePathCache;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -166,9 +166,9 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             || ELEMENT_MIGRATED.name().equals(intent));
   }
 
-  private static FlowNodeInstanceRecord toFNIRecord(
+  private static FNITreePathCacheCompositeKey toCompositeKey(
       final Record<?> record, final ProcessInstanceRecordValue recordValue) {
-    return new FlowNodeInstanceRecord(
+    return new FNITreePathCacheCompositeKey(
         record.getPartitionId(),
         record.getKey(),
         recordValue.getFlowScopeKey(),
@@ -194,7 +194,8 @@ public class FlowNodeInstanceZeebeRecordProcessor {
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
     if (entity.getTreePath() == null) {
-      final String parentTreePath = treePathCache.resolveTreePath(toFNIRecord(record, recordValue));
+      final String parentTreePath =
+          treePathCache.resolveTreePath(toCompositeKey(record, recordValue));
       entity.setTreePath(
           String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
       entity.setLevel(parentTreePath.split("/").length);

--- a/operate/importer-common/pom.xml
+++ b/operate/importer-common/pom.xml
@@ -126,7 +126,11 @@
       <artifactId>spring-boot-test</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FNITreePathCacheCompositeKey.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FNITreePathCacheCompositeKey.java
@@ -17,8 +17,8 @@
 package io.camunda.operate.zeebeimport.cache;
 
 /**
- * Flow nodes instance record with the most important properties to be used by the {@link
- * FlowNodeInstanceTreePathCache}.
+ * The composite key for the tree path cache {@link FlowNodeInstanceTreePathCache} that contains the
+ * most important properties of a flow node instance to be used by the cache.
  *
  * @param partitionId the partition id where the flow node was processed
  * @param recordKey the key of the flow node
@@ -26,5 +26,5 @@ package io.camunda.operate.zeebeimport.cache;
  *     (on root)
  * @param processInstanceKey the corresponding process instance key for the flow node
  */
-public record FlowNodeInstanceRecord(
+public record FNITreePathCacheCompositeKey(
     int partitionId, long recordKey, long flowScopeKey, long processInstanceKey) {}

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceRecord.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceRecord.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+/**
+ * Flow nodes instance record with the most important properties to be used by the {@link
+ * FlowNodeInstanceTreePathCache}.
+ *
+ * @param partitionId the partition id where the flow node was processed
+ * @param recordKey the key of the flow node
+ * @param flowScopeKey the scope key of the flow node, might be equal to the process instance key
+ *     (on root)
+ * @param processInstanceKey the corresponding process instance key for the flow node
+ */
+public record FlowNodeInstanceRecord(
+    int partitionId, long recordKey, long flowScopeKey, long processInstanceKey) {}

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
@@ -123,15 +123,20 @@ public final class FlowNodeInstanceTreePathCache {
             "Cache miss: resolved treePath {} for flowScopeKey {} via given resolver.",
             parentTreePath,
             flowNodeInstanceRecord.flowScopeKey());
-      }
 
-      if (parentTreePath == null) {
-        LOGGER.warn(
-            "Unable to find parent tree path for flow node instance id [{}], parent flow node instance id [{}]",
-            flowNodeInstanceRecord.recordKey(),
-            flowNodeInstanceRecord.flowScopeKey());
-        parentTreePath =
-            ConversionUtils.toStringOrNull(flowNodeInstanceRecord.processInstanceKey());
+        // add missing treePath to cache
+        if (parentTreePath != null) {
+          partitionCache.put(
+              ConversionUtils.toStringOrNull(flowNodeInstanceRecord.flowScopeKey()),
+              parentTreePath);
+        } else {
+          LOGGER.warn(
+              "Unable to find parent tree path for flow node instance id [{}], parent flow node instance id [{}]",
+              flowNodeInstanceRecord.recordKey(),
+              flowNodeInstanceRecord.flowScopeKey());
+          parentTreePath =
+              ConversionUtils.toStringOrNull(flowNodeInstanceRecord.processInstanceKey());
+        }
       }
     }
     partitionCache.put(

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+import io.camunda.operate.util.ConversionUtils;
+import io.camunda.operate.util.SoftHashMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A cache for the treePath of flow node instances.
+ *
+ * <p>The cache can handle multiple different partitions (need to be specified on construction). For
+ * each partition a separate internal cache are used, where the given cacheSize is as upper bound to
+ * store key-values.
+ *
+ * <p>On construction a treePath resolver can be specified that should resolve the treePath if it is
+ * not part of the cache. As it can be that the value has been evicited due to reaching the cache
+ * size or the flow scope haven't been seen before (due to recreation of cache, etc.).
+ *
+ * <p>When resolving the treePath for a given flow node instance record {@link
+ * FlowNodeInstanceRecord} the treePath with the corresponding flowScopekey is stored in the cache
+ * itself. Be aware that only X elements are to be guaranteed in the cache (corresponding to the
+ * given cacheSize on construction).
+ */
+public final class FlowNodeInstanceTreePathCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FlowNodeInstanceTreePathCache.class);
+  private final Map<Integer, Map<String, String>> backedTreePathCache;
+  private final Function<Long, String> treePathResolver;
+
+  /**
+   * Constructs the tree patch cache, backed by caches per given partitions.
+   *
+   * @param partitionIds a list of partition ids the cache should cover, it might be that the
+   *     corresponding Importer is only importing a sparse of existing partition ids
+   * @param cacheSize the size of the caches assigned per partition
+   * @param treePathResolver the resolver to find corresponding treePath if not existing in the
+   *     cache
+   */
+  public FlowNodeInstanceTreePathCache(
+      final List<Integer> partitionIds,
+      final int cacheSize,
+      final Function<Long, String> treePathResolver) {
+    backedTreePathCache = new HashMap<>();
+    partitionIds.forEach(
+        partitionId ->
+            backedTreePathCache.computeIfAbsent(partitionId, (id) -> new SoftHashMap<>(cacheSize)));
+    this.treePathResolver = treePathResolver;
+  }
+
+  /**
+   * Resolve the treePath for the given flow node instance (FNI) record {@link
+   * FlowNodeInstanceRecord}.
+   *
+   * <p>When the flow scope and process instance key are equal, the value is returned as treePath,
+   * as it corresponds to a FNI on root level.
+   *
+   * <p>When the cache doesn't contain the treePath for a given flowScopeKey, the corresponding
+   * treePathResolver is used (specified on cache construction).
+   *
+   * <p>Does the resolver has also no knowledge about the treePath the process instance key is used.
+   *
+   * @param flowNodeInstanceRecord record that contains information used to resolve the tree path
+   *     for the flow node instance
+   * @return the treePath of the flow node instance
+   * @throws IllegalArgumentException when the flow node instance record doesn't correspond to a
+   *     supported partition
+   */
+  public String resolveTreePath(final FlowNodeInstanceRecord flowNodeInstanceRecord) {
+    final var partitionCache = backedTreePathCache.get(flowNodeInstanceRecord.partitionId());
+    if (partitionCache == null) {
+      final IllegalArgumentException illegalArgumentException =
+          new IllegalArgumentException(
+              String.format(
+                  "Expected to find treePath cache for partitionId %d, but found nothing. Possible partition Ids are: '%s'.",
+                  flowNodeInstanceRecord.partitionId(), backedTreePathCache.keySet()));
+
+      LOGGER.error(
+          "Couldn't resolve tree path for given partition id {}",
+          flowNodeInstanceRecord.partitionId(),
+          illegalArgumentException);
+      throw illegalArgumentException;
+    }
+
+    return resolveTreePath(partitionCache, flowNodeInstanceRecord);
+  }
+
+  private String resolveTreePath(
+      final Map<String, String> partitionCache,
+      final FlowNodeInstanceRecord flowNodeInstanceRecord) {
+    String parentTreePath;
+    // if scopeKey differs from processInstanceKey, then it's inner tree level and we need to search
+    // for parent 1st
+    if (flowNodeInstanceRecord.flowScopeKey() == flowNodeInstanceRecord.processInstanceKey()) {
+      parentTreePath = ConversionUtils.toStringOrNull(flowNodeInstanceRecord.processInstanceKey());
+    } else {
+      // find parent flow node instance
+      parentTreePath =
+          partitionCache.get(ConversionUtils.toStringOrNull(flowNodeInstanceRecord.flowScopeKey()));
+
+      // cache miss: resolve tree path
+      if (parentTreePath == null) {
+        parentTreePath = treePathResolver.apply(flowNodeInstanceRecord.flowScopeKey());
+        LOGGER.debug(
+            "Cache miss: resolved treePath {} for flowScopeKey {} via given resolver.",
+            parentTreePath,
+            flowNodeInstanceRecord.flowScopeKey());
+      }
+
+      if (parentTreePath == null) {
+        LOGGER.warn(
+            "Unable to find parent tree path for flow node instance id [{}], parent flow node instance id [{}]",
+            flowNodeInstanceRecord.recordKey(),
+            flowNodeInstanceRecord.flowScopeKey());
+        parentTreePath =
+            ConversionUtils.toStringOrNull(flowNodeInstanceRecord.processInstanceKey());
+      }
+    }
+    partitionCache.put(
+        ConversionUtils.toStringOrNull(flowNodeInstanceRecord.recordKey()),
+        String.join(
+            "/",
+            parentTreePath,
+            ConversionUtils.toStringOrNull(flowNodeInstanceRecord.recordKey())));
+    return parentTreePath;
+  }
+}

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
@@ -40,7 +40,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   }
 
   @Test
-  public void shouldShouldResolveTreePathForRootLevelFNI() {
+  public void shouldResolveTreePathForRootLevelFNI() {
     // given
     // flow scope key and PI key is equal - no need to resolve tree path
     final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
@@ -55,7 +55,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   }
 
   @Test
-  public void shouldShouldResolveTreePathFromPreviousRecord() {
+  public void shouldResolveTreePathFromPreviousRecord() {
     // given
     // root fni are added to the cache
     final var rootFlowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
@@ -76,7 +76,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   }
 
   @Test
-  public void shouldShouldTryToResolve() {
+  public void shouldTryToResolve() {
     // given
     // resolver can't resolve value - returned tree Path is equal to process instance key
     final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
@@ -91,7 +91,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   }
 
   @Test
-  public void shouldShouldResolveTreePath() {
+  public void shouldResolveTreePath() {
     // given
     // resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
@@ -103,6 +103,24 @@ public class FlowNodeInstanceTreePathCacheTest {
 
     // then
     assertThat(treePath).isEqualTo(expectedTreePath);
+
+    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+  }
+
+  @Test
+  public void shouldNotResolveTreePathTwice() {
+    // given
+    // cache is empty and resolver can resolve tree path
+    final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
+    spyResolverCache.put(0xABCDL, expectedTreePath);
+    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+    final String firstTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // when
+    final String secondTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(firstTreePath).isEqualTo(secondTreePath).isEqualTo(expectedTreePath);
 
     Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
   }

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class FlowNodeInstanceTreePathCacheTest {
+
+  private HashMap<Long, String> spyResolverCache;
+  private FlowNodeInstanceTreePathCache treePathCache;
+
+  @BeforeEach
+  void setup() {
+    spyResolverCache = spy(new HashMap<Long, String>());
+    treePathCache = new FlowNodeInstanceTreePathCache(List.of(1, 2), 10, spyResolverCache::get);
+  }
+
+  @Test
+  public void shouldShouldResolveTreePathForRootLevelFNI() {
+    // given
+    // flow scope key and PI key is equal - no need to resolve tree path
+    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(Long.toString(0xABCD));
+
+    Mockito.verifyNoInteractions(spyResolverCache);
+  }
+
+  @Test
+  public void shouldShouldResolveTreePathFromPreviousRecord() {
+    // given
+    // root fni are added to the cache
+    final var rootFlowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
+    final String firstTreePath = treePathCache.resolveTreePath(rootFlowNodeInstanceRecord);
+
+    final var leafFlowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xFACE, 0xCAFE, 0xABCD);
+
+    // when
+    // fni with flow scope key of previous root FNI
+    final String secondTreePath = treePathCache.resolveTreePath(leafFlowNodeInstanceRecord);
+
+    // then cache should resolve without using the resolver
+    assertThat(secondTreePath)
+        .contains(firstTreePath)
+        .isEqualTo(String.join("/", Long.toString(0xABCD), Long.toString(0xCAFE)));
+
+    Mockito.verifyNoInteractions(spyResolverCache);
+  }
+
+  @Test
+  public void shouldShouldTryToResolve() {
+    // given
+    // resolver can't resolve value - returned tree Path is equal to process instance key
+    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(Long.toString(0xEFDA));
+
+    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+  }
+
+  @Test
+  public void shouldShouldResolveTreePath() {
+    // given
+    // resolver can resolve tree path
+    final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
+    spyResolverCache.put(0xABCDL, expectedTreePath);
+    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(expectedTreePath);
+
+    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+  }
+
+  @Test
+  public void shouldThrowErrorWhenPartitionIdDoesNotFit() {
+    // given
+    // partition Id doesn't correspond to expected
+    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(3, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when - then
+    assertThatThrownBy(() -> treePathCache.resolveTreePath(flowNodeInstanceRecord))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected to find treePath cache for partitionId 3, but found nothing. Possible partition Ids are: '[1, 2]'.");
+  }
+}

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
@@ -43,7 +43,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   public void shouldResolveTreePathForRootLevelFNI() {
     // given
     // flow scope key and PI key is equal - no need to resolve tree path
-    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
 
     // when
     final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
@@ -58,10 +58,12 @@ public class FlowNodeInstanceTreePathCacheTest {
   public void shouldResolveTreePathFromPreviousRecord() {
     // given
     // root fni are added to the cache
-    final var rootFlowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xABCD);
+    final var rootFlowNodeInstanceRecord =
+        new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
     final String firstTreePath = treePathCache.resolveTreePath(rootFlowNodeInstanceRecord);
 
-    final var leafFlowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xFACE, 0xCAFE, 0xABCD);
+    final var leafFlowNodeInstanceRecord =
+        new FNITreePathCacheCompositeKey(1, 0xFACE, 0xCAFE, 0xABCD);
 
     // when
     // fni with flow scope key of previous root FNI
@@ -79,7 +81,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   public void shouldTryToResolve() {
     // given
     // resolver can't resolve value - returned tree Path is equal to process instance key
-    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when
     final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
@@ -96,7 +98,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
     spyResolverCache.put(0xABCDL, expectedTreePath);
-    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when
     final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
@@ -113,7 +115,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // cache is empty and resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
     spyResolverCache.put(0xABCDL, expectedTreePath);
-    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(1, 0xCAFE, 0xABCD, 0xEFDA);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
     final String firstTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
 
     // when
@@ -129,7 +131,7 @@ public class FlowNodeInstanceTreePathCacheTest {
   public void shouldThrowErrorWhenPartitionIdDoesNotFit() {
     // given
     // partition Id doesn't correspond to expected
-    final var flowNodeInstanceRecord = new FlowNodeInstanceRecord(3, 0xCAFE, 0xABCD, 0xEFDA);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(3, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when - then
     assertThatThrownBy(() -> treePathCache.resolveTreePath(flowNodeInstanceRecord))

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
@@ -30,13 +30,15 @@ import org.mockito.Mockito;
 
 public class FlowNodeInstanceTreePathCacheTest {
 
-  private HashMap<Long, String> spyResolverCache;
+  private HashMap<Long, String> spyTreePathResolver;
   private FlowNodeInstanceTreePathCache treePathCache;
 
   @BeforeEach
   void setup() {
-    spyResolverCache = spy(new HashMap<Long, String>());
-    treePathCache = new FlowNodeInstanceTreePathCache(List.of(1, 2), 10, spyResolverCache::get);
+    // treePathResolver is in this case a simple map, but in production it might be
+    // the ES flow node store to query elastic to find the treePath
+    spyTreePathResolver = spy(new HashMap<>());
+    treePathCache = new FlowNodeInstanceTreePathCache(List.of(1, 2), 10, spyTreePathResolver::get);
   }
 
   @Test
@@ -51,7 +53,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // then
     assertThat(treePath).isEqualTo(Long.toString(0xABCD));
 
-    Mockito.verifyNoInteractions(spyResolverCache);
+    Mockito.verifyNoInteractions(spyTreePathResolver);
   }
 
   @Test
@@ -74,7 +76,7 @@ public class FlowNodeInstanceTreePathCacheTest {
         .contains(firstTreePath)
         .isEqualTo(String.join("/", Long.toString(0xABCD), Long.toString(0xCAFE)));
 
-    Mockito.verifyNoInteractions(spyResolverCache);
+    Mockito.verifyNoInteractions(spyTreePathResolver);
   }
 
   @Test
@@ -89,7 +91,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // then
     assertThat(treePath).isEqualTo(Long.toString(0xEFDA));
 
-    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
   }
 
   @Test
@@ -97,7 +99,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // given
     // resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
-    spyResolverCache.put(0xABCDL, expectedTreePath);
+    spyTreePathResolver.put(0xABCDL, expectedTreePath);
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when
@@ -106,7 +108,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // then
     assertThat(treePath).isEqualTo(expectedTreePath);
 
-    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
   }
 
   @Test
@@ -114,7 +116,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // given
     // cache is empty and resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
-    spyResolverCache.put(0xABCDL, expectedTreePath);
+    spyTreePathResolver.put(0xABCDL, expectedTreePath);
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
     final String firstTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
 
@@ -124,7 +126,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     // then
     assertThat(firstTreePath).isEqualTo(secondTreePath).isEqualTo(expectedTreePath);
 
-    Mockito.verify(spyResolverCache, times(1)).get(eq(0xABCDL));
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
   }
 
   @Test


### PR DESCRIPTION
## PR Description

The PR is divided into three commits, first a bigger refactoring to extract the treePath cache and make it easier to test and maintain. As a second step the cache has been integrated into the existing FlowNodeInstanceProcessor, at the end the bug was fixed to add the missing flowScopeKey with corresponding treePath.


> [!Important]
>
> I wanted to keep the PR small, and stop here and keep it simple for now. So as not to overwhelm the reviewer with too many changes.
> 
> The next steps are:
> 
> 1. Add metrics for cache access and misses, metric for time of resolver
> 2. Clean up - keys don't need to be strings
> 3. Fixing the issue with adding unnecessary leafes to the cache https://github.com/camunda/camunda/issues/22076 
> 4. Adjust processor to not use treePath if element completes, terminates, etc https://github.com/camunda/camunda/issues/22075

### Refactoring

Create a new class for the treePath cache, FlowNodeInstanceTreePathCache.

The FlowNodeInstanceTreePathCache comprises the corresponding multi-level HashMap (with SoftHashMap), and the resolvment via a given treePathResolver.

A new record was created to encapsulate the necessary values like, partitionId, recordKey, flowScopeKey, and processInstanceKey. This allows us to reduce the dependency to the Zeebe protocol. Allows us to move the cache to the common importer module.

As the resolver is available via DI the treePath cache can be easily tested via unit tests.

New tests and documentation were added to cover and describe the behavior of the cache.

### Integration

The integration was rather simple and allowed to remove several code/complexity from the processor.

### Fix

Previously when the treePath of the flowScope was not part of the cache the resolver was used to resolve the treePath. This was done every time as the resolved treePath was not added to the cache. Causing unnecessary multiple calls to the resolver.
<!-- Describe the goal and purpose of this PR. -->

## Related issues

closes https://github.com/camunda/camunda/issues/22074
