### PR TITLE
feat: POC - centralized resource authorization for search services

### DIFF
--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -37,7 +37,7 @@ public class AuthorizationServices<T>
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, false);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -37,7 +37,7 @@ public final class DecisionDefinitionServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -33,7 +33,7 @@ public final class DecisionRequirementsServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -30,7 +30,7 @@ public class IncidentServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   public SearchQueryResult<IncidentEntity> search(

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -46,7 +46,7 @@ public final class ProcessInstanceServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -30,7 +30,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, false);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -40,7 +40,7 @@ public final class UserTaskServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -33,7 +33,7 @@ public final class VariableServices
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(brokerClient, searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication, true);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/entities/ProcessInstanceEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/ProcessInstanceEntity.java
@@ -8,6 +8,7 @@
 package io.camunda.service.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.service.security.auth.ResourceAuthorizationKey;
 import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -15,7 +16,7 @@ public record ProcessInstanceEntity(
     Long key,
     String processName,
     Integer processVersion,
-    String bpmnProcessId,
+    @ResourceAuthorizationKey(forResourceType = "process-definition") String bpmnProcessId,
     Long parentProcessInstanceKey,
     Long parentFlowNodeInstanceKey,
     String startDate,

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -24,13 +24,18 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
       final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
-      final Authentication authentication) {
+      final Authentication authentication,
+      final boolean withResourceAuthorization) {
     super(brokerClient, searchClient, transformers, authentication);
-    executor = initiateExecutor();
+    executor = initiateExecutor(withResourceAuthorization);
   }
 
-  private SearchClientBasedQueryExecutor initiateExecutor() {
-    return new SearchClientBasedQueryExecutor(searchClient, transformers, authentication);
+  private SearchClientBasedQueryExecutor initiateExecutor(final boolean withResourceAuthorization) {
+    var executor = new SearchClientBasedQueryExecutor(searchClient, transformers, authentication);
+    if (withResourceAuthorization) {
+      executor = executor.withResourceAuthorization();
+    }
+    return executor;
   }
 
   public abstract SearchQueryResult<D> search(final Q query);

--- a/service/src/main/java/io/camunda/service/security/auth/ResourceAuthorizationKey.java
+++ b/service/src/main/java/io/camunda/service/security/auth/ResourceAuthorizationKey.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.security.auth;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This annotation is used to mark fields that are subject to resource authorization checks.
+ *
+ * <p>Fields annotated with {@code @ResourceAuthorizationKey} indicate that they are involved in
+ * determining whether a user has the appropriate access rights for a specific resource type. These
+ * fields are used during the authorization filtering process, where the system checks if the
+ * authenticated user has permission to access the associated resource.
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * public record ProcessInstanceEntity(
+ *         Long key,
+ *         String processName,
+ *         Integer processVersion,
+ *         @ResourceAuthorizationKey(resourceType = "process-definition") String bpmnProcessId) {}
+ * }</pre>
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ResourceAuthorizationKey {
+
+  /**
+   * Defines the type of resource that this field represents for authorization purposes. This is
+   * used to match the resource type with the user's authorizations.
+   */
+  String forResourceType();
+}

--- a/service/src/main/java/io/camunda/service/security/auth/ResourceAuthorizationSearchChecker.java
+++ b/service/src/main/java/io/camunda/service/security/auth/ResourceAuthorizationSearchChecker.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.security.auth;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.service.search.query.SearchQueryBuilders.authorizationSearchQuery;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.service.entities.AuthorizationEntity;
+import io.camunda.service.search.core.SearchClientBasedQueryExecutor;
+import io.camunda.service.transformers.ServiceTransformers;
+import java.util.Arrays;
+import java.util.List;
+
+public class ResourceAuthorizationSearchChecker {
+
+  private final SearchClientBasedQueryExecutor searchExecutor;
+
+  public ResourceAuthorizationSearchChecker(
+      final CamundaSearchClient camundaSearchClient,
+      final ServiceTransformers serviceTransformers) {
+    searchExecutor =
+        new SearchClientBasedQueryExecutor(camundaSearchClient, serviceTransformers, null);
+  }
+
+  /**
+   * Creates a search query that checks the user's authorization for accessing the resource entity.
+   *
+   * <p>This method looks for fields in the resource entity class that are annotated with
+   * {@code @ResourceAuthorizationKey}. For each such field, it generates a query that ensures the
+   * authenticated user has permission to access the resource.
+   */
+  public SearchQuery getResourceAuthorizationCheck(
+      final Authentication authentication, final Class<?> resourceEntityClass) {
+    return Arrays.stream(resourceEntityClass.getFields())
+        .filter(field -> field.isAnnotationPresent(ResourceAuthorizationKey.class))
+        .map(
+            field ->
+                createResourceAuthorizationQuery(
+                    field.getAnnotation(ResourceAuthorizationKey.class),
+                    field.getName(),
+                    authentication.authenticatedUserId()))
+        .reduce(matchAll(), SearchQueryBuilders::and);
+  }
+
+  private SearchQuery createResourceAuthorizationQuery(
+      final ResourceAuthorizationKey resourceAuthorizationKey,
+      final String fieldName,
+      final String userId) {
+    final String resourceType = resourceAuthorizationKey.forResourceType();
+    final List<AuthorizationEntity> authorizations = getAuthorizationEntities(userId, resourceType);
+    final var authorizedResourceKeys =
+        authorizations.stream()
+            .map(AuthorizationEntity::value)
+            .map(AuthorizationEntity.Authorization::resourceKey)
+            .toList();
+    if (authorizedResourceKeys.isEmpty()) {
+      return matchNone();
+    }
+    if (authorizedResourceKeys.contains("*")) {
+      return matchAll();
+    }
+    return stringTerms(fieldName, authorizedResourceKeys);
+  }
+
+  private List<AuthorizationEntity> getAuthorizationEntities(
+      final String userId, final String resourceType) {
+    final var searchQuery =
+        authorizationSearchQuery(s -> s.filter(f -> f.ownerKey(userId).resourceType(resourceType)));
+    return searchExecutor.search(searchQuery, AuthorizationEntity.class).items();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This pull request introduces a centralized resource-based authorization filtering for entities search.

1.	`@ResourceAuthorizationKey` annotation:
  •	A new annotation used to mark fields in resource entity classes that are used by authorization filtering.
  •	The annotation includes a `forResourceType()` attribute used to match user authorizations.

Example
```java
public record ProcessInstanceEntity(
    Long key,
    String processName,
    Integer processVersion,
    String bpmnProcessId,
    @ResourceAuthorizationKey(forResourceType = "process-definition") String  String bpmnProcessId)
```

2.	`ResourceAuthorizationSearchChecker`:
  •	Search for fields annotated with `@ResourceAuthorizationKey` in the entity class.
  •	Constructs a search query to fetch the authorizations of the authenticated user for the resource type specified by the annotated fields.
  •	If no authorized resource keys are found, the checker generates `matchNone()` query.
  •	If the wildcard resource key "*" is found, the user is granted access to all resources `matchAll()`.
  •	Otherwise, a `stringTerms()` query is constructed to filter based on the resource key field.

`ResourceAuthorizationSearchChecker` is then called after building the main query, along with authentication query (tenants filter query)
`ResourceAuthorizationSearchChecker` can be enabled at service level (for example, it is disabled for Authorizations and Users search services)

This still miss checks over the permission `READ` or `CREATE` ... and also supports filtering on string keys only

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
