### PR TITLE
Do not update treePath on FNI completed or terminated

### DIFF
--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -19,26 +19,24 @@ package io.camunda.operate.zeebeimport.v8_4.processors;
 import static io.camunda.operate.zeebeimport.util.ImportUtil.tenantOrDefault;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 
+import io.camunda.operate.Metrics;
 import io.camunda.operate.entities.FlowNodeInstanceEntity;
-import io.camunda.operate.entities.FlowNodeState;
-import io.camunda.operate.entities.FlowNodeType;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.FlowNodeInstanceTemplate;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
-import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.zeebe.PartitionHolder;
-import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
 import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceTreePathCache;
+import io.camunda.operate.zeebeimport.cache.TreePathCacheMetricsImpl;
+import io.camunda.operate.zeebeimport.v8_4.processors.fni.FNITransformer;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,24 +54,26 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private static final Set<String> AI_FINISH_STATES =
       Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
   private static final Set<String> AI_START_STATES = Set.of(ELEMENT_ACTIVATING.name());
-  private final FlowNodeStore flowNodeStore;
   private final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
-
-  // treePath by flowNodeInstanceKey caches
-  private final FlowNodeInstanceTreePathCache treePathCache;
+  private final FNITransformer fniTransformer;
 
   public FlowNodeInstanceZeebeRecordProcessor(
       final FlowNodeStore flowNodeStore,
       final FlowNodeInstanceTemplate flowNodeInstanceTemplate,
       final OperateProperties operateProperties,
-      final PartitionHolder partitionHolder) {
-    this.flowNodeStore = flowNodeStore;
+      final PartitionHolder partitionHolder,
+      final Metrics metrics) {
     this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     final var flowNodeTreeCacheSize = operateProperties.getImporter().getFlowNodeTreeCacheSize();
     final var partitionIds = partitionHolder.getPartitionIds();
-    treePathCache =
+    // treePath by flowNodeInstanceKey caches
+    final FlowNodeInstanceTreePathCache treePathCache =
         new FlowNodeInstanceTreePathCache(
-            partitionIds, flowNodeTreeCacheSize, flowNodeStore::findParentTreePathFor);
+            partitionIds,
+            flowNodeTreeCacheSize,
+            flowNodeStore::findParentTreePathFor,
+            new TreePathCacheMetricsImpl(partitionIds, metrics));
+    fniTransformer = new FNITransformer(treePathCache::resolveTreePath);
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
@@ -117,7 +117,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       for (final Record<ProcessInstanceRecordValue> record : wiRecords) {
 
         if (shouldProcessProcessInstanceRecord(record)) {
-          fniEntity = updateFlowNodeInstance(record, fniEntity);
+          fniEntity = fniTransformer.toFlowNodeInstanceEntity(record, fniEntity);
         }
       }
       if (fniEntity != null) {
@@ -130,12 +130,16 @@ public class FlowNodeInstanceZeebeRecordProcessor {
           updateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, fniEntity.getPartitionId());
           updateFields.put(FlowNodeInstanceTemplate.TYPE, fniEntity.getType());
           updateFields.put(FlowNodeInstanceTemplate.STATE, fniEntity.getState());
-          updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, fniEntity.getTreePath());
           updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, fniEntity.getFlowNodeId());
           updateFields.put(
               FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, fniEntity.getProcessDefinitionKey());
           updateFields.put(FlowNodeInstanceTemplate.BPMN_PROCESS_ID, fniEntity.getBpmnProcessId());
-          updateFields.put(FlowNodeInstanceTemplate.LEVEL, fniEntity.getLevel());
+
+          if (fniEntity.getTreePath() != null) {
+            updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, fniEntity.getTreePath());
+            updateFields.put(FlowNodeInstanceTemplate.LEVEL, fniEntity.getLevel());
+          }
+
           if (fniEntity.getStartDate() != null) {
             updateFields.put(FlowNodeInstanceTemplate.START_DATE, fniEntity.getStartDate());
           }
@@ -163,66 +167,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
         && (AI_START_STATES.contains(intent)
             || AI_FINISH_STATES.contains(intent)
             || ELEMENT_MIGRATED.name().equals(intent));
