### PR TITLE
ci: remove duplicate setup-node step

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -20,11 +20,6 @@ runs:
       shell: bash
       run: npm install -g yarn
 
-    - name: Setup NodeJS
-      uses: actions/setup-node@v4
-      with:
-        node-version: "20"
-
     - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
       with:
         directory: ${{ inputs.directory }}


### PR DESCRIPTION
## Description

Originally copy-pasted in https://github.com/camunda/camunda/commit/ec1c2c8e41e5b6f01992d4443916a14b696fca0d#diff-d74e0a2290e7e6217d9fd60bba30de401471132cee30cd126e3ec52c15d59868 but it became redundant due to the new action to set up GHA caching in https://github.com/camunda/camunda/issues/21424

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
