### PR TITLE
ci: use zeebe snapshot image for operate e2e tests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -50,7 +50,7 @@ jobs:
           - 9200:9200
           - 9300:9300
       zeebe:
-        image: camunda/zeebe:8.5.7
+        image: camunda/zeebe:SNAPSHOT
         env:
           JAVA_TOOL_OPTIONS: "-Xms512m -Xmx512m"
           ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/operate/client/e2e-playwright/tests/processes.mocks.ts
+++ b/operate/client/e2e-playwright/tests/processes.mocks.ts
@@ -11,11 +11,12 @@ import {zeebeGrpcApi} from '../api/zeebe-grpc';
 const {deployProcesses, createSingleInstance} = zeebeGrpcApi;
 
 const setup = async () => {
-  await deployProcesses(['orderProcess_v_1.bpmn']);
+  const deployResponse = await deployProcesses(['orderProcess_v_1.bpmn']);
+  const deployedProcess = deployResponse.deployments[0]?.process;
 
   const instanceWithoutAnIncident = await createSingleInstance(
     'orderProcess',
-    1,
+    deployedProcess!.version,
   );
 
   await deployProcesses(['processWithAnIncident.bpmn']);
@@ -29,7 +30,12 @@ const setup = async () => {
 
   const instanceToCancel = await createSingleInstance('processToDelete', 1);
 
-  return {instanceWithoutAnIncident, instanceWithAnIncident, instanceToCancel};
+  return {
+    deployedProcess,
+    instanceWithoutAnIncident,
+    instanceWithAnIncident,
+    instanceToCancel,
+  };
 };
 
 export {setup};

--- a/operate/client/e2e-playwright/tests/processes.spec.ts
+++ b/operate/client/e2e-playwright/tests/processes.spec.ts
@@ -149,17 +149,17 @@ test.describe('Processes', () => {
     page,
   }) => {
     const instance = initialData.instanceWithoutAnIncident;
+    const version = initialData.deployedProcess!.version.toString();
 
-    await filtersPanel.displayOptionalFilter('Process Instance Key(s)');
-
-    // Filter by Process Instance Key
-    await filtersPanel.processInstanceKeysFilter.fill(
-      instance.processInstanceKey,
-    );
-
-    await expect(page.getByTestId('diagram')).not.toBeInViewport();
-
-    await filtersPanel.selectProcess('Order process');
+    processesPage.navigateToProcesses({
+      searchParams: {
+        active: 'true',
+        incidents: 'true',
+        ids: instance.processInstanceKey,
+        process: instance.bpmnProcessId,
+        version,
+      },
+    });
 
     // Select "Ship Articles" flow node
     const shipArticlesTaskId = 'shipArticles';
@@ -178,7 +178,7 @@ test.describe('Processes', () => {
         incidents: 'true',
         ids: instance.processInstanceKey,
         process: 'orderProcess',
-        version: '1',
+        version,
         flowNodeId: shipArticlesTaskId,
       })}`,
     );
@@ -202,7 +202,7 @@ test.describe('Processes', () => {
         incidents: 'true',
         ids: instance.processInstanceKey,
         process: 'orderProcess',
-        version: '1',
+        version,
         flowNodeId: checkPaymentTaskId,
       })}`,
     );


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR changes the image version of zeebe for Operate E2E tests. Instead of the latest version (which is the latest patch version of the previous minor), we need to use an up-to-date zeebe to be able to run tests for most recent features.

Note: This is just a short-term solution. In the future we should build the single jar instead of using a zeebe docker image.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