-  }
-
-  private static FNITreePathCacheCompositeKey toCompositeKey(
-      final Record<?> record, final ProcessInstanceRecordValue recordValue) {
-    return new FNITreePathCacheCompositeKey(
-        record.getPartitionId(),
-        record.getKey(),
-        recordValue.getFlowScopeKey(),
-        recordValue.getProcessInstanceKey());
-  }
-
-  private FlowNodeInstanceEntity updateFlowNodeInstance(
-      final Record<ProcessInstanceRecordValue> record, FlowNodeInstanceEntity entity) {
-    if (entity == null) {
-      entity = new FlowNodeInstanceEntity();
-    }
-
-    final var recordValue = record.getValue();
-    final var intentStr = record.getIntent().name();
-
-    entity.setKey(record.getKey());
-    entity.setId(ConversionUtils.toStringOrNull(record.getKey()));
-    entity.setPartitionId(record.getPartitionId());
-    entity.setFlowNodeId(recordValue.getElementId());
-    entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
-    entity.setProcessDefinitionKey(recordValue.getProcessDefinitionKey());
-    entity.setBpmnProcessId(recordValue.getBpmnProcessId());
-    entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
-
-    if (entity.getTreePath() == null) {
-
-      final String parentTreePath =
-          treePathCache.resolveTreePath(toCompositeKey(record, recordValue));
-      entity.setTreePath(
-          String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
-      entity.setLevel(parentTreePath.split("/").length);
-    }
-
-    if (AI_FINISH_STATES.contains(intentStr)) {
-      if (intentStr.equals(ELEMENT_TERMINATED.name())) {
-        entity.setState(FlowNodeState.TERMINATED);
-      } else {
-        entity.setState(FlowNodeState.COMPLETED);
-      }
-      entity.setEndDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
-    } else {
-      entity.setState(FlowNodeState.ACTIVE);
-      if (AI_START_STATES.contains(intentStr)) {
-        entity.setStartDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
-        entity.setPosition(record.getPosition());
-      }
-    }
-
-    entity.setType(
-        FlowNodeType.fromZeebeBpmnElementType(
-            recordValue.getBpmnElementType() == null
-                ? null
-                : recordValue.getBpmnElementType().name()));
-
-    return entity;
   }
 
   private boolean canOptimizeFlowNodeInstanceIndexing(final FlowNodeInstanceEntity entity) {

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/fni/FNITransformer.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/fni/FNITransformer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.v8_4.processors.fni;
+
+import static io.camunda.operate.zeebeimport.util.ImportUtil.tenantOrDefault;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
+
+import io.camunda.operate.entities.FlowNodeInstanceEntity;
+import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.entities.FlowNodeType;
+import io.camunda.operate.util.ConversionUtils;
+import io.camunda.operate.util.DateUtil;
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.time.Instant;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Transfomer to transform a given Zeebe flow node instance record to a {@link
+ * FlowNodeInstanceEntity}.
+ */
+public class FNITransformer {
+
+  private static final Set<String> FINISH_STATES =
+      Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
+  private static final Set<String> START_STATES = Set.of(ELEMENT_ACTIVATING.name());
+  private final Function<FNITreePathCacheCompositeKey, String> treePathResolver;
+
+  public FNITransformer(final Function<FNITreePathCacheCompositeKey, String> treePathResolver) {
+    this.treePathResolver = treePathResolver;
+  }
+
+  private static FNITreePathCacheCompositeKey toCompositeKey(
+      final Record<?> record, final ProcessInstanceRecordValue recordValue) {
+    return new FNITreePathCacheCompositeKey(
+        record.getPartitionId(),
+        record.getKey(),
+        recordValue.getFlowScopeKey(),
+        recordValue.getProcessInstanceKey());
+  }
+
+  /**
+   * Transform the given Zeebe flow node instance record into a {@link FlowNodeInstanceEntity}.
+   *
+   * <p>If the given entity is not-null the entity will be updated/extended.
+   *
+   * @param record the Zeebe flow node instance record
+   * @param entity the entity which should be updated, if null a new entity is created
+   * @return the newly created or updated entity
+   */
+  public FlowNodeInstanceEntity toFlowNodeInstanceEntity(
+      final Record<ProcessInstanceRecordValue> record, FlowNodeInstanceEntity entity) {
+    if (entity == null) {
+      entity = new FlowNodeInstanceEntity();
+    }
+
+    final var recordValue = record.getValue();
+    final var intentStr = record.getIntent().name();
+
+    entity.setKey(record.getKey());
+    entity.setId(ConversionUtils.toStringOrNull(record.getKey()));
+    entity.setPartitionId(record.getPartitionId());
+    entity.setFlowNodeId(recordValue.getElementId());
+    entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
+    entity.setProcessDefinitionKey(recordValue.getProcessDefinitionKey());
+    entity.setBpmnProcessId(recordValue.getBpmnProcessId());
+    entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
+
+    if (FINISH_STATES.contains(intentStr)) {
+      if (intentStr.equals(ELEMENT_TERMINATED.name())) {
+        entity.setState(FlowNodeState.TERMINATED);
+      } else {
+        entity.setState(FlowNodeState.COMPLETED);
+      }
+      entity.setEndDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+    } else {
+      entity.setState(FlowNodeState.ACTIVE);
+      if (START_STATES.contains(intentStr)) {
+        entity.setStartDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+        entity.setPosition(record.getPosition());
+      }
+
+      // We resolve the treePath only when necessary, for example when not done earlier
+      // and when in an active state, for completed and terminated we expect the treePath
+      // already be resolved before so we skip this to reduce the load on our cache / backend
+      // storage
+      if (entity.getTreePath() == null) {
+        final String parentTreePath = treePathResolver.apply(toCompositeKey(record, recordValue));
+        entity.setTreePath(
+            String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
+        entity.setLevel(parentTreePath.split("/").length);
+      }
+    }
+
+    entity.setType(
+        FlowNodeType.fromZeebeBpmnElementType(
+            recordValue.getBpmnElementType() == null
+                ? null
+                : recordValue.getBpmnElementType().name()));
+
+    return entity;
+  }
+}

--- a/operate/importer-8_4/src/main/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
+++ b/operate/importer-8_4/src/main/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.processors.fni;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.FlowNodeInstanceEntity;
+import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.entities.FlowNodeType;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class FNITransformerTest {
+
+  private FNITransformer fniTransformer;
+
+  @BeforeEach
+  public void setup() {
+    fniTransformer =
+        new FNITransformer(
+            key -> String.format("%d/%d", key.processInstanceKey(), key.flowScopeKey()));
+  }
+
+  @Test
+  public void shouldTransformActivateFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createStartingZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
+    assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformMigratedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createMigratedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
+    assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+  }
+
+  @Test
+  public void shouldTransformCompletedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createCompletedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isNull();
+    assertThat(flowNodeInstanceEntity.getLevel()).isZero();
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.COMPLETED);
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformMultipleRecordsIntoEntity() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var activated = createStartingZeebeRecord(time);
+    var flowNodeInstanceEntity = fniTransformer.toFlowNodeInstanceEntity(activated, null);
+    final var completed = createCompletedZeebeRecord(time);
+
+    // when
+    flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(completed, flowNodeInstanceEntity);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.COMPLETED);
+    assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformTerminatedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createTerminatedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isNull();
+    assertThat(flowNodeInstanceEntity.getLevel()).isZero();
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.TERMINATED);
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  private static void assertGeneralValues(final FlowNodeInstanceEntity entity) {
+    assertThat(entity.getBpmnProcessId()).isEqualTo("process");
+    assertThat(entity.getFlowNodeId()).isEqualTo("element");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(123);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(1);
+    assertThat(entity.getKey()).isEqualTo(4L);
+    assertThat(entity.getTenantId()).isEqualTo("none");
+    assertThat(entity.getType()).isEqualTo(FlowNodeType.START_EVENT);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createStartingZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createMigratedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_MIGRATED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createCompletedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createTerminatedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createZeebeRecord(
+      final long timestamp, final ProcessInstanceIntent intent) {
+    final var recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnProcessId("process")
+            .withElementId("element")
+            .withTenantId("none")
+            .withProcessDefinitionKey(123)
+            .withBpmnElementType(BpmnElementType.START_EVENT)
+            .withFlowScopeKey(3)
+            .withProcessInstanceKey(1)
+            .withVersion(12)
+            .withBpmnEventType(BpmnEventType.NONE)
+            .build();
+    final var record = Mockito.mock(io.camunda.zeebe.protocol.record.Record.class);
+    when(record.getKey()).thenReturn(4L);
+    when(record.getValue()).thenReturn(recordValue);
+    when(record.getIntent()).thenReturn(intent);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getTimestamp()).thenReturn(timestamp);
+    return record;
+  }
+}

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -54,7 +54,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       LoggerFactory.getLogger(FlowNodeInstanceZeebeRecordProcessor.class);
   private static final Set<String> AI_START_STATES = Set.of(ELEMENT_ACTIVATING.name());
 
