### PR TITLE
fix: use proper count variable for task assigned notification

### DIFF
--- a/tasklist/client/src/modules/internationalization/locales/de.json
+++ b/tasklist/client/src/modules/internationalization/locales/de.json
@@ -57,7 +57,7 @@
     "taskDetailsNewVariableNameFieldLabel": "Variablenname",
     "notificationActionButtonLabel": "Aktion",
     "nativeNotificationOneNewTaskAssigned": "1 Aufgabe ist Ihnen zugewiesen.",
-    "nativeNotificationMultipleTasksAssigned": "{{numTasks}} Aufgaben sind Ihnen zugewiesen.",
+    "nativeNotificationMultipleTasksAssigned": "{{count}} Aufgaben sind Ihnen zugewiesen.",
     "nativeNotificationFiftyOrMoreTasksAssigned": "50+ Aufgaben sind Ihnen zugewiesen.",
     "nativeNotificationNewTasksMessageBody": "Klicken Sie hier, um die Details anzuzeigen.",
     "processesFirstTimeModalAriaLabel": "Starten Sie Ihren Prozess auf Abruf",

--- a/tasklist/client/src/modules/internationalization/locales/en.json
+++ b/tasklist/client/src/modules/internationalization/locales/en.json
@@ -57,7 +57,7 @@
     "taskDetailsNewVariableNameFieldLabel": "Name",
     "notificationActionButtonLabel": "Action",
     "nativeNotificationOneNewTaskAssigned": "1 task is assigned to you.",
-    "nativeNotificationMultipleTasksAssigned": "{{numTasks}} tasks are assigned to you.",
+    "nativeNotificationMultipleTasksAssigned": "{{count}} tasks are assigned to you.",
     "nativeNotificationFiftyOrMoreTasksAssigned": "50+ tasks are assigned to you.",
     "nativeNotificationNewTasksMessageBody": "Click here to see the details.",
     "processesFirstTimeModalAriaLabel": "Start your process on demand",

--- a/tasklist/client/src/modules/internationalization/locales/es.json
+++ b/tasklist/client/src/modules/internationalization/locales/es.json
@@ -57,7 +57,7 @@
     "taskDetailsNewVariableNameFieldLabel": "Nombre",
     "notificationActionButtonLabel": "Acción",
     "nativeNotificationOneNewTaskAssigned": "1 tarea está asignada a usted.",
-    "nativeNotificationMultipleTasksAssigned": "{{numTasks}} tareas están asignadas a usted.",
+    "nativeNotificationMultipleTasksAssigned": "{{count}} tareas están asignadas a usted.",
     "nativeNotificationFiftyOrMoreTasksAssigned": "50+ tareas están asignadas a usted.",
     "nativeNotificationNewTasksMessageBody": "Haga clic aquí para ver los detalles.",
     "processesFirstTimeModalAriaLabel": "Inicie su proceso a demanda",

--- a/tasklist/client/src/modules/internationalization/locales/fr.json
+++ b/tasklist/client/src/modules/internationalization/locales/fr.json
@@ -57,7 +57,7 @@
     "taskDetailsNewVariableNameFieldLabel": "Nom",
     "notificationActionButtonLabel": "Action",
     "nativeNotificationOneNewTaskAssigned": "1 tâche vous est assignée.",
-    "nativeNotificationMultipleTasksAssigned": "{{numTasks}} tâches vous sont assignées.",
+    "nativeNotificationMultipleTasksAssigned": "{{count}} tâches vous sont assignées.",
     "nativeNotificationFiftyOrMoreTasksAssigned": "50+ tâches vous sont assignées.",
     "nativeNotificationNewTasksMessageBody": "Cliquez ici pour voir les détails.",
     "processesFirstTimeModalAriaLabel": "Démarrez votre processus à la demande",


### PR DESCRIPTION
## Description

Ensures the task assignment notification translations use the proper count variable so that the number is injected during the translation. 

## Related issues

Closes #21768
