### PR TITLE
Migrate element instances marked as parallel multi instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/MultiInstanceOutputCollectionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/MultiInstanceOutputCollectionBehavior.java
@@ -88,6 +88,14 @@ public final class MultiInstanceOutputCollectionBehavior {
               // collection, but that is slower.
               final var currentCollection =
                   stateBehavior.getLocalVariable(flowScopeContext, variableName);
+              if (currentCollection == null) {
+                return Either.left(
+                    new Failure(
+                        "Expected the output collection variable '%s' to be of type list, but it was NIL"
+                            .formatted(bufferAsString(variableName)),
+                        ErrorType.EXTRACT_VALUE_ERROR,
+                        flowScopeContext.getElementInstanceKey()));
+              }
               return replaceAt(
                       currentCollection,
                       loopCounter,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -197,7 +197,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     final String targetElementId = sourceElementIdToTargetElementId.get(elementId);
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
     requireSameElementType(
-        targetProcessDefinition, targetElementId, elementInstanceRecord, processInstanceKey);
+        targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireSameUserTaskImplementation(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireUnchangedFlowScope(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -239,6 +239,12 @@ public class ProcessInstanceMigrationMigrateProcessor
         sourceProcessDefinition,
         targetProcessDefinition,
         elementId);
+    requireSameMultiInstanceLoopCharacteristics(
+        sourceProcessDefinition,
+        elementId,
+        targetProcessDefinition,
+        targetElementId,
+        processInstanceKey);
     requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -55,7 +55,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.EVENT_BASED_GATEWAY,
           BpmnElementType.BUSINESS_RULE_TASK,
           BpmnElementType.SCRIPT_TASK,
-          BpmnElementType.SEND_TASK);
+          BpmnElementType.SEND_TASK,
+          BpmnElementType.MULTI_INSTANCE_BODY);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -561,11 +561,7 @@ public final class ProcessInstanceMigrationPreconditions {
           sourceFlowScopeElement.getValue().getElementIdBuffer();
       final AbstractFlowElement targetFlowElement =
           targetProcessDefinition.getProcess().getElementById(targetElementId);
-      DirectBuffer actualFlowScopeId = targetFlowElement.getFlowScope().getId();
-
-      if (expectedFlowScopeId.equals(actualFlowScopeId)) {
-        return;
-      }
+      DirectBuffer actualFlowScopeId;
 
       // if target element is a multi instance body, we should check the inner activity flow scope
       // because the inner activity of the multi instance body can still match the source element's
@@ -580,6 +576,11 @@ public final class ProcessInstanceMigrationPreconditions {
         if (expectedFlowScopeId.equals(actualFlowScopeId)) {
           return;
         }
+      }
+
+      actualFlowScopeId = targetFlowElement.getFlowScope().getId();
+      if (expectedFlowScopeId.equals(actualFlowScopeId)) {
+        return;
       }
 
       final String reason =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -451,8 +451,9 @@ public final class ProcessInstanceMigrationPreconditions {
   public static void requireSameElementType(
       final DeployedProcess targetProcessDefinition,
       final String targetElementId,
-      final ProcessInstanceRecord elementInstanceRecord,
+      final ElementInstance elementInstance,
       final long processInstanceKey) {
+    final ProcessInstanceRecord elementInstanceRecord = elementInstance.getValue();
     BpmnElementType targetElementType =
         targetProcessDefinition.getProcess().getElementById(targetElementId).getElementType();
 
@@ -462,8 +463,10 @@ public final class ProcessInstanceMigrationPreconditions {
 
     // if target element is a multi instance body, we should check the inner activity element type
     // because the inner activity of the multi instance body can still match the source element's
-    // type
-    if (targetElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+    // type. Also, multi instance loop counter indicates that the element instance is inside a multi
+    // instance body.
+    if (elementInstance.getMultiInstanceLoopCounter() > 0
+        && targetElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
       final ExecutableMultiInstanceBody targetElement =
           targetProcessDefinition
               .getProcess()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
@@ -30,13 +30,14 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Arrays;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
 public class MigrateMultiInstanceBodyTest {
 
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
@@ -48,7 +49,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -82,7 +83,7 @@ public class MigrateMultiInstanceBodyTest {
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
     final var processInstanceKey =
-        engine
+        ENGINE
             .processInstance()
             .ofBpmnProcessId(processId)
             .withVariable("jobTypes", Arrays.asList("a", "b", "c"))
@@ -98,7 +99,7 @@ public class MigrateMultiInstanceBodyTest {
         .containsExactly("a", "b", "c");
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -156,9 +157,9 @@ public class MigrateMultiInstanceBodyTest {
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "b"),
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "c"));
 
-    engine.job().ofInstance(processInstanceKey).withType("a").complete();
-    engine.job().ofInstance(processInstanceKey).withType("b").complete();
-    engine.job().ofInstance(processInstanceKey).withType("c").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("a").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("b").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("c").complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -180,7 +181,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetMessageName = helper.getMessageName() + 2;
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -220,7 +221,7 @@ public class MigrateMultiInstanceBodyTest {
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
     final var processInstanceKey =
-        engine
+        ENGINE
             .processInstance()
             .ofBpmnProcessId(processId)
             .withVariable("keys", Arrays.asList("a", "b", "c"))
@@ -236,7 +237,7 @@ public class MigrateMultiInstanceBodyTest {
         .containsExactly("a", "b", "c");
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -300,9 +301,9 @@ public class MigrateMultiInstanceBodyTest {
         .containsExactly(
             tuple(targetProcessId, "a"), tuple(targetProcessId, "b"), tuple(targetProcessId, "c"));
 
-    engine.message().withName(sourceMessageName).withCorrelationKey("a").publish();
-    engine.message().withName(sourceMessageName).withCorrelationKey("b").publish();
-    engine.message().withName(sourceMessageName).withCorrelationKey("c").publish();
+    ENGINE.message().withName(sourceMessageName).withCorrelationKey("a").publish();
+    ENGINE.message().withName(sourceMessageName).withCorrelationKey("b").publish();
+    ENGINE.message().withName(sourceMessageName).withCorrelationKey("c").publish();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -322,7 +323,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -363,7 +364,7 @@ public class MigrateMultiInstanceBodyTest {
     final long targetProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
-    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -374,7 +375,7 @@ public class MigrateMultiInstanceBodyTest {
         .hasSize(3);
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -440,7 +441,7 @@ public class MigrateMultiInstanceBodyTest {
             .limit(3)
             .toList();
 
-    jobs.forEach(job -> engine.job().withKey(job.getKey()).complete());
+    jobs.forEach(job -> ENGINE.job().withKey(job.getKey()).complete());
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -461,7 +462,7 @@ public class MigrateMultiInstanceBodyTest {
     final String childProcessId = helper.getBpmnProcessId() + "_source_child";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -500,7 +501,7 @@ public class MigrateMultiInstanceBodyTest {
     final long targetProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
-    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -518,7 +519,7 @@ public class MigrateMultiInstanceBodyTest {
             .toList();
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -561,7 +562,7 @@ public class MigrateMultiInstanceBodyTest {
 
     childProcessInstances.forEach(
         instance ->
-            engine
+            ENGINE
                 .job()
                 .ofInstance(instance.getValue().getProcessInstanceKey())
                 .withType("A")
@@ -585,7 +586,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -619,7 +620,7 @@ public class MigrateMultiInstanceBodyTest {
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
     final var processInstanceKey =
-        engine
+        ENGINE
             .processInstance()
             .ofBpmnProcessId(processId)
             .withVariable("jobTypes", Arrays.asList("a", "b", "c"))
@@ -634,7 +635,7 @@ public class MigrateMultiInstanceBodyTest {
         .extracting(JobRecordValue::getType)
         .containsExactly("a", "b", "c");
 
-    engine.job().ofInstance(processInstanceKey).withType("a").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("a").complete();
 
     assertThat(
             RecordingExporter.jobRecords(JobIntent.COMPLETED)
@@ -646,7 +647,7 @@ public class MigrateMultiInstanceBodyTest {
         .isPresent();
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -702,8 +703,8 @@ public class MigrateMultiInstanceBodyTest {
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "b"),
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "c"));
 
-    engine.job().ofInstance(processInstanceKey).withType("b").complete();
-    engine.job().ofInstance(processInstanceKey).withType("c").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("b").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("c").complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -723,7 +724,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -760,7 +761,7 @@ public class MigrateMultiInstanceBodyTest {
     final long targetProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
-    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
 
     final var jobs =
         RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -769,7 +770,7 @@ public class MigrateMultiInstanceBodyTest {
             .limit(3)
             .toList();
 
-    engine.job().withKey(jobs.getFirst().getKey()).complete();
+    ENGINE.job().withKey(jobs.getFirst().getKey()).complete();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -777,7 +778,7 @@ public class MigrateMultiInstanceBodyTest {
             .getFirst();
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -794,10 +795,10 @@ public class MigrateMultiInstanceBodyTest {
         .isNotNull();
 
     // after migrating, we can successfully resolve the incident
-    engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
     // and complete the two still active jobs without problems
-    jobs.stream().skip(1).forEach(job -> engine.job().withKey(job.getKey()).complete());
+    jobs.stream().skip(1).forEach(job -> ENGINE.job().withKey(job.getKey()).complete());
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -817,7 +818,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(processId)
@@ -857,7 +858,7 @@ public class MigrateMultiInstanceBodyTest {
     final long targetProcessDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
-    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
 
     final var jobs =
         RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -866,7 +867,7 @@ public class MigrateMultiInstanceBodyTest {
             .limit(3)
             .toList();
 
-    engine.job().withKey(jobs.getFirst().getKey()).complete();
+    ENGINE.job().withKey(jobs.getFirst().getKey()).complete();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -874,7 +875,7 @@ public class MigrateMultiInstanceBodyTest {
             .getFirst();
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -891,10 +892,10 @@ public class MigrateMultiInstanceBodyTest {
         .isNotNull();
 
     // after migrating, we can successfully resolve the incident
-    engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
     // and complete the two still active jobs without problems
-    jobs.stream().skip(1).forEach(job -> engine.job().withKey(job.getKey()).complete());
+    jobs.stream().skip(1).forEach(job -> ENGINE.job().withKey(job.getKey()).complete());
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -914,7 +915,7 @@ public class MigrateMultiInstanceBodyTest {
     final String targetProcessId = helper.getBpmnProcessId() + "2";
 
     final var deployment =
-        engine
+        ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(sourceProcessId)
@@ -952,7 +953,7 @@ public class MigrateMultiInstanceBodyTest {
         extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
 
     final var processInstanceKey =
-        engine.processInstance().ofBpmnProcessId(sourceProcessId).create();
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
 
     final var jobs =
         RecordingExporter.jobRecords(JobIntent.CREATED)
@@ -961,7 +962,7 @@ public class MigrateMultiInstanceBodyTest {
             .limit(3)
             .toList();
 
-    engine.job().withKey(jobs.getFirst().getKey()).complete();
+    ENGINE.job().withKey(jobs.getFirst().getKey()).complete();
 
     final var resultsVariable =
         RecordingExporter.variableRecords(VariableIntent.UPDATED)
@@ -971,7 +972,7 @@ public class MigrateMultiInstanceBodyTest {
             .getFirst();
 
     // when
-    engine
+    ENGINE
         .processInstance()
         .withInstanceKey(processInstanceKey)
         .migration()
@@ -981,7 +982,7 @@ public class MigrateMultiInstanceBodyTest {
 
     // then
     // after migrating, we can complete one of the still active jobs
-    engine.job().withKey(jobs.get(1).getKey()).complete();
+    ENGINE.job().withKey(jobs.get(1).getKey()).complete();
 
     // but that raises an incident
     final var incident =
@@ -993,7 +994,7 @@ public class MigrateMultiInstanceBodyTest {
             "Expected the output collection variable 'results2' to be of type list, but it was NIL");
 
     // we can resolve the incident by creating the new output collection variable 'results2'
-    engine
+    ENGINE
         .variables()
         .ofScope(resultsVariable.getValue().getScopeKey())
         .withDocument("{\"results2\": [1, null, null]}")
@@ -1001,7 +1002,7 @@ public class MigrateMultiInstanceBodyTest {
         .update();
 
     // and when we resolve the incident
-    engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
     // then the new output collection can be filled correctly
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
@@ -160,6 +160,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -303,6 +304,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -363,6 +365,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withElementId("A")
                 .limit(3))
         .describedAs("Wait until all service tasks have activated")
@@ -439,6 +442,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -498,6 +502,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withParentProcessInstanceKey(processInstanceKey)
                 .withElementId("A")
                 .limit(3))
         .describedAs("Wait until all service tasks have activated")
@@ -505,6 +510,7 @@ public class MigrateMultiInstanceBodyTest {
 
     final var childProcessInstances =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
             .withElementId("A")
             .limit(3)
             .toList();
@@ -561,6 +567,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -698,6 +705,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -839,6 +847,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")
@@ -983,6 +992,7 @@ public class MigrateMultiInstanceBodyTest {
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
                 .withProcessDefinitionKey(targetProcessDefinitionKey)
                 .withElementType(BpmnElementType.END_EVENT)
                 .withElementId("multi_instance_target_process_end")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
@@ -1,0 +1,704 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateMultiInstanceBodyTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateParallelMultiInstanceServiceTask() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "serviceTask1",
+                        t ->
+                            t.zeebeJobTypeExpression("jobType")
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("jobTypes")
+                                            .zeebeInputElement("jobType")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "serviceTask2",
+                        t ->
+                            t.zeebeJobTypeExpression("jobType")
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("jobTypes")
+                                            .zeebeInputElement("jobType")))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("jobTypes", Arrays.asList("a", "b", "c"))
+            .create();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .hasSize(3)
+        .extracting(Record::getValue)
+        .extracting(JobRecordValue::getType)
+        .containsExactly("a", "b", "c");
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("serviceTask1", "serviceTask2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("serviceTask2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getVersion()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1));
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getType()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "a"),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "b"),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "c"));
+
+    engine.job().ofInstance(processInstanceKey).withType("a").complete();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType("a")
+                .withElementId("serviceTask2")
+                .findAny())
+        .describedAs("Expect that one of the service tasks in the multi-instance body is completed")
+        .isPresent();
+  }
+
+  @Test
+  public void shouldMigrateParallelMultiInstanceReceiveTask() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String sourceMessageName = helper.getMessageName();
+    final String targetMessageName = helper.getMessageName() + 2;
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .receiveTask(
+                        "receive1",
+                        t ->
+                            t.message(
+                                    m ->
+                                        m.name(sourceMessageName)
+                                            .zeebeCorrelationKeyExpression("key"))
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("keys")
+                                            .zeebeInputElement("key")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .receiveTask(
+                        "receive2",
+                        t ->
+                            t.message(
+                                    m ->
+                                        m.name(targetMessageName)
+                                            .zeebeCorrelationKeyExpression("key"))
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("keys")
+                                            .zeebeInputElement("key")))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("keys", Arrays.asList("a", "b", "c"))
+            .create();
+
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .hasSize(3)
+        .extracting(Record::getValue)
+        .extracting(MessageSubscriptionRecordValue::getCorrelationKey)
+        .containsExactly("a", "b", "c");
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("receive1", "receive2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("receive2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.RECEIVE_TASK)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getVersion()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "receive2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "receive2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "receive2", 1));
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(sourceMessageName)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(r -> tuple(r.getBpmnProcessId(), r.getElementId(), r.getCorrelationKey()))
+        .containsExactly(
+            tuple(targetProcessId, "receive2", "a"),
+            tuple(targetProcessId, "receive2", "b"),
+            tuple(targetProcessId, "receive2", "c"));
+
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(sourceMessageName)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(r -> tuple(r.getBpmnProcessId(), r.getCorrelationKey()))
+        .containsExactly(
+            tuple(targetProcessId, "a"), tuple(targetProcessId, "b"), tuple(targetProcessId, "c"));
+
+    engine.message().withName(sourceMessageName).withCorrelationKey("a").publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(sourceMessageName)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("receive2")
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("a");
+
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName(sourceMessageName)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("a");
+  }
+
+  @Test
+  public void shouldMigrateParallelMultiInstanceSubprocess() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .subProcess(
+                        "sub1",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .subProcessDone()
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub2",
+                        sub ->
+                            sub.multiInstance(
+                                b ->
+                                    b.zeebeInputCollectionExpression("[1,2,3]")
+                                        .zeebeInputElement("index")))
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .endEvent("multi_instance_child_process_end")
+                    .subProcessDone()
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("A")
+                .limit(3))
+        .describedAs("Wait until all service tasks have activated")
+        .hasSize(3);
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("sub1", "sub2")
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("sub2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SUB_PROCESS)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getVersion()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "sub2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "sub2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "sub2", 1));
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getType()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "B", "A"),
+            tuple(targetProcessDefinitionKey, targetProcessId, "B", "A"),
+            tuple(targetProcessDefinitionKey, targetProcessId, "B", "A"));
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("multi_instance_child_process_end")
+                .findAny())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isPresent();
+  }
+
+  @Test
+  public void shouldMigrateParallelMultiInstanceCallActivity() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final String childProcessId = helper.getBpmnProcessId() + "_source_child";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .callActivity(
+                        "callActivity1",
+                        c ->
+                            c.zeebeProcessId(childProcessId)
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("[1,2,3]")
+                                            .zeebeInputElement("index")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .callActivity(
+                        "callActivity2",
+                        c ->
+                            c.zeebeProcessId(childProcessId)
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("[1,2,3]")
+                                            .zeebeInputElement("index")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(childProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent("multi_instance_child_process_end")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("A")
+                .limit(3))
+        .describedAs("Wait until all service tasks have activated")
+        .hasSize(3);
+
+    final var childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withElementId("A")
+            .getFirst()
+            .getValue()
+            .getProcessInstanceKey();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("callActivity1", "callActivity2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("callActivity2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.CALL_ACTIVITY)
+                .limit(3))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getVersion()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "callActivity2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "callActivity2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "callActivity2", 1));
+
+    engine.job().ofInstance(childProcessInstanceKey).withType("A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .withElementId("multi_instance_child_process_end")
+                .findAny())
+        .describedAs("Expect that the process instance is continued in the target process")
+        .isPresent();
+  }
+
+  @Test
+  public void shouldMigratePartiallyCompleteParallelMultiInstance() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask(
+                        "serviceTask1",
+                        t ->
+                            t.zeebeJobTypeExpression("jobType")
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("jobTypes")
+                                            .zeebeInputElement("jobType")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask(
+                        "serviceTask2",
+                        t ->
+                            t.zeebeJobTypeExpression("jobType")
+                                .multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("jobTypes")
+                                            .zeebeInputElement("jobType")))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("jobTypes", Arrays.asList("a", "b", "c"))
+            .create();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .hasSize(3)
+        .extracting(Record::getValue)
+        .extracting(JobRecordValue::getType)
+        .containsExactly("a", "b", "c");
+
+    engine.job().ofInstance(processInstanceKey).withType("a").complete();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType("a")
+                .withElementId("serviceTask1")
+                .findAny())
+        .describedAs("Expect that one of the service tasks in the multi-instance body is completed")
+        .isPresent();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("serviceTask1", "serviceTask2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("serviceTask2")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getVersion()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1));
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            r ->
+                tuple(
+                    r.getProcessDefinitionKey(),
+                    r.getBpmnProcessId(),
+                    r.getElementId(),
+                    r.getType()))
+        .containsExactly(
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "b"),
+            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "c"));
+
+    engine.job().ofInstance(processInstanceKey).withType("b").complete();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withType("b")
+                .withElementId("serviceTask2")
+                .findAny())
+        .describedAs("Expect that one of the service tasks in the multi-instance body is completed")
+        .isPresent();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
@@ -785,60 +785,11 @@ public class MigrateMultiInstanceBodyTest {
 
     // then
     Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
-                .getFirst()
-                .getValue())
-        .describedAs("Expect that process definition key is changed")
-        .hasProcessDefinitionKey(targetProcessDefinitionKey)
-        .describedAs("Expect that bpmn process id and element id changed")
-        .hasBpmnProcessId(targetProcessId)
-        .hasElementId("serviceTask2")
-        .describedAs("Expect that version number did not change")
-        .hasVersion(1);
-
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.SERVICE_TASK)
-                .limit(3))
-        .extracting(Record::getValue)
-        .extracting(
-            r ->
-                tuple(
-                    r.getProcessDefinitionKey(),
-                    r.getBpmnProcessId(),
-                    r.getElementId(),
-                    r.getVersion()))
-        .containsExactly(
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1));
-
-    Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.MIGRATED)
                 .withRecordKey(incident.getKey())
                 .getFirst()
                 .getValue())
         .isNotNull();
-
-    assertThat(
-            RecordingExporter.jobRecords(JobIntent.MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(2))
-        .hasSize(2)
-        .extracting(Record::getValue)
-        .extracting(
-            r ->
-                tuple(
-                    r.getProcessDefinitionKey(),
-                    r.getBpmnProcessId(),
-                    r.getElementId(),
-                    r.getType()))
-        .containsExactly(
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"));
 
     // after migrating, we can successfully resolve the incident
     engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
@@ -931,60 +882,11 @@ public class MigrateMultiInstanceBodyTest {
 
     // then
     Assertions.assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.MULTI_INSTANCE_BODY)
-                .getFirst()
-                .getValue())
-        .describedAs("Expect that process definition key is changed")
-        .hasProcessDefinitionKey(targetProcessDefinitionKey)
-        .describedAs("Expect that bpmn process id and element id changed")
-        .hasBpmnProcessId(targetProcessId)
-        .hasElementId("serviceTask2")
-        .describedAs("Expect that version number did not change")
-        .hasVersion(1);
-
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.SERVICE_TASK)
-                .limit(3))
-        .extracting(Record::getValue)
-        .extracting(
-            r ->
-                tuple(
-                    r.getProcessDefinitionKey(),
-                    r.getBpmnProcessId(),
-                    r.getElementId(),
-                    r.getVersion()))
-        .containsExactly(
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", 1));
-
-    Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.MIGRATED)
                 .withRecordKey(incident.getKey())
                 .getFirst()
                 .getValue())
         .isNotNull();
-
-    assertThat(
-            RecordingExporter.jobRecords(JobIntent.MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(2))
-        .hasSize(2)
-        .extracting(Record::getValue)
-        .extracting(
-            r ->
-                tuple(
-                    r.getProcessDefinitionKey(),
-                    r.getBpmnProcessId(),
-                    r.getElementId(),
-                    r.getType()))
-        .containsExactly(
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"),
-            tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"));
 
     // after migrating, we can successfully resolve the incident
     engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMultiInstanceBodyTest.java
@@ -760,7 +760,14 @@ public class MigrateMultiInstanceBodyTest {
 
     final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
 
-    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+    final var jobs =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("A")
+            .limit(3)
+            .toList();
+
+    engine.job().withKey(jobs.getFirst().getKey()).complete();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -833,17 +840,11 @@ public class MigrateMultiInstanceBodyTest {
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"),
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"));
 
-    // after resolving the incident, the first failing job should be completed without a problem
+    // after migrating, we can successfully resolve the incident
     engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
-    final var jobs =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withType("A")
-            .withProcessInstanceKey(processInstanceKey)
-            .limit(3)
-            .toList();
-
-    jobs.forEach(job -> engine.job().withKey(job.getKey()).complete());
+    // and complete the two still active jobs without problems
+    jobs.stream().skip(1).forEach(job -> engine.job().withKey(job.getKey()).complete());
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
@@ -905,7 +906,14 @@ public class MigrateMultiInstanceBodyTest {
 
     final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
 
-    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+    final var jobs =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("A")
+            .limit(3)
+            .toList();
+
+    engine.job().withKey(jobs.getFirst().getKey()).complete();
 
     final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
@@ -978,17 +986,11 @@ public class MigrateMultiInstanceBodyTest {
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"),
             tuple(targetProcessDefinitionKey, targetProcessId, "serviceTask2", "A"));
 
-    // after resolving the incident, the first failing job should be completed without a problem
+    // after migrating, we can successfully resolve the incident
     engine.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
-    final var jobs =
-        RecordingExporter.jobRecords(JobIntent.CREATED)
-            .withType("A")
-            .withProcessInstanceKey(processInstanceKey)
-            .limit(3)
-            .toList();
-
-    jobs.forEach(job -> engine.job().withKey(job.getKey()).complete());
+    // and complete the two still active jobs without problems
+    jobs.stream().skip(1).forEach(job -> engine.job().withKey(job.getKey()).complete());
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
@@ -671,6 +671,96 @@ public class MigrateProcessInstanceRejectionTest {
   }
 
   @Test
+  public void shouldRejectCommandWhenFlowScopeIsChangedInsideMultiInstanceBody() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .subProcess(
+                        "sub1",
+                        s ->
+                            s.multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("[1,2,3]")
+                                            .zeebeInputElement("index"))
+                                .embeddedSubProcess()
+                                .startEvent()
+                                .serviceTask("task1", t -> t.zeebeJobType("task"))
+                                .endEvent()
+                                .subProcessDone())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub2",
+                        s ->
+                            s.multiInstance(
+                                    b ->
+                                        b.zeebeInputCollectionExpression("[1,2,3]")
+                                            .zeebeInputElement("index"))
+                                .embeddedSubProcess()
+                                .startEvent()
+                                .subProcess(
+                                    "subsub2",
+                                    ss ->
+                                        ss.embeddedSubProcess()
+                                            .startEvent()
+                                            .serviceTask("task2", t -> t.zeebeJobType("task"))
+                                            .endEvent())
+                                .subProcessDone())
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withType("task")
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(3))
+        .describedAs("Wait until all service tasks have activated")
+        .hasSize(3);
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("sub1", "sub2")
+            .addMappingInstruction("task1", "task2")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%s' \
+                but the flow scope of active element with id 'task1' is changed. \
+                The flow scope of the active element is expected to be 'sub2' but was 'subsub2'. \
+                The flow scope of an element cannot be changed during migration yet.""",
+                processInstanceKey))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
   public void shouldRejectCommandWhenElementFlowScopeIsChangedInTargetProcessDefinitionDeeper() {
     // given
     final var deployment =


### PR DESCRIPTION
## Description

Following cases should be supported:

### Migrate multi-instance service tasks

<img width="307" alt="Screenshot 2024-09-10 at 18 19 45" src="https://github.com/user-attachments/assets/711eeb59-5a1d-4675-bdd0-cd5859feb9cf">

A multi-instance service task itself, its instances and created jobs (per instance) should be migrated. A mapping should be provided between A->B.

### Migrate multi-instance receive tasks

<img width="306" alt="Screenshot 2024-09-10 at 18 20 33" src="https://github.com/user-attachments/assets/8f58efa4-93fe-4ddd-b281-cb62b81ef767">

A multi-instance receive task itself, its instances and created message subscriptions (per instance) should be migrated. A mapping should be provided between A->B.

### Migrate multi-instance embedded subprocess

<img width="400" alt="Screenshot 2024-09-10 at 18 23 30" src="https://github.com/user-attachments/assets/45d37e1a-a0f9-43ba-b253-cfc230edd89c">

A multi-instance embedded subprocess itself, its instances and any active element inside instances should be migrated. A mapping should be provided between sub1->sub2 and A->B.

### Migrate multi-instance call activities

<img width="306" alt="Screenshot 2024-09-10 at 18 24 21" src="https://github.com/user-attachments/assets/95a0513d-473b-40eb-8ba7-9c2369f1f837">

A multi-instance call activity should be migrated. A mapping should be provided between A->B. 

Please note that it is not possible to migrate each call activity instance because they belong to another process instance. A new migration should be defined per called activity to migrate each child instance because they are separate process instances.

####  Notes
- Migrating multi-instance body with some of its instances are completed should be possible as well. For example, if 2 instances out of 3 is completed for a multi-instance service task, remaining active instance should be migrated.
- Migrating large set of multi instances (exceeding batch size) is left out of scope. Migrating such multi instances will exceed `MAX_MESSAGE_SIZE` and fail.

## Related issues

closes #22129  