-  private final FlowNodeStore flowNodeStore;
   private final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   private final FNITransformer fniTransformer;
 
@@ -64,7 +63,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       final OperateProperties operateProperties,
       final PartitionHolder partitionHolder,
       final Metrics metrics) {
-    this.flowNodeStore = flowNodeStore;
     this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     final var flowNodeTreeCacheSize = operateProperties.getImporter().getFlowNodeTreeCacheSize();
     final var partitionIds = partitionHolder.getPartitionIds();

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -28,7 +28,6 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.zeebe.PartitionHolder;
-import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
 import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceTreePathCache;
 import io.camunda.operate.zeebeimport.cache.TreePathCacheMetricsImpl;
 import io.camunda.operate.zeebeimport.processors.fni.FNITransformer;
@@ -133,12 +132,15 @@ public class FlowNodeInstanceZeebeRecordProcessor {
           updateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, fniEntity.getPartitionId());
           updateFields.put(FlowNodeInstanceTemplate.TYPE, fniEntity.getType());
           updateFields.put(FlowNodeInstanceTemplate.STATE, fniEntity.getState());
-          updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, fniEntity.getTreePath());
           updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, fniEntity.getFlowNodeId());
           updateFields.put(
               FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, fniEntity.getProcessDefinitionKey());
           updateFields.put(FlowNodeInstanceTemplate.BPMN_PROCESS_ID, fniEntity.getBpmnProcessId());
