### PR TITLE
ci: include new gcp-perf-core-*-default runners to allowed labels (linter)

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -48,6 +48,10 @@ self-hosted-runner:
   - gcp-core-8-default
   - gcp-core-16-default
   - gcp-core-32-default
+  - gcp-perf-core-2-default
+  - gcp-perf-core-4-default
+  - gcp-perf-core-8-default
+  - gcp-perf-core-16-default
   # by Zeebe team, to be deprecated after https://github.com/camunda/camunda/issues/18212
   - amd64
   - '16'


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

This PR adds new runner labels (`gcp-perf-core-*`) to those authorized by the linter.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
