### PR TITLE
Re-enable process instance migration tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
@@ -790,7 +790,7 @@ public class MigrateMessageEventSubprocessTest {
         .contains("active element with id '" + processId + "' has a catch event attached")
         .contains("catch event attached that is mapped to a catch event with id 'start2'")
         .contains(
-            "There are multiple mapping instructions that target this catch event: 'startA1', 'startA2'")
+            "There are multiple mapping instructions that target this catch event: 'startA1', 'startB1'")
         .contains("Catch events cannot be merged by process instance migration")
         .contains("Please ensure the mapping instructions target a catch event only once");
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageEventSubprocessTest.java
@@ -25,7 +25,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -612,7 +611,6 @@ public class MigrateMessageEventSubprocessTest {
         .isNotNull();
   }
 
-  @Ignore("This rejection will be supported with #21615")
   @Test
   public void shouldRejectCommandWhenMappedCatchEventIsAttachedToDifferentElement() {
     // given
@@ -711,7 +709,6 @@ public class MigrateMessageEventSubprocessTest {
         .contains("Catch events must stay attached to the same element instance");
   }
 
-  @Ignore("This rejection will be supported with #21615")
   @Test
   public void shouldRejectCommandWhenMappedCatchEventsAreMerged() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
@@ -41,7 +41,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -211,7 +210,6 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerBefore() {
     // given
@@ -310,7 +308,6 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerAfter() {
     // given
@@ -715,7 +712,6 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithNonInterruptingTimerBefore() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentTest.java
@@ -36,7 +36,6 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -199,7 +198,6 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerBefore() {
     // given
@@ -292,7 +290,6 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerAfter() {
     // given
@@ -680,7 +677,6 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
-  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithNonInterruptingTimerBefore() {
     // given


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This unignores some tests for process instance migration that were previously ignored. They are now supported functionality, so we can re-enable them.

## Related issues

NA
