### PR TITLE
Don't allow changing event type of mapped catch event during instance migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -229,6 +229,12 @@ public class ProcessInstanceMigrationMigrateProcessor
         sourceElementIdToTargetElementId);
     requireNoDuplicateTargetsInCatchEventMappings(
         processInstanceKey, sourceProcessDefinition, elementId, sourceElementIdToTargetElementId);
+    requireNoCatchEventMappingToChangeEventType(
+        processInstanceKey,
+        sourceElementIdToTargetElementId,
+        sourceProcessDefinition,
+        targetProcessDefinition,
+        elementId);
     requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -789,7 +789,6 @@ public final class ProcessInstanceMigrationPreconditions {
                 Expected to migrate process instance '%s' but active element with id '%s' \
                 has a catch event with id '%s' that is mapped to a catch event with id '%s'. \
                 These catch events have different event types: '%s' and '%s'. \
-                Catch events cannot change their event type during process instance migration. \
                 The event type of a catch event cannot be changed by process instance migration. \
                 Please ensure the event type of the catch event remains the same \
                 or remove the mapping instruction for these catch events.""",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.auth.impl.TenantAuthorizationCheckerImpl;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -747,6 +748,61 @@ public final class ProcessInstanceMigrationPreconditions {
                 reason, RejectionType.INVALID_STATE);
           }
         });
+  }
+
+  /**
+   * It should not be possible to change the event type of a catch event during process instance
+   * migration. This would mean that the catch event is subscribed to a different event type than
+   * before.
+   *
+   * @param processInstanceKey process instance key to be logged
+   * @param mappingInstructions mapping instructions (source catch event id to target catch event
+   *     id)
+   * @param sourceProcessDefinition source process definition to check
+   * @param targetProcessDefinition target process definition to check
+   * @param sourceElementId source element id to check
+   */
+  public static void requireNoCatchEventMappingToChangeEventType(
+      final long processInstanceKey,
+      final Map<String, String> mappingInstructions,
+      final DeployedProcess sourceProcessDefinition,
+      final DeployedProcess targetProcessDefinition,
+      final String sourceElementId) {
+    final var sourceElement = sourceProcessDefinition.getProcess().getElementById(sourceElementId);
+    if (!(sourceElement instanceof final ExecutableCatchEventSupplier sourceElementWithEvents)) {
+      return;
+    }
+
+    for (final ExecutableCatchEvent sourceCatchEvent : sourceElementWithEvents.getEvents()) {
+      final String sourceCatchEventId = BufferUtil.bufferAsString(sourceCatchEvent.getId());
+      if (!mappingInstructions.containsKey(sourceCatchEventId)) {
+        continue;
+      }
+
+      final String targetCatchEventId = mappingInstructions.get(sourceCatchEventId);
+      final var targetCatchEvent =
+          targetProcessDefinition.getProcess().getElementById(targetCatchEventId);
+      if (sourceCatchEvent.getEventType() != targetCatchEvent.getEventType()) {
+        final var reason =
+            String.format(
+                """
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has a catch event with id '%s' that is mapped to a catch event with id '%s'. \
+                These catch events have different event types: '%s' and '%s'. \
+                Catch events cannot change their event type during process instance migration. \
+                The event type of a catch event cannot be changed by process instance migration. \
+                Please ensure the event type of the catch event remains the same \
+                or remove the mapping instruction for these catch events.""",
+                processInstanceKey,
+                sourceElementId,
+                sourceCatchEventId,
+                targetCatchEventId,
+                sourceCatchEvent.getEventType(),
+                targetCatchEvent.getEventType());
+        throw new ProcessInstanceMigrationPreconditionFailedException(
+            reason, RejectionType.INVALID_STATE);
+      }
+    }
   }
 
   /**

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -796,5 +797,76 @@ public class MigrateMessageEventSubprocessTest {
             "There are multiple mapping instructions that target this catch event: 'startA1', 'startA2'")
         .contains("Catch events cannot be merged by process instance migration")
         .contains("Please ensure the mapping instructions target a catch event only once");
+  }
+
+  @Test
+  public void shouldRejectCommandWhenMappedCatchEventChangesEventType() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .eventSubProcess(
+                        "sub1",
+                        s ->
+                            s.startEvent("start1")
+                                .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                                .endEvent())
+                    .startEvent()
+                    .userTask("userTask1")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .eventSubProcess(
+                        "sub2", s -> s.startEvent("start2").timerWithDuration("PT1M").endEvent())
+                    .startEvent()
+                    .userTask("userTask2")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("key", helper.getCorrelationValue() + "1"))
+            .create();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("userTask1")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("userTask1", "userTask2")
+            .addMappingInstruction("start1", "start2")
+            .expectRejection()
+            .migrate();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .extracting(Record::getRejectionReason)
+        .asString()
+        .contains("Expected to migrate process instance '" + processInstanceKey + "'")
+        .contains("active element with id '" + processId + "' has a catch event")
+        .contains(
+            "has a catch event with id 'start1' that is mapped to a catch event with id 'start2'")
+        .contains("These catch events have different event types: 'MESSAGE' and 'TIMER'")
+        .contains("The event type of a catch event cannot be changed by process instance migration")
+        .contains("Please ensure the event type of the catch event remains the same")
+        .contains("or remove the mapping instruction for these catch events");
   }
 }


### PR DESCRIPTION
## Description

This PR rejects process instance migration attempts where a mapping instruction changes the event type of a catch event subscription.

It should not be possible to change the event type (e.g. `MESSAGE`) to another event type (e.g. `TIMER`) of a mapped catch event during instance migration.

For example, a user task subscribed to a message boundary event cannot be changed to a timer boundary event by providing a mapping between the two boundary events. This would mean the user expects the underlying event subscription to be migrated, but a message subscription cannot be changed to a timer subscription like this. Instead, we expect the user to not map these boundary events. According to [our docs](https://docs.camunda.io/docs/next/components/concepts/process-instance-migration/#dealing-with-attached-boundary-events) this should unsubscribe the user task from the message and subscribe it to the timer.

> - If a boundary event is mapped, the associated subscription is migrated.
> - If a boundary event in the source process is not mapped, then the associated subscription is closed during migration.
> - If a boundary event of the target process is not the target of a mapping instruction, then a new subscription is opened during migration.

## Related issues

closes #22146 
