### PR TITLE
Add request handlers for cluster scale request for scaling brokers and partitions

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.management.cluster.Error;
 import java.util.List;
@@ -145,8 +145,8 @@ public class ClusterEndpoint {
       final boolean force,
       final Optional<Integer> replicationFactor) {
     try {
-      final ScaleRequest scaleRequest =
-          new ScaleRequest(
+      final BrokerScaleRequest scaleRequest =
+          new BrokerScaleRequest(
               ids.stream().map(String::valueOf).map(MemberId::from).collect(Collectors.toSet()),
               replicationFactor,
               dryRun);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationCoordinatorSupplier.java
@@ -10,12 +10,15 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import java.util.Collection;
+import java.util.Set;
 import java.util.function.Supplier;
 
 public interface ClusterConfigurationCoordinatorSupplier {
   MemberId getDefaultCoordinator();
 
   MemberId getNextCoordinator(Collection<MemberId> members);
+
+  MemberId getNextCoordinatorExcluding(Set<MemberId> memberIds);
 
   class ClusterClusterConfigurationAwareCoordinatorSupplier
       implements ClusterConfigurationCoordinatorSupplier {
@@ -43,6 +46,13 @@ public interface ClusterConfigurationCoordinatorSupplier {
     @Override
     public MemberId getNextCoordinator(final Collection<MemberId> members) {
       return lowestMemberId(members);
+    }
+
+    @Override
+    public MemberId getNextCoordinatorExcluding(final Set<MemberId> memberIds) {
+      final var currentMembers = clusterTopologySupplier.get().members().keySet();
+      final var newMembers = currentMembers.stream().filter(m -> !memberIds.contains(m)).toList();
+      return lowestMemberId(newMembers);
     }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -8,13 +8,13 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ScaleRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 
@@ -35,7 +35,7 @@ public interface ClusterConfigurationManagementApi {
   ActorFuture<ClusterConfigurationChangeResponse> reassignPartitions(
       ReassignPartitionsRequest reassignPartitionsRequest);
 
-  ActorFuture<ClusterConfigurationChangeResponse> scaleMembers(ScaleRequest scaleRequest);
+  ActorFuture<ClusterConfigurationChangeResponse> scaleMembers(BrokerScaleRequest scaleRequest);
 
   /**
    * Forces a scale down of the cluster. The members that are not specified in the request will be
@@ -45,7 +45,7 @@ public interface ClusterConfigurationManagementApi {
    * <p>This is expected to be used to force remove a set of brokers when they are unreachable.
    */
   ActorFuture<ClusterConfigurationChangeResponse> forceScaleDown(
-      ScaleRequest forceScaleDownRequest);
+      BrokerScaleRequest forceScaleDownRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -9,8 +9,11 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -46,6 +49,15 @@ public interface ClusterConfigurationManagementApi {
    */
   ActorFuture<ClusterConfigurationChangeResponse> forceScaleDown(
       BrokerScaleRequest forceScaleDownRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> scaleCluster(
+      ClusterScaleRequest clusterScaleRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
+      ClusterPatchRequest clusterPatchRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
+      ForceRemoveBrokersRequest forceRemoveBrokersRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -35,9 +35,10 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record ScaleRequest(Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)
+  record BrokerScaleRequest(
+      Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)
       implements ClusterConfigurationManagementRequest {
-    public ScaleRequest(final Set<MemberId> members, final boolean dryRun) {
+    public BrokerScaleRequest(final Set<MemberId> members, final boolean dryRun) {
       this(members, Optional.empty(), dryRun);
     }
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -137,6 +138,18 @@ public final class ClusterConfigurationManagementRequestSender {
         serializer::encodeClusterPatchRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      forceRemoveBrokers(final ForceRemoveBrokersRequest forceRemoveBrokersRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.FORCE_REMOVE_BROKERS.topic(),
+        forceRemoveBrokersRequest,
+        serializer::encodeForceRemoveBrokersRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getNextCoordinatorExcluding(
+            forceRemoveBrokersRequest.membersToRemove()),
         TIMEOUT);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -9,13 +9,13 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ScaleRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -95,7 +95,7 @@ public final class ClusterConfigurationManagementRequestSender {
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> scaleMembers(
-      final ScaleRequest scaleRequest) {
+      final BrokerScaleRequest scaleRequest) {
     return communicationService.send(
         ClusterConfigurationRequestTopics.SCALE_MEMBERS.topic(),
         scaleRequest,
@@ -106,7 +106,7 @@ public final class ClusterConfigurationManagementRequestSender {
   }
 
   public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
-      forceScaleDown(final ScaleRequest forceScaleDownRequest) {
+      forceScaleDown(final BrokerScaleRequest forceScaleDownRequest) {
     return communicationService.send(
         ClusterConfigurationRequestTopics.FORCE_SCALE_DOWN.topic(),
         forceScaleDownRequest,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
@@ -113,6 +115,28 @@ public final class ClusterConfigurationManagementRequestSender {
         serializer::encodeScaleRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getNextCoordinator(forceScaleDownRequest.members()),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> scaleCluster(
+      final ClusterScaleRequest clusterScaleRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.SCALE_CLUSTER.topic(),
+        clusterScaleRequest,
+        serializer::encodeClusterScaleRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> patchCluster(
+      final ClusterPatchRequest clusterPatchRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.PATCH_CLUSTER.topic(),
+        clusterPatchRequest,
+        serializer::encodeClusterPatchRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -16,7 +17,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
@@ -102,7 +102,7 @@ public final class ClusterConfigurationManagementRequestsHandler
 
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> scaleMembers(
-      final ScaleRequest scaleRequest) {
+      final BrokerScaleRequest scaleRequest) {
     return handleRequest(
         scaleRequest.dryRun(),
         new ScaleRequestTransformer(scaleRequest.members(), scaleRequest.newReplicationFactor()));
@@ -110,7 +110,7 @@ public final class ClusterConfigurationManagementRequestsHandler
 
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> forceScaleDown(
-      final ScaleRequest forceScaleDownRequest) {
+      final BrokerScaleRequest forceScaleDownRequest) {
     final Optional<Integer> optionalNewReplicationFactor =
         forceScaleDownRequest.newReplicationFactor();
     if (optionalNewReplicationFactor.isPresent()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -11,8 +11,11 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -126,6 +129,38 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         forceScaleDownRequest.dryRun(),
         new ForceScaleDownRequestTransformer(forceScaleDownRequest.members(), localMemberId));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> scaleCluster(
+      final ClusterScaleRequest clusterScaleRequest) {
+    return handleRequest(
+        clusterScaleRequest.dryRun(),
+        new ClusterScaleRequestTransformer(
+            clusterScaleRequest.newClusterSize(),
+            clusterScaleRequest.newPartitionCount(),
+            clusterScaleRequest.newReplicationFactor()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
+      final ClusterPatchRequest clusterPatchRequest) {
+    return handleRequest(
+        clusterPatchRequest.dryRun(),
+        new ClusterPatchRequestTransformer(
+            clusterPatchRequest.membersToAdd(),
+            clusterPatchRequest.membersToRemove(),
+            clusterPatchRequest.newPartitionCount(),
+            clusterPatchRequest.newReplicationFactor()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
+      final ForceRemoveBrokersRequest forceRemoveBrokersRequest) {
+    return handleRequest(
+        forceRemoveBrokersRequest.dryRun(),
+        new ForceRemoveBrokersRequestTransformer(
+            forceRemoveBrokersRequest.membersToRemove(), localMemberId));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -46,6 +46,9 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerForceScaleDownHandler();
     registerDisableExporterHandler();
     registerEnableExporterHandler();
+    registerClusterScaleRequestHandler();
+    registerClusterPatchRequestHandler();
+    registerForceRemoveBrokersRequestHandler();
   }
 
   @Override
@@ -158,6 +161,30 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.ENABLE_EXPORTER.topic(),
         serializer::decodeExporterEnableRequest,
         request -> mapResponse(clusterConfigurationManagementApi.enableExporter(request)),
+        this::encodeResponse);
+  }
+
+  private void registerForceRemoveBrokersRequestHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.FORCE_REMOVE_BROKERS.topic(),
+        serializer::decodeForceRemoveBrokersRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.forceRemoveBrokers(request)),
+        this::encodeResponse);
+  }
+
+  private void registerClusterPatchRequestHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.PATCH_CLUSTER.topic(),
+        serializer::decodeClusterPatchRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.patchCluster(request)),
+        this::encodeResponse);
+  }
+
+  private void registerClusterScaleRequestHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.SCALE_CLUSTER.topic(),
+        serializer::decodeClusterScaleRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.scaleCluster(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -18,7 +18,12 @@ public enum ClusterConfigurationRequestTopics {
   CANCEL_CHANGE("topology-change-cancel"),
   FORCE_SCALE_DOWN("topology-force-scale-down"),
   DISABLE_EXPORTER("topology-exporter-disable"),
-  ENABLE_EXPORTER("topology-exporter-enable");
+  ENABLE_EXPORTER("topology-exporter-enable"),
+
+  SCALE_CLUSTER("topology-cluster-scale"),
+  PATCH_CLUSTER("topology-cluster-patch"),
+  FORCE_REMOVE_BROKERS("topology-broker-force-remove");
+
   private final String topic;
 
   ClusterConfigurationRequestTopics(final String topic) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.serializer;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -27,7 +28,7 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeReassignPartitionsRequest(
       ClusterConfigurationManagementRequest.ReassignPartitionsRequest reassignPartitionsRequest);
 
-  byte[] encodeScaleRequest(ClusterConfigurationManagementRequest.ScaleRequest scaleRequest);
+  byte[] encodeScaleRequest(BrokerScaleRequest scaleRequest);
 
   byte[] encodeCancelChangeRequest(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);
@@ -53,7 +54,7 @@ public interface ClusterConfigurationRequestsSerializer {
   ClusterConfigurationManagementRequest.ReassignPartitionsRequest decodeReassignPartitionsRequest(
       byte[] encodedState);
 
-  ClusterConfigurationManagementRequest.ScaleRequest decodeScaleRequest(byte[] encodedState);
+  BrokerScaleRequest decodeScaleRequest(byte[] encodedState);
 
   ClusterConfigurationManagementRequest.CancelChangeRequest decodeCancelChangeRequest(
       byte[] encodedState);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -39,6 +39,15 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeExporterEnableRequest(
       ClusterConfigurationManagementRequest.ExporterEnableRequest exporterEnableRequest);
 
+  byte[] encodeClusterScaleRequest(
+      ClusterConfigurationManagementRequest.ClusterScaleRequest clusterScaleRequest);
+
+  byte[] encodeClusterPatchRequest(
+      ClusterConfigurationManagementRequest.ClusterPatchRequest clusterPatchRequest);
+
+  byte[] encodeForceRemoveBrokersRequest(
+      ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest forceRemoveBrokersRequest);
+
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
 
@@ -63,6 +72,15 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedRequest);
 
   ClusterConfigurationManagementRequest.ExporterEnableRequest decodeExporterEnableRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.ClusterScaleRequest decodeClusterScaleRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.ClusterPatchRequest decodeClusterPatchRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest decodeForceRemoveBrokersRequest(
       byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -14,8 +14,11 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -682,6 +685,44 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeClusterScaleRequest(final ClusterScaleRequest clusterScaleRequest) {
+    final var builder =
+        Requests.ClusterScaleRequest.newBuilder().setDryRun(clusterScaleRequest.dryRun());
+
+    clusterScaleRequest.newClusterSize().ifPresent(builder::setNewClusterSize);
+    clusterScaleRequest.newReplicationFactor().ifPresent(builder::setNewReplicationFactor);
+    clusterScaleRequest.newPartitionCount().ifPresent(builder::setNewPartitionCount);
+
+    return builder.build().toByteArray();
+  }
+
+  @Override
+  public byte[] encodeClusterPatchRequest(final ClusterPatchRequest clusterPatchRequest) {
+    final var builder =
+        Requests.ClusterPatchRequest.newBuilder().setDryRun(clusterPatchRequest.dryRun());
+
+    clusterPatchRequest.newPartitionCount().ifPresent(builder::setNewPartitionCount);
+    clusterPatchRequest.newReplicationFactor().ifPresent(builder::setNewReplicationFactor);
+    clusterPatchRequest.membersToAdd().stream()
+        .forEach(memberId -> builder.addMembersToAdd(memberId.id()));
+    clusterPatchRequest.membersToRemove().stream()
+        .forEach(memberId -> builder.addMembersToRemove(memberId.id()));
+
+    return builder.build().toByteArray();
+  }
+
+  @Override
+  public byte[] encodeForceRemoveBrokersRequest(
+      final ForceRemoveBrokersRequest forceRemoveBrokersRequest) {
+    return Requests.ForceRemoveBrokersRequest.newBuilder()
+        .addAllMembersToRemove(
+            forceRemoveBrokersRequest.membersToRemove().stream().map(MemberId::id).toList())
+        .setDryRun(forceRemoveBrokersRequest.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -799,6 +840,71 @@ public class ProtoBufSerializer
               : Optional.empty();
       return new ExporterEnableRequest(
           exporterEnableRequest.getExporterId(), initializeFrom, exporterEnableRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public ClusterScaleRequest decodeClusterScaleRequest(final byte[] encodedRequest) {
+    try {
+      final var clusterScaleRequest = Requests.ClusterScaleRequest.parseFrom(encodedRequest);
+      final Optional<Integer> newClusterSize =
+          clusterScaleRequest.hasNewClusterSize()
+              ? Optional.of(clusterScaleRequest.getNewClusterSize())
+              : Optional.empty();
+      final Optional<Integer> newReplicationFactor =
+          clusterScaleRequest.hasNewReplicationFactor()
+              ? Optional.of(clusterScaleRequest.getNewReplicationFactor())
+              : Optional.empty();
+      final Optional<Integer> newPartitionCount =
+          clusterScaleRequest.hasNewPartitionCount()
+              ? Optional.of(clusterScaleRequest.getNewPartitionCount())
+              : Optional.empty();
+      return new ClusterScaleRequest(
+          newClusterSize, newPartitionCount, newReplicationFactor, clusterScaleRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public ClusterPatchRequest decodeClusterPatchRequest(final byte[] encodedRequest) {
+    try {
+      final var clusterPatchRequest = Requests.ClusterPatchRequest.parseFrom(encodedRequest);
+      final Optional<Integer> newPartitionCount =
+          clusterPatchRequest.hasNewPartitionCount()
+              ? Optional.of(clusterPatchRequest.getNewPartitionCount())
+              : Optional.empty();
+      final Optional<Integer> newReplicationFactor =
+          clusterPatchRequest.hasNewReplicationFactor()
+              ? Optional.of(clusterPatchRequest.getNewReplicationFactor())
+              : Optional.empty();
+      return new ClusterPatchRequest(
+          clusterPatchRequest.getMembersToAddList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()),
+          clusterPatchRequest.getMembersToRemoveList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()),
+          newPartitionCount,
+          newReplicationFactor,
+          clusterPatchRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public ForceRemoveBrokersRequest decodeForceRemoveBrokersRequest(final byte[] encodedRequest) {
+    try {
+      final var forceRemoveBrokersRequest =
+          Requests.ForceRemoveBrokersRequest.parseFrom(encodedRequest);
+      return new ForceRemoveBrokersRequest(
+          forceRemoveBrokersRequest.getMembersToRemoveList().stream()
+              .map(MemberId::from)
+              .collect(Collectors.toSet()),
+          forceRemoveBrokersRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -12,6 +12,7 @@ import com.google.protobuf.Timestamp;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
@@ -19,7 +20,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossipState;
 import io.camunda.zeebe.dynamic.config.protocol.Requests;
@@ -641,9 +641,9 @@ public class ProtoBufSerializer
   }
 
   @Override
-  public byte[] encodeScaleRequest(final ScaleRequest scaleRequest) {
+  public byte[] encodeScaleRequest(final BrokerScaleRequest scaleRequest) {
     final var builder =
-        Requests.ScaleRequest.newBuilder()
+        Requests.BrokerScaleRequest.newBuilder()
             .addAllMemberIds(scaleRequest.members().stream().map(MemberId::id).toList())
             .setDryRun(scaleRequest.dryRun());
 
@@ -752,14 +752,14 @@ public class ProtoBufSerializer
   }
 
   @Override
-  public ScaleRequest decodeScaleRequest(final byte[] encodedState) {
+  public BrokerScaleRequest decodeScaleRequest(final byte[] encodedState) {
     try {
-      final var scaleRequest = Requests.ScaleRequest.parseFrom(encodedState);
+      final var scaleRequest = Requests.BrokerScaleRequest.parseFrom(encodedState);
       final Optional<Integer> newReplicationFactor =
           scaleRequest.hasNewReplicationFactor()
               ? Optional.of(scaleRequest.getNewReplicationFactor())
               : Optional.empty();
-      return new ScaleRequest(
+      return new BrokerScaleRequest(
           scaleRequest.getMemberIdsList().stream().map(MemberId::from).collect(Collectors.toSet()),
           newReplicationFactor,
           scaleRequest.getDryRun());

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -34,6 +34,26 @@ message BrokerScaleRequest {
   optional uint32 newReplicationFactor = 3;
 }
 
+message ClusterScaleRequest {
+  optional uint32 newClusterSize = 1;
+  optional uint32 newPartitionCount = 2;
+  optional uint32 newReplicationFactor = 3;
+  bool dryRun = 4;
+}
+
+message ClusterPatchRequest {
+  repeated string membersToAdd = 1;
+  repeated string membersToRemove = 2;
+  optional uint32 newPartitionCount = 3;
+  optional uint32 newReplicationFactor = 4;
+  bool dryRun = 5;
+}
+
+message ForceRemoveBrokersRequest {
+  repeated string membersToRemove = 1;
+  bool dryRun = 2;
+}
+
 message ReassignAllPartitionsRequest {
   // The ids of the brokers to which all partitions should be re-distributed
   repeated string memberIds = 1;

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -28,7 +28,7 @@ message LeavePartitionRequest {
   bool dryRun = 3;
 }
 
-message ScaleRequest {
+message BrokerScaleRequest {
   repeated string memberIds = 1;
   bool dryRun = 2;
   optional uint32 newReplicationFactor = 3;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.Node;
 import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
 import io.atomix.cluster.impl.DiscoveryMembershipProtocol;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier.ClusterClusterConfigurationAwareCoordinatorSupplier;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -216,8 +217,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldScaleBrokers() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(Set.of(id0, id1), false);
+    final var request = new BrokerScaleRequest(Set.of(id0, id1), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
@@ -239,9 +239,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldScaleBrokersWithNewReplicationFactor() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(
-            Set.of(id0, id1), Optional.of(2), false);
+    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(2), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
@@ -265,9 +263,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldRejectScaleRequestWithInvalidReplicationFactor() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(
-            Set.of(id0, id1), Optional.of(0), false);
+    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(0), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
@@ -289,9 +285,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldReduceReplicationFactorWithoutScalingDown() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(
-            Set.of(id0, id1), Optional.of(1), false);
+    final var request = new BrokerScaleRequest(Set.of(id0, id1), Optional.of(1), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
@@ -317,8 +311,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldForceScaleDown() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(Set.of(id0, id2), false);
+    final var request = new BrokerScaleRequest(Set.of(id0, id2), false);
     final ClusterConfiguration currentTopology =
         ClusterConfiguration.init()
             .addMember(id0, MemberState.initializeAsActive(Map.of()))
@@ -394,9 +387,7 @@ final class ClusterConfigurationManagementApiTest {
   @Test
   void shouldReturnInvalidErrorForInvalidRequests() {
     // given
-    final var request =
-        new ClusterConfigurationManagementRequest.ScaleRequest(
-            Set.of(), false); // invalid request when no brokers
+    final var request = new BrokerScaleRequest(Set.of(), false); // invalid request when no brokers
     recordingCoordinator.setCurrentTopology(initialTopology);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -12,8 +12,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -128,6 +131,54 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeExporterEnableRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(exporterEnableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeClusterScaleRequest() {
+    // given
+    final var clusterScaleRequest =
+        new ClusterScaleRequest(Optional.of(3), Optional.of(15), Optional.of(4), true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterScaleRequest(clusterScaleRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterScaleRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(clusterScaleRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeClusterPatchRequest() {
+    // given
+    final var clusterPatchRequest =
+        new ClusterPatchRequest(
+            Set.of(MemberId.from("6"), MemberId.from("7")),
+            Set.of(MemberId.from("4"), MemberId.from("5")),
+            Optional.of(10),
+            Optional.of(4),
+            true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodeClusterPatchRequest(clusterPatchRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeClusterPatchRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(clusterPatchRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeForceRemoveBrokersRequest() {
+    // given
+    final var forceRemoveBrokersRequest =
+        new ForceRemoveBrokersRequest(Set.of(MemberId.from("6"), MemberId.from("7")), true);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeForceRemoveBrokersRequest(forceRemoveBrokersRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeForceRemoveBrokersRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(forceRemoveBrokersRequest);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds the request handlers and client sender for 
* ClusterPatchRequest that can change cluster configuration by providing a set of members to add or remove
* ClusterScaleRequest that can change cluster configuration by providing a new cluster size
* ForceRemoveBroker that can force remove the given set of brokers.

On the gateway endpoint, we will have just one request exposed to the client. The gateway will map it to one of these three request based on the provided input. Alternative was to define one request in the protobuf and let `ClusterConfigurationManagementRequestsHandler` map it. However, this felt unnecessary as this way we can define the user facing endpoint independent of the internal implementation. 

The tests verifies the integration of the API client and server. The test covering different combinations of the input are already covered by the unit tests for the corresponding request transformers.

## Related issues

closes #21482
