### PR TITLE
Do not store leaf FNI in treePath Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*/.idea
 .idea/*
 !.idea/codeStyles
 !.idea/externalDependencies.xml

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -73,7 +73,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             flowNodeTreeCacheSize,
             flowNodeStore::findParentTreePathFor,
             new TreePathCacheMetricsImpl(partitionIds, metrics));
-    fniTransformer = new FNITransformer(treePathCache::resolveTreePath);
+    fniTransformer = new FNITransformer(treePathCache);
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)

--- a/operate/importer-8_4/src/main/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerCacheTreePathTest.java
+++ b/operate/importer-8_4/src/main/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerCacheTreePathTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.processors.fni;
+
+import static io.camunda.operate.zeebeimport.processors.fni.FNITransformerTest.createZeebeRecord;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.operate.zeebeimport.cache.TreePathCache;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mockito;
+
+public class FNITransformerCacheTreePathTest {
+
+  private FNITransformer fniTransformer;
+  private TreePathCache mockTreePathCache;
+
+  @BeforeEach
+  public void setup() {
+    mockTreePathCache = Mockito.mock(TreePathCache.class);
+    when(mockTreePathCache.resolveParentTreePath(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final FNITreePathCacheCompositeKey compositeKey = invocationOnMock.getArgument(0);
+              return String.format(
+                  "%d/%d", compositeKey.processInstanceKey(), compositeKey.flowScopeKey());
+            });
+    fniTransformer = new FNITransformer(mockTreePathCache);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BpmnElementType.class,
+      names = {"SUB_PROCESS", "PROCESS", "EVENT_SUB_PROCESS", "MULTI_INSTANCE_BODY"},
+      mode = Mode.INCLUDE)
+  void shouldCacheContainerFNI(final BpmnElementType elementType) {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record =
+        createZeebeRecord(time, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementType);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(1)).cacheTreePath(any(), eq("1/3/4"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BpmnElementType.class,
+      names = {"SUB_PROCESS", "PROCESS", "EVENT_SUB_PROCESS", "MULTI_INSTANCE_BODY"},
+      mode = Mode.EXCLUDE)
+  void shouldNotCacheNonContainerFNI(final BpmnElementType elementType) {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record =
+        createZeebeRecord(time, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementType);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(0)).cacheTreePath(any(), any());
+  }
+}

--- a/operate/importer-8_5/pom.xml
+++ b/operate/importer-8_5/pom.xml
@@ -96,6 +96,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -73,7 +73,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             flowNodeTreeCacheSize,
             flowNodeStore::findParentTreePathFor,
             new TreePathCacheMetricsImpl(partitionIds, metrics));
-    fniTransformer = new FNITransformer(treePathCache::resolveTreePath);
+    fniTransformer = new FNITransformer(treePathCache);
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformer.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformer.java
@@ -1,9 +1,18 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 package io.camunda.operate.zeebeimport.processors.fni;
 
@@ -18,14 +27,15 @@ import io.camunda.operate.entities.FlowNodeType;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.operate.zeebeimport.cache.TreePathCache;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import java.time.Instant;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
- * Transfomer to transform a given Zeebe flow node instance record to a {@link
+ * Transformer to transform a given Zeebe flow node instance record to a {@link
  * FlowNodeInstanceEntity}.
  */
 public class FNITransformer {
@@ -33,10 +43,17 @@ public class FNITransformer {
   private static final Set<String> FINISH_STATES =
       Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
   private static final Set<String> START_STATES = Set.of(ELEMENT_ACTIVATING.name());
-  private final Function<FNITreePathCacheCompositeKey, String> treePathResolver;
 
-  public FNITransformer(final Function<FNITreePathCacheCompositeKey, String> treePathResolver) {
-    this.treePathResolver = treePathResolver;
+  private static final Set<BpmnElementType> CONTAINER_TYPES =
+      Set.of(
+          BpmnElementType.SUB_PROCESS,
+          BpmnElementType.EVENT_SUB_PROCESS,
+          BpmnElementType.MULTI_INSTANCE_BODY,
+          BpmnElementType.PROCESS);
+  private final TreePathCache treePathCache;
+
+  public FNITransformer(final TreePathCache treePathCache) {
+    this.treePathCache = treePathCache;
   }
 
   private static FNITreePathCacheCompositeKey toCompositeKey(
@@ -94,10 +111,19 @@ public class FNITransformer {
       // already be resolved before so we skip this to reduce the load on our cache / backend
       // storage
       if (entity.getTreePath() == null) {
-        final String parentTreePath = treePathResolver.apply(toCompositeKey(record, recordValue));
-        entity.setTreePath(
-            String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
+        final FNITreePathCacheCompositeKey compositeKey = toCompositeKey(record, recordValue);
+        final String parentTreePath = treePathCache.resolveParentTreePath(compositeKey);
+
+        final String treePath =
+            String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey()));
+        entity.setTreePath(treePath);
         entity.setLevel(parentTreePath.split("/").length);
+
+        // We cache only treePath's of container types to reduce way too many evictions
+        // when storing leafs, which are never requested
+        if (CONTAINER_TYPES.contains(recordValue.getBpmnElementType())) {
+          treePathCache.cacheTreePath(compositeKey, treePath);
+        }
       }
     }
 

--- a/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerCacheTreePathTest.java
+++ b/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerCacheTreePathTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.processors.fni;
+
+import static io.camunda.operate.zeebeimport.processors.fni.FNITransformerTest.createZeebeRecord;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.operate.zeebeimport.cache.TreePathCache;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mockito;
+
+public class FNITransformerCacheTreePathTest {
+
+  private FNITransformer fniTransformer;
+  private TreePathCache mockTreePathCache;
+
+  @BeforeEach
+  public void setup() {
+    mockTreePathCache = Mockito.mock(TreePathCache.class);
+    when(mockTreePathCache.resolveParentTreePath(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final FNITreePathCacheCompositeKey compositeKey = invocationOnMock.getArgument(0);
+              return String.format(
+                  "%d/%d", compositeKey.processInstanceKey(), compositeKey.flowScopeKey());
+            });
+    fniTransformer = new FNITransformer(mockTreePathCache);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BpmnElementType.class,
+      names = {"SUB_PROCESS", "PROCESS", "EVENT_SUB_PROCESS", "MULTI_INSTANCE_BODY"},
+      mode = Mode.INCLUDE)
+  void shouldCacheContainerFNI(final BpmnElementType elementType) {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record =
+        createZeebeRecord(time, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementType);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(1)).cacheTreePath(any(), eq("1/3/4"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BpmnElementType.class,
+      names = {"SUB_PROCESS", "PROCESS", "EVENT_SUB_PROCESS", "MULTI_INSTANCE_BODY"},
+      mode = Mode.EXCLUDE)
+  void shouldNotCacheNonContainerFNI(final BpmnElementType elementType) {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record =
+        createZeebeRecord(time, ProcessInstanceIntent.ELEMENT_ACTIVATING, elementType);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(0)).cacheTreePath(any(), any());
+  }
+}

--- a/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
+++ b/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/processors/fni/FNITransformerTest.java
@@ -1,18 +1,31 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Zeebe Community License 1.1. You may not use this file
- * except in compliance with the Zeebe Community License 1.1.
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 package io.camunda.operate.zeebeimport.processors.fni;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.entities.FlowNodeInstanceEntity;
 import io.camunda.operate.entities.FlowNodeState;
 import io.camunda.operate.entities.FlowNodeType;
+import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
+import io.camunda.operate.zeebeimport.cache.TreePathCache;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -27,12 +40,19 @@ import org.mockito.Mockito;
 public class FNITransformerTest {
 
   private FNITransformer fniTransformer;
+  private TreePathCache mockTreePathCache;
 
   @BeforeEach
   public void setup() {
-    fniTransformer =
-        new FNITransformer(
-            key -> String.format("%d/%d", key.processInstanceKey(), key.flowScopeKey()));
+    mockTreePathCache = Mockito.mock(TreePathCache.class);
+    when(mockTreePathCache.resolveParentTreePath(any()))
+        .thenAnswer(
+            invocationOnMock -> {
+              final FNITreePathCacheCompositeKey compositeKey = invocationOnMock.getArgument(0);
+              return String.format(
+                  "%d/%d", compositeKey.processInstanceKey(), compositeKey.flowScopeKey());
+            });
+    fniTransformer = new FNITransformer(mockTreePathCache);
   }
 
   @Test
@@ -54,6 +74,32 @@ public class FNITransformerTest {
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getStartDate().toInstant())
         .isEqualTo(Instant.ofEpochMilli(time));
+  }
+
+  @Test
+  public void shouldNotCacheLeafFNI() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createStartingZeebeRecord(time);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(0)).cacheTreePath(any(), any());
+  }
+
+  @Test
+  public void shouldCacheContainerFNI() {
+    // given
+    final var time = System.currentTimeMillis();
+    final var record = createStartingZeebeRecord(time);
+
+    // when
+    fniTransformer.toFlowNodeInstanceEntity(record, null);
+
+    // then
+    Mockito.verify(mockTreePathCache, times(0)).cacheTreePath(any(), any());
   }
 
   @Test
@@ -172,15 +218,22 @@ public class FNITransformerTest {
     return createZeebeRecord(timestamp, ProcessInstanceIntent.ELEMENT_TERMINATED);
   }
 
-  private static io.camunda.zeebe.protocol.record.Record createZeebeRecord(
+  protected static io.camunda.zeebe.protocol.record.Record createZeebeRecord(
       final long timestamp, final ProcessInstanceIntent intent) {
+    return createZeebeRecord(timestamp, intent, BpmnElementType.START_EVENT);
+  }
+
+  protected static io.camunda.zeebe.protocol.record.Record createZeebeRecord(
+      final long timestamp,
+      final ProcessInstanceIntent intent,
+      final BpmnElementType bpmnElementType) {
     final var recordValue =
         ImmutableProcessInstanceRecordValue.builder()
             .withBpmnProcessId("process")
             .withElementId("element")
             .withTenantId("none")
             .withProcessDefinitionKey(123)
-            .withBpmnElementType(BpmnElementType.START_EVENT)
+            .withBpmnElementType(bpmnElementType)
             .withFlowScopeKey(3)
             .withProcessInstanceKey(1)
             .withVersion(12)

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCache.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCache.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+public interface TreePathCache {
+
+  /**
+   * Resolve the parent treePath for the given {@link FNITreePathCacheCompositeKey}, which contains
+   * information to the corresponding flow node instance.
+   *
+   * <p>When the flow scope and process instance key are equal, the PI key is returned as treePath,
+   * as it corresponds to a FNI on root level.
+   *
+   * <p>When the cache doesn't contain (as it might be evicted) the parent treePath for a given flow
+   * node instance, the implementation should be able to resolve it somehow else.
+   *
+   * <p>If the treePath can't be resolved the process instance key should be returned.
+   *
+   * @param compositeKey a composite key that contains information used to resolve the parent tree
+   *     path for the flow node instance
+   * @return the parent treePath of the flow node instance
+   * @throws IllegalArgumentException when the flow node instance record doesn't correspond to a
+   *     supported partition
+   */
+  String resolveParentTreePath(final FNITreePathCacheCompositeKey compositeKey);
+
+  /**
+   * Cache the treePath together with the given key part of the {@link
+   * FNITreePathCacheCompositeKey}.
+   *
+   * <p>Used for flow node instances that are a container element, like process, sub-process, event
+   * sub-process, etc. This allows to resolve the treePath as parent treePath later on corresponding
+   * children's.
+   *
+   * @param compositeKey a composite key that contains information of flow node instance
+   * @param treePath the treePath of the flow node instance
+   */
+  void cacheTreePath(FNITreePathCacheCompositeKey compositeKey, String treePath);
+}

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCacheTest.java
@@ -48,7 +48,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
 
     // when
-    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+    final String treePath = treePathCache.resolveParentTreePath(flowNodeInstanceRecord);
 
     // then
     assertThat(treePath).isEqualTo(Long.toString(0xABCD));
@@ -57,45 +57,44 @@ public class FlowNodeInstanceTreePathCacheTest {
   }
 
   @Test
-  public void shouldResolveTreePathFromPreviousRecord() {
+  public void shouldResolveParentTreePathFromPreviousRecordWhenCached() {
     // given
     // root fni are added to the cache
     final var rootFlowNodeInstanceRecord =
         new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
-    final String firstTreePath = treePathCache.resolveTreePath(rootFlowNodeInstanceRecord);
+    final String treePath = String.join("/", Long.toString(0xABCD), Long.toString(0xCAFE));
+    treePathCache.cacheTreePath(rootFlowNodeInstanceRecord, treePath);
 
     final var leafFlowNodeInstanceRecord =
         new FNITreePathCacheCompositeKey(1, 0xFACE, 0xCAFE, 0xABCD);
 
     // when
     // fni with flow scope key of previous root FNI
-    final String secondTreePath = treePathCache.resolveTreePath(leafFlowNodeInstanceRecord);
+    final String secondTreePath = treePathCache.resolveParentTreePath(leafFlowNodeInstanceRecord);
 
     // then cache should resolve without using the resolver
-    assertThat(secondTreePath)
-        .contains(firstTreePath)
-        .isEqualTo(String.join("/", Long.toString(0xABCD), Long.toString(0xCAFE)));
+    assertThat(secondTreePath).isEqualTo(treePath);
 
     Mockito.verifyNoInteractions(spyTreePathResolver);
   }
 
   @Test
-  public void shouldTryToResolve() {
+  public void shouldReturnProcessInstanceWhenNothingCachedAndStored() {
     // given
     // resolver can't resolve value - returned tree Path is equal to process instance key
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when
-    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+    final String parentTreePath = treePathCache.resolveParentTreePath(flowNodeInstanceRecord);
 
     // then
-    assertThat(treePath).isEqualTo(Long.toString(0xEFDA));
+    assertThat(parentTreePath).isEqualTo(Long.toString(0xEFDA));
 
     Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
   }
 
   @Test
-  public void shouldResolveTreePath() {
+  public void shouldResolveParentTreePathViaResolver() {
     // given
     // resolver can resolve tree path
     final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
@@ -103,7 +102,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when
-    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+    final String treePath = treePathCache.resolveParentTreePath(flowNodeInstanceRecord);
 
     // then
     assertThat(treePath).isEqualTo(expectedTreePath);
@@ -115,13 +114,13 @@ public class FlowNodeInstanceTreePathCacheTest {
   public void shouldNotResolveTreePathTwice() {
     // given
     // cache is empty and resolver can resolve tree path
-    final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
+    final String expectedTreePath = String.join("/", Long.toString(0xEFDA), Long.toString(0xABCD));
     spyTreePathResolver.put(0xABCDL, expectedTreePath);
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
-    final String firstTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+    final String firstTreePath = treePathCache.resolveParentTreePath(flowNodeInstanceRecord);
 
     // when
-    final String secondTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+    final String secondTreePath = treePathCache.resolveParentTreePath(flowNodeInstanceRecord);
 
     // then
     assertThat(firstTreePath).isEqualTo(secondTreePath).isEqualTo(expectedTreePath);
@@ -136,7 +135,7 @@ public class FlowNodeInstanceTreePathCacheTest {
     final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(3, 0xCAFE, 0xABCD, 0xEFDA);
 
     // when - then
-    assertThatThrownBy(() -> treePathCache.resolveTreePath(flowNodeInstanceRecord))
+    assertThatThrownBy(() -> treePathCache.resolveParentTreePath(flowNodeInstanceRecord))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Expected to find treePath cache for partitionId 3, but found nothing. Possible partition Ids are: '[1, 2]'.");


### PR DESCRIPTION
## PR Description

Be aware that this PR bases on changes from https://github.com/camunda/camunda/pull/22215


**Problem description:**

We want to reduce the load on the cache and unnecessarily evictions of important values.

> * We use the tree path cache only to select tree path values of parent flow node instances. Accordingly, we should only cache values for flow node instances that can have child instances (process, sub process, event sub process, multi-instance body)
> * The current implementation puts unnecessarily many values into the tree path cache, leading to higher memory consumption and earlier eviction of values that are important to be cached


### What the PR contains

 * Introduces a new interface for TreePathCache
 * Extract storing of treePath as separate method of the cache
   * give control to outside when to cache treePath and corresponding key 
 * Adjust FNI transformer such that the treePath is only cached for container FNIs
   * This change should allow to reduce load on the cache and potential evictions
 * Add several different tests related to that


## Related issues

closes https://github.com/camunda/camunda/issues/22076
