### PR TITLE
Support adding permissions through the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
@@ -839,4 +840,27 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   CreateUserCommandStep1 newUserCreateCommand();
+
+  /**
+   * Command to add permissions to an owner.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newAddPermissionsCommand(ownerKey)
+   *  .resourceType(resourceType)
+   *  .permission(permissionType)
+   *  .resourceIds(resourceIds)
+   *  .permission(permissionType)
+   *  .resourceId(resourceId)
+   *  .resourceId(resourceId)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * @param ownerKey the key of the owner
+   * @return a builder for the command
+   */
+  AddPermissionsCommandStep1 newAddPermissionsCommand(long ownerKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AddPermissionsCommandStep1.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import java.util.List;
+
+public interface AddPermissionsCommandStep1 {
+
+  /**
+   * Sets the resource type for which the permissions should be added.
+   *
+   * @param resourceType the resource type
+   * @return the builder for this command
+   */
+  AddPermissionsCommandStep2 resourceType(ResourceTypeEnum resourceType);
+
+  interface AddPermissionsCommandStep2 {
+
+    /**
+     * Sets the permission type of the permissions that should be added.
+     *
+     * @param permissionType the permission type
+     * @return the builder for this command
+     */
+    AddPermissionsCommandStep3 permission(PermissionTypeEnum permissionType);
+  }
+
+  interface AddPermissionsCommandStep3 {
+
+    /**
+     * Adds all resourceIds in the list to the add permissions request.
+     *
+     * @param resourceIds the list of resource ids
+     * @return the builder for this command
+     */
+    AddPermissionsCommandStep4 resourceIds(List<String> resourceIds);
+
+    /**
+     * Adds a resourceId to the add permissions request.
+     *
+     * @param resourceId the resource id
+     * @return the builder for this command
+     */
+    AddPermissionsCommandStep4 resourceId(String resourceId);
+  }
+
+  interface AddPermissionsCommandStep4
+      extends AddPermissionsCommandStep2,
+          AddPermissionsCommandStep3,
+          FinalCommandStep<AddPermissionsResponse> {}
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AddPermissionsResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface AddPermissionsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CreateUserResponse.java
@@ -15,4 +15,12 @@
  */
 package io.camunda.zeebe.client.api.response;
 
-public interface CreateUserResponse {}
+public interface CreateUserResponse {
+
+  /**
+   * Returns the key of the created user.
+   *
+   * @return the key of the created user.
+   */
+  long getUserKey();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
@@ -61,6 +62,7 @@ import io.camunda.zeebe.client.api.search.query.ProcessInstanceQuery;
 import io.camunda.zeebe.client.api.search.query.UserTaskQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.zeebe.client.impl.command.AddPermissionsCommandImpl;
 import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
@@ -558,6 +560,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public CreateUserCommandStep1 newUserCreateCommand() {
     return new CreateUserCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public AddPermissionsCommandStep1 newAddPermissionsCommand(final long ownerKey) {
+    return new AddPermissionsCommandImpl(ownerKey, httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AddPermissionsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AddPermissionsCommandImpl.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep2;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep3;
+import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep4;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ActionEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class AddPermissionsCommandImpl
+    implements AddPermissionsCommandStep1,
+        AddPermissionsCommandStep2,
+        AddPermissionsCommandStep3,
+        AddPermissionsCommandStep4 {
+
+  private final String path;
+  private final AuthorizationPatchRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private AuthorizationPatchRequestPermissionsInner currentPermission;
+
+  public AddPermissionsCommandImpl(
+      final long ownerKey, final HttpClient httpClient, final JsonMapper jsonMapper) {
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new AuthorizationPatchRequest().action(ActionEnum.ADD);
+    path = "/authorizations/" + ownerKey;
+  }
+
+  @Override
+  public AddPermissionsCommandStep2 resourceType(final ResourceTypeEnum resourceType) {
+    ArgumentUtil.ensureNotNull("resourceType", resourceType);
+    request.resourceType(resourceType);
+    return this;
+  }
+
+  @Override
+  public AddPermissionsCommandStep3 permission(final PermissionTypeEnum permissionType) {
+    ArgumentUtil.ensureNotNull("permissionType", permissionType);
+    currentPermission = new AuthorizationPatchRequestPermissionsInner();
+    currentPermission.permissionType(permissionType);
+    request.addPermissionsItem(currentPermission);
+    return this;
+  }
+
+  @Override
+  public AddPermissionsCommandStep4 resourceIds(final List<String> resourceIds) {
+    ArgumentUtil.ensureNotNullOrEmpty("resourceIds", resourceIds);
+    resourceIds.forEach(this::resourceId);
+    return this;
+  }
+
+  @Override
+  public AddPermissionsCommandStep4 resourceId(final String resourceId) {
+    ArgumentUtil.ensureNotNullNorEmpty("resourceId", resourceId);
+    currentPermission.addResourceIdsItem(resourceId);
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<AddPermissionsResponse> requestTimeout(final Duration requestTimeout) {
+    ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<AddPermissionsResponse> send() {
+    final HttpZeebeFuture<AddPermissionsResponse> result = new HttpZeebeFuture<>();
+    httpClient.post(path, jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.impl.command;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 
 public final class ArgumentUtil {
 
@@ -71,5 +72,16 @@ public final class ArgumentUtil {
       throw new IllegalArgumentException(
           String.format("%s must be equal to or after %s", property, otherInstant));
     }
+  }
+
+  public static void ensureNotEmpty(final String property, final List<?> value) {
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException(property + " must not be empty");
+    }
+  }
+
+  public static void ensureNotNullOrEmpty(final String property, final List<?> value) {
+    ensureNotNull(property, value);
+    ensureNotEmpty(property, value);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ArgumentUtil.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.impl.command;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.function.Predicate;
 
 public final class ArgumentUtil {
 
@@ -28,9 +29,7 @@ public final class ArgumentUtil {
   }
 
   public static void ensureNotEmpty(final String property, final String value) {
-    if (value.isEmpty()) {
-      throw new IllegalArgumentException(property + " must not be empty");
-    }
+    ensureNotEmpty(property, value, String::isEmpty);
   }
 
   public static void ensureNotNullNorEmpty(final String property, final String value) {
@@ -75,13 +74,18 @@ public final class ArgumentUtil {
   }
 
   public static void ensureNotEmpty(final String property, final List<?> value) {
-    if (value.isEmpty()) {
-      throw new IllegalArgumentException(property + " must not be empty");
-    }
+    ensureNotEmpty(property, value, List::isEmpty);
   }
 
   public static void ensureNotNullOrEmpty(final String property, final List<?> value) {
     ensureNotNull(property, value);
     ensureNotEmpty(property, value);
+  }
+
+  private static <T> void ensureNotEmpty(
+      final String property, final T value, final Predicate<T> isEmptyPredicate) {
+    if (isEmptyPredicate.test(value)) {
+      throw new IllegalArgumentException(property + " must not be empty");
+    }
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateUserCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateUserCommandImpl.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.response.CreateUserResponse;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.impl.response.CreateUserResponseImpl;
+import io.camunda.zeebe.client.protocol.rest.UserCreateResponse;
 import io.camunda.zeebe.client.protocol.rest.UserRequest;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -54,7 +56,14 @@ public final class CreateUserCommandImpl implements CreateUserCommandStep1 {
     ArgumentUtil.ensureNotNull("name", request.getName());
     ArgumentUtil.ensureNotNull("password", request.getPassword());
     final HttpZeebeFuture<CreateUserResponse> result = new HttpZeebeFuture<>();
-    httpClient.post("/users", jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    final CreateUserResponseImpl response = new CreateUserResponseImpl(jsonMapper);
+    httpClient.post(
+        "/users",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        UserCreateResponse.class,
+        response::setResponse,
+        result);
     return result;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateUserResponseImpl.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.impl.response;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateUserResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CreateUserResponseImpl.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.CreateUserResponse;
+import io.camunda.zeebe.client.protocol.rest.UserCreateResponse;
+
+public class CreateUserResponseImpl implements CreateUserResponse {
+
+  private final JsonMapper jsonMapper;
+  private long userKey;
+
+  public CreateUserResponseImpl(final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+  }
+
+  @Override
+  public long getUserKey() {
+    return userKey;
+  }
+
+  public CreateUserResponseImpl setResponse(final UserCreateResponse response) {
+    userKey = response.getUserKey();
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/authorization/AddPermissionsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/authorization/AddPermissionsTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ActionEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+public final class AddPermissionsTest extends ClientRestTest {
+
+  @Test
+  void shouldSendCommand() {
+    // when
+    client
+        .newAddPermissionsCommand(1L)
+        .resourceType(ResourceTypeEnum.DEPLOYMENT)
+        .permission(PermissionTypeEnum.CREATE)
+        .resourceId("resourceId1")
+        .permission(PermissionTypeEnum.UPDATE)
+        .resourceIds(Arrays.asList("resourceId2", "resourceId3"))
+        .permission(PermissionTypeEnum.DELETE)
+        .resourceIds(Arrays.asList("resourceId4", "resourceId5"))
+        .resourceId("resourceId6")
+        .send()
+        .join();
+
+    // then
+    final AuthorizationPatchRequest request =
+        gatewayService.getLastRequest(AuthorizationPatchRequest.class);
+    assertThat(request.getAction()).isEqualTo(ActionEnum.ADD);
+    assertThat(request.getResourceType()).isEqualTo(ResourceTypeEnum.DEPLOYMENT);
+
+    assertThat(request.getPermissions())
+        .hasSize(3)
+        .extracting(
+            AuthorizationPatchRequestPermissionsInner::getPermissionType,
+            AuthorizationPatchRequestPermissionsInner::getResourceIds)
+        .containsExactly(
+            tuple(PermissionTypeEnum.CREATE, Collections.singletonList("resourceId1")),
+            tuple(PermissionTypeEnum.UPDATE, Arrays.asList("resourceId2", "resourceId3")),
+            tuple(
+                PermissionTypeEnum.DELETE,
+                Arrays.asList("resourceId4", "resourceId5", "resourceId6")));
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullResourceType() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(null)
+                    .permission(PermissionTypeEnum.CREATE)
+                    .resourceId("resourceId")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourceType must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullPermissionType() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .permission(null)
+                    .resourceId("resourceId")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("permissionType must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullResourceId() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .permission(PermissionTypeEnum.CREATE)
+                    .resourceId(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourceId must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyResourceId() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .permission(PermissionTypeEnum.CREATE)
+                    .resourceId("")
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourceId must not be empty");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNullResourceIds() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .permission(PermissionTypeEnum.CREATE)
+                    .resourceIds(null)
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourceIds must not be null");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnEmptyResourceIds() {
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newAddPermissionsCommand(1L)
+                    .resourceType(ResourceTypeEnum.DEPLOYMENT)
+                    .permission(PermissionTypeEnum.CREATE)
+                    .resourceIds(Collections.emptyList())
+                    .send()
+                    .join())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("resourceIds must not be empty");
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -22,6 +22,7 @@ import io.camunda.service.entities.UserEntity;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.client.protocol.rest.UserRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.List;
@@ -64,7 +65,7 @@ public class BasicAuthIT {
   void setUp() throws JsonProcessingException {
     when(userService.withAuthentication(any(Authentication.class))).thenReturn(userService);
     when(userService.createUser(any()))
-        .thenReturn(CompletableFuture.completedFuture(new UserRecord()));
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(new UserRecord())));
     when(userService.search(any()))
         .thenReturn(
             new SearchQueryResult<>(

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -22,7 +22,6 @@ import io.camunda.service.entities.UserEntity;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
-import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.client.protocol.rest.UserRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.List;
@@ -65,7 +64,7 @@ public class BasicAuthIT {
   void setUp() throws JsonProcessingException {
     when(userService.withAuthentication(any(Authentication.class))).thenReturn(userService);
     when(userService.createUser(any()))
-        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(new UserRecord())));
+        .thenReturn(CompletableFuture.completedFuture(new UserRecord()));
     when(userService.search(any()))
         .thenReturn(
             new SearchQueryResult<>(

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -93,7 +93,7 @@ public class BasicAuthIT {
     final MvcResult mvcResult =
         mockMvc.perform(request).andExpect(request().asyncStarted()).andReturn();
     mvcResult.getAsyncResult();
-    mockMvc.perform(asyncDispatch(mvcResult)).andExpect(status().isNoContent());
+    mockMvc.perform(asyncDispatch(mvcResult)).andExpect(status().isAccepted());
   }
 
   @Test

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -15,6 +15,7 @@ import io.camunda.service.search.query.UserQuery;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.concurrent.CompletableFuture;
@@ -43,8 +44,8 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
     return new UserServices(brokerClient, searchClient, transformers, authentication);
   }
 
-  public CompletableFuture<UserRecord> createUser(final CreateUserRequest request) {
-    return sendBrokerRequest(
+  public CompletableFuture<BrokerResponse<UserRecord>> createUser(final CreateUserRequest request) {
+    return sendBrokerRequestWithFullResponse(
         new BrokerUserCreateRequest()
             .setUsername(request.username())
             .setName(request.name())

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -15,7 +15,6 @@ import io.camunda.service.search.query.UserQuery;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.concurrent.CompletableFuture;
@@ -44,8 +43,8 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
     return new UserServices(brokerClient, searchClient, transformers, authentication);
   }
 
-  public CompletableFuture<BrokerResponse<UserRecord>> createUser(final CreateUserRequest request) {
-    return sendBrokerRequestWithFullResponse(
+  public CompletableFuture<UserRecord> createUser(final CreateUserRequest request) {
+    return sendBrokerRequest(
         new BrokerUserCreateRequest()
             .setUsername(request.username())
             .setName(request.name())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
@@ -88,7 +88,7 @@ public final class AuthorizationAddPermissionProcessor
   private static final class OwnerNotFoundException extends RuntimeException {
 
     public static final String OWNER_NOT_FOUND_MESSAGE =
-        "Expected to find owner with key: '%d', but not found";
+        "Expected to find owner with key: '%d', but none was found";
 
     public OwnerNotFoundException(final long ownerKey) {
       super(OWNER_NOT_FOUND_MESSAGE.formatted(ownerKey));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -97,6 +97,6 @@ public class AddPermissionAuthorizationTest {
         .describedAs("Owner is not found")
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to find owner with key: '%d', but not found".formatted(ownerKey));
+            "Expected to find owner with key: '%d', but none was found".formatted(ownerKey));
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1010,9 +1010,13 @@ paths:
               $ref: "#/components/schemas/UserRequest"
         required: true
       responses:
-        "204":
+        "202":
           description: |
             The user was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserCreateResponse"
         "400":
           description: |
             The user could not be created.
@@ -2075,6 +2079,12 @@ components:
           type: "string"
         email:
           type: "string"
+    UserCreateResponse:
+      type: "object"
+      properties:
+        userKey:
+          type: "integer"
+          format: "int64"
     UserSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2083,6 +2083,7 @@ components:
       type: "object"
       properties:
         userKey:
+          description: The key of the created user
           type: "integer"
           format: "int64"
     UserSearchQueryRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -259,10 +259,8 @@ public final class ResponseMapper {
     return new ResponseEntity<>(response, HttpStatus.OK);
   }
 
-  public static ResponseEntity<Object> toUserCreateResponse(
-      final BrokerResponse<UserRecord> brokerResponse) {
-    final var response =
-        new UserCreateResponse().userKey(brokerResponse.getResponse().getUserKey());
+  public static ResponseEntity<Object> toUserCreateResponse(final UserRecord userRecord) {
+    final var response = new UserCreateResponse().userKey(userRecord.getUserKey());
     return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.gateway.protocol.rest.MessageCorrelationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UserCreateResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -38,6 +39,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import java.util.Collections;
 import java.util.Iterator;
@@ -255,6 +257,13 @@ public final class ResponseMapper {
             .key(brokerResponse.getKey())
             .tenantId(brokerResponse.getResponse().getTenantId());
     return new ResponseEntity<>(response, HttpStatus.OK);
+  }
+
+  public static ResponseEntity<Object> toUserCreateResponse(
+      final BrokerResponse<UserRecord> brokerResponse) {
+    final var response =
+        new UserCreateResponse().userKey(brokerResponse.getResponse().getUserKey());
+    return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
   }
 
   static class RestJobActivationResult implements JobActivationResult<JobActivationResponse> {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -11,6 +11,7 @@ import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
@@ -42,8 +43,9 @@ public class UserController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> createUser(final CreateUserRequest request) {
-    return RequestMapper.executeServiceMethodWithNoContentResult(
+    return RequestMapper.executeServiceMethod(
         () ->
-            userServices.withAuthentication(RequestMapper.getAuthentication()).createUser(request));
+            userServices.withAuthentication(RequestMapper.getAuthentication()).createUser(request),
+        ResponseMapper::toUserCreateResponse);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -17,7 +17,6 @@ import io.camunda.service.CamundaServiceException;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.service.security.auth.Authentication;
-import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.usermanagement.UserController;
@@ -63,8 +62,7 @@ public class UserControllerTest extends RestControllerTest {
             .setEmail(dto.email())
             .setPassword(dto.password());
 
-    when(userServices.createUser(dto))
-        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(userRecord)));
+    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
 
     // when
     webClient

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.service.CamundaServiceException;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserServices.CreateUserRequest;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.usermanagement.UserController;
@@ -51,7 +52,7 @@ public class UserControllerTest extends RestControllerTest {
   }
 
   @Test
-  void createUserShouldReturnNoContent() {
+  void createUserShouldReturnAccepted() {
     // given
     final var dto = validCreateUserRequest();
 
@@ -62,7 +63,8 @@ public class UserControllerTest extends RestControllerTest {
             .setEmail(dto.email())
             .setPassword(dto.password());
 
-    when(userServices.createUser(dto)).thenReturn(CompletableFuture.completedFuture(userRecord));
+    when(userServices.createUser(dto))
+        .thenReturn(CompletableFuture.completedFuture(new BrokerResponse<>(userRecord)));
 
     // when
     webClient
@@ -73,7 +75,7 @@ public class UserControllerTest extends RestControllerTest {
         .bodyValue(dto)
         .exchange()
         .expectStatus()
-        .isNoContent();
+        .isAccepted();
 
     // then
     verify(userServices, times(1)).createUser(dto);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationCreateRequest.java
@@ -22,7 +22,7 @@ public class BrokerAuthorizationCreateRequest extends BrokerExecuteCommand<Autho
   private final AuthorizationRecord requestDto = new AuthorizationRecord();
 
   public BrokerAuthorizationCreateRequest() {
-    super(ValueType.AUTHORIZATION, AuthorizationIntent.CREATE);
+    super(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION);
   }
 
   public BrokerAuthorizationCreateRequest setOwnerKey(final Long ownerKey) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionAction;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class AddPermissionsTest {
+
+  ZeebeClient client;
+
+  @TestZeebe
+  final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  void init() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  void shouldAddPermissionsToOwner() {
+    // given
+    final long ownerKey = createUser();
+
+    // when
+    client
+        .newAddPermissionsCommand(ownerKey)
+        .resourceType(ResourceTypeEnum.DEPLOYMENT)
+        .permission(PermissionTypeEnum.CREATE)
+        .resourceId("resourceId")
+        .send()
+        .join();
+
+    // then
+    final var recordValue =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)
+            .withOwnerKey(ownerKey)
+            .limit(1)
+            .getFirst()
+            .getValue();
+    assertThat(recordValue.getAction()).isEqualTo(PermissionAction.ADD);
+    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);
+    assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
+    final var permission = recordValue.getPermissions().getFirst();
+    assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);
+    assertThat(permission.getResourceIds()).containsExactly("resourceId");
+  }
+
+  @Test
+  void shouldRejectWhenOwnerNotFound() {
+    // given
+    final var nonExistingOwnerKey = 1L;
+
+    // when
+    final var future =
+        client
+            .newAddPermissionsCommand(nonExistingOwnerKey)
+            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .permission(PermissionTypeEnum.CREATE)
+            .resourceId("resourceId")
+            .send();
+
+    // then
+    assertThatThrownBy(future::join)
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to find owner with key: '%d', but none was found"
+                .formatted(nonExistingOwnerKey));
+  }
+
+  private long createUser() {
+    return client
+        .newUserCreateCommand()
+        .username("foo")
+        .name("Foo Bar")
+        .email("bar@baz.com")
+        .password("zabraboof")
+        .send()
+        .join()
+        .getUserKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
@@ -39,16 +39,18 @@ class CreateUserTest {
   @Test
   void shouldCreateUser() {
     // when
-    client
-        .newUserCreateCommand()
-        .username("username")
-        .name("name")
-        .email("email@example.com")
-        .password("password")
-        .send()
-        .join();
+    final var response =
+        client
+            .newUserCreateCommand()
+            .username("username")
+            .name("name")
+            .email("email@example.com")
+            .password("password")
+            .send()
+            .join();
 
     // then
+    assertThat(response.getUserKey()).isGreaterThan(0);
     ZeebeAssertHelper.assertUserCreated(
         "username",
         (user) -> {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AuthorizationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/AuthorizationRecordStream.java
@@ -23,4 +23,8 @@ public class AuthorizationRecordStream
       final Stream<Record<AuthorizationRecordValue>> wrappedStream) {
     return new AuthorizationRecordStream(wrappedStream);
   }
+
+  public AuthorizationRecordStream withOwnerKey(final long ownerKey) {
+    return valueFilter(v -> v.getOwnerKey() == ownerKey);
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -443,6 +444,10 @@ public final class RecordingExporter implements Exporter {
   public static AuthorizationRecordStream authorizationRecords() {
     return new AuthorizationRecordStream(
         records(ValueType.AUTHORIZATION, AuthorizationRecordValue.class));
+  }
+
+  public static AuthorizationRecordStream authorizationRecords(final AuthorizationIntent intent) {
+    return authorizationRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds the possibility to add permissions to an authorization in the Java Client

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22147
