### PR TITLE
feat: Define task listeners in zeebe `bpmn` model module

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -235,6 +235,8 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeScriptImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeSubscriptionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskHeadersImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskListenerImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskListenersImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskScheduleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskImpl;
@@ -666,6 +668,8 @@ public class Bpmn {
     ZeebeUserTaskImpl.registerType(bpmnModelBuilder);
     ZeebeExecutionListenersImpl.registerType(bpmnModelBuilder);
     ZeebeExecutionListenerImpl.registerType(bpmnModelBuilder);
+    ZeebeTaskListenersImpl.registerType(bpmnModelBuilder);
+    ZeebeTaskListenerImpl.registerType(bpmnModelBuilder);
     ZeebePriorityDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeVersionTagImpl.registerType(bpmnModelBuilder);
   }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -27,9 +27,12 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -214,5 +217,20 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
     header.setValue(value);
 
     return myself;
+  }
+
+  public B zeebeTaskListener(final Consumer<TaskListenerBuilder> taskListenerBuilderConsumer) {
+    final ZeebeTaskListener listener = createTaskListenerElement();
+    listener.setRetries(ZeebeTaskListener.DEFAULT_RETRIES);
+
+    final TaskListenerBuilder builder = new TaskListenerBuilder(listener, myself);
+    taskListenerBuilderConsumer.accept(builder);
+    return myself;
+  }
+
+  private ZeebeTaskListener createTaskListenerElement() {
+    final ZeebeTaskListeners taskListeners =
+        myself.getCreateSingleExtensionElement(ZeebeTaskListeners.class);
+    return myself.createChild(taskListeners, ZeebeTaskListener.class);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/TaskListenerBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/TaskListenerBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+
+public class TaskListenerBuilder {
+
+  private final ZeebeTaskListener element;
+  private final AbstractBaseElementBuilder<?, ?> elementBuilder;
+
+  protected TaskListenerBuilder(
+      final ZeebeTaskListener element, final AbstractBaseElementBuilder<?, ?> elementBuilder) {
+    this.element = element;
+    this.elementBuilder = elementBuilder;
+  }
+
+  public TaskListenerBuilder eventType(final ZeebeTaskListenerEventType eventType) {
+    element.setEventType(eventType);
+    return this;
+  }
+
+  public TaskListenerBuilder create() {
+    return eventType(ZeebeTaskListenerEventType.create);
+  }
+
+  public TaskListenerBuilder update() {
+    return eventType(ZeebeTaskListenerEventType.update);
+  }
+
+  public TaskListenerBuilder assignment() {
+    return eventType(ZeebeTaskListenerEventType.assignment);
+  }
+
+  public TaskListenerBuilder complete() {
+    return eventType(ZeebeTaskListenerEventType.complete);
+  }
+
+  public TaskListenerBuilder cancel() {
+    return eventType(ZeebeTaskListenerEventType.cancel);
+  }
+
+  public TaskListenerBuilder type(final String type) {
+    element.setType(type);
+    return this;
+  }
+
+  public TaskListenerBuilder typeExpression(final String typeExpression) {
+    return type(elementBuilder.asZeebeExpression(typeExpression));
+  }
+
+  public TaskListenerBuilder retries(final String retries) {
+    element.setRetries(retries);
+    return this;
+  }
+
+  public TaskListenerBuilder retriesExpression(final String retriesExpression) {
+    return retries(elementBuilder.asZeebeExpression(retriesExpression));
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -97,6 +97,8 @@ public class ZeebeConstants {
 
   public static final String ELEMENT_EXECUTION_LISTENERS = "executionListeners";
   public static final String ELEMENT_EXECUTION_LISTENER = "executionListener";
+  public static final String ELEMENT_TASK_LISTENERS = "taskListeners";
+  public static final String ELEMENT_TASK_LISTENER = "taskListener";
 
   public static final String ELEMENT_VERSION_TAG = "versionTag";
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskListenerImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskListenerImpl.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeTaskListenerImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeTaskListener {
+
+  protected static Attribute<ZeebeTaskListenerEventType> eventTypeAttribute;
+  protected static Attribute<String> typeAttribute;
+  protected static Attribute<String> retriesAttribute;
+
+  public ZeebeTaskListenerImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public ZeebeTaskListenerEventType getEventType() {
+    return eventTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setEventType(final ZeebeTaskListenerEventType eventType) {
+    eventTypeAttribute.setValue(this, eventType);
+  }
+
+  @Override
+  public String getType() {
+    return typeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setType(final String type) {
+    typeAttribute.setValue(this, type);
+  }
+
+  @Override
+  public String getRetries() {
+    return retriesAttribute.getValue(this);
+  }
+
+  @Override
+  public void setRetries(final String retries) {
+    retriesAttribute.setValue(this, retries);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeTaskListener.class, ZeebeConstants.ELEMENT_TASK_LISTENER)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeTaskListenerImpl::new);
+
+    eventTypeAttribute =
+        typeBuilder
+            .enumAttribute(ZeebeConstants.ATTRIBUTE_EVENT_TYPE, ZeebeTaskListenerEventType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_TYPE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    retriesAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_RETRIES)
+            .defaultValue(ZeebeTaskListener.DEFAULT_RETRIES)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskListenersImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeTaskListenersImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListeners;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.child.ChildElementCollection;
+
+public class ZeebeTaskListenersImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeTaskListeners {
+
+  protected static ChildElementCollection<ZeebeTaskListener> taskListenersCollection;
+
+  public ZeebeTaskListenersImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public Collection<ZeebeTaskListener> getTaskListeners() {
+    return taskListenersCollection.get(this);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeTaskListeners.class, ZeebeConstants.ELEMENT_TASK_LISTENERS)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeTaskListenersImpl::new);
+
+    taskListenersCollection =
+        typeBuilder.sequence().elementCollection(ZeebeTaskListener.class).build();
+
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListener.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeTaskListener extends BpmnModelElementInstance {
+
+  String DEFAULT_RETRIES = "3";
+
+  ZeebeTaskListenerEventType getEventType();
+
+  void setEventType(ZeebeTaskListenerEventType eventType);
+
+  String getType();
+
+  void setType(String type);
+
+  String getRetries();
+
+  void setRetries(String retries);
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+/**
+ * Represents the various event types for `task listeners` in a BPMN workflow. Task listeners allow
+ * users to execute custom logic during specific lifecycle events of a user task in a process.
+ *
+ * <ul>
+ *   <li>{@code create} - Triggered when the user task is created.
+ *   <li>{@code assignment} - Triggered when the user task is assigned/claimed or unassigned.
+ *   <li>{@code update} - Triggered when the user task details are updated.
+ *   <li>{@code complete} - Triggered when the user task is completed.
+ *   <li>{@code cancel} - Triggered when the user task is canceled.
+ * </ul>
+ */
+public enum ZeebeTaskListenerEventType {
+  create,
+  assignment,
+  update,
+  complete,
+  cancel
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListeners.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListeners.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import java.util.Collection;
+
+public interface ZeebeTaskListeners extends BpmnModelElementInstance {
+
+  Collection<ZeebeTaskListener> getTaskListeners();
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeSubscription;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -95,6 +96,12 @@ public final class ZeebeDesignTimeValidators {
             .hasNonEmptyAttribute(
                 ZeebeExecutionListener::getRetries, ZeebeConstants.ATTRIBUTE_RETRIES));
     validators.add(new ExecutionListenersValidator());
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebeTaskListener.class)
+            .hasNonEmptyEnumAttribute(
+                ZeebeTaskListener::getEventType, ZeebeConstants.ATTRIBUTE_EVENT_TYPE)
+            .hasNonEmptyAttribute(ZeebeTaskListener::getType, ZeebeConstants.ATTRIBUTE_TYPE)
+            .hasNonEmptyAttribute(ZeebeTaskListener::getRetries, ZeebeConstants.ATTRIBUTE_RETRIES));
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeSubscription.class)
             .hasNonEmptyAttribute(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import java.io.ByteArrayInputStream;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Test;
+
+public class ZeebeTaskListenerTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "eventType", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "type", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "retries", false, false, "3"));
+  }
+
+  @Test
+  public void shouldThrowExceptionForInvalidTaskListenerEventType() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .userTask(
+                "my_user_task",
+                t ->
+                    t.zeebeUserTask().zeebeTaskListener(l -> l.cancel().type("rejection_listener")))
+            .endEvent()
+            .done();
+
+    final String modelXml =
+        Bpmn.convertToString(modelInstance)
+            .replace("eventType=\"cancel\"", "eventType=\"rejection\"");
+
+    // when
+    final ZeebeTaskListeners taskListeners =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .<UserTask>getModelElementById("my_user_task")
+            .getSingleExtensionElement(ZeebeTaskListeners.class);
+
+    // then
+    final Optional<ZeebeTaskListener> first = taskListeners.getTaskListeners().stream().findFirst();
+
+    assertThat(first).isPresent();
+    assertThatThrownBy(() -> first.get().getEventType())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "No enum constant io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType.rejection");
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener.DEFAULT_RETRIES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.Test;
+
+public class ZeebeTaskListenersTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Arrays.asList(
+        new ChildElementAssumption(BpmnModelConstants.ZEEBE_NS, ZeebeTaskListener.class));
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Test
+  public void shouldReadTaskListenerElements() {
+    // given
+    modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "my_user_task",
+                t ->
+                    t.zeebeUserTask()
+                        .zeebeTaskListener(l -> l.create().type("create_listener").retries("2"))
+                        .zeebeTaskListener(l -> l.update().type("update_listener"))
+                        .zeebeTaskListener(l -> l.update().type("update_listener_2").retries("33"))
+                        .zeebeTaskListener(
+                            l -> l.assignment().type("assignment_listener").retries("4"))
+                        .zeebeTaskListener(l -> l.complete().type("complete_listener").retries("5"))
+                        .zeebeTaskListener(l -> l.cancel().type("cancel_listener").retries("6")))
+            .endEvent()
+            .done();
+
+    final ModelElementInstance userTask = modelInstance.getModelElementById("my_user_task");
+
+    // when
+    final Collection<ZeebeTaskListener> taskListeners = getTaskListeners(userTask);
+
+    // then
+    assertThat(taskListeners)
+        .extracting("eventType", "type", "retries")
+        .containsExactly(
+            tuple(ZeebeTaskListenerEventType.create, "create_listener", "2"),
+            tuple(ZeebeTaskListenerEventType.update, "update_listener", DEFAULT_RETRIES),
+            tuple(ZeebeTaskListenerEventType.update, "update_listener_2", "33"),
+            tuple(ZeebeTaskListenerEventType.assignment, "assignment_listener", "4"),
+            tuple(ZeebeTaskListenerEventType.complete, "complete_listener", "5"),
+            tuple(ZeebeTaskListenerEventType.cancel, "cancel_listener", "6"));
+  }
+
+  private Collection<ZeebeTaskListener> getTaskListeners(
+      final ModelElementInstance elementInstance) {
+    return elementInstance
+        .getUniqueChildElementByType(ExtensionElements.class)
+        .getUniqueChildElementByType(ZeebeTaskListeners.class)
+        .getChildElementsByType(ZeebeTaskListener.class);
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.TaskListenerBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ZeebeTaskListenersValidationTest {
+
+  @Test
+  @DisplayName("task listener with not defined `type` property")
+  void testTaskListenerTypeNotDefined() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "my_user_task",
+                ut -> ut.zeebeUserTask().zeebeTaskListener(TaskListenerBuilder::complete))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ZeebeTaskListener.class, "Attribute 'type' must be present and not empty"));
+  }
+
+  @Test
+  @DisplayName("task listener with not defined `eventType` property")
+  void testEventTypeNotDefined() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.testEventTypeNotDefined.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeTaskListener.class, "Attribute 'eventType' must be present and not empty"));
+  }
+}

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.testEventTypeNotDefined.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.testEventTypeNotDefined.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+  xmlns:zeebe="http://camunda.org/schema/zeebe/1.0"
+  xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+  exporter="Zeebe BPMN Model" exporterVersion="8.6.0-SNAPSHOT"
+  id="definitions_10a4983c-bfa8-45a3-a23e-4c3a54e5f3c1"
+  xmlns:modeler="http://camunda.org/schema/modeler/1.0" modeler:executionPlatform="Camunda Cloud"
+  modeler:executionPlatformVersion="8.6.0-SNAPSHOT"
+  targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <process id="process_bce8fd3e-9715-4483-895f-18faf5e179bb" isExecutable="true">
+    <startEvent id="startEvent_e04ab35c-7ea3-4e74-ac03-c468e866708c">
+      <outgoing>sequenceFlow_b5b62cfb-7be8-4451-a6d5-9348d8fc0f5d</outgoing>
+    </startEvent>
+    <userTask id="my_user_task" name="my_user_task">
+      <extensionElements>
+        <zeebe:userTask/>
+        <zeebe:priorityDefinition/>
+        <zeebe:taskListeners>
+          <zeebe:taskListener type="my_listener"/>
+        </zeebe:taskListeners>
+      </extensionElements>
+      <incoming>sequenceFlow_b5b62cfb-7be8-4451-a6d5-9348d8fc0f5d</incoming>
+      <outgoing>sequenceFlow_52b3e40b-ed4b-4a4a-8108-cd897630f393</outgoing>
+    </userTask>
+    <sequenceFlow id="sequenceFlow_b5b62cfb-7be8-4451-a6d5-9348d8fc0f5d"
+      sourceRef="startEvent_e04ab35c-7ea3-4e74-ac03-c468e866708c" targetRef="my_user_task"/>
+    <endEvent id="endEvent_2db36fcf-1cc8-4fa2-adc9-a57695bad306">
+      <incoming>sequenceFlow_52b3e40b-ed4b-4a4a-8108-cd897630f393</incoming>
+    </endEvent>
+    <sequenceFlow id="sequenceFlow_52b3e40b-ed4b-4a4a-8108-cd897630f393" sourceRef="my_user_task"
+      targetRef="endEvent_2db36fcf-1cc8-4fa2-adc9-a57695bad306"/>
+  </process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_ba325c44-09a5-4d24-bbe9-82e260451e4f">
+    <bpmndi:BPMNPlane bpmnElement="process_bce8fd3e-9715-4483-895f-18faf5e179bb"
+      id="BPMNPlane_cddf6231-589c-45bc-b605-8b970f8702b1">
+      <bpmndi:BPMNShape bpmnElement="startEvent_e04ab35c-7ea3-4e74-ac03-c468e866708c"
+        id="BPMNShape_fff1c710-88d3-4d27-90cf-df15fbd2af33">
+        <dc:Bounds height="36.0" width="36.0" x="100.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape bpmnElement="my_user_task"
+        id="BPMNShape_70cbe660-9802-4f87-bb3e-04fb0929b70d">
+        <dc:Bounds height="80.0" width="100.0" x="186.0" y="78.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sequenceFlow_b5b62cfb-7be8-4451-a6d5-9348d8fc0f5d"
+        id="BPMNEdge_dec820ff-5fa8-4f7a-b45e-c4d2ad520255">
+        <di:waypoint x="136.0" y="118.0"/>
+        <di:waypoint x="186.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape bpmnElement="endEvent_2db36fcf-1cc8-4fa2-adc9-a57695bad306"
+        id="BPMNShape_052fdae2-ca34-4d23-8dc4-a008a6455355">
+        <dc:Bounds height="36.0" width="36.0" x="336.0" y="100.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge bpmnElement="sequenceFlow_52b3e40b-ed4b-4a4a-8108-cd897630f393"
+        id="BPMNEdge_3e84d872-a6e0-4296-a288-9d0ba79db23d">
+        <di:waypoint x="286.0" y="118.0"/>
+        <di:waypoint x="336.0" y="118.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>


### PR DESCRIPTION
## Description

This PR introduces the ability to define Task Listeners for Zeebe User Task elements through the BPMN model API. 

Changes:
- Added `ZeebeTaskListeners` and `ZeebeTaskListener` extension models to support task listeners parsing from XML:
  ```xml
  <zeebe:taskListeners>
     <zeebe:taskListener eventType="create" type="create_listener" retries="2"/>
     <zeebe:taskListener eventType="assignment" type="assignment_listener"/>
     <zeebe:taskListener eventType="update" type="update_listener" retries="8"/>
     <zeebe:taskListener eventType="complete" type="complete_listener"/>
  </zeebe:taskListeners>
  ```
- Implemented the task listener builder in the `AbstractUserTaskBuilder` class to simplify the construction of task listeners.
- Added validation for the following task listener properties:
  - `eventType` is a required field.
  - `type` is a required field.
  - `retries` defaults to `"3"` if missing in the XML definition.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21975 
