### PR TITLE
feat: support basic auth login webapps

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -7,10 +7,11 @@
  */
 package io.camunda.authentication;
 
+import static io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder.aCamundaUser;
+
 import io.camunda.service.UserServices;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import java.util.Objects;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -32,9 +33,11 @@ public class CamundaUserDetailsService implements UserDetailsService {
         .findFirst()
         .map(
             candidate ->
-                User.builder()
-                    .username(candidate.username())
-                    .password(candidate.password())
+                aCamundaUser()
+                    .withUserKey(candidate.key())
+                    .withName(candidate.name())
+                    .withUsername(candidate.username())
+                    .withPassword(candidate.password())
                     .build())
         .orElseThrow(() -> new UsernameNotFoundException(username));
   }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.entity;
+
+import java.util.Collections;
+import org.springframework.security.core.userdetails.User;
+
+public class CamundaUser extends User {
+  private final Long userKey;
+  private final String name;
+
+  public CamundaUser(
+      final Long userKey, final String name, final String username, final String password) {
+    super(username, password, Collections.emptyList());
+    this.userKey = userKey;
+    this.name = name;
+  }
+
+  public Long getUserKey() {
+    return userKey;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public static final class CamundaUserBuilder {
+    private Long userKey;
+    private String name;
+    private String username;
+    private String password;
+
+    private CamundaUserBuilder() {}
+
+    public static CamundaUserBuilder aCamundaUser() {
+      return new CamundaUserBuilder();
+    }
+
+    public CamundaUserBuilder withUserKey(final Long userKey) {
+      this.userKey = userKey;
+      return this;
+    }
+
+    public CamundaUserBuilder withName(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public CamundaUserBuilder withUsername(final String username) {
+      this.username = username;
+      return this;
+    }
+
+    public CamundaUserBuilder withPassword(final String password) {
+      this.password = password;
+      return this;
+    }
+
+    public CamundaUser build() {
+      return new CamundaUser(userKey, name, username, password);
+    }
+  }
+}

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.service.UserServices;
 import io.camunda.service.entities.UserEntity;
 import io.camunda.service.search.query.SearchQueryResult;
@@ -21,7 +22,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 public class CamundaUserDetailsServiceTest {
@@ -43,11 +43,16 @@ public class CamundaUserDetailsServiceTest {
     when(userService.search(any()))
         .thenReturn(
             new SearchQueryResult<>(
-                1, List.of(new UserEntity(1L, TEST_USER_ID, "", "", "password1")), null));
+                1,
+                List.of(new UserEntity(1L, TEST_USER_ID, "Foo Bar", "not@tested", "password1")),
+                null));
     // when
-    final UserDetails user = userDetailsService.loadUserByUsername(TEST_USER_ID);
+    final CamundaUser user = (CamundaUser) userDetailsService.loadUserByUsername(TEST_USER_ID);
 
     // then
+    assertThat(user).isInstanceOf(CamundaUser.class);
+    assertThat(user.getUserKey()).isEqualTo(1L);
+    assertThat(user.getName()).isEqualTo("Foo Bar");
     assertThat(user.getUsername()).isEqualTo(TEST_USER_ID);
     assertThat(user.getPassword()).isEqualTo("password1");
   }

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -40,7 +40,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>operate-mvc-auth-commons</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-authentication</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-client-java</artifactId>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/AuthBasicUserService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/AuthBasicUserService.java
@@ -7,42 +7,31 @@
  */
 package io.camunda.operate.webapp.security.auth;
 
-import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.webapp.rest.dto.UserDto;
 import io.camunda.operate.webapp.security.AbstractUserService;
-import org.springframework.beans.factory.annotation.Autowired;
+import io.camunda.operate.webapp.security.Permission;
+import java.util.List;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile({
-  "!"
-      + OperateProfileService.LDAP_AUTH_PROFILE
-      + " & ! "
-      + OperateProfileService.SSO_AUTH_PROFILE
-      + " & !"
-      + OperateProfileService.IDENTITY_AUTH_PROFILE
-      + " & !"
-      + OperateProfileService.AUTH_BASIC
-})
-public class AuthUserService extends AbstractUserService<UsernamePasswordAuthenticationToken> {
-
-  @Autowired private RolePermissionService rolePermissionService;
-
+@Profile("auth-basic")
+public class AuthBasicUserService extends AbstractUserService<UsernamePasswordAuthenticationToken> {
   @Override
   public UserDto createUserDtoFrom(final UsernamePasswordAuthenticationToken authentication) {
-    final User user = (User) authentication.getPrincipal();
+    final var user = (UserDetails) authentication.getPrincipal();
+
     return new UserDto()
-        .setUserId(user.getUserId())
-        .setDisplayName(user.getDisplayName())
-        .setCanLogout(true)
-        .setPermissions(rolePermissionService.getPermissions(user.getRoles()));
+        .setUserId(String.valueOf(user.getUsername()))
+        .setDisplayName(user.getUsername())
+        .setCanLogout(false)
+        .setPermissions(List.of(Permission.READ, Permission.WRITE));
   }
 
   @Override
   public String getUserToken(final UsernamePasswordAuthenticationToken authentication) {
-    throw new UnsupportedOperationException(
-        "Get token is not supported for Elasticsearch authentication");
+    throw new UnsupportedOperationException("Get token is not supported for basic authentication");
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/AuthBasicUserService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/AuthBasicUserService.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.operate.webapp.security.auth;
 
+import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.operate.webapp.rest.dto.UserDto;
 import io.camunda.operate.webapp.security.AbstractUserService;
 import io.camunda.operate.webapp.security.Permission;
 import java.util.List;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -21,11 +21,11 @@ import org.springframework.stereotype.Component;
 public class AuthBasicUserService extends AbstractUserService<UsernamePasswordAuthenticationToken> {
   @Override
   public UserDto createUserDtoFrom(final UsernamePasswordAuthenticationToken authentication) {
-    final var user = (UserDetails) authentication.getPrincipal();
+    final var camundaUser = (CamundaUser) authentication.getPrincipal();
 
     return new UserDto()
-        .setUserId(String.valueOf(user.getUsername()))
-        .setDisplayName(user.getUsername())
+        .setUserId(String.valueOf(camundaUser.getUserKey()))
+        .setDisplayName(camundaUser.getName())
         .setCanLogout(false)
         .setPermissions(List.of(Permission.READ, Permission.WRITE));
   }


### PR DESCRIPTION
## Description

I created a [PR](https://github.com/camunda/camunda/pull/19830) previously that looked to support basic auth in operate, that PR went stale and things have changed since then so I've opened this PR to complete the circle.

Some things to note:

1. With this PR I can start the single application with `auth-basic, operate, tasklist` and log in using a user in my ES
2. The UI correctly shows the name of the user
3. Tasklist functioned without alterations
4. I've extended the base Spring class because I think this is the best approach here to add our own fields in, and support a full transition from the web app security classes to our own (as there are more custom fields needed)