-          updateFields.put(FlowNodeInstanceTemplate.LEVEL, fniEntity.getLevel());
+
+          if (fniEntity.getTreePath() != null) {
+            updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, fniEntity.getTreePath());
+            updateFields.put(FlowNodeInstanceTemplate.LEVEL, fniEntity.getLevel());
+          }
           if (fniEntity.getStartDate() != null) {
             updateFields.put(FlowNodeInstanceTemplate.START_DATE, fniEntity.getStartDate());
           }
@@ -166,15 +168,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
         && (AI_START_STATES.contains(intent)
             || AI_FINISH_STATES.contains(intent)
             || ELEMENT_MIGRATED.name().equals(intent));
-  }
-
-  private static FNITreePathCacheCompositeKey toCompositeKey(
-      final Record<?> record, final ProcessInstanceRecordValue recordValue) {
-    return new FNITreePathCacheCompositeKey(
-        record.getPartitionId(),
-        record.getKey(),
-        recordValue.getFlowScopeKey(),
-        recordValue.getProcessInstanceKey());
   }
 
   private boolean canOptimizeFlowNodeInstanceIndexing(final FlowNodeInstanceEntity entity) {

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformer.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformer.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.operate.zeebeimport.processors.fni;
+
+import static io.camunda.operate.zeebeimport.util.ImportUtil.tenantOrDefault;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
+
+import io.camunda.operate.entities.FlowNodeInstanceEntity;
+import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.entities.FlowNodeType;
+import io.camunda.operate.util.ConversionUtils;
+import io.camunda.operate.util.DateUtil;
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.time.Instant;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Transfomer to transform a given Zeebe flow node instance record to a {@link
+ * FlowNodeInstanceEntity}.
+ */
+public class FNITransformer {
+
+  private static final Set<String> FINISH_STATES =
+      Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
+  private static final Set<String> START_STATES = Set.of(ELEMENT_ACTIVATING.name());
+  private final Function<FNITreePathCacheCompositeKey, String> treePathResolver;
+
+  public FNITransformer(final Function<FNITreePathCacheCompositeKey, String> treePathResolver) {
+    this.treePathResolver = treePathResolver;
+  }
+
+  private static FNITreePathCacheCompositeKey toCompositeKey(
+      final Record<?> record, final ProcessInstanceRecordValue recordValue) {
+    return new FNITreePathCacheCompositeKey(
+        record.getPartitionId(),
+        record.getKey(),
+        recordValue.getFlowScopeKey(),
+        recordValue.getProcessInstanceKey());
+  }
+
+  /**
+   * Transform the given Zeebe flow node instance record into a {@link FlowNodeInstanceEntity}.
+   *
+   * <p>If the given entity is not-null the entity will be updated/extended.
+   *
+   * @param record the Zeebe flow node instance record
+   * @param entity the entity which should be updated, if null a new entity is created
+   * @return the newly created or updated entity
+   */
+  public FlowNodeInstanceEntity toFlowNodeInstanceEntity(
+      final Record<ProcessInstanceRecordValue> record, FlowNodeInstanceEntity entity) {
+    if (entity == null) {
+      entity = new FlowNodeInstanceEntity();
+    }
+
+    final var recordValue = record.getValue();
+    final var intentStr = record.getIntent().name();
+
+    entity.setKey(record.getKey());
+    entity.setId(ConversionUtils.toStringOrNull(record.getKey()));
+    entity.setPartitionId(record.getPartitionId());
+    entity.setFlowNodeId(recordValue.getElementId());
+    entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
+    entity.setProcessDefinitionKey(recordValue.getProcessDefinitionKey());
+    entity.setBpmnProcessId(recordValue.getBpmnProcessId());
+    entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
+
+    if (entity.getTreePath() == null) {
+      final String parentTreePath = treePathResolver.apply(toCompositeKey(record, recordValue));
+      entity.setTreePath(
+          String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
+      entity.setLevel(parentTreePath.split("/").length);
+    }
+
+    if (FINISH_STATES.contains(intentStr)) {
+      if (intentStr.equals(ELEMENT_TERMINATED.name())) {
+        entity.setState(FlowNodeState.TERMINATED);
+      } else {
+        entity.setState(FlowNodeState.COMPLETED);
+      }
+      entity.setEndDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+    } else {
+      entity.setState(FlowNodeState.ACTIVE);
+      if (START_STATES.contains(intentStr)) {
+        entity.setStartDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+        entity.setPosition(record.getPosition());
+      }
+    }
+
+    entity.setType(
+        FlowNodeType.fromZeebeBpmnElementType(
+            recordValue.getBpmnElementType() == null
+                ? null
+                : recordValue.getBpmnElementType().name()));
+
+    return entity;
+  }
+}

--- a/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
+++ b/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.operate.zeebeimport.processors.fni;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.FlowNodeInstanceEntity;
+import io.camunda.operate.entities.FlowNodeState;
+import io.camunda.operate.entities.FlowNodeType;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.protocol.record.value.ImmutableProcessInstanceRecordValue;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class FNITransformerTest {
+
+  private FNITransformer fniTransformer;
+
+  @BeforeEach
+  public void setup() {
+    fniTransformer =
+        new FNITransformer(
+            key -> String.format("%d/%d", key.processInstanceKey(), key.flowScopeKey()));
+  }
+
+  @Test
+  public void shouldTransformActivateFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createStartingZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
+    assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformMigratedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createMigratedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
+    assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+  }
+
+  @Test
+  public void shouldTransformCompletedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createCompletedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.COMPLETED);
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformTerminatedFNIRecord() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createTerminatedZeebeRecord(time);
+
+    // when
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.TERMINATED);
+    assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  private static void assertGeneralValues(final FlowNodeInstanceEntity entity) {
+    assertThat(entity.getBpmnProcessId()).isEqualTo("process");
+    assertThat(entity.getFlowNodeId()).isEqualTo("element");
+    assertThat(entity.getProcessDefinitionKey()).isEqualTo(123);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(1);
+    assertThat(entity.getLevel()).isEqualTo(2);
+    assertThat(entity.getKey()).isEqualTo(4L);
+    assertThat(entity.getTenantId()).isEqualTo("none");
+    assertThat(entity.getType()).isEqualTo(FlowNodeType.START_EVENT);
+    assertThat(entity.getTreePath()).isEqualTo("1/3/4");
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createStartingZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createMigratedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_MIGRATED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createCompletedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_COMPLETED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createTerminatedZeebeRecord(
+      final long timestamp) {
+    return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_TERMINATED);
+  }
+
+  private static io.camunda.zeebe.protocol.record.Record createZeebeRecord(
+      final long timestamp, final ProcessInstanceIntent intent) {
+    final var recordValue =
+        ImmutableProcessInstanceRecordValue.builder()
+            .withBpmnProcessId("process")
+            .withElementId("element")
+            .withTenantId("none")
+            .withProcessDefinitionKey(123)
+            .withBpmnElementType(BpmnElementType.START_EVENT)
+            .withFlowScopeKey(3)
+            .withProcessInstanceKey(1)
+            .withVersion(12)
+            .withBpmnEventType(BpmnEventType.NONE)
+            .build();
+    final var record = Mockito.mock(io.camunda.zeebe.protocol.record.Record.class);
+    when(record.getKey()).thenReturn(4L);
+    when(record.getValue()).thenReturn(recordValue);
+    when(record.getIntent()).thenReturn(intent);
+    when(record.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+    when(record.getRecordType()).thenReturn(RecordType.EVENT);
+    when(record.getTimestamp()).thenReturn(timestamp);
+    return record;
+  }
+}

