### PR TITLE
ci: mitigate incident by disabling usage of ARM runners

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -30,9 +30,9 @@ jobs:
             runner: windows-latest
           - os: linux
             runner: [ self-hosted, linux, amd64 ]
-          - os: linux
-            runner: "aws-arm-core-4-default"
-            arch: arm64
+          # - os: linux
+          #   runner: "aws-arm-core-4-default"
+          #   arch: arm64
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
## Description

This PR attempts to mitigate the impact of https://app.incident.io/camunda/incidents/1756 which currently blocks the merge queue to `main` and all merges that depend on Zeebe tests. This mitigation makes the tradeoff to slightly reduce test coverage of Zeebe on ARM machines until the incident is resolved, to unlock other developers.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

https://app.incident.io/camunda/incidents/1756
