### PR TITLE
fix: reject on missing process in timer trigger

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -39,6 +39,8 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
 
   private static final String NO_TIMER_FOUND_MESSAGE =
       "Expected to trigger timer with key '%d', but no such timer was found";
+  private static final String NO_PROCESS_DEFINITION_FOUND_MESSAGE =
+      "Expected to find a process definition with key '%d', but no such definition was found";
   private static final String NO_ACTIVE_TIMER_MESSAGE =
       "Expected to trigger a timer with key '%d', but the timer is not active anymore";
   private static final DirectBuffer NO_VARIABLES = new UnsafeBuffer();
@@ -85,14 +87,27 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
     final var timerInstance = timerInstanceState.get(elementInstanceKey, record.getKey());
     if (timerInstance == null) {
       rejectionWriter.appendRejection(
-          record, RejectionType.NOT_FOUND, String.format(NO_TIMER_FOUND_MESSAGE, record.getKey()));
+          record, RejectionType.NOT_FOUND, NO_TIMER_FOUND_MESSAGE.formatted(record.getKey()));
+      return;
+    }
+
+    final var tenantId = timer.getTenantId();
+    // this is an additional safeguard to avoid banning unrelated instances
+    // as noticed in https://github.com/camunda/camunda/issues/20677
+    final var deployedProcess =
+        processState.getProcessByKeyAndTenant(processDefinitionKey, tenantId);
+    if (deployedProcess == null) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.NOT_FOUND,
+          NO_PROCESS_DEFINITION_FOUND_MESSAGE.formatted(processDefinitionKey));
       return;
     }
 
     final var catchEvent =
         processState.getFlowElement(
             processDefinitionKey,
-            timer.getTenantId(),
+            tenantId,
             timer.getTargetElementIdBuffer(),
             ExecutableCatchEvent.class);
     if (isStartEvent(elementInstanceKey)) {
@@ -104,7 +119,7 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
           processInstanceKey,
           timer.getTargetElementIdBuffer(),
           NO_VARIABLES,
-          timer.getTenantId());
+          tenantId);
     } else {
       final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
       if (!eventHandle.canTriggerElement(elementInstance, timer.getTargetElementIdBuffer())) {
@@ -123,9 +138,7 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
 
   private void rejectNoActiveTimer(final TypedRecord<TimerRecord> record) {
     rejectionWriter.appendRejection(
-        record,
-        RejectionType.INVALID_STATE,
-        String.format(NO_ACTIVE_TIMER_MESSAGE, record.getKey()));
+        record, RejectionType.INVALID_STATE, NO_ACTIVE_TIMER_MESSAGE.formatted(record.getKey()));
   }
 
   private boolean isStartEvent(final long elementInstanceKey) {
@@ -141,9 +154,8 @@ public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRe
         event.getTimerFactory().apply(expressionProcessor, record.getElementInstanceKey());
     if (timer.isLeft()) {
       final String message =
-          String.format(
-              "Expected to reschedule repeating timer for element with id '%s', but an error occurred: %s",
-              BufferUtil.bufferAsString(event.getId()), timer.getLeft().getMessage());
+          "Expected to reschedule repeating timer for element with id '%s', but an error occurred: %s"
+              .formatted(BufferUtil.bufferAsString(event.getId()), timer.getLeft().getMessage());
       throw new IllegalStateException(message);
       // todo(#4208): raise incident instead of throwing an exception
     }


### PR DESCRIPTION
## Description

Rejects the Timer.TRIGGER command when the related process definition cannot be found.

Otherwise, the command can run into an exception that leads to banning the related process instance. For start timer events, this means banning the last process instance that was created by the start timer trigger.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20677 