--- a/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
+++ b/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
@@ -48,6 +48,8 @@ public class FNITransformerTest {
     // then
     assertThat(flowNodeInstanceEntity).isNotNull();
     assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
     assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
@@ -67,6 +69,8 @@ public class FNITransformerTest {
     // then
     assertThat(flowNodeInstanceEntity).isNotNull();
     assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
     assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
@@ -85,8 +89,34 @@ public class FNITransformerTest {
     // then
     assertThat(flowNodeInstanceEntity).isNotNull();
     assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isNull();
+    assertThat(flowNodeInstanceEntity.getLevel()).isZero();
     assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.COMPLETED);
     assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
+    assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldTransformMultipleRecordsIntoEntity() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var activated = createStartingZeebeRecord(time);
+    var flowNodeInstanceEntity = fniTransformer.toFlowNodeInstanceEntity(activated, null);
+    final var completed = createCompletedZeebeRecord(time);
+
+    // when
+    flowNodeInstanceEntity =
+        fniTransformer.toFlowNodeInstanceEntity(completed, flowNodeInstanceEntity);
+
+    // then
+    assertThat(flowNodeInstanceEntity).isNotNull();
+    assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isEqualTo("1/3/4");
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(2);
+    assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.COMPLETED);
+    assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
+        .isEqualTo(Instant.ofEpochMilli(time));
     assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
         .isEqualTo(Instant.ofEpochMilli(time));
   }
