### PR TITLE
build: use java 21 for optimize release and image

### DIFF
--- a/optimize.Dockerfile
+++ b/optimize.Dockerfile
@@ -65,7 +65,7 @@ EXPOSE 8090 8091
 
 VOLUME /tmp
 
-RUN apk add --no-cache bash curl tini openjdk17-jre tzdata && \
+RUN apk add --no-cache bash curl tini openjdk21-jre tzdata && \
     apk -U upgrade && \
     curl "https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-for-it.sh" --output /usr/local/bin/wait-for-it.sh && \
     chmod +x /usr/local/bin/wait-for-it.sh && \

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -610,7 +610,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
         <configuration>
-          <release>17</release>
+          <release>${maven.compiler.target}</release>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
## Description

This PR fixes the Java version used to build Optimize in a couple of places where the configuration was still set with Java 17.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
