### PR TITLE
ci: avoid duplicate aborted job detection

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -361,13 +361,6 @@ jobs:
       - docker-checks
     steps:
       - uses: actions/checkout@v4
-      - name: Check for aborted jobs
-        continue-on-error: true
-        uses: ./.github/actions/observe-aborted-jobs
-        with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
   deploy-docker-snapshot:


### PR DESCRIPTION
## Description

Since #21074 the Zeebe CI is called from Unified CI. The [detection in](https://github.com/camunda/camunda/blob/76c8d6a3c8d89978f96a16b86406fa7520dcae91/.github/workflows/ci.yml#L572-L578) `ci.yml` will also cover `zeebe-ci.yml` jobs and calling the action twice leads to duplicates with slightly different timestamps as seen in:

* https://github.com/camunda/camunda/actions/runs/10829587107/job/30047928378
* https://github.com/camunda/camunda/actions/runs/10829587107/job/30048056335

![image](https://github.com/user-attachments/assets/92d73d9e-3552-4aea-ac0a-a9d83c1b6666)

This distorts the data and makes it appear as if there is a higher abort rate then there actually is.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
