### PR TITLE
feat: write continuation commands at the end of distribution queues

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionContinueProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
 import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
@@ -414,14 +415,19 @@ public final class EngineProcessors {
         new CommandRedistributor(
             scheduledTaskStateFactory.get().getDistributionState(), interPartitionCommandSender));
 
+    final var distributionState = processingState.getDistributionState();
     typedRecordProcessors.onCommand(
         ValueType.COMMAND_DISTRIBUTION,
         CommandDistributionIntent.ACKNOWLEDGE,
         new CommandDistributionAcknowledgeProcessor(
-            commandDistributionBehavior, processingState.getDistributionState(), writers));
+            commandDistributionBehavior, distributionState, writers));
     typedRecordProcessors.onCommand(
         ValueType.COMMAND_DISTRIBUTION,
         CommandDistributionIntent.FINISH,
         new CommandDistributionFinishProcessor(writers, commandDistributionBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.COMMAND_DISTRIBUTION,
+        CommandDistributionIntent.CONTINUE,
+        new CommandDistributionContinueProcessor(distributionState, writers));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
 import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
 import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
@@ -413,12 +414,14 @@ public final class EngineProcessors {
         new CommandRedistributor(
             scheduledTaskStateFactory.get().getDistributionState(), interPartitionCommandSender));
 
-    final var commandDistributionAcknowledgeProcessor =
-        new CommandDistributionAcknowledgeProcessor(
-            commandDistributionBehavior, processingState.getDistributionState(), writers);
     typedRecordProcessors.onCommand(
         ValueType.COMMAND_DISTRIBUTION,
         CommandDistributionIntent.ACKNOWLEDGE,
-        commandDistributionAcknowledgeProcessor);
+        new CommandDistributionAcknowledgeProcessor(
+            commandDistributionBehavior, processingState.getDistributionState(), writers));
+    typedRecordProcessors.onCommand(
+        ValueType.COMMAND_DISTRIBUTION,
+        CommandDistributionIntent.FINISH,
+        new CommandDistributionFinishProcessor(writers, commandDistributionBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessor.java
@@ -70,7 +70,7 @@ public final class ClockProcessor implements DistributedTypedRecordProcessor<Clo
       responseWriter.writeEventOnCommand(eventKey, resultIntent, clockRecord, command);
     }
 
-    commandDistributionBehavior.withKey(eventKey).distribute(command);
+    commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -179,7 +179,7 @@ public final class DeploymentCreateProcessor
         key, DeploymentIntent.CREATED, recordWithoutResource, command);
     stateWriter.appendFollowUpEvent(key, DeploymentIntent.CREATED, recordWithoutResource);
 
-    distributionBehavior.withKey(key).distribute(command);
+    distributionBehavior.withKey(key).unordered().distribute(command);
   }
 
   private void processDistributedRecord(final TypedRecord<DeploymentRecord> command) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
@@ -57,7 +57,9 @@ public class CommandDistributionAcknowledgeProcessor
     stateWriter.appendFollowUpEvent(
         distributionKey, CommandDistributionIntent.ACKNOWLEDGED, recordValue);
 
-    commandDistributionBehavior.distributeNextInQueue(distributionKey, partitionId);
+    distributionState
+        .getQueueIdForDistribution(distributionKey)
+        .ifPresent(queueId -> commandDistributionBehavior.advanceQueue(queueId, partitionId));
 
     if (!distributionState.hasPendingDistribution(distributionKey)) {
       // We write an empty command here as a distribution could contain a lot of data. Because of

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.distribution;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
@@ -27,6 +28,7 @@ public class CommandDistributionAcknowledgeProcessor
 
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final DistributionState distributionState;
+  private final TypedCommandWriter commandWriter;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
 
@@ -36,6 +38,7 @@ public class CommandDistributionAcknowledgeProcessor
       final Writers writers) {
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.distributionState = distributionState;
+    commandWriter = writers.command();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
   }
@@ -57,21 +60,20 @@ public class CommandDistributionAcknowledgeProcessor
     stateWriter.appendFollowUpEvent(
         distributionKey, CommandDistributionIntent.ACKNOWLEDGED, recordValue);
 
