### PR TITLE
remove priority filter from v2 API

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -16,7 +16,6 @@
 package io.camunda.zeebe.client.api.search.filter;
 
 import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRequestFilter;
-import io.camunda.zeebe.client.protocol.rest.PriorityValueFilter;
 
 /** Interface for defining user task filters in search queries. */
 public interface UserTaskFilter extends SearchRequestFilter {
@@ -100,12 +99,4 @@ public interface UserTaskFilter extends SearchRequestFilter {
    * @return the updated filter
    */
   UserTaskFilter bpmnProcessId(final String bpmnProcessId);
-
-  /**
-   * Filters user tasks by the specified Priority criteria.
-   *
-   * @param priorityFilter for the tasks to search for
-   * @return the updated filter
-   */
-  UserTaskFilter priority(final PriorityValueFilter priorityFilter);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.search.filter;
 
 import io.camunda.zeebe.client.api.search.filter.UserTaskFilter;
 import io.camunda.zeebe.client.impl.search.TypedSearchRequestPropertyProvider;
-import io.camunda.zeebe.client.protocol.rest.PriorityValueFilter;
 import io.camunda.zeebe.client.protocol.rest.UserTaskFilterRequest;
 
 public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserTaskFilterRequest>
@@ -90,12 +89,6 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   @Override
   public UserTaskFilter bpmnProcessId(final String bpmnProcessId) {
     filter.setBpmnDefinitionId(bpmnProcessId);
-    return this;
-  }
-
-  @Override
-  public UserTaskFilter priority(final PriorityValueFilter priorityFilter) {
-    filter.setPriority(priorityFilter);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.usertask;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.client.protocol.rest.PriorityValueFilter;
 import io.camunda.zeebe.client.protocol.rest.UserTaskSearchQueryRequest;
 import io.camunda.zeebe.client.util.ClientRestTest;
 import org.junit.jupiter.api.Test;
@@ -132,20 +131,5 @@ public final class SearchUserTaskTest extends ClientRestTest {
     final UserTaskSearchQueryRequest request =
         gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
     assertThat(request.getFilter().getTenantIds()).isEqualTo("tenant1");
-  }
-
-  @Test
-  void shouldSearchUserTaskByPriority() {
-    // when
-    client
-        .newUserTaskQuery()
-        .filter(f -> f.priority(new PriorityValueFilter().eq(20)))
-        .send()
-        .join();
-
-    // then
-    final UserTaskSearchQueryRequest request =
-        gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
-    assertThat(request.getFilter().getPriority().getEq()).isEqualTo(20);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -29,13 +29,13 @@ class UserTaskQueryTest {
   private static Long userTaskKeyTaskAssigned;
 
   @TestZeebe
-  private static final TestStandaloneCamunda TEST_STANDALONE_CAMUNDA = new TestStandaloneCamunda();
+  private static TestStandaloneCamunda testStandaloneCamunda = new TestStandaloneCamunda();
 
   private static ZeebeClient camundaClient;
 
   @BeforeAll
   public static void setup() {
-    camundaClient = TEST_STANDALONE_CAMUNDA.newClientBuilder().build();
+    camundaClient = testStandaloneCamunda.newClientBuilder().build();
 
     deployProcess("process", "simple.bpmn", "test", "", "");
     deployProcess("process-2", "simple-2.bpmn", "test-2", "group", "user");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -8,7 +8,6 @@
 package io.camunda.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -180,12 +179,12 @@ class UserTaskQueryTest {
     final var resultDefaultPriority =
         camundaClient.newUserTaskQuery().filter(f -> f.bpmnProcessId("process-2")).send().join();
     assertThat(resultDefaultPriority.items().size()).isEqualTo(1);
-    assertEquals(50, resultDefaultPriority.items().getFirst().getPriority());
+    assertThat(resultDefaultPriority.items().getFirst().getPriority()).isEqualTo(50);
 
     final var resultDefinedPriority =
         camundaClient.newUserTaskQuery().filter(f -> f.bpmnProcessId("process-3")).send().join();
     assertThat(resultDefinedPriority.items().size()).isEqualTo(1);
-    assertEquals(30, resultDefinedPriority.items().getFirst().getPriority());
+    assertThat(resultDefinedPriority.items().getFirst().getPriority()).isEqualTo(30);
   }
 
   private static void deployProcess(

--- a/service/src/main/java/io/camunda/service/search/filter/UserTaskFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/UserTaskFilter.java
@@ -25,8 +25,7 @@ public final record UserTaskFilter(
     List<Long> processDefinitionKeys,
     List<String> candidateUsers,
     List<String> candidateGroups,
-    List<String> tenantIds,
-    ComparableValueFilter priority)
+    List<String> tenantIds)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<UserTaskFilter> {
@@ -40,7 +39,6 @@ public final record UserTaskFilter(
     private List<String> candidateUsers;
     private List<String> candidateGroups;
     private List<String> tenantIds;
-    private ComparableValueFilter priority;
 
     public Builder keys(final Long... values) {
       return keys(collectValuesAsList(values));
@@ -132,11 +130,6 @@ public final record UserTaskFilter(
       return this;
     }
 
-    public Builder priority(final ComparableValueFilter value) {
-      priority = value;
-      return this;
-    }
-
     @Override
     public UserTaskFilter build() {
       return new UserTaskFilter(
@@ -149,8 +142,7 @@ public final record UserTaskFilter(
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(candidateUsers, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroups, Collections.emptyList()),
-          Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
-          priority);
+          Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
@@ -45,7 +45,6 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
     final var assigneesQuery = getAssigneesQuery(filter.assignees());
     final var stateQuery = getStateQuery(filter.states());
     final var tenantQuery = getTenantQuery(filter.tenantIds());
-    final var priorityQuery = getComparableFilter(filter.priority(), "priority");
 
     // Temporary internal condition - in order to bring only Zeebe User Tasks from Tasklist Indices
     final var userTaksImplementationQuery = getUserTasksImplementationOnly();
@@ -61,8 +60,7 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
         processDefinitionKeyQuery,
         tenantQuery,
         userTaksImplementationQuery,
-        elementIdQuery,
-        priorityQuery);
+        elementIdQuery);
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1688,10 +1688,6 @@ components:
           type: string
         bpmnDefinitionId:
           type: string
-        priority:
-          type: object
-          allOf:
-            - $ref: "#/components/schemas/PriorityValueFilter"
     UserTaskItem:
       type: object
       properties:
@@ -2837,29 +2833,6 @@ components:
           description: The tenant ID of the message.
           type: string
 
-    PriorityValueFilter:
-      type: object
-      properties:
-        eq:
-          type: integer
-          minimum: 0
-          maximum: 100
-        gt:
-          type: integer
-          minimum: 0
-          maximum: 100
-        gte:
-          type: integer
-          minimum: 0
-          maximum: 100
-        lt:
-          type: integer
-          minimum: 0
-          maximum: 100
-        lte:
-          type: integer
-          minimum: 0
-          maximum: 100
     DocumentReference:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -276,11 +276,6 @@ public final class SearchQueryRequestMapper {
       if (filter.getTenantIds() != null) {
         builder.tenantIds(filter.getTenantIds());
       }
-
-      // priority
-      if (filter.getPriority() != null) {
-        builder.priority(mapPriorityFilter(filter.getPriority()));
-      }
     }
 
     return builder.build();
@@ -548,20 +543,11 @@ public final class SearchQueryRequestMapper {
     }
   }
 
-  private static DateValueFilter toDateValueFilter(String text) {
+  private static DateValueFilter toDateValueFilter(final String text) {
     if (StringUtils.isEmpty(text)) {
       return null;
     }
     final var date = OffsetDateTime.parse(text);
     return new DateValueFilter.Builder().before(date).after(date).build();
-  }
-
-  private static ComparableValueFilter mapPriorityFilter(final PriorityValueFilter priority) {
-    return new ComparableValueFilter.Builder()
-        .eq(priority.getEq())
-        .gt(priority.getGt())
-        .lt(priority.getLt())
-        .lte(priority.getLte())
-        .build();
   }
 }


### PR DESCRIPTION
## Description
Remove `priority` filter from V2 API as discussed in [slack](https://camunda.slack.com/archives/C06UKS51QV9/p1726118755520559) and [epic](https://github.com/camunda/product-hub/issues/217#issuecomment-2340692913).

Partial revert of [PR](https://github.com/camunda/camunda/pull/20626).

User Tasks can still be filtered by `priority` from the Tasklist V1 API. The V2 `priority` filter should be added again in 8.7 when Advanced Search is drafted.
