### PR TITLE
fix: introduce timeout when waiting for backup snapshot to finish

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
@@ -11,12 +11,23 @@ public class BackupProperties {
 
   private String repositoryName;
 
+  private long snapshotTimeoutMillis = 0;
+
   public String getRepositoryName() {
     return repositoryName;
   }
 
-  public BackupProperties setRepositoryName(String repositoryName) {
+  public BackupProperties setRepositoryName(final String repositoryName) {
     this.repositoryName = repositoryName;
+    return this;
+  }
+
+  public long getSnapshotTimeoutMillis() {
+    return snapshotTimeoutMillis;
+  }
+
+  public BackupProperties setSnapshotTimeoutMillis(final long snapshotTimeoutMillis) {
+    this.snapshotTimeoutMillis = snapshotTimeoutMillis;
     return this;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
@@ -11,7 +11,7 @@ public class BackupProperties {
 
   private String repositoryName;
 
-  private long snapshotTimeoutMillis = 0;
+  private int snapshotTimeout = 0;
 
   public String getRepositoryName() {
     return repositoryName;
@@ -22,12 +22,12 @@ public class BackupProperties {
     return this;
   }
 
-  public long getSnapshotTimeoutMillis() {
-    return snapshotTimeoutMillis;
+  public int getSnapshotTimeout() {
+    return snapshotTimeout;
   }
 
-  public BackupProperties setSnapshotTimeoutMillis(final long snapshotTimeoutMillis) {
-    this.snapshotTimeoutMillis = snapshotTimeoutMillis;
+  public BackupProperties setSnapshotTimeout(final int snapshotTimeout) {
+    this.snapshotTimeout = snapshotTimeout;
     return this;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -15,7 +15,8 @@ import java.util.regex.Pattern;
 public class Metadata {
 
   public static final String SNAPSHOT_NAME_PREFIX = "camunda_operate_";
-  private static final String SNAPSHOT_NAME_PATTERN = "{prefix}{version}_part_{index}_of_{count}";
+  private static final String SNAPSHOT_NAME_PATTERN =
+      "{prefix}{version}_{prefix}{version}_part_{index}_of_{count}{index}_of_{count}";
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =
       Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");
@@ -25,12 +26,12 @@ public class Metadata {
   private Integer partNo;
   private Integer partCount;
 
-  public static String buildSnapshotNamePrefix(Long backupId) {
+  public static String buildSnapshotNamePrefix(final Long backupId) {
     return SNAPSHOT_NAME_PREFIX_PATTERN.replace("{backupId}", String.valueOf(backupId));
   }
 
   // backward compatibility with v. 8.1
-  public static Long extractBackupIdFromSnapshotName(String snapshotName) {
+  public static Long extractBackupIdFromSnapshotName(final String snapshotName) {
     final Matcher matcher = BACKUPID_PATTERN.matcher(snapshotName);
     if (matcher.matches()) {
       return Long.valueOf(matcher.group(1));
@@ -44,7 +45,7 @@ public class Metadata {
     return backupId;
   }
 
-  public Metadata setBackupId(Long backupId) {
+  public Metadata setBackupId(final Long backupId) {
     this.backupId = backupId;
     return this;
   }
@@ -53,7 +54,7 @@ public class Metadata {
     return version;
   }
 
-  public Metadata setVersion(String version) {
+  public Metadata setVersion(final String version) {
     this.version = version;
     return this;
   }
@@ -62,7 +63,7 @@ public class Metadata {
     return partNo;
   }
 
-  public Metadata setPartNo(Integer partNo) {
+  public Metadata setPartNo(final Integer partNo) {
     this.partNo = partNo;
     return this;
   }
@@ -71,7 +72,7 @@ public class Metadata {
     return partCount;
   }
 
-  public Metadata setPartCount(Integer partCount) {
+  public Metadata setPartCount(final Integer partCount) {
     this.partCount = partCount;
     return this;
   }
@@ -90,7 +91,7 @@ public class Metadata {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -7,8 +7,9 @@
  */
 package io.camunda.operate.webapp.elasticsearch.backup;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeast;
@@ -70,7 +71,7 @@ public class ElasticsearchBackupRepositoryTest {
     final boolean finished =
         backupRepository.waitForFinishedSnapshotWithTimeout(repositoryName, snapshotName);
 
-    assertThat(finished).isFalse();
+    assertFalse(finished);
     verify(backupRepository, atLeast(5)).findSnapshots(repositoryName, backupId);
   }
 
@@ -91,7 +92,7 @@ public class ElasticsearchBackupRepositoryTest {
     final boolean finished =
         backupRepository.waitForFinishedSnapshotWithTimeout(repositoryName, snapshotName);
 
-    assertThat(finished).isTrue();
+    assertTrue(finished);
     verify(backupRepository, times(3)).findSnapshots(repositoryName, backupId);
   }
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.elasticsearch.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.OperateProperties;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.SnapshotClient;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchBackupRepositoryTest {
+
+  private final String repositoryName = "repo1";
+  private final long backupId = 555;
+  private final String snapshotName = "camunda_operate_" + backupId + "_8.6_part_1_of_6";
+  @Mock private RestHighLevelClient esClient;
+  @Mock private SnapshotClient snapshotClient;
+  @Mock private ObjectMapper objectMapper;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private OperateProperties operateProperties;
+
+  @InjectMocks
+  private ElasticsearchBackupRepository backupRepository = spy(new ElasticsearchBackupRepository());
+
+  @Test
+  public void testWaitingForSnapshotWithTimeout() {
+    final long timeout = 1000L;
+    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
+
+    // mock calls to `findSnapshot` and `operateProperties`
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state()).thenReturn(snapshotState);
+    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+    when(operateProperties.getBackup().getSnapshotTimeoutMillis()).thenReturn(timeout);
+    doReturn(List.of(snapshotInfo)).when(backupRepository).findSnapshots(any(), any());
+
+    final boolean finished =
+        backupRepository.waitForFinishedSnapshotWithTimeout(repositoryName, snapshotName);
+
+    assertThat(finished).isFalse();
+    verify(backupRepository, atLeast(5)).findSnapshots(repositoryName, backupId);
+  }
+
+  @Test
+  public void testWaitingForSnapshotTillCompleted() {
+    final long timeout = 0L;
+
+    // mock calls to `findSnapshot` and `operateProperties`
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state())
+        .thenReturn(SnapshotState.IN_PROGRESS)
+        .thenReturn(SnapshotState.IN_PROGRESS)
+        .thenReturn(SnapshotState.SUCCESS);
+    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+    when(operateProperties.getBackup().getSnapshotTimeoutMillis()).thenReturn(timeout);
+    doReturn(List.of(snapshotInfo)).when(backupRepository).findSnapshots(any(), any());
+
+    final boolean finished =
+        backupRepository.waitForFinishedSnapshotWithTimeout(repositoryName, snapshotName);
+
+    assertThat(finished).isTrue();
+    verify(backupRepository, times(3)).findSnapshots(repositoryName, backupId);
+  }
+
+  @Test
+  public void testWaitingForSnapshotWithoutTimeout() {
+    final long timeout = 0L;
+    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
+
+    // mock calls to `findSnapshot` and `operateProperties`
+    final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class, RETURNS_DEEP_STUBS);
+    when(snapshotInfo.state()).thenReturn(snapshotState);
+    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+    when(operateProperties.getBackup().getSnapshotTimeoutMillis()).thenReturn(timeout);
+    doReturn(List.of(snapshotInfo)).when(backupRepository).findSnapshots(any(), any());
+
+    // we expect infinite loop, so we call snapshotting in separate thread
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final Future<?> future =
+        executor.submit(
+            () -> {
+              backupRepository.waitForFinishedSnapshotWithTimeout(repositoryName, snapshotName);
+            });
+
+    try {
+      // Set a timeout of 2 seconds for the function to complete
+      future.get(2, TimeUnit.SECONDS);
+    } catch (final TimeoutException e) {
+      // expected
+      return;
+    } catch (final InterruptedException | ExecutionException e) {
+      // ignore
+    } finally {
+      // Shutdown the executor
+      executor.shutdownNow();
+    }
+
+    fail("Expected to continue waiting for snapshotting to finish.");
+  }
+}


### PR DESCRIPTION
## Description

* introduce timeout when waiting for backup snapshot to finish
* add configuration parameter `camunda.operate.backup.snapshotTimeout` to set the timeout (default no timeout).

## Related issues

closes #18049 