### PR TITLE
fix: support Bearer token with typ AT+JWT

### DIFF
--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -356,6 +356,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
@@ -431,7 +436,6 @@
           <ignoredUnusedDeclaredDependencies>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
             <dep>jakarta.annotation:jakarta.annotation-api</dep>
-            <dep>com.nimbusds:nimbus-jose-jwt</dep>
             <dep>com.github.spotbugs:spotbugs-annotations</dep>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -380,6 +380,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
@@ -546,7 +551,6 @@
           <ignoredUnusedDeclaredDependencies>
             <dep>jakarta.servlet:jakarta.servlet-api</dep>
             <dep>jakarta.annotation:jakarta.annotation-api</dep>
-            <dep>com.nimbusds:nimbus-jose-jwt</dep>
             <dep>org.springframework:spring-aspects</dep>
           </ignoredUnusedDeclaredDependencies>
           <ignoredNonTestScopedDependencies>

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurer.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.tasklist.webapp.security.oauth;
 
+import static com.nimbusds.jose.JOSEObjectType.JWT;
 import static io.camunda.tasklist.webapp.security.BaseWebConfigurer.sendJSONErrorMessage;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.IDENTITY_AUTH_PROFILE;
 
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import io.camunda.identity.sdk.IdentityConfiguration;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -21,6 +24,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -44,7 +49,7 @@ public class IdentityOAuth2WebConfigurer {
 
   @Autowired private IdentityJwt2AuthenticationTokenConverter jwtConverter;
 
-  public void configure(HttpSecurity http) throws Exception {
+  public void configure(final HttpSecurity http) throws Exception {
     if (isJWTEnabled()) {
       http.oauth2ResourceServer(
           serverCustomizer ->
@@ -54,9 +59,22 @@ public class IdentityOAuth2WebConfigurer {
                       jwtCustomizer ->
                           jwtCustomizer
                               .jwtAuthenticationConverter(jwtConverter)
-                              .jwkSetUri(getJwkSetUriProperty())));
+                              .decoder(jwtDecoder())));
       LOGGER.info("Enabled OAuth2 JWT access to Tasklist API");
     }
+  }
+
+  /**
+   * JwtDecoder that supports both the "jwt" (standard JWT) and "at+jwt" (Access Token JWT) JOSE
+   * types for token validation.
+   */
+  private JwtDecoder jwtDecoder() {
+    return NimbusJwtDecoder.withJwkSetUri(getJwkSetUriProperty())
+        .jwtProcessorCustomizer(
+            processor ->
+                processor.setJWSTypeVerifier(
+                    new DefaultJOSEObjectTypeVerifier<>(JWT, new JOSEObjectType("at+jwt"))))
+        .build();
   }
 
   private String getJwkSetUriProperty() {

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityOAuth2WebConfigurerTest.java
@@ -9,16 +9,25 @@ package io.camunda.tasklist.webapp.security.oauth;
 
 import static io.camunda.tasklist.webapp.security.oauth.IdentityOAuth2WebConfigurer.SPRING_SECURITY_OAUTH_2_RESOURCESERVER_JWT_JWK_SET_URI;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
 import io.camunda.identity.sdk.IdentityConfiguration;
+import java.util.function.BiConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.core.env.Environment;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class IdentityOAuth2WebConfigurerTest {
@@ -26,6 +35,8 @@ class IdentityOAuth2WebConfigurerTest {
   @Mock private Environment environment;
 
   @Mock private IdentityConfiguration identityConfiguration;
+
+  @Mock private IdentityJwt2AuthenticationTokenConverter jwtConverter;
 
   @InjectMocks private IdentityOAuth2WebConfigurer webConfigurer;
 
@@ -50,7 +61,47 @@ class IdentityOAuth2WebConfigurerTest {
     webConfigurer.configure(httpSecurity);
 
     // then
-    verify(httpSecurity, times(1)).oauth2ResourceServer(any());
+    // then
+    final var oauth2ResourceServerCustomizer =
+        captureFrom(
+            httpSecurity,
+            Customizer.class,
+            (o, t) -> {
+              try {
+                o.oauth2ResourceServer(t);
+              } catch (final Exception e) {
+                fail(e);
+              }
+            });
+    final var serverConfigurer = mock(OAuth2ResourceServerConfigurer.class);
+    when(serverConfigurer.authenticationEntryPoint(any())).thenReturn(serverConfigurer);
+    oauth2ResourceServerCustomizer.customize(serverConfigurer);
+    final var jwtCustomizer =
+        captureFrom(serverConfigurer, Customizer.class, OAuth2ResourceServerConfigurer::jwt);
+    final OAuth2ResourceServerConfigurer<HttpSecurity>.JwtConfigurer jwtConfigurer =
+        mock(OAuth2ResourceServerConfigurer.JwtConfigurer.class);
+    when(jwtConfigurer.jwtAuthenticationConverter(jwtConverter)).thenReturn(jwtConfigurer);
+    jwtCustomizer.customize(jwtConfigurer);
+
+    final JwtDecoder jwtDecoder =
+        captureFrom(
+            jwtConfigurer, JwtDecoder.class, OAuth2ResourceServerConfigurer.JwtConfigurer::decoder);
+    assertThat(jwtDecoder).isInstanceOf(NimbusJwtDecoder.class);
+
+    final NimbusJwtDecoder nimbusJwtDecoder = (NimbusJwtDecoder) jwtDecoder;
+
+    // Use reflection to verify JWSTypeVerifier configuration
+    final var processor = ReflectionTestUtils.getField(nimbusJwtDecoder, "jwtProcessor");
+    final var jwsTypeVerifier = ReflectionTestUtils.invokeMethod(processor, "getJWSTypeVerifier");
+
+    assertThat(jwsTypeVerifier).isNotNull();
+    assertThat(jwsTypeVerifier).isInstanceOf(DefaultJOSEObjectTypeVerifier.class);
+
+    final var joseVerifier = (DefaultJOSEObjectTypeVerifier<?>) jwsTypeVerifier;
+
+    // Ensure that both jwt and at+jwt types are being verified
+    assertThat(joseVerifier.getAllowedTypes())
+        .containsExactlyInAnyOrder(new JOSEObjectType("jwt"), new JOSEObjectType("at+jwt"));
   }
 
   @Test
@@ -92,5 +143,12 @@ class IdentityOAuth2WebConfigurerTest {
         (String) (ReflectionTestUtils.invokeGetterMethod(webConfigurer, "getJwkSetUriProperty"));
 
     assertThat(result).isEqualTo("http://localhost:1111");
+  }
+
+  private <O, T> T captureFrom(
+      final O from, final Class<T> tClass, final BiConsumer<O, T> consumer) {
+    final var argumentCaptor = ArgumentCaptor.forClass(tClass);
+    consumer.accept(verify(from, times(1)), argumentCaptor.capture());
+    return argumentCaptor.getValue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Mainly inspired from https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/366
In `IdentityOAuth2Resource`, this PR configures a `JwtDecoder` that supports both the standard "jwt" and "at+jwt" (Access Token JWT) JOSE types. The default decoder used by spring security supports only "jwt" type


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22118
closes #22119 
