### PR TITLE
Extend internal API to return process version tags

### DIFF
--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ProcessZeebeRecordProcessor.java
@@ -96,7 +96,6 @@ public class ProcessZeebeRecordProcessor {
             .setKey(process.getProcessDefinitionKey())
             .setBpmnProcessId(process.getBpmnProcessId())
             .setVersion(process.getVersion())
-            .setVersionTag(process.getVersionTag())
             .setTenantId(tenantOrDefault(process.getTenantId()));
 
     final byte[] byteArray = process.getResource();
@@ -106,6 +105,10 @@ public class ProcessZeebeRecordProcessor {
 
     final String resourceName = process.getResourceName();
     processEntity.setResourceName(resourceName);
+
+    if (!process.getVersionTag().isEmpty()) {
+      processEntity.setVersionTag(process.getVersionTag());
+    }
 
     final Optional<ProcessEntity> diagramData =
         xmlUtil.extractDiagramData(byteArray, process.getBpmnProcessId());

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessCacheZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessCacheZeebeImportIT.java
@@ -78,4 +78,22 @@ public class ProcessCacheZeebeImportIT extends OperateZeebeAbstractIT {
 
     verify(processCache, times(1)).putToCache(any(), any());
   }
+
+  @Test
+  public void testProcessVersionTagReturned() {
+    // has versionTag
+    final Long processDefinitionKey1 =
+        ZeebeTestUtil.deployProcess(zeebeClient, null, "demoProcess_v_1.bpmn");
+    // has no versionTag
+    final Long processDefinitionKey2 =
+        ZeebeTestUtil.deployProcess(zeebeClient, null, "processWithGateway.bpmn");
+
+    searchTestRule.processAllRecordsAndWait(processIsDeployedCheck, processDefinitionKey1);
+    searchTestRule.processAllRecordsAndWait(processIsDeployedCheck, processDefinitionKey2);
+
+    String demoProcessVersionTag = processCache.getProcessVersionTag(processDefinitionKey1);
+    assertThat(demoProcessVersionTag).isEqualTo("demo-tag_v1");
+    demoProcessVersionTag = processCache.getProcessVersionTag(processDefinitionKey2);
+    assertThat(demoProcessVersionTag).isNull();
+  }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/ProcessZeebeImportIT.java
@@ -64,6 +64,7 @@ public class ProcessZeebeImportIT extends OperateZeebeAbstractIT {
     assertThat(processEntity.getVersion()).isEqualTo(1);
     assertThat(processEntity.getBpmnXml()).isNotEmpty();
     assertThat(processEntity.getName()).isEqualTo("Demo process");
+    assertThat(processEntity.getVersionTag()).isEqualTo("demo-tag_v1");
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
@@ -216,6 +216,33 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   }
 
   @Test
+  public void shouldHaveVersionTagOfProcessInListView() throws PersistenceException, IOException {
+    final String versionTag = "tag-v1";
+    final long instanceKey = 333L;
+    final long definitionKey = 123L;
+    when(processCache.getProcessNameOrDefaultValue(eq(definitionKey), anyString()))
+        .thenReturn(newProcessName);
+    when(processCache.getProcessVersionTag(eq(definitionKey))).thenReturn(versionTag);
+    final ProcessInstanceForListViewEntity pi =
+        createProcessInstance().setProcessInstanceKey(instanceKey);
+    final Record<ProcessInstanceRecordValue> zeebeRecord =
+        createZeebeRecordFromPi(
+            pi,
+            b -> b.withIntent(ELEMENT_COMPLETED),
+            b ->
+                b.withVersion(1)
+                    .withBpmnProcessId(newBpmnProcessId)
+                    .withProcessDefinitionKey(definitionKey));
+
+    importProcessInstanceZeebeRecord(zeebeRecord);
+    final ProcessInstanceForListViewEntity actualPI = findProcessInstanceByKey(instanceKey);
+
+    assertThat(actualPI.getProcessInstanceKey()).isEqualTo(instanceKey);
+    assertThat(actualPI.getKey()).isEqualTo(pi.getKey());
+    assertThat(actualPI.getProcessVersionTag()).isEqualTo(versionTag);
+  }
+
+  @Test
   public void shouldOverrideIncidentErrorMsg() throws IOException, PersistenceException {
     // having
     // flow node instance entity with position = 1

--- a/operate/qa/integration-tests/src/test/resources/demoProcess_v_1.bpmn
+++ b/operate/qa/integration-tests/src/test/resources/demoProcess_v_1.bpmn
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
   <bpmn:process id="demoProcess" name="Demo process" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="demo-tag_v1" />
+    </bpmn:extensionElements>
     <bpmn:startEvent id="start" name="start">
       <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
     </bpmn:startEvent>

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>8.5.0</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.6.0-alpha5</version.zeebe.docker.current>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 
   </properties>

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -257,6 +257,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
                                   ProcessIndex.ID,
                                   ProcessIndex.NAME,
                                   ProcessIndex.VERSION,
+                                  ProcessIndex.VERSION_TAG,
                                   ProcessIndex.BPMN_PROCESS_ID,
                                   ProcessIndex.TENANT_ID
                                 },

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -122,13 +122,13 @@ public class ElasticsearchProcessStore implements ProcessStore {
   private final OperateProperties operateProperties;
 
   public ElasticsearchProcessStore(
-      ProcessIndex processIndex,
-      ListViewTemplate listViewTemplate,
-      List<ProcessInstanceDependant> processInstanceDependantTemplates,
-      @Qualifier("operateObjectMapper") ObjectMapper objectMapper,
-      OperateProperties operateProperties,
-      RestHighLevelClient esClient,
-      TenantAwareElasticsearchClient tenantAwareClient) {
+      final ProcessIndex processIndex,
+      final ListViewTemplate listViewTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependantTemplates,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final OperateProperties operateProperties,
+      final RestHighLevelClient esClient,
+      final TenantAwareElasticsearchClient tenantAwareClient) {
     this.processIndex = processIndex;
     this.listViewTemplate = listViewTemplate;
     this.processInstanceDependantTemplates = processInstanceDependantTemplates;
@@ -139,7 +139,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public Optional<Long> getDistinctCountFor(String fieldName) {
+  public Optional<Long> getDistinctCountFor(final String fieldName) {
     final String indexAlias = processIndex.getAlias();
     LOGGER.debug("Called distinct count for field {} in index alias {}.", fieldName, indexAlias);
     final SearchRequest searchRequest =
@@ -157,7 +157,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
       final Cardinality distinctFieldCounts =
           searchResponse.getAggregations().get(DISTINCT_FIELD_COUNTS);
       return Optional.of(distinctFieldCounts.getValue());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error(
           String.format(
               "Error in distinct count for field %s in index alias %s.", fieldName, indexAlias),
@@ -167,19 +167,19 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public void refreshIndices(String... indices) {
+  public void refreshIndices(final String... indices) {
     if (indices == null || indices.length == 0) {
       throw new OperateRuntimeException("Refresh indices needs at least one index to refresh.");
     }
     try {
       esClient.indices().refresh(new RefreshRequest(indices), RequestOptions.DEFAULT);
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       throw new OperateRuntimeException("Failed to refresh indices " + Arrays.asList(indices), ex);
     }
   }
 
   @Override
-  public ProcessEntity getProcessByKey(Long processDefinitionKey) {
+  public ProcessEntity getProcessByKey(final Long processDefinitionKey) {
     final SearchRequest searchRequest =
         new SearchRequest(processIndex.getAlias())
             .source(
@@ -197,7 +197,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with key '%s'.", processDefinitionKey));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining the process: %s", e.getMessage());
       LOGGER.error(message, e);
@@ -206,7 +206,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public String getDiagramByKey(Long processDefinitionKey) {
+  public String getDiagramByKey(final Long processDefinitionKey) {
     final IdsQueryBuilder q = idsQuery().addIds(processDefinitionKey.toString());
 
     final SearchRequest searchRequest =
@@ -226,7 +226,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
         throw new NotFoundException(
             String.format("Could not find process with id '%s'.", processDefinitionKey));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining the process diagram: %s", e.getMessage());
@@ -237,7 +237,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
-      String tenantId, @Nullable Set<String> allowedBPMNProcessIds) {
+      final String tenantId, @Nullable final Set<String> allowedBPMNProcessIds) {
     final String tenantsGroupsAggName = "group_by_tenantId";
     final String groupsAggName = "group_by_bpmnProcessId";
     final String processesAggName = "processes";
@@ -289,7 +289,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
                           final TopHits processes = tenantB.getAggregations().get(processesAggName);
                           final SearchHit[] hits = processes.getHits().getHits();
-                          for (SearchHit searchHit : hits) {
+                          for (final SearchHit searchHit : hits) {
                             final ProcessEntity processEntity =
                                 fromSearchHit(searchHit.getSourceAsString());
                             result.get(groupKey).add(processEntity);
@@ -298,7 +298,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
               });
 
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining grouped processes: %s", e.getMessage());
@@ -309,7 +309,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
   @Override
   public Map<Long, ProcessEntity> getProcessesIdsToProcessesWithFields(
-      @Nullable Set<String> allowedBPMNIds, int maxSize, String... fields) {
+      @Nullable final Set<String> allowedBPMNIds, final int maxSize, final String... fields) {
     final Map<Long, ProcessEntity> map = new HashMap<>();
 
     final SearchSourceBuilder sourceBuilder =
@@ -333,7 +333,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
                 map.put(entity.getKey(), entity);
               });
       return map;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining processes: %s", e.getMessage());
       LOGGER.error(message, e);
@@ -342,7 +342,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public long deleteProcessDefinitionsByKeys(Long... processDefinitionKeys) {
+  public long deleteProcessDefinitionsByKeys(final Long... processDefinitionKeys) {
     if (processDefinitionKeys == null || processDefinitionKeys.length == 0) {
       return 0;
     }
@@ -352,13 +352,14 @@ public class ElasticsearchProcessStore implements ProcessStore {
     try {
       final BulkByScrollResponse response = esClient.deleteByQuery(query, RequestOptions.DEFAULT);
       return response.getDeleted();
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       throw new OperateRuntimeException("Failed to delete process definitions by keys", ex);
     }
   }
 
   @Override
-  public ProcessInstanceForListViewEntity getProcessInstanceListViewByKey(Long processInstanceKey) {
+  public ProcessInstanceForListViewEntity getProcessInstanceListViewByKey(
+      final Long processInstanceKey) {
     try {
       final QueryBuilder query =
           joinWithAnd(
@@ -386,13 +387,13 @@ public class ElasticsearchProcessStore implements ProcessStore {
         throw new NotFoundException(
             (String.format("Could not find process instance with id '%s'.", processInstanceKey)));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
   }
 
   @Override
-  public Map<String, Long> getCoreStatistics(@Nullable Set<String> allowedBPMNIds) {
+  public Map<String, Long> getCoreStatistics(@Nullable final Set<String> allowedBPMNIds) {
     final SearchSourceBuilder sourceBuilder =
         new SearchSourceBuilder()
             .size(0)
@@ -415,7 +416,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
       final long incidentCount =
           ((SingleBucketAggregation) aggregations.get("incidents")).getDocCount();
       return Map.of("running", runningCount, "incidents", incidentCount);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining process instance core statistics: %s",
@@ -426,7 +427,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public String getProcessInstanceTreePathById(String processInstanceId) {
+  public String getProcessInstanceTreePathById(final String processInstanceId) {
     final QueryBuilder query =
         joinWithAnd(
             termQuery(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION),
@@ -442,7 +443,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
         throw new NotFoundException(
             String.format("Process instance not found: %s", processInstanceId));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining tree path for process instance: %s",
@@ -453,7 +454,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
   @Override
   public List<Map<String, String>> createCallHierarchyFor(
-      List<String> processInstanceIds, String currentProcessInstanceId) {
+      final List<String> processInstanceIds, final String currentProcessInstanceId) {
     final List<Map<String, String>> callHierarchy = new ArrayList<>();
 
     final List<String> processInstanceIdsWithoutCurrentProcess =
@@ -496,7 +497,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
                 });
             return null;
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining process instance call hierarchy: %s",
@@ -507,7 +508,8 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public long deleteDocument(String indexName, String idField, String id) throws IOException {
+  public long deleteDocument(final String indexName, final String idField, final String id)
+      throws IOException {
     final DeleteByQueryRequest query =
         new DeleteByQueryRequest(indexName).setQuery(QueryBuilders.termsQuery(idField, id));
     final BulkByScrollResponse response = esClient.deleteByQuery(query, RequestOptions.DEFAULT);
@@ -516,7 +518,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public void deleteProcessInstanceFromTreePath(String processInstanceKey) {
+  public void deleteProcessInstanceFromTreePath(final String processInstanceKey) {
     final BulkRequest bulkRequest = new BulkRequest();
     // select process instance - get tree path
     final String treePath = getProcessInstanceTreePathById(processInstanceKey);
@@ -568,7 +570,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
           esClient,
           bulkRequest,
           operateProperties.getElasticsearch().getBulkRequestMaxSizeInBytes());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new OperateRuntimeException(
           String.format(
               "Exception occurred when deleting process instance %s from tree path: %s",
@@ -578,10 +580,10 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
   @Override
   public List<ProcessInstanceForListViewEntity> getProcessInstancesByProcessAndStates(
-      long processDefinitionKey,
-      Set<ProcessInstanceState> states,
-      int size,
-      String[] includeFields) {
+      final long processDefinitionKey,
+      final Set<ProcessInstanceState> states,
+      final int size,
+      final String[] includeFields) {
 
     if (states == null || states.isEmpty()) {
       throw new OperateRuntimeException("Parameter 'states' is needed to search by states.");
@@ -601,7 +603,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
       final SearchResponse response = tenantAwareClient.search(searchRequest);
       return ElasticsearchUtil.mapSearchHits(
           response.getHits().getHits(), objectMapper, ProcessInstanceForListViewEntity.class);
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       throw new OperateRuntimeException(
           String.format(
               "Failed to search process instances by processDefinitionKey [%s] and states [%s]",
@@ -612,7 +614,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
 
   @Override
   public List<ProcessInstanceForListViewEntity> getProcessInstancesByParentKeys(
-      Set<Long> parentProcessInstanceKeys, int size, String[] includeFields) {
+      final Set<Long> parentProcessInstanceKeys, final int size, final String[] includeFields) {
 
     if (parentProcessInstanceKeys == null || parentProcessInstanceKeys.isEmpty()) {
       throw new OperateRuntimeException(
@@ -633,14 +635,14 @@ public class ElasticsearchProcessStore implements ProcessStore {
           () ->
               ElasticsearchUtil.scroll(
                   searchRequest, ProcessInstanceForListViewEntity.class, objectMapper, esClient));
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       throw new OperateRuntimeException(
           "Failed to search process instances by parentProcessInstanceKeys", ex);
     }
   }
 
   @Override
-  public long deleteProcessInstancesAndDependants(Set<Long> processInstanceKeys) {
+  public long deleteProcessInstancesAndDependants(final Set<Long> processInstanceKeys) {
     if (processInstanceKeys == null || processInstanceKeys.isEmpty()) {
       return 0;
     }
@@ -651,7 +653,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
             .filter(template -> !(template instanceof OperationTemplate))
             .toList();
     try {
-      for (ProcessInstanceDependant template : processInstanceDependantsWithoutOperation) {
+      for (final ProcessInstanceDependant template : processInstanceDependantsWithoutOperation) {
         final String indexName = ((TemplateDescriptor) template).getAlias();
         final DeleteByQueryRequest query =
             new DeleteByQueryRequest(indexName)
@@ -669,7 +671,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
                       ListViewTemplate.PROCESS_INSTANCE_KEY, processInstanceKeys));
       final BulkByScrollResponse response = esClient.deleteByQuery(query, RequestOptions.DEFAULT);
       count += response.getDeleted();
-    } catch (IOException ex) {
+    } catch (final IOException ex) {
       throw new OperateRuntimeException(
           "Failed to delete process instances and dependants by keys", ex);
     }
@@ -677,7 +679,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
     return count;
   }
 
-  private QueryBuilder buildQuery(String tenantId, Set<String> allowedBPMNProcessIds) {
+  private QueryBuilder buildQuery(final String tenantId, final Set<String> allowedBPMNProcessIds) {
     final TermsQueryBuilder bpmnProcessIdQ =
         allowedBPMNProcessIds != null ? termsQuery(BPMN_PROCESS_ID, allowedBPMNProcessIds) : null;
     final TermQueryBuilder tenantIdQ =
@@ -689,7 +691,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
     return q;
   }
 
-  private ProcessEntity fromSearchHit(String processString) {
+  private ProcessEntity fromSearchHit(final String processString) {
     return ElasticsearchUtil.fromSearchHit(processString, objectMapper, ProcessEntity.class);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -131,6 +131,7 @@ public class OpensearchProcessStore implements ProcessStore {
             ProcessIndex.ID,
             ProcessIndex.NAME,
             ProcessIndex.VERSION,
+            ProcessIndex.VERSION_TAG,
             ProcessIndex.BPMN_PROCESS_ID,
             ProcessIndex.TENANT_ID);
     final Query query =

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -69,7 +69,7 @@ public class OpensearchProcessStore implements ProcessStore {
   @Autowired private List<ProcessInstanceDependant> processInstanceDependantTemplates;
 
   @Override
-  public Optional<Long> getDistinctCountFor(String fieldName) {
+  public Optional<Long> getDistinctCountFor(final String fieldName) {
     final SearchResponse<Void> response;
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
@@ -81,7 +81,7 @@ public class OpensearchProcessStore implements ProcessStore {
     try {
       response = richOpenSearchClient.doc().search(searchRequestBuilder, Void.class);
       return Optional.of(response.aggregations().get(DISTINCT_FIELD_COUNTS).cardinality().value());
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error(
           String.format(
               "Error in distinct count for field %s in index alias %s.",
@@ -92,12 +92,12 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public void refreshIndices(String... indices) {
+  public void refreshIndices(final String... indices) {
     richOpenSearchClient.index().refresh(indices);
   }
 
   @Override
-  public ProcessEntity getProcessByKey(Long processDefinitionKey) {
+  public ProcessEntity getProcessByKey(final Long processDefinitionKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
             .query(withTenantCheck(term(ProcessIndex.KEY, processDefinitionKey)));
@@ -109,7 +109,7 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public String getDiagramByKey(Long processDefinitionKey) {
+  public String getDiagramByKey(final Long processDefinitionKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
             .query(withTenantCheck(ids(processDefinitionKey.toString())));
@@ -122,7 +122,7 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Override
   public Map<ProcessKey, List<ProcessEntity>> getProcessesGrouped(
-      String tenantId, Set<String> allowedBPMNProcessIds) {
+      final String tenantId, final Set<String> allowedBPMNProcessIds) {
     final String tenantsGroupsAggName = "group_by_tenantId";
     final String groupsAggName = "group_by_bpmnProcessId";
     final String processesAggName = "processes";
@@ -197,7 +197,7 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Override
   public Map<Long, ProcessEntity> getProcessesIdsToProcessesWithFields(
-      Set<String> allowedBPMNIds, int maxSize, String... fields) {
+      final Set<String> allowedBPMNIds, final int maxSize, final String... fields) {
     final Query query =
         allowedBPMNIds == null
             ? matchAll()
@@ -216,7 +216,7 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public long deleteProcessDefinitionsByKeys(Long... processDefinitionKeys) {
+  public long deleteProcessDefinitionsByKeys(final Long... processDefinitionKeys) {
     if (CollectionUtil.isEmpty(processDefinitionKeys)) {
       return 0;
     }
@@ -227,7 +227,8 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public ProcessInstanceForListViewEntity getProcessInstanceListViewByKey(Long processInstanceKey) {
+  public ProcessInstanceForListViewEntity getProcessInstanceListViewByKey(
+      final Long processInstanceKey) {
     final var searchRequestBuilder =
         searchRequestBuilder(listViewTemplate, ALL)
             .query(
@@ -245,7 +246,7 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public Map<String, Long> getCoreStatistics(Set<String> allowedBPMNIds) {
+  public Map<String, Long> getCoreStatistics(final Set<String> allowedBPMNIds) {
     final Query incidentsQuery =
         and(term(INCIDENT, true), term(JOIN_RELATION, PROCESS_INSTANCE_JOIN_RELATION));
     final Query runningQuery = term(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE.name());
@@ -280,7 +281,7 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public String getProcessInstanceTreePathById(String processInstanceId) {
+  public String getProcessInstanceTreePathById(final String processInstanceId) {
     record Result(String treePath) {}
     final var searchRequestBuilder =
         searchRequestBuilder(listViewTemplate)
@@ -299,7 +300,7 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Override
   public List<Map<String, String>> createCallHierarchyFor(
-      List<String> processInstanceIds, String currentProcessInstanceId) {
+      final List<String> processInstanceIds, final String currentProcessInstanceId) {
     record Result(
         String id, String processDefinitionKey, String processName, String bpmnProcessId) {}
     final List<String> processInstanceIdsWithoutCurrentProcess =
@@ -325,12 +326,13 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public long deleteDocument(String indexName, String idField, String id) throws IOException {
+  public long deleteDocument(final String indexName, final String idField, final String id)
+      throws IOException {
     return richOpenSearchClient.doc().delete(indexName, idField, id).deleted();
   }
 
   @Override
-  public void deleteProcessInstanceFromTreePath(String processInstanceKey) {
+  public void deleteProcessInstanceFromTreePath(final String processInstanceKey) {
     record Result(String id, String treePath) {}
     record ProcessEntityUpdate(String treePath) {}
 
@@ -357,7 +359,7 @@ public class OpensearchProcessStore implements ProcessStore {
     final Map<String, String> idToIndex = new HashMap<>();
     final Consumer<List<Hit<Result>>> hitsConsumer =
         hits -> {
-          for (Hit<Result> hit : hits) {
+          for (final Hit<Result> hit : hits) {
             results.add(hit.source());
             idToIndex.put(hit.id(), hit.index());
           }
@@ -392,10 +394,10 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Override
   public List<ProcessInstanceForListViewEntity> getProcessInstancesByProcessAndStates(
-      long processDefinitionKey,
-      Set<ProcessInstanceState> states,
-      int size,
-      String[] includeFields) {
+      final long processDefinitionKey,
+      final Set<ProcessInstanceState> states,
+      final int size,
+      final String[] includeFields) {
     if (CollectionUtil.isEmpty(states)) {
       throw new OperateRuntimeException("Parameter 'states' is needed to search by states.");
     }
@@ -418,7 +420,7 @@ public class OpensearchProcessStore implements ProcessStore {
 
   @Override
   public List<ProcessInstanceForListViewEntity> getProcessInstancesByParentKeys(
-      Set<Long> parentProcessInstanceKeys, int size, String[] includeFields) {
+      final Set<Long> parentProcessInstanceKeys, final int size, final String[] includeFields) {
     if (CollectionUtil.isEmpty(parentProcessInstanceKeys)) {
       throw new OperateRuntimeException(
           "Parameter 'parentProcessInstanceKeys' is needed to search by parents.");
@@ -438,7 +440,7 @@ public class OpensearchProcessStore implements ProcessStore {
   }
 
   @Override
-  public long deleteProcessInstancesAndDependants(Set<Long> processInstanceKeys) {
+  public long deleteProcessInstancesAndDependants(final Set<Long> processInstanceKeys) {
     if (CollectionUtil.isEmpty(processInstanceKeys)) {
       return 0;
     }
@@ -448,7 +450,7 @@ public class OpensearchProcessStore implements ProcessStore {
         processInstanceDependantTemplates.stream()
             .filter(template -> !(template instanceof OperationTemplate))
             .toList();
-    for (ProcessInstanceDependant template : processInstanceDependantsWithoutOperation) {
+    for (final ProcessInstanceDependant template : processInstanceDependantsWithoutOperation) {
       final String indexName = ((TemplateDescriptor) template).getAlias();
       count +=
           richOpenSearchClient
@@ -466,7 +468,7 @@ public class OpensearchProcessStore implements ProcessStore {
     return count;
   }
 
-  private Query withTenantIdQuery(@Nullable String tenantId, @Nullable Query query) {
+  private Query withTenantIdQuery(@Nullable final String tenantId, @Nullable final Query query) {
     final Query tenantIdQ = tenantId != null ? term(ProcessIndex.TENANT_ID, tenantId) : null;
 
     if (query != null || tenantId != null) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ProcessDto.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.rest.dto;
 
 import io.camunda.operate.entities.ProcessEntity;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Objects;
 
 @Schema(name = "Process object")
 public class ProcessDto implements CreatableFromEntity<ProcessDto, ProcessEntity> {
@@ -21,6 +22,7 @@ public class ProcessDto implements CreatableFromEntity<ProcessDto, ProcessEntity
   private String name;
   private int version;
   private String bpmnProcessId;
+  private String versionTag;
 
   public String getId() {
     return id;
@@ -58,46 +60,43 @@ public class ProcessDto implements CreatableFromEntity<ProcessDto, ProcessEntity
     return this;
   }
 
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public ProcessDto setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
+    return this;
+  }
+
   @Override
   public ProcessDto fillFrom(final ProcessEntity processEntity) {
-    this.setId(processEntity.getId())
+    setId(processEntity.getId())
         .setBpmnProcessId(processEntity.getBpmnProcessId())
         .setName(processEntity.getName())
-        .setVersion(processEntity.getVersion());
+        .setVersion(processEntity.getVersion())
+        .setVersionTag(processEntity.getVersionTag());
     return this;
   }
 
   @Override
   public int hashCode() {
-    int result = id != null ? id.hashCode() : 0;
-    result = 31 * result + (name != null ? name.hashCode() : 0);
-    result = 31 * result + version;
-    result = 31 * result + (bpmnProcessId != null ? bpmnProcessId.hashCode() : 0);
-    return result;
+    return Objects.hash(id, name, version, bpmnProcessId, versionTag);
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     final ProcessDto that = (ProcessDto) o;
-
-    if (version != that.version) {
-      return false;
-    }
-    if (id != null ? !id.equals(that.id) : that.id != null) {
-      return false;
-    }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
-      return false;
-    }
-    return bpmnProcessId != null
-        ? bpmnProcessId.equals(that.bpmnProcessId)
-        : that.bpmnProcessId == null;
+    return version == that.version
+        && Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.equals(versionTag, that.versionTag);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Return version tag in the API responses of `GET /api/processes/<id>` and `POST api/processes/grouped`.

Added test for the import of the version tags from zeebe for `operate-process` and `operate-list-view` indices.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/22069
