### PR TITLE
feat: Update clock endpoints path

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockPinCommandImpl.java
@@ -65,8 +65,7 @@ public class ClockPinCommandImpl implements ClockPinCommandStep1 {
   @Override
   public ZeebeFuture<PinClockResponse> send() {
     final HttpZeebeFuture<PinClockResponse> result = new HttpZeebeFuture<>();
-    httpClient.put(
-        "/administration/clock", jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    httpClient.put("/clock", jsonMapper.toJson(request), httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockResetCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ClockResetCommandImpl.java
@@ -44,7 +44,7 @@ public class ClockResetCommandImpl implements ClockResetCommandStep1 {
   @Override
   public ZeebeFuture<ResetClockResponse> send() {
     final HttpZeebeFuture<ResetClockResponse> result = new HttpZeebeFuture<>();
-    httpClient.post("/administration/clock/reset", "", httpRequestConfig.build(), result);
+    httpClient.post("/clock/reset", "", httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
@@ -29,8 +29,8 @@ public class RestGatewayPaths {
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
   private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/message/correlation";
-  private static final String URL_CLOCK_PIN = REST_API_PATH + "/administration/clock";
-  private static final String URL_CLOCK_RESET = REST_API_PATH + "/administration/clock/reset";
+  private static final String URL_CLOCK_PIN = REST_API_PATH + "/clock";
+  private static final String URL_CLOCK_RESET = REST_API_PATH + "/clock/reset";
   private static final String URL_INCIDENT_RESOLUTION = REST_API_PATH + "/incidents/%s/resolution";
 
   /**

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -579,7 +579,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
 
-  /administration/clock:
+  /clock:
     put:
       tags:
         - Clock
@@ -614,7 +614,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-  /administration/clock/reset:
+  /clock/reset:
     post:
       tags:
         - Clock

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ClockController.java
@@ -21,18 +21,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
-@RequestMapping("/v2/administration")
-public class AdministrationController {
+@RequestMapping("/v2/clock")
+public class ClockController {
 
   private final ClockServices clockServices;
 
   @Autowired
-  public AdministrationController(final ClockServices clockServices) {
+  public ClockController(final ClockServices clockServices) {
     this.clockServices = clockServices;
   }
 
   @PutMapping(
-      path = "/clock",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> pinClock(
@@ -43,7 +42,7 @@ public class AdministrationController {
   }
 
   @PostMapping(
-      path = "/clock/reset",
+      path = "/reset",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
   public CompletableFuture<ResponseEntity<Object>> resetClock() {
     return RequestMapper.executeServiceMethodWithNoContentResult(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ClockControllerTest.java
@@ -32,10 +32,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 
-@WebMvcTest(AdministrationController.class)
-public class AdministrationControllerTest extends RestControllerTest {
+@WebMvcTest(ClockController.class)
+public class ClockControllerTest extends RestControllerTest {
 
-  private static final String CLOCK_URL = "/v2/administration/clock";
+  private static final String CLOCK_URL = "/v2/clock";
   private static final String RESET_CLOCK_URL = CLOCK_URL.concat("/reset");
 
   @MockBean private ClockServices clockServices;


### PR DESCRIPTION
## Description
This PR implements changes to move the clock endpoints out of the `/v2/administration/clock` path to `/v2/clock` path, as per recent feedback.

### Changes:
- Updated URL for the clock endpoints:
  - Changed from `PUT /v2/administration/clock` to `PUT /v2/clock`.
  - Changed from `POST /v2/administration/clock/reset` to `POST /v2/clock/reset`.
- Updated Zeebe Java client to use the new clock endpoint URLs.
- Updated the REST API definition in `rest-api.yaml` for clock endpoints.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22138 
