### PR TITLE
feat: Import versionTag field to operate process index

### DIFF
--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessor.java
@@ -19,6 +19,7 @@ import static io.camunda.operate.schema.templates.ListViewTemplate.JOB_POSITION;
 import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_KEY;
 import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_NAME;
 import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_VERSION;
+import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_VERSION_TAG;
 import static io.camunda.operate.schema.templates.ListViewTemplate.START_DATE;
 import static io.camunda.operate.schema.templates.ListViewTemplate.STATE;
 import static io.camunda.operate.schema.templates.ListViewTemplate.VAR_NAME;
@@ -300,6 +301,9 @@ public class ListViewZeebeRecordProcessor {
         if (piEntity.getEndDate() != null) {
           updateFields.put(ListViewTemplate.END_DATE, piEntity.getEndDate());
         }
+        if (piEntity.getProcessVersionTag() != null) {
+          updateFields.put(ListViewTemplate.PROCESS_VERSION_TAG, piEntity.getProcessVersionTag());
+        }
         updateFields.put(ListViewTemplate.PROCESS_NAME, piEntity.getProcessName());
         updateFields.put(ListViewTemplate.PROCESS_VERSION, piEntity.getProcessVersion());
         updateFields.put(ListViewTemplate.PROCESS_KEY, piEntity.getProcessDefinitionKey());
@@ -420,6 +424,7 @@ public class ListViewZeebeRecordProcessor {
             + "ctx._source.%s = params.%s; " // process version
             + "ctx._source.%s = params.%s; " // process key
             + "ctx._source.%s = params.%s; " // bpmnProcessId
+            + "if (params.%s != null) { ctx._source.%s = params.%s; }" // process version tag
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // start date
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // end date
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // state
@@ -437,6 +442,9 @@ public class ListViewZeebeRecordProcessor {
         PROCESS_KEY,
         BPMN_PROCESS_ID,
         BPMN_PROCESS_ID,
+        PROCESS_VERSION_TAG,
+        PROCESS_VERSION_TAG,
+        PROCESS_VERSION_TAG,
         START_DATE,
         START_DATE,
         START_DATE,
@@ -517,6 +525,7 @@ public class ListViewZeebeRecordProcessor {
         .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setBpmnProcessId(recordValue.getBpmnProcessId())
         .setProcessVersion(recordValue.getVersion())
+        .setProcessVersionTag(processCache.getProcessVersionTag(piEntity.getProcessDefinitionKey()))
         .setProcessName(
             processCache.getProcessNameOrDefaultValue(
                 piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()));

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
@@ -95,6 +95,7 @@ public class ProcessZeebeRecordProcessor {
             .setKey(process.getProcessDefinitionKey())
             .setBpmnProcessId(process.getBpmnProcessId())
             .setVersion(process.getVersion())
+            .setVersionTag(process.getVersionTag())
             .setTenantId(tenantOrDefault(process.getTenantId()));
 
     final byte[] byteArray = process.getResource();

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
@@ -83,6 +83,7 @@ public class ProcessZeebeRecordProcessor {
       final Map<String, Object> updateFields = new HashMap<>();
       updateFields.put(ListViewTemplate.PROCESS_NAME, processEntity.getName());
       updateFields.put(ListViewTemplate.PROCESS_VERSION, processEntity.getVersion());
+      updateFields.put(ListViewTemplate.PROCESS_VERSION_TAG, processEntity.getVersion());
       batchRequest.update(
           listViewTemplate.getFullQualifiedName(), processInstanceKey.toString(), updateFields);
     }

--- a/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
+++ b/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
@@ -32,7 +32,8 @@ public class ProcessCache {
   private final Map<Long, ProcessEntity> cache = new ConcurrentHashMap<>();
   @Autowired private ProcessStore processStore;
 
-  public String getProcessNameOrDefaultValue(Long processDefinitionKey, String defaultValue) {
+  public String getProcessNameOrDefaultValue(
+      final Long processDefinitionKey, final String defaultValue) {
     final ProcessEntity cachedProcessData =
         getCachedProcessEntity(processDefinitionKey).orElse(null);
     String processName = defaultValue;
@@ -46,7 +47,8 @@ public class ProcessCache {
     return processName;
   }
 
-  public String getProcessNameOrBpmnProcessId(Long processDefinitionKey, String defaultValue) {
+  public String getProcessNameOrBpmnProcessId(
+      final Long processDefinitionKey, final String defaultValue) {
     final ProcessEntity cachedProcessData =
         getCachedProcessEntity(processDefinitionKey).orElse(null);
     String processName = null;
@@ -64,7 +66,7 @@ public class ProcessCache {
   }
 
   public String getFlowNodeNameOrDefaultValue(
-      Long processDefinitionKey, String flowNodeId, String defaultValue) {
+      final Long processDefinitionKey, final String flowNodeId, final String defaultValue) {
     final ProcessEntity cachedProcessData =
         getCachedProcessEntity(processDefinitionKey).orElse(null);
     String flowNodeName = defaultValue;
@@ -85,7 +87,7 @@ public class ProcessCache {
     return flowNodeName;
   }
 
-  private Optional<ProcessEntity> getCachedProcessEntity(Long processDefinitionKey) {
+  private Optional<ProcessEntity> getCachedProcessEntity(final Long processDefinitionKey) {
     ProcessEntity cachedProcessData = cache.get(processDefinitionKey);
     if (cachedProcessData == null) {
       final Optional<ProcessEntity> processMaybe =
@@ -98,16 +100,16 @@ public class ProcessCache {
     return Optional.ofNullable(cachedProcessData);
   }
 
-  private Optional<ProcessEntity> readProcessByKey(Long processDefinitionKey) {
+  private Optional<ProcessEntity> readProcessByKey(final Long processDefinitionKey) {
     try {
       return Optional.of(processStore.getProcessByKey(processDefinitionKey));
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       return Optional.empty();
     }
   }
 
   public Optional<ProcessEntity> findOrWaitProcess(
-      Long processDefinitionKey, int attempts, long sleepInMilliseconds) {
+      final Long processDefinitionKey, final int attempts, final long sleepInMilliseconds) {
     int attemptsCount = 0;
     Optional<ProcessEntity> foundProcess = Optional.empty();
     while (foundProcess.isEmpty() && attemptsCount < attempts) {
@@ -131,7 +133,7 @@ public class ProcessCache {
     return foundProcess;
   }
 
-  public void putToCache(Long processDefinitionKey, ProcessEntity process) {
+  public void putToCache(final Long processDefinitionKey, final ProcessEntity process) {
     if (cache.size() >= CACHE_MAX_SIZE) {
       // remove 1st element
       final Iterator<Long> iterator = cache.keySet().iterator();

--- a/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
+++ b/operate/schema/src/main/java/io/camunda/operate/cache/ProcessCache.java
@@ -65,6 +65,16 @@ public class ProcessCache {
     return processName;
   }
 
+  public String getProcessVersionTag(final Long processDefinitionKey) {
+    final ProcessEntity cachedProcessData =
+        getCachedProcessEntity(processDefinitionKey).orElse(null);
+    String processVersionTag = null;
+    if (cachedProcessData != null) {
+      processVersionTag = cachedProcessData.getVersionTag();
+    }
+    return processVersionTag;
+  }
+
   public String getFlowNodeNameOrDefaultValue(
       final Long processDefinitionKey, final String flowNodeId, final String defaultValue) {
     final ProcessEntity cachedProcessData =

--- a/operate/schema/src/main/java/io/camunda/operate/entities/ProcessEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/ProcessEntity.java
@@ -29,13 +29,13 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return name;
   }
 
-  public ProcessEntity setName(String name) {
+  public ProcessEntity setName(final String name) {
     this.name = name;
     return this;
   }
 
   @Override
-  public ProcessEntity setId(String id) {
+  public ProcessEntity setId(final String id) {
     super.setId(id);
     setKey(ConversionUtils.toLongOrNull(id));
     return this;
@@ -74,7 +74,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return version;
   }
 
-  public ProcessEntity setVersion(int version) {
+  public ProcessEntity setVersion(final int version) {
     this.version = version;
     return this;
   }
@@ -92,7 +92,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return bpmnProcessId;
   }
 
-  public ProcessEntity setBpmnProcessId(String bpmnProcessId) {
+  public ProcessEntity setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
     return this;
   }
@@ -101,7 +101,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return bpmnXml;
   }
 
-  public ProcessEntity setBpmnXml(String bpmnXml) {
+  public ProcessEntity setBpmnXml(final String bpmnXml) {
     this.bpmnXml = bpmnXml;
     return this;
   }
@@ -110,7 +110,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return resourceName;
   }
 
-  public ProcessEntity setResourceName(String resourceName) {
+  public ProcessEntity setResourceName(final String resourceName) {
     this.resourceName = resourceName;
     return this;
   }
@@ -122,7 +122,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return flowNodes;
   }
 
-  public ProcessEntity setFlowNodes(List<ProcessFlowNodeEntity> flowNodes) {
+  public ProcessEntity setFlowNodes(final List<ProcessFlowNodeEntity> flowNodes) {
     this.flowNodes = flowNodes;
     return this;
   }
@@ -131,7 +131,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return tenantId;
   }
 
-  public ProcessEntity setTenantId(String tenantId) {
+  public ProcessEntity setTenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/entities/ProcessEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/ProcessEntity.java
@@ -18,6 +18,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
 
   private String name;
   private int version;
+  private String versionTag;
   private String bpmnProcessId;
   private String bpmnXml;
   private String resourceName;
@@ -48,6 +49,9 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
         + '\''
         + ", version="
         + version
+        + '\''
+        + ", versionTag="
+        + versionTag
         + ", bpmnProcessId='"
         + bpmnProcessId
         + '\''
@@ -72,6 +76,15 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
 
   public ProcessEntity setVersion(int version) {
     this.version = version;
+    return this;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public ProcessEntity setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
     return this;
   }
 
@@ -124,7 +137,21 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        name,
+        version,
+        versionTag,
+        bpmnProcessId,
+        bpmnXml,
+        resourceName,
+        flowNodes,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -136,17 +163,12 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     }
     final ProcessEntity that = (ProcessEntity) o;
     return version == that.version
+        && Objects.equals(versionTag, that.versionTag)
         && Objects.equals(name, that.name)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(bpmnXml, that.bpmnXml)
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(flowNodes, that.flowNodes)
         && Objects.equals(tenantId, that.tenantId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        super.hashCode(), name, version, bpmnProcessId, bpmnXml, resourceName, flowNodes, tenantId);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/listview/ProcessInstanceForListViewEntity.java
@@ -22,6 +22,7 @@ public class ProcessInstanceForListViewEntity
   private Long processDefinitionKey;
   private String processName;
   private Integer processVersion;
+  private String processVersionTag;
   private String bpmnProcessId;
 
   private OffsetDateTime startDate;
@@ -81,6 +82,15 @@ public class ProcessInstanceForListViewEntity
 
   public ProcessInstanceForListViewEntity setProcessVersion(final Integer processVersion) {
     this.processVersion = processVersion;
+    return this;
+  }
+
+  public String getProcessVersionTag() {
+    return processVersionTag;
+  }
+
+  public ProcessInstanceForListViewEntity setProcessVersionTag(final String processVersionTag) {
+    this.processVersionTag = processVersionTag;
     return this;
   }
 
@@ -205,6 +215,28 @@ public class ProcessInstanceForListViewEntity
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        processDefinitionKey,
+        processName,
+        processVersion,
+        processVersionTag,
+        bpmnProcessId,
+        startDate,
+        endDate,
+        state,
+        batchOperationIds,
+        parentProcessInstanceKey,
+        parentFlowNodeInstanceKey,
+        treePath,
+        incident,
+        tenantId,
+        joinRelation,
+        position);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -220,6 +252,7 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processName, that.processName)
         && Objects.equals(processVersion, that.processVersion)
+        && Objects.equals(processVersionTag, that.processVersionTag)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(startDate, that.startDate)
         && Objects.equals(endDate, that.endDate)
@@ -231,26 +264,5 @@ public class ProcessInstanceForListViewEntity
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(joinRelation, that.joinRelation)
         && Objects.equals(position, that.position);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        super.hashCode(),
-        processDefinitionKey,
-        processName,
-        processVersion,
-        bpmnProcessId,
-        startDate,
-        endDate,
-        state,
-        batchOperationIds,
-        parentProcessInstanceKey,
-        parentFlowNodeInstanceKey,
-        treePath,
-        incident,
-        tenantId,
-        joinRelation,
-        position);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/entities/listview/ProcessInstanceForListViewEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/listview/ProcessInstanceForListViewEntity.java
@@ -52,8 +52,8 @@ public class ProcessInstanceForListViewEntity
     return getKey();
   }
 
-  public ProcessInstanceForListViewEntity setProcessInstanceKey(Long processInstanceKey) {
-    this.setKey(processInstanceKey);
+  public ProcessInstanceForListViewEntity setProcessInstanceKey(final Long processInstanceKey) {
+    setKey(processInstanceKey);
     return this;
   }
 
@@ -61,7 +61,7 @@ public class ProcessInstanceForListViewEntity
     return processDefinitionKey;
   }
 
-  public ProcessInstanceForListViewEntity setProcessDefinitionKey(Long processDefinitionKey) {
+  public ProcessInstanceForListViewEntity setProcessDefinitionKey(final Long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
     return this;
   }
@@ -70,7 +70,7 @@ public class ProcessInstanceForListViewEntity
     return processName;
   }
 
-  public ProcessInstanceForListViewEntity setProcessName(String processName) {
+  public ProcessInstanceForListViewEntity setProcessName(final String processName) {
     this.processName = processName;
     return this;
   }
@@ -79,7 +79,7 @@ public class ProcessInstanceForListViewEntity
     return processVersion;
   }
 
-  public ProcessInstanceForListViewEntity setProcessVersion(Integer processVersion) {
+  public ProcessInstanceForListViewEntity setProcessVersion(final Integer processVersion) {
     this.processVersion = processVersion;
     return this;
   }
@@ -88,7 +88,7 @@ public class ProcessInstanceForListViewEntity
     return startDate;
   }
 
-  public ProcessInstanceForListViewEntity setStartDate(OffsetDateTime startDate) {
+  public ProcessInstanceForListViewEntity setStartDate(final OffsetDateTime startDate) {
     this.startDate = startDate;
     return this;
   }
@@ -97,7 +97,7 @@ public class ProcessInstanceForListViewEntity
     return endDate;
   }
 
-  public ProcessInstanceForListViewEntity setEndDate(OffsetDateTime endDate) {
+  public ProcessInstanceForListViewEntity setEndDate(final OffsetDateTime endDate) {
     this.endDate = endDate;
     return this;
   }
@@ -106,7 +106,7 @@ public class ProcessInstanceForListViewEntity
     return state;
   }
 
-  public ProcessInstanceForListViewEntity setState(ProcessInstanceState state) {
+  public ProcessInstanceForListViewEntity setState(final ProcessInstanceState state) {
     this.state = state;
     return this;
   }
@@ -115,7 +115,8 @@ public class ProcessInstanceForListViewEntity
     return batchOperationIds;
   }
 
-  public ProcessInstanceForListViewEntity setBatchOperationIds(List<String> batchOperationIds) {
+  public ProcessInstanceForListViewEntity setBatchOperationIds(
+      final List<String> batchOperationIds) {
     this.batchOperationIds = batchOperationIds;
     return this;
   }
@@ -124,7 +125,7 @@ public class ProcessInstanceForListViewEntity
     return bpmnProcessId;
   }
 
-  public ProcessInstanceForListViewEntity setBpmnProcessId(String bpmnProcessId) {
+  public ProcessInstanceForListViewEntity setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
     return this;
   }
@@ -134,7 +135,7 @@ public class ProcessInstanceForListViewEntity
   }
 
   public ProcessInstanceForListViewEntity setParentProcessInstanceKey(
-      Long parentProcessInstanceKey) {
+      final Long parentProcessInstanceKey) {
     this.parentProcessInstanceKey = parentProcessInstanceKey;
     return this;
   }
@@ -144,7 +145,7 @@ public class ProcessInstanceForListViewEntity
   }
 
   public ProcessInstanceForListViewEntity setParentFlowNodeInstanceKey(
-      Long parentFlowNodeInstanceKey) {
+      final Long parentFlowNodeInstanceKey) {
     this.parentFlowNodeInstanceKey = parentFlowNodeInstanceKey;
     return this;
   }
@@ -153,7 +154,7 @@ public class ProcessInstanceForListViewEntity
     return treePath;
   }
 
-  public ProcessInstanceForListViewEntity setTreePath(String treePath) {
+  public ProcessInstanceForListViewEntity setTreePath(final String treePath) {
     this.treePath = treePath;
     return this;
   }
@@ -162,7 +163,7 @@ public class ProcessInstanceForListViewEntity
     return incident;
   }
 
-  public ProcessInstanceForListViewEntity setIncident(boolean incident) {
+  public ProcessInstanceForListViewEntity setIncident(final boolean incident) {
     this.incident = incident;
     return this;
   }
@@ -171,7 +172,7 @@ public class ProcessInstanceForListViewEntity
     return tenantId;
   }
 
-  public ProcessInstanceForListViewEntity setTenantId(String tenantId) {
+  public ProcessInstanceForListViewEntity setTenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }
@@ -180,7 +181,7 @@ public class ProcessInstanceForListViewEntity
     return joinRelation;
   }
 
-  public ProcessInstanceForListViewEntity setJoinRelation(ListViewJoinRelation joinRelation) {
+  public ProcessInstanceForListViewEntity setJoinRelation(final ListViewJoinRelation joinRelation) {
     this.joinRelation = joinRelation;
     return this;
   }
@@ -189,7 +190,7 @@ public class ProcessInstanceForListViewEntity
     return sortValues;
   }
 
-  public ProcessInstanceForListViewEntity setSortValues(Object[] sortValues) {
+  public ProcessInstanceForListViewEntity setSortValues(final Object[] sortValues) {
     this.sortValues = sortValues;
     return this;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/ProcessIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/ProcessIndex.java
@@ -19,6 +19,7 @@ public class ProcessIndex extends AbstractIndexDescriptor implements Prio4Backup
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String NAME = "name";
   public static final String VERSION = "version";
+  public static final String VERSION_TAG = "versionTag";
   public static final String BPMN_XML = "bpmnXml";
   public static final String RESOURCE_NAME = "resourceName";
   public static final String FLOWNODES = "flowNodes";

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/ListViewTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/ListViewTemplate.java
@@ -20,6 +20,7 @@ public class ListViewTemplate extends AbstractTemplateDescriptor implements Prio
   public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String PROCESS_VERSION = "processVersion";
+  public static final String PROCESS_VERSION_TAG = "processVersionTag";
   public static final String PROCESS_KEY = "processDefinitionKey";
   public static final String PROCESS_NAME = "processName";
   public static final String START_DATE = "startDate";

--- a/operate/schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
@@ -28,6 +28,9 @@
 			"version": {
 				"type": "long"
 			},
+      "versionTag": {
+        "type": "keyword"
+      },
 			"flowNodes": {
               "properties": {
                 "id": {

--- a/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -83,6 +83,9 @@
 			"processVersion": {
 				"type": "long"
 			},
+      "processVersionTag": {
+        "type": "keyword"
+      },
 			"bpmnProcessId": {
 				"type": "keyword"
 			},

--- a/operate/schema/src/main/resources/schema/opensearch/create/index/operate-process.json
+++ b/operate/schema/src/main/resources/schema/opensearch/create/index/operate-process.json
@@ -28,6 +28,9 @@
 			"version": {
 				"type": "long"
       },
+      "versionTag": {
+        "type": "keyword"
+      },
       "flowNodes": {
         "type": "object",
         "properties": {

--- a/operate/schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
+++ b/operate/schema/src/main/resources/schema/opensearch/create/template/operate-list-view.json
@@ -84,6 +84,9 @@
 			"processVersion": {
 				"type": "long"
 			},
+      "processVersionTag": {
+        "type": "keyword"
+      },
 			"bpmnProcessId": {
 				"type": "keyword"
 			},


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added `versionTag`/`processVersionTag` to the `operate-process` and `operate-list-view` indices in preparation for returning this field for process and process-instance requests and made the necessary changes in the relevant importer parts.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/22068