@@ -104,6 +134,8 @@ public class FNITransformerTest {
     // then
     assertThat(flowNodeInstanceEntity).isNotNull();
     assertGeneralValues(flowNodeInstanceEntity);
+    assertThat(flowNodeInstanceEntity.getTreePath()).isNull();
+    assertThat(flowNodeInstanceEntity.getLevel()).isZero();
     assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.TERMINATED);
     assertThat(flowNodeInstanceEntity.getStartDate()).isNull();
     assertThat(flowNodeInstanceEntity.getEndDate().toInstant())
@@ -115,11 +147,9 @@ public class FNITransformerTest {
     assertThat(entity.getFlowNodeId()).isEqualTo("element");
     assertThat(entity.getProcessDefinitionKey()).isEqualTo(123);
     assertThat(entity.getProcessInstanceKey()).isEqualTo(1);
-    assertThat(entity.getLevel()).isEqualTo(2);
     assertThat(entity.getKey()).isEqualTo(4L);
     assertThat(entity.getTenantId()).isEqualTo("none");
     assertThat(entity.getType()).isEqualTo(FlowNodeType.START_EVENT);
-    assertThat(entity.getTreePath()).isEqualTo("1/3/4");
   }
 
   private static io.camunda.zeebe.protocol.record.Record createStartingZeebeRecord(


### PR DESCRIPTION
## Description

To reduce the load on our cache and respectively our backend (ES or OS) we do not resolve the treePath on COMPLETED nor TERMINATED. Furthermore, we do no update the property in the index, as we expect it to be set earlier. 

This not resolving of the treePath is especially interesting when Operate has been restarted, the cache is empty and we are importing an COMPLETED event. This can happen in cases where instances are long-living. See related comment https://github.com/camunda/camunda/issues/22075#issuecomment-2338272792

### What the PR does

First, we had to extract the logic to transform a Zeebe flow node instance record
to an Operate Flow node instance entity into a separate class.

This encapsulates the transformation's logic and improves
maintainability and testability.

As a second step the bug has been fixed, that when FNI is in state COMPLETED or TERMINATED, we do not need to resolve nor update the treePath. With skipping this step we can reduce
the load on ES/OS.


## Related issues

closes #22075 
