### PR TITLE
fix: use operate-incident-8.3.0_alias index name

### DIFF
--- a/service/src/main/java/io/camunda/service/transformers/filter/IncidentFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/IncidentFilterTransformer.java
@@ -57,7 +57,7 @@ public class IncidentFilterTransformer implements FilterTransformer<IncidentFilt
 
   @Override
   public List<String> toIndices(final IncidentFilter filter) {
-    return List.of("operate-incident-8.3.0_alias");
+    return List.of("operate-incident-8.3.1_alias");
   }
 
   private SearchQuery getHasActiveOperationQuery(final boolean hasActiveOperation) {


### PR DESCRIPTION
## Description

* Search was failing due to wrong index name. Should we make it configurable?
* Fix wrong incident index alias name

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