-    distributionState
-        .getQueueIdForDistribution(distributionKey)
-        .ifPresent(queueId -> commandDistributionBehavior.advanceQueue(queueId, partitionId));
+    final var queueId = distributionState.getQueueIdForDistribution(distributionKey);
+    queueId.ifPresent(
+        queue -> commandDistributionBehavior.distributeNextInQueue(queue, partitionId));
 
     if (!distributionState.hasPendingDistribution(distributionKey)) {
-      // We write an empty command here as a distribution could contain a lot of data. Because of
-      // this we could exceed the max message size. As we only need the distributionKey in the
-      // FINISHED event applier an empty record will suffice here.
-      stateWriter.appendFollowUpEvent(
-          distributionKey,
-          CommandDistributionIntent.FINISHED,
+      final var finishRecord =
           new CommandDistributionRecord()
               .setPartitionId(record.getPartitionId())
               .setValueType(recordValue.getValueType())
-              .setIntent(recordValue.getIntent()));
+              .setIntent(recordValue.getIntent());
+      queueId.ifPresent(finishRecord::setQueueId);
+
+      commandWriter.appendFollowUpCommand(
+          distributionKey, CommandDistributionIntent.FINISH, finishRecord);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -83,7 +83,7 @@ public final class CommandDistributionBehavior {
    *     completed. Additionally, the key determines the order in which the commands are distributed
    *     if they are distributed ordered, i.e. a queue is specified.
    */
-  public CommandDistributionRequestBuilder withKey(final long distributionKey) {
+  public RequestBuilder withKey(final long distributionKey) {
     return new DistributionRequest(distributionKey);
   }
 
@@ -248,32 +248,21 @@ public final class CommandDistributionBehavior {
         });
   }
 
-  public interface CommandDistributionRequestBuilder {
-    /**
-     * Distributes the command in an unordered way. This means that the command is sent to the
-     * receiving partitions without any guarantee of order.
-     *
-     * @return the builder
-     */
-    CommandDistributionRequestBuilder unordered();
+  public interface RequestBuilder {
+    DistributionRequestBuilder unordered();
 
-    /**
-     * Appends this command to the specified queue to be distributed in the natural sort order of
-     * the distribution key. Ordering is maintained separately for each partition the command is
-     * distributed to.
-     *
-     * @param queue the queue to append the command to.
-     */
-    CommandDistributionRequestBuilder inQueue(String queue);
+    DistributionRequestBuilder inQueue(String queue);
+  }
 
+  public interface DistributionRequestBuilder {
     /** Specifies the single partition that this command will be distributed to. */
-    CommandDistributionRequestBuilder forPartition(int partition);
+    DistributionRequestBuilder forPartition(int partition);
 
     /** Specifies the partitions that this command will be distributed to. */
-    CommandDistributionRequestBuilder forPartitions(Set<Integer> partitions);
+    DistributionRequestBuilder forPartitions(Set<Integer> partitions);
 
     /** Specifies that this command will be distributed to all partitions except the local one. */
-    CommandDistributionRequestBuilder forOtherPartitions();
+    DistributionRequestBuilder forOtherPartitions();
 
     /** Distributes the command as specified. */
     <T extends UnifiedRecordValue> void distribute(TypedRecord<T> command);
@@ -283,7 +272,7 @@ public final class CommandDistributionBehavior {
         final ValueType valueType, final Intent intent, final T value);
   }
 
-  private class DistributionRequest implements CommandDistributionRequestBuilder {
+  private class DistributionRequest implements RequestBuilder, DistributionRequestBuilder {
     final long distributionKey;
     String queue;
     Set<Integer> partitions = routingInfo.partitions();
@@ -293,31 +282,31 @@ public final class CommandDistributionBehavior {
     }
 
     @Override
-    public CommandDistributionRequestBuilder unordered() {
+    public DistributionRequest unordered() {
       queue = null;
       return this;
     }
 
     @Override
-    public CommandDistributionRequestBuilder inQueue(final String queue) {
+    public DistributionRequest inQueue(final String queue) {
       this.queue = Objects.requireNonNull(queue);
       return this;
     }
 
     @Override
-    public CommandDistributionRequestBuilder forPartition(final int partition) {
+    public DistributionRequestBuilder forPartition(final int partition) {
       partitions = Set.of(partition);
       return this;
     }
 
     @Override
-    public CommandDistributionRequestBuilder forPartitions(final Set<Integer> partitions) {
+    public DistributionRequestBuilder forPartitions(final Set<Integer> partitions) {
       this.partitions = Objects.requireNonNull(partitions);
       return this;
     }
 
     @Override
-    public CommandDistributionRequestBuilder forOtherPartitions() {
+    public DistributionRequestBuilder forOtherPartitions() {
       partitions = routingInfo.partitions();
       return this;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -196,16 +196,11 @@ public final class CommandDistributionBehavior {
   }
 
   private void handleContinuationCommand(final long key, final CommandDistributionRecord record) {
-    final var intent = record.getIntent();
-    final var value = record.getCommandValue();
-
-    commandWriter.appendFollowUpCommand(key, intent, value);
-
     commandDistributionContinuation.reset();
     commandDistributionContinuation.setQueueId(record.getQueueId());
     commandDistributionContinuation.setPartitionId(currentPartitionId);
-    stateWriter.appendFollowUpEvent(
-        key, CommandDistributionIntent.CONTINUATION_COMPLETED, commandDistributionContinuation);
+    commandWriter.appendFollowUpCommand(
+        key, CommandDistributionIntent.CONTINUE, commandDistributionContinuation);
   }
 
   private void startDistributing(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -342,13 +342,13 @@ public final class CommandDistributionBehavior {
 
   private class DistributionRequest
       implements RequestBuilder, DistributionRequestBuilder, ContinuationRequestBuilder {
-    final long distributionKey;
+    final long key;
     String queue;
     Set<Integer> partitions = routingInfo.partitions();
     private boolean awaitNonEmptyQueue;
 
-    public DistributionRequest(final long distributionKey) {
-      this.distributionKey = distributionKey;
+    public DistributionRequest(final long key) {
+      this.key = key;
     }
 
     @Override
@@ -390,12 +390,7 @@ public final class CommandDistributionBehavior {
     @Override
     public <T extends UnifiedRecordValue> void distribute(final TypedRecord<T> command) {
       distributeCommand(
-          queue,
-          distributionKey,
-          command.getValueType(),
-          command.getIntent(),
-          command.getValue(),
-          partitions);
+          queue, key, command.getValueType(), command.getIntent(), command.getValue(), partitions);
     }
 
     @Override
@@ -403,7 +398,7 @@ public final class CommandDistributionBehavior {
         final ValueType valueType, final Intent intent, final T value) {
       distributeCommand(
           queue,
-          distributionKey,
+          key,
           Objects.requireNonNull(valueType),
           Objects.requireNonNull(intent),
           Objects.requireNonNull(value),
@@ -420,7 +415,7 @@ public final class CommandDistributionBehavior {
     public <T extends UnifiedRecordValue> void continueWith(final TypedRecord<T> command) {
       requestContinuation(
           queue,
-          distributionKey,
+          key,
           awaitNonEmptyQueue,
           command.getValueType(),
           command.getIntent(),
@@ -430,7 +425,7 @@ public final class CommandDistributionBehavior {
     @Override
     public <T extends UnifiedRecordValue> void continueWith(
         final ValueType valueType, final Intent intent, final T value) {
-      requestContinuation(queue, distributionKey, awaitNonEmptyQueue, valueType, intent, value);
+      requestContinuation(queue, key, awaitNonEmptyQueue, valueType, intent, value);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -57,6 +57,8 @@ public final class CommandDistributionBehavior {
       new CommandDistributionRecord();
   private final CommandDistributionRecord commandDistributionAcknowledge =
       new CommandDistributionRecord();
+  private final CommandDistributionRecord commandDistributionContinuation =
+      new CommandDistributionRecord();
 
   public CommandDistributionBehavior(
       final DistributionState distributionState,
@@ -287,15 +289,15 @@ public final class CommandDistributionBehavior {
       return;
     }
 
-    final var distributionRecord = new CommandDistributionRecord();
-    distributionRecord.setQueueId(queue);
-    distributionRecord.setPartitionId(currentPartitionId);
-    distributionRecord.setValueType(valueType);
-    distributionRecord.setIntent(intent);
-    distributionRecord.setCommandValue(value);
+    commandDistributionContinuation.reset();
+    commandDistributionContinuation.setQueueId(queue);
+    commandDistributionContinuation.setPartitionId(currentPartitionId);
+    commandDistributionContinuation.setValueType(valueType);
+    commandDistributionContinuation.setIntent(intent);
+    commandDistributionContinuation.setCommandValue(value);
 
     stateWriter.appendFollowUpEvent(
-        key, CommandDistributionIntent.CONTINUATION_REQUESTED, distributionRecord);
+        key, CommandDistributionIntent.CONTINUATION_REQUESTED, commandDistributionContinuation);
   }
 
   public interface RequestBuilder {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -174,15 +174,10 @@ public final class CommandDistributionBehavior {
         commandDistributionEnqueued.setQueueId(queue).setPartitionId(partition));
   }
 
-  void advanceQueue(final String queueId, final int partition) {
-    distributeNextInQueue(queueId, partition);
-    continueAfterQueue(queueId);
-  }
-
   /**
    * If the given distribution was part of a queue, the next distribution from the queue is started.
    */
-  private void distributeNextInQueue(final String queue, final int partition) {
+  void distributeNextInQueue(final String queue, final int partition) {
     distributionState
         .getNextQueuedDistributionKey(queue, partition)
         .ifPresent(
@@ -193,7 +188,7 @@ public final class CommandDistributionBehavior {
                     nextDistributionKey));
   }
 
-  private void continueAfterQueue(final String queue) {
+  void continueAfterQueue(final String queue) {
     if (distributionState.hasQueuedDistributions(queue)) {
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -192,12 +192,13 @@ public final class CommandDistributionBehavior {
     if (distributionState.hasQueuedDistributions(queue)) {
       return;
     }
-    distributionState.forEachContinuationCommand(queue, this::handleContinuationCommand);
+    distributionState.forEachContinuationCommand(
+        queue, key -> handleContinuationCommand(queue, key));
   }
 
-  private void handleContinuationCommand(final long key, final CommandDistributionRecord record) {
+  private void handleContinuationCommand(final String queue, final long key) {
     commandDistributionContinuation.reset();
-    commandDistributionContinuation.setQueueId(record.getQueueId());
+    commandDistributionContinuation.setQueueId(queue);
     commandDistributionContinuation.setPartitionId(currentPartitionId);
     commandWriter.appendFollowUpCommand(
         key, CommandDistributionIntent.CONTINUE, commandDistributionContinuation);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -206,8 +206,11 @@ public final class CommandDistributionBehavior {
 
     commandWriter.appendFollowUpCommand(key, intent, value);
 
-    record.setPartitionId(currentPartitionId);
-    stateWriter.appendFollowUpEvent(key, CommandDistributionIntent.CONTINUATION_COMPLETED, record);
+    commandDistributionContinuation.reset();
+    commandDistributionContinuation.setQueueId(record.getQueueId());
+    commandDistributionContinuation.setPartitionId(currentPartitionId);
+    stateWriter.appendFollowUpEvent(
+        key, CommandDistributionIntent.CONTINUATION_COMPLETED, commandDistributionContinuation);
   }
 
   private void startDistributing(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
@@ -41,7 +41,6 @@ public class CommandDistributionContinueProcessor
     final var continuationCommand = continuationRecord.getCommandValue();
     commandWriter.appendFollowUpCommand(key, intent, continuationCommand);
 
-    stateWriter.appendFollowUpEvent(
-        key, CommandDistributionIntent.CONTINUATION_COMPLETED, distributionRecord);
+    stateWriter.appendFollowUpEvent(key, CommandDistributionIntent.CONTINUED, distributionRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.DistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class CommandDistributionContinueProcessor
+    implements TypedRecordProcessor<CommandDistributionRecord> {
+
+  private final DistributionState distributionState;
+  private final TypedCommandWriter commandWriter;
+  private final TypedEventWriter stateWriter;
+
+  public CommandDistributionContinueProcessor(
+      final DistributionState distributionState, final Writers writers) {
+    this.distributionState = distributionState;
+    commandWriter = writers.command();
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<CommandDistributionRecord> record) {
+    final var key = record.getKey();
+    final var distributionRecord = record.getValue();
+    final var queue = distributionRecord.getQueueId();
+
+    final var continuationRecord = distributionState.getContinuationRecord(queue, key);
+    final var intent = continuationRecord.getIntent();
+    final var continuationCommand = continuationRecord.getCommandValue();
+    commandWriter.appendFollowUpCommand(key, intent, continuationCommand);
+
+    stateWriter.appendFollowUpEvent(
+        key, CommandDistributionIntent.CONTINUATION_COMPLETED, distributionRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionFinishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionFinishProcessor.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Optional;
+
+public class CommandDistributionFinishProcessor
+    implements TypedRecordProcessor<CommandDistributionRecord> {
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final StateWriter stateWriter;
+
+  public CommandDistributionFinishProcessor(
+      final Writers writers, final CommandDistributionBehavior commandDistributionBehavior) {
+    stateWriter = writers.state();
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<CommandDistributionRecord> record) {
+    final var distributionRecord = record.getValue();
+    Optional.ofNullable(distributionRecord.getQueueId())
+        .ifPresent(commandDistributionBehavior::continueAfterQueue);
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), CommandDistributionIntent.FINISHED, distributionRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
@@ -369,6 +369,7 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
     } else {
       commandDistributionBehavior
           .withKey(distributionKey)
+          .unordered()
           .forPartition(processMessageSubscriptionRecord.getSubscriptionPartitionId())
           .distribute(
               ValueType.MESSAGE_SUBSCRIPTION,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -103,7 +103,7 @@ public class ResourceDeletionDeleteProcessor
     tryDeleteResources(command);
 
     stateWriter.appendFollowUpEvent(eventKey, ResourceDeletionIntent.DELETED, value);
-    commandDistributionBehavior.withKey(eventKey).distribute(command);
+    commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
     responseWriter.writeEventOnCommand(eventKey, ResourceDeletionIntent.DELETING, value, command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -89,7 +89,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
             activateElement(subscriptionRecord, signalRecord.getVariablesBuffer());
           }
         });
-    commandDistributionBehavior.withKey(eventKey).distribute(command);
+    commandDistributionBehavior.withKey(eventKey).unordered().distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -64,7 +64,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(key, UserIntent.UPDATED, updatedUser);
     responseWriter.writeEventOnCommand(key, UserIntent.UPDATED, updatedUser, command);
 
-    distributionBehavior.withKey(key).distribute(command);
+    distributionBehavior.withKey(key).unordered().distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CommandDistributionContinuationRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/analyzers/CommandDistributionContinuationRequestedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.analyzers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public class CommandDistributionContinuationRequestedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+  final MutableDistributionState distributionState;
+
+  public CommandDistributionContinuationRequestedApplier(
+      final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.addContinuationCommand(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuationCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuationCompletedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+
+public class CommandDistributionContinuationCompletedApplier
+    implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
+  final MutableDistributionState distributionState;
+
+  public CommandDistributionContinuationCompletedApplier(
+      final MutableDistributionState distributionState) {
+    this.distributionState = distributionState;
+  }
+
+  @Override
+  public void applyState(final long key, final CommandDistributionRecord value) {
+    distributionState.removeContinuationCommand(key, value.getQueueId());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuationRequestedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuationRequestedApplier.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.state.analyzers;
+package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CommandDistributionContinuedApplier.java
@@ -12,12 +12,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 
-public class CommandDistributionContinuationCompletedApplier
+public class CommandDistributionContinuedApplier
     implements TypedEventApplier<CommandDistributionIntent, CommandDistributionRecord> {
   final MutableDistributionState distributionState;
 
-  public CommandDistributionContinuationCompletedApplier(
-      final MutableDistributionState distributionState) {
+  public CommandDistributionContinuedApplier(final MutableDistributionState distributionState) {
     this.distributionState = distributionState;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForVersion;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.analyzers.CommandDistributionContinuationRequestedApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -419,6 +420,9 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.ENQUEUED,
         new CommandDistributionEnqueuedApplier(distributionState));
+    register(
+        CommandDistributionIntent.CONTINUATION_REQUESTED,
+        new CommandDistributionContinuationRequestedApplier(distributionState));
   }
 
   private void registerAuthorizationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -423,8 +423,8 @@ public final class EventAppliers implements EventApplier {
         CommandDistributionIntent.CONTINUATION_REQUESTED,
         new CommandDistributionContinuationRequestedApplier(distributionState));
     register(
-        CommandDistributionIntent.CONTINUATION_COMPLETED,
-        new CommandDistributionContinuationCompletedApplier(distributionState));
+        CommandDistributionIntent.CONTINUED,
+        new CommandDistributionContinuedApplier(distributionState));
   }
 
   private void registerAuthorizationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForVersion;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.analyzers.CommandDistributionContinuationRequestedApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -423,6 +423,9 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.CONTINUATION_REQUESTED,
         new CommandDistributionContinuationRequestedApplier(distributionState));
+    register(
+        CommandDistributionIntent.CONTINUATION_COMPLETED,
+        new CommandDistributionContinuationCompletedApplier(distributionState));
   }
 
   private void registerAuthorizationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -179,6 +179,14 @@ public class DbDistributionState implements MutableDistributionState {
   }
 
   @Override
+  public void removeContinuationCommand(final long key, final String queue) {
+    queueId.wrapString(queue);
+    distributionKey.wrapLong(key);
+
+    continuationCommandColumnFamily.deleteExisting(continuationCommandKey);
+  }
+
+  @Override
   public boolean hasRetriableDistribution(final long distributionKey) {
     this.distributionKey.wrapLong(distributionKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -327,14 +327,7 @@ public class DbDistributionState implements MutableDistributionState {
         queueId,
         (key, value) -> {
           final var continuationKey = key.second().getValue();
-
-          final var commandDistributionRecord = new CommandDistributionRecord();
-          commandDistributionRecord.setQueueId(queue);
-          commandDistributionRecord.setValueType(value.getValueType());
-          commandDistributionRecord.setIntent(value.getIntent());
-          commandDistributionRecord.setCommandValue(value.getCommandValue());
-
-          consumer.visit(continuationKey, commandDistributionRecord);
+          consumer.visit(continuationKey);
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -338,4 +338,22 @@ public class DbDistributionState implements MutableDistributionState {
           return true;
         });
   }
+
+  @Override
+  public CommandDistributionRecord getContinuationRecord(final String queue, final long key) {
+    queueId.wrapString(queue);
+    continuationKey.wrapLong(key);
+
+    final var persistedCommandDistribution =
+        continuationCommandColumnFamily.get(continuationByQueueKey);
+    if (persistedCommandDistribution == null) {
+      return null;
+    }
+
+    return new CommandDistributionRecord()
+        .setQueueId(queue)
+        .setValueType(persistedCommandDistribution.getValueType())
+        .setIntent(persistedCommandDistribution.getIntent())
+        .setCommandValue(persistedCommandDistribution.getCommandValue());
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -271,4 +271,17 @@ public class DbDistributionState implements MutableDistributionState {
     return Optional.ofNullable(commandDistributionRecordColumnFamily.get(this.distributionKey))
         .flatMap(PersistedCommandDistribution::getQueueId);
   }
+
+  @Override
+  public boolean hasQueuedDistributions(final String queue) {
+    queueId.wrapString(queue);
+    final var hasQueuedDistributions = new MutableBoolean();
+    queuedCommandDistributionColumnFamily.whileEqualPrefix(
+        queueId,
+        (key, value) -> {
+          hasQueuedDistributions.set(true);
+          return false;
+        });
+    return hasQueuedDistributions.get();
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -307,4 +307,21 @@ public class DbDistributionState implements MutableDistributionState {
         });
     return hasQueuedDistributions.get();
   }
+
+  @Override
+  public void forEachContinuationCommand(
+      final String queue, final ContinuationCommandVisitor consumer) {
+    queueId.wrapString(queue);
+    continuationCommandColumnFamily.whileEqualPrefix(
+        queueId,
+        (key, value) -> {
+          final var commandDistributionRecord = new CommandDistributionRecord();
+          commandDistributionRecord.setQueueId(queue);
+          commandDistributionRecord.setValueType(value.getValueType());
+          commandDistributionRecord.setIntent(value.getIntent());
+          commandDistributionRecord.setCommandValue(value.getCommandValue());
+          consumer.visit(key.second().getValue(), commandDistributionRecord);
+          return true;
+        });
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -85,6 +85,14 @@ public interface DistributionState {
    */
   Optional<String> getQueueIdForDistribution(long distributionKey);
 
+  /**
+   * Returns whether there are any queued distributions for the given queue.
+   *
+   * @param queue the queue to look up
+   * @return true if there are queued distributions for the given queue, otherwise false
+   */
+  boolean hasQueuedDistributions(String queue);
+
   /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
   @FunctionalInterface
   interface PendingDistributionVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -117,6 +117,6 @@ public interface DistributionState {
   @FunctionalInterface
   interface ContinuationCommandVisitor {
     /** Visits a registered continuation command. */
-    void visit(final long key, final CommandDistributionRecord continuationCommand);
+    void visit(final long key);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -93,6 +93,9 @@ public interface DistributionState {
    */
   boolean hasQueuedDistributions(String queue);
 
+  /** Visits each continuation command registered for the given queue. */
+  void forEachContinuationCommand(String queue, ContinuationCommandVisitor consumer);
+
   /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
   @FunctionalInterface
   interface PendingDistributionVisitor {
@@ -104,5 +107,11 @@ public interface DistributionState {
      * @param pendingDistribution The pending distribution itself as command distribution record
      */
     void visit(final long distributionKey, final CommandDistributionRecord pendingDistribution);
+  }
+
+  @FunctionalInterface
+  interface ContinuationCommandVisitor {
+    /** Visits a registered continuation command. */
+    void visit(final long key, final CommandDistributionRecord continuationCommand);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -96,6 +96,11 @@ public interface DistributionState {
   /** Visits each continuation command registered for the given queue. */
   void forEachContinuationCommand(String queue, ContinuationCommandVisitor consumer);
 
+  /**
+   * Returns the continuation command for the given key and queue or null if no such command exists.
+   */
+  CommandDistributionRecord getContinuationRecord(String queue, long key);
+
   /** This visitor can visit pending distributions of {@link CommandDistributionRecord}. */
   @FunctionalInterface
   interface PendingDistributionVisitor {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -75,4 +75,6 @@ public interface MutableDistributionState extends DistributionState {
 
   void addContinuationCommand(
       final long key, final CommandDistributionRecord commandDistributionRecord);
+
+  void removeContinuationCommand(long key, String queue);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDistributionState.java
@@ -72,4 +72,7 @@ public interface MutableDistributionState extends DistributionState {
 
   /** Removes the queued distribution from the queue */
   void removeQueuedDistribution(String queue, int partitionId, long distributionKey);
+
+  void addContinuationCommand(
+      final long key, final CommandDistributionRecord commandDistributionRecord);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -89,7 +89,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to all partitions
-    behavior.withKey(key).distribute(command);
+    behavior.withKey(key).unordered().distribute(command);
 
     // then no command distribution is started
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords()).isEmpty();
@@ -111,7 +111,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to all partitions
-    behavior.withKey(key).distribute(command);
+    behavior.withKey(key).unordered().distribute(command);
 
     // then command distribution is started on partition 1 and distributing to all other partitions
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
@@ -147,7 +147,7 @@ class CommandDistributionBehaviorTest {
             mockInterpartitionCommandSender);
 
     // when distributing to partitions 1 and 3
-    behavior.withKey(key).forPartitions(Set.of(1, 3)).distribute(command);
+    behavior.withKey(key).unordered().forPartitions(Set.of(1, 3)).distribute(command);
 
     // then command distribution is started on partition 2 and distributing to all other partitions
     Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -354,19 +354,10 @@ public final class DistributionStateTest {
     distributionState.addContinuationCommand(3L, record3);
 
     // then
-    final var found = new LinkedList<ContinuationCommand>();
-    distributionState.forEachContinuationCommand(
-        queue,
-        (key, record) ->
-            found.add(
-                new ContinuationCommand(
-                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+    final var found = new LinkedList<Long>();
+    distributionState.forEachContinuationCommand(queue, found::add);
 
-    assertThat(found)
-        .containsExactly(
-            new ContinuationCommand(1L, "continuation1"),
-            new ContinuationCommand(2L, "continuation2"),
-            new ContinuationCommand(3L, "continuation3"));
+    assertThat(found).containsExactly(1L, 2L, 3L);
   }
 
   @Test
@@ -384,18 +375,10 @@ public final class DistributionStateTest {
     distributionState.addContinuationCommand(3L, record3);
 
     // then
-    final var found = new LinkedList<ContinuationCommand>();
-    distributionState.forEachContinuationCommand(
-        queue1,
-        (key, record) ->
-            found.add(
-                new ContinuationCommand(
-                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+    final var found = new LinkedList<Long>();
+    distributionState.forEachContinuationCommand(queue1, found::add);
 
-    assertThat(found)
-        .containsExactly(
-            new ContinuationCommand(1L, "continuation1"),
-            new ContinuationCommand(3L, "continuation3"));
+    assertThat(found).containsExactly(1L, 3L);
   }
 
   @Test
@@ -427,18 +410,10 @@ public final class DistributionStateTest {
     distributionState.removeContinuationCommand(2L, queue);
 
     // then
-    final var found = new LinkedList<ContinuationCommand>();
-    distributionState.forEachContinuationCommand(
-        queue,
-        (key, record) ->
-            found.add(
-                new ContinuationCommand(
-                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+    final var found = new LinkedList<Long>();
+    distributionState.forEachContinuationCommand(queue, found::add);
 
-    assertThat(found)
-        .containsExactly(
-            new ContinuationCommand(1L, "continuation1"),
-            new ContinuationCommand(3L, "continuation3"));
+    assertThat(found).containsExactly(1L, 3L);
   }
 
   private CommandDistributionRecord createContinuationCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -17,11 +17,14 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -313,6 +316,128 @@ public final class DistributionStateTest {
     assertThat(visits).isEmpty();
   }
 
+  @Test
+  public void shouldDetectEmptyQueue() {
+    // when
+    final var hasQueuedDistributions = distributionState.hasQueuedDistributions("empty-queue");
+
+    // then
+    assertThat(hasQueuedDistributions).isFalse();
+  }
+
+  @Test
+  public void shouldDetectNonEmptyQueue() {
+    // given
+    final var queue = "test-queue";
+    final var distributionKey = 1L;
+    final var distributionRecord = createCommandDistributionRecord();
+    distributionState.addCommandDistribution(distributionKey, distributionRecord);
+
+    // when
+    distributionState.enqueueCommandDistribution(queue, distributionKey, 2);
+
+    // then
+    assertThat(distributionState.hasQueuedDistributions(queue)).isTrue();
+  }
+
+  @Test
+  public void shouldFindAllContinuationCommands() {
+    // given
+    final var queue = "test-queue";
+    final var record1 = createContinuationCommand(queue, "continuation1");
+    final var record2 = createContinuationCommand(queue, "continuation2");
+    final var record3 = createContinuationCommand(queue, "continuation3");
+
+    // when
+    distributionState.addContinuationCommand(1L, record1);
+    distributionState.addContinuationCommand(2L, record2);
+    distributionState.addContinuationCommand(3L, record3);
+
+    // then
+    final var found = new LinkedList<ContinuationCommand>();
+    distributionState.forEachContinuationCommand(
+        queue,
+        (key, record) ->
+            found.add(
+                new ContinuationCommand(
+                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+
+    assertThat(found)
+        .containsExactly(
+            new ContinuationCommand(1L, "continuation1"),
+            new ContinuationCommand(2L, "continuation2"),
+            new ContinuationCommand(3L, "continuation3"));
+  }
+
+  @Test
+  public void shouldFindContinuationCommandsForSpecificQueue() {
+    // given
+    final var queue1 = "test-queue-1";
+    final var queue2 = "test-queue-2";
+    final var record1 = createContinuationCommand(queue1, "continuation1");
+    final var record2 = createContinuationCommand(queue2, "continuation2");
+    final var record3 = createContinuationCommand(queue1, "continuation3");
+
+    // when
+    distributionState.addContinuationCommand(1L, record1);
+    distributionState.addContinuationCommand(2L, record2);
+    distributionState.addContinuationCommand(3L, record3);
+
+    // then
+    final var found = new LinkedList<ContinuationCommand>();
+    distributionState.forEachContinuationCommand(
+        queue1,
+        (key, record) ->
+            found.add(
+                new ContinuationCommand(
+                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+
+    assertThat(found)
+        .containsExactly(
+            new ContinuationCommand(1L, "continuation1"),
+            new ContinuationCommand(3L, "continuation3"));
+  }
+
+  @Test
+  public void shouldRemoveContinuationCommand() {
+    // given
+    final var queue = "test-queue";
+    final var record1 = createContinuationCommand(queue, "continuation1");
+    final var record2 = createContinuationCommand(queue, "continuation2");
+    final var record3 = createContinuationCommand(queue, "continuation3");
+
+    distributionState.addContinuationCommand(1L, record1);
+    distributionState.addContinuationCommand(2L, record2);
+    distributionState.addContinuationCommand(3L, record3);
+
+    // when
+    distributionState.removeContinuationCommand(2L, queue);
+
+    // then
+    final var found = new LinkedList<ContinuationCommand>();
+    distributionState.forEachContinuationCommand(
+        queue,
+        (key, record) ->
+            found.add(
+                new ContinuationCommand(
+                    key, ((SignalRecord) record.getCommandValue()).getSignalName())));
+
+    assertThat(found)
+        .containsExactly(
+            new ContinuationCommand(1L, "continuation1"),
+            new ContinuationCommand(3L, "continuation3"));
+  }
+
+  private CommandDistributionRecord createContinuationCommand(
+      final String queueName, final String id) {
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setQueueId(queueName)
+        .setValueType(ValueType.SIGNAL)
+        .setIntent(SignalIntent.BROADCAST)
+        .setCommandValue(new SignalRecord().setSignalName(id));
+  }
+
   private CommandDistributionRecord createCommandDistributionRecord() {
     return new CommandDistributionRecord()
         .setPartitionId(1)
@@ -343,6 +468,8 @@ public final class DistributionStateTest {
 
     return deploymentRecord;
   }
+
+  record ContinuationCommand(long key, String continuationId) {}
 
   record RetriableDistribution(long key, CommandDistributionRecord record) {}
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/distribution/DistributionStateTest.java
@@ -399,6 +399,19 @@ public final class DistributionStateTest {
   }
 
   @Test
+  public void shouldFindSingleContinuationCommand() {
+    // given
+    final var queue = "test-queue";
+    final var record = createContinuationCommand(queue, "continuation");
+
+    // when
+    distributionState.addContinuationCommand(1L, record);
+
+    // then
+    assertThat(distributionState.getContinuationRecord(queue, 1L)).isNotNull();
+  }
+
+  @Test
   public void shouldRemoveContinuationCommand() {
     // given
     final var queue = "test-queue";

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -195,7 +195,8 @@ public enum ZbColumnFamilies implements EnumValue {
   ROUTING(96),
 
   QUEUED_DISTRIBUTION(97),
-  RETRIABLE_DISTRIBUTION(98);
+  RETRIABLE_DISTRIBUTION(98),
+  DISTRIBUTION_CONTINUATION(99);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -23,7 +23,7 @@ public enum CommandDistributionIntent implements Intent {
   FINISHED(4),
   ENQUEUED(5),
   CONTINUATION_REQUESTED(6),
-  CONTINUATION_COMPLETED(7),
+  CONTINUED(7),
   FINISH(8),
   CONTINUE(9);
 
@@ -47,7 +47,7 @@ public enum CommandDistributionIntent implements Intent {
       case FINISHED:
       case ENQUEUED:
       case CONTINUATION_REQUESTED:
-      case CONTINUATION_COMPLETED:
+      case CONTINUED:
         return true;
       default:
         return false;
@@ -71,7 +71,7 @@ public enum CommandDistributionIntent implements Intent {
       case 6:
         return CONTINUATION_REQUESTED;
       case 7:
-        return CONTINUATION_COMPLETED;
+        return CONTINUED;
       case 8:
         return FINISH;
       case 9:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -21,7 +21,8 @@ public enum CommandDistributionIntent implements Intent {
   ACKNOWLEDGE(2),
   ACKNOWLEDGED(3),
   FINISHED(4),
-  ENQUEUED(5);
+  ENQUEUED(5),
+  CONTINUATION_REQUESTED(6);
 
   private final short value;
 
@@ -42,6 +43,7 @@ public enum CommandDistributionIntent implements Intent {
       case ACKNOWLEDGED:
       case FINISHED:
       case ENQUEUED:
+      case CONTINUATION_REQUESTED:
         return true;
       default:
         return false;
@@ -62,6 +64,8 @@ public enum CommandDistributionIntent implements Intent {
         return FINISHED;
       case 5:
         return ENQUEUED;
+      case 6:
+        return CONTINUATION_REQUESTED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -23,7 +23,8 @@ public enum CommandDistributionIntent implements Intent {
   FINISHED(4),
   ENQUEUED(5),
   CONTINUATION_REQUESTED(6),
-  CONTINUATION_COMPLETED(7);
+  CONTINUATION_COMPLETED(7),
+  FINISH(8);
 
   private final short value;
 
@@ -70,6 +71,8 @@ public enum CommandDistributionIntent implements Intent {
         return CONTINUATION_REQUESTED;
       case 7:
         return CONTINUATION_COMPLETED;
+      case 8:
+        return FINISH;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -22,7 +22,8 @@ public enum CommandDistributionIntent implements Intent {
   ACKNOWLEDGED(3),
   FINISHED(4),
   ENQUEUED(5),
-  CONTINUATION_REQUESTED(6);
+  CONTINUATION_REQUESTED(6),
+  CONTINUATION_COMPLETED(7);
 
   private final short value;
 
@@ -44,6 +45,7 @@ public enum CommandDistributionIntent implements Intent {
       case FINISHED:
       case ENQUEUED:
       case CONTINUATION_REQUESTED:
+      case CONTINUATION_COMPLETED:
         return true;
       default:
         return false;
@@ -66,6 +68,8 @@ public enum CommandDistributionIntent implements Intent {
         return ENQUEUED;
       case 6:
         return CONTINUATION_REQUESTED;
+      case 7:
+        return CONTINUATION_COMPLETED;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -24,7 +24,8 @@ public enum CommandDistributionIntent implements Intent {
   ENQUEUED(5),
   CONTINUATION_REQUESTED(6),
   CONTINUATION_COMPLETED(7),
-  FINISH(8);
+  FINISH(8),
+  CONTINUE(9);
 
   private final short value;
 
@@ -73,6 +74,8 @@ public enum CommandDistributionIntent implements Intent {
         return CONTINUATION_COMPLETED;
       case 8:
         return FINISH;
+      case 9:
+        return CONTINUE;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -826,13 +826,7 @@ public class CompactRecordLogger {
     final var intent = (CommandDistributionIntent) record.getIntent();
     final var targetPartitionWord =
         switch (intent) {
-          case STARTED,
-                  FINISH,
-                  FINISHED,
-                  CONTINUATION_REQUESTED,
-                  CONTINUE,
-                  CONTINUATION_COMPLETED ->
-              "on";
+          case STARTED, FINISH, FINISHED, CONTINUATION_REQUESTED, CONTINUE, CONTINUED -> "on";
           case DISTRIBUTING, ENQUEUED -> "to";
           case ACKNOWLEDGE, ACKNOWLEDGED -> "for";
         };

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -826,7 +826,7 @@ public class CompactRecordLogger {
     final var intent = (CommandDistributionIntent) record.getIntent();
     final var targetPartitionWord =
         switch (intent) {
-          case STARTED, FINISHED, CONTINUATION_REQUESTED, CONTINUATION_COMPLETED -> "on";
+          case STARTED, FINISH, FINISHED, CONTINUATION_REQUESTED, CONTINUATION_COMPLETED -> "on";
           case DISTRIBUTING, ENQUEUED -> "to";
           case ACKNOWLEDGE, ACKNOWLEDGED -> "for";
         };

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -826,7 +826,13 @@ public class CompactRecordLogger {
     final var intent = (CommandDistributionIntent) record.getIntent();
     final var targetPartitionWord =
         switch (intent) {
-          case STARTED, FINISH, FINISHED, CONTINUATION_REQUESTED, CONTINUATION_COMPLETED -> "on";
+          case STARTED,
+                  FINISH,
+                  FINISHED,
+                  CONTINUATION_REQUESTED,
+                  CONTINUE,
+                  CONTINUATION_COMPLETED ->
+              "on";
           case DISTRIBUTING, ENQUEUED -> "to";
           case ACKNOWLEDGE, ACKNOWLEDGED -> "for";
         };

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -826,7 +826,7 @@ public class CompactRecordLogger {
     final var intent = (CommandDistributionIntent) record.getIntent();
     final var targetPartitionWord =
         switch (intent) {
-          case STARTED, FINISHED -> "on";
+          case STARTED, FINISHED, CONTINUATION_REQUESTED, CONTINUATION_COMPLETED -> "on";
           case DISTRIBUTING, ENQUEUED -> "to";
           case ACKNOWLEDGE, ACKNOWLEDGED -> "for";
         };


### PR DESCRIPTION
This adds the concept of _Continuation Commands_ to the command distribution behavior. In particular, we allow registering an arbitrary amount of commands that will be written once a queue is or becomes empty.
 
```java
commandDistributionBehavior
  .withKey(123L)
  .afterQueue("my-custom-queue")
  .continueWith(myCallbackCommand);
```
Requesting a continuation command on an empty queue will just immediately write the command and nothing else.

To do this, I've added a new column family to persist continuation commands as well as two events to register a new continuation command and to remove it again after it is written.

The commands and events are written as follow up commands/events for a given _continuation key_.

:warning: As usual, tests are missing because behaviors are not really testable with the usual `EngineRule` infrastructure. The first use case will have to add required tests.

closes https://github.com/camunda/camunda/issues/21449
