### PR TITLE
Fix automatic licensing in java client

### DIFF
--- a/.idea/scopes/apache_license_scope.xml
+++ b/.idea/scopes/apache_license_scope.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="apache-license-scope" pattern="file[camunda-client-java]:*/||file[zeebe-exporter-api]:*/||file[zeebe-protocol]:*/||file[zeebe-gateway-protocol-impl]:*/||file[zeebe-bpmn-model]:*/" />
+  <scope name="apache-license-scope" pattern="file[zeebe-client-java]:*/||file[zeebe-exporter-api]:*/||file[zeebe-protocol]:*/||file[zeebe-gateway-protocol-impl]:*/||file[zeebe-bpmn-model]:*/" />
 </component>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With the rename of the java client to camunda-java-client the automatic licensing was changed. This is not valid, as the
 module is still called zeebe-java-client. Because of this, creating a new class here adds an invalid license header.

Before this change the Camunda license was added:

```
/*
 * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
 * one or more contributor license agreements. See the NOTICE file distributed
 * with this work for additional information regarding copyright ownership.
 * Licensed under the Camunda License 1.0. You may not use this file
 * except in compliance with the Camunda License 1.0.
 */
```

After this change the Apache 2 license header is added:

```
/*
 * Copyright © 2017 camunda services GmbH (info@camunda.com)
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an "AS IS" BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

N/A
