### PR TITLE
[Backport: main] Add tree path cache metrics

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -120,4 +120,8 @@ public class Metrics {
   public Timer getTimer(final String name, final String... tags) {
     return registry.timer(name, tags);
   }
+
+  public Timer getHistogram(final String name, final String... tags) {
+    return Timer.builder(name).publishPercentileHistogram().tags(tags).register(registry);
+  }
 }

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -43,7 +43,7 @@ public class Metrics {
   public static final String TIMER_NAME_ARCHIVER_DELETE_QUERY =
       OPERATE_NAMESPACE + "archiver.delete.query";
   public static final String TIMER_NAME_IMPORT_FNI_TREE_PATH_CACHE_ACCESS =
-      OPERATE_NAMESPACE + "fni.tree.path.cache.access";
+      OPERATE_NAMESPACE + "import.fni.tree.path.cache.access";
   // Counters:
   public static final String COUNTER_NAME_EVENTS_PROCESSED = "events.processed";
   public static final String COUNTER_NAME_EVENTS_PROCESSED_FINISHED_WI =

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -9,7 +9,9 @@ package io.camunda.operate;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
+import java.util.Arrays;
 import java.util.Queue;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
@@ -42,16 +44,24 @@ public class Metrics {
       OPERATE_NAMESPACE + "archiver.reindex.query";
   public static final String TIMER_NAME_ARCHIVER_DELETE_QUERY =
       OPERATE_NAMESPACE + "archiver.delete.query";
+  public static final String TIMER_NAME_FNI_CACHE_ACCESS =
+      OPERATE_NAMESPACE + "fni.tree.path.cache.access";
   // Counters:
   public static final String COUNTER_NAME_EVENTS_PROCESSED = "events.processed";
   public static final String COUNTER_NAME_EVENTS_PROCESSED_FINISHED_WI =
       "events.processed.finished.process.instances";
   public static final String COUNTER_NAME_COMMANDS = "commands";
   public static final String COUNTER_NAME_ARCHIVED = "archived.process.instances";
+  public static final String COUNTER_NAME_FNI_TREE_PATH_CACHE_RESULT =
+      OPERATE_NAMESPACE + "fni.tree.path.cache.result";
   // Gauges:
   public static final String GAUGE_IMPORT_QUEUE_SIZE = "import.queue.size";
   public static final String GAUGE_BPMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.bpmn.count";
   public static final String GAUGE_DMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.dmn.count";
+
+  public static final String GAUGE_NAME_FNI_TREE_PATH_CACHE_SIZE =
+      OPERATE_NAMESPACE + "fni.tree.path.cache.size";
+
   // Tags
   // -----
   //  Keys:
@@ -79,26 +89,35 @@ public class Metrics {
    * @param count - Number to count
    * @param tags - key value pairs of tags as Strings - The size of tags varargs must be even.
    */
-  public void recordCounts(String name, long count, String... tags) {
+  public void recordCounts(final String name, final long count, final String... tags) {
     registry.counter(OPERATE_NAMESPACE + name, tags).increment(count);
   }
 
   public <T> void registerGauge(
-      String name, T stateObject, ToDoubleFunction<T> valueFunction, String... tags) {
+      final String name,
+      final T stateObject,
+      final ToDoubleFunction<T> valueFunction,
+      final String... tags) {
     Gauge.builder(OPERATE_NAMESPACE + name, stateObject, valueFunction)
         .tags(tags)
         .register(registry);
   }
 
-  public void registerGaugeSupplier(String name, Supplier<Number> gaugeSupplier, String... tags) {
+  public void registerGauge(final String name, final long size, final Tag... tags) {
+    registry.gauge(name, Arrays.asList(tags), size);
+  }
+
+  public void registerGaugeSupplier(
+      final String name, final Supplier<Number> gaugeSupplier, final String... tags) {
     Gauge.builder(name, gaugeSupplier).tags(tags).register(registry);
   }
 
-  public <E> void registerGaugeQueueSize(String name, Queue<E> queue, String... tags) {
+  public <E> void registerGaugeQueueSize(
+      final String name, final Queue<E> queue, final String... tags) {
     registerGauge(name, queue, q -> q.size(), tags);
   }
 
-  public Timer getTimer(String name, String... tags) {
+  public Timer getTimer(final String name, final String... tags) {
     return registry.timer(name, tags);
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -9,9 +9,7 @@ package io.camunda.operate;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import java.util.Arrays;
 import java.util.Queue;
 import java.util.function.Supplier;
 import java.util.function.ToDoubleFunction;
@@ -44,7 +42,7 @@ public class Metrics {
       OPERATE_NAMESPACE + "archiver.reindex.query";
   public static final String TIMER_NAME_ARCHIVER_DELETE_QUERY =
       OPERATE_NAMESPACE + "archiver.delete.query";
-  public static final String TIMER_NAME_FNI_CACHE_ACCESS =
+  public static final String TIMER_NAME_IMPORT_FNI_TREE_PATH_CACHE_ACCESS =
       OPERATE_NAMESPACE + "fni.tree.path.cache.access";
   // Counters:
   public static final String COUNTER_NAME_EVENTS_PROCESSED = "events.processed";
@@ -52,15 +50,16 @@ public class Metrics {
       "events.processed.finished.process.instances";
   public static final String COUNTER_NAME_COMMANDS = "commands";
   public static final String COUNTER_NAME_ARCHIVED = "archived.process.instances";
-  public static final String COUNTER_NAME_FNI_TREE_PATH_CACHE_RESULT =
-      OPERATE_NAMESPACE + "fni.tree.path.cache.result";
+  public static final String COUNTER_NAME_IMPORT_FNI_TREE_PATH_CACHE_RESULT =
+      "import.fni.tree.path.cache.result";
+
   // Gauges:
-  public static final String GAUGE_IMPORT_QUEUE_SIZE = "import.queue.size";
+  public static final String GAUGE_IMPORT_QUEUE_SIZE = OPERATE_NAMESPACE + "import.queue.size";
   public static final String GAUGE_BPMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.bpmn.count";
   public static final String GAUGE_DMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.dmn.count";
 
-  public static final String GAUGE_NAME_FNI_TREE_PATH_CACHE_SIZE =
-      OPERATE_NAMESPACE + "fni.tree.path.cache.size";
+  public static final String GAUGE_NAME_IMPORT_FNI_TREE_PATH_CACHE_SIZE =
+      OPERATE_NAMESPACE + "import.fni.tree.path.cache.size";
 
   // Tags
   // -----
@@ -98,13 +97,7 @@ public class Metrics {
       final T stateObject,
       final ToDoubleFunction<T> valueFunction,
       final String... tags) {
-    Gauge.builder(OPERATE_NAMESPACE + name, stateObject, valueFunction)
-        .tags(tags)
-        .register(registry);
-  }
-
-  public void registerGauge(final String name, final long size, final Tag... tags) {
-    registry.gauge(name, Arrays.asList(tags), size);
+    Gauge.builder(name, stateObject, valueFunction).tags(tags).register(registry);
   }
 
   public void registerGaugeSupplier(

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -69,7 +69,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             partitionIds,
             flowNodeTreeCacheSize,
             flowNodeStore::findParentTreePathFor,
-            new TreePathCacheMetricsImpl(metrics));
+            new TreePathCacheMetricsImpl(partitionIds, metrics));
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.operate.zeebeimport.processors;
 import static io.camunda.operate.zeebeimport.util.ImportUtil.tenantOrDefault;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 
+import io.camunda.operate.Metrics;
 import io.camunda.operate.entities.FlowNodeInstanceEntity;
 import io.camunda.operate.entities.FlowNodeState;
 import io.camunda.operate.entities.FlowNodeType;
@@ -23,6 +24,7 @@ import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.operate.zeebeimport.cache.FNITreePathCacheCompositeKey;
 import io.camunda.operate.zeebeimport.cache.FlowNodeInstanceTreePathCache;
+import io.camunda.operate.zeebeimport.cache.TreePathCacheMetricsImpl;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -56,14 +58,18 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       final FlowNodeStore flowNodeStore,
       final FlowNodeInstanceTemplate flowNodeInstanceTemplate,
       final OperateProperties operateProperties,
-      final PartitionHolder partitionHolder) {
+      final PartitionHolder partitionHolder,
+      final Metrics metrics) {
     this.flowNodeStore = flowNodeStore;
     this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     final var flowNodeTreeCacheSize = operateProperties.getImporter().getFlowNodeTreeCacheSize();
     final var partitionIds = partitionHolder.getPartitionIds();
     treePathCache =
         new FlowNodeInstanceTreePathCache(
-            partitionIds, flowNodeTreeCacheSize, flowNodeStore::findParentTreePathFor);
+            partitionIds,
+            flowNodeTreeCacheSize,
+            flowNodeStore::findParentTreePathFor,
+            new TreePathCacheMetricsImpl(metrics));
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
@@ -9,6 +9,7 @@ package io.camunda.operate.zeebeimport.cache;
 
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.SoftHashMap;
+import io.camunda.operate.zeebeimport.cache.TreePathCacheMetrics.CacheResult;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ public final class FlowNodeInstanceTreePathCache {
   private static final Logger LOGGER = LoggerFactory.getLogger(FlowNodeInstanceTreePathCache.class);
   private final Map<Integer, Map<String, String>> backedTreePathCache;
   private final Function<Long, String> treePathResolver;
+  private final TreePathCacheMetrics treePathCacheMetrics;
 
   /**
    * Constructs the tree patch cache, backed by caches per given partitions.
@@ -50,11 +52,30 @@ public final class FlowNodeInstanceTreePathCache {
       final List<Integer> partitionIds,
       final int cacheSize,
       final Function<Long, String> treePathResolver) {
+    this(partitionIds, cacheSize, treePathResolver, new NoopCacheMetrics());
+  }
+
+  /**
+   * Constructs the tree patch cache, backed by caches per given partitions.
+   *
+   * @param partitionIds a list of partition ids the cache should cover, it might be that the
+   *     corresponding Importer is only importing a sparse of existing partition ids
+   * @param cacheSize the size of the caches assigned per partition
+   * @param treePathResolver the resolver to find corresponding treePath if not existing in the
+   *     cache
+   * @param treePathCacheMetrics metrics that are collected during cache usage
+   */
+  public FlowNodeInstanceTreePathCache(
+      final List<Integer> partitionIds,
+      final int cacheSize,
+      final Function<Long, String> treePathResolver,
+      final TreePathCacheMetrics treePathCacheMetrics) {
     backedTreePathCache = new HashMap<>();
     partitionIds.forEach(
         partitionId ->
             backedTreePathCache.computeIfAbsent(partitionId, (id) -> new SoftHashMap<>(cacheSize)));
     this.treePathResolver = treePathResolver;
+    this.treePathCacheMetrics = treePathCacheMetrics;
   }
 
   /**
@@ -76,22 +97,27 @@ public final class FlowNodeInstanceTreePathCache {
    *     supported partition
    */
   public String resolveTreePath(final FNITreePathCacheCompositeKey compositeKey) {
-    final var partitionCache = backedTreePathCache.get(compositeKey.partitionId());
+    final int partitionId = compositeKey.partitionId();
+    final var partitionCache = backedTreePathCache.get(partitionId);
     if (partitionCache == null) {
       final IllegalArgumentException illegalArgumentException =
           new IllegalArgumentException(
               String.format(
                   "Expected to find treePath cache for partitionId %d, but found nothing. Possible partition Ids are: '%s'.",
-                  compositeKey.partitionId(), backedTreePathCache.keySet()));
+                  partitionId, backedTreePathCache.keySet()));
 
       LOGGER.error(
           "Couldn't resolve tree path for given partition id {}",
-          compositeKey.partitionId(),
+          partitionId,
           illegalArgumentException);
       throw illegalArgumentException;
     }
 
-    return resolveTreePath(partitionCache, compositeKey);
+    final var treePath =
+        treePathCacheMetrics.recordTimeOfTreePathResolvement(
+            () -> resolveTreePath(partitionCache, compositeKey));
+    treePathCacheMetrics.reportCacheSize(partitionId, partitionCache.size());
+    return treePath;
   }
 
   private String resolveTreePath(
@@ -102,12 +128,14 @@ public final class FlowNodeInstanceTreePathCache {
     if (compositeKey.flowScopeKey() == compositeKey.processInstanceKey()) {
       parentTreePath = ConversionUtils.toStringOrNull(compositeKey.processInstanceKey());
     } else {
+      var cacheResult = CacheResult.HIT;
       // find parent flow node instance
       parentTreePath =
           partitionCache.get(ConversionUtils.toStringOrNull(compositeKey.flowScopeKey()));
 
       // cache miss: resolve tree path
       if (parentTreePath == null) {
+        cacheResult = CacheResult.MISS;
         parentTreePath = treePathResolver.apply(compositeKey.flowScopeKey());
         LOGGER.debug(
             "Cache miss: resolved treePath {} for flowScopeKey {} via given resolver.",
@@ -126,6 +154,7 @@ public final class FlowNodeInstanceTreePathCache {
           parentTreePath = ConversionUtils.toStringOrNull(compositeKey.processInstanceKey());
         }
       }
+      treePathCacheMetrics.reportCacheResult(compositeKey.partitionId(), cacheResult);
     }
     partitionCache.put(
         ConversionUtils.toStringOrNull(compositeKey.recordKey()),

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/FlowNodeInstanceTreePathCache.java
@@ -115,7 +115,7 @@ public final class FlowNodeInstanceTreePathCache {
 
     final var treePath =
         treePathCacheMetrics.recordTimeOfTreePathResolvement(
-            () -> resolveTreePath(partitionCache, compositeKey));
+            partitionId, () -> resolveTreePath(partitionCache, compositeKey));
     treePathCacheMetrics.reportCacheSize(partitionId, partitionCache.size());
     return treePath;
   }

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/NoopCacheMetrics.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/NoopCacheMetrics.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+public class NoopCacheMetrics implements TreePathCacheMetrics {
+
+  @Override
+  public void reportCacheResult(final int partitionId, final CacheResult result) {}
+
+  @Override
+  public void reportCacheSize(final int partitionId, final int size) {}
+}

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/NoopCacheMetrics.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/NoopCacheMetrics.java
@@ -1,18 +1,9 @@
 /*
- * Copyright Camunda Services GmbH
- *
- * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
- * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
- *
- * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
- * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
- * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
- * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
- *
- * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
- *
- * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.operate.zeebeimport.cache;
 

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetrics.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetrics.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+import java.util.function.Supplier;
+
+/** Metrics interface to observer the {@link FlowNodeInstanceTreePathCache} access and results. */
+public interface TreePathCacheMetrics {
+
+  /**
+   * Report the cache access and the corresponding result, whether it was a {@link CacheResult#HIT}
+   * or {@link CacheResult#MISS}.
+   *
+   * @param partitionId the corresponding partition the cache belongs to
+   * @param result the cache access result
+   */
+  void reportCacheResult(int partitionId, CacheResult result);
+
+  /**
+   * Record the cache resolution, implementations can track the time that is elapsed during the
+   * call.
+   *
+   * @param resolving the method to resolve the searched value either by look up in the cache or
+   *     using any other resolution strategy
+   * @return the result of the resolution
+   */
+  default String recordTimeOfTreePathResolvement(final Supplier<String> resolving) {
+    return resolving.get();
+  }
+
+  /**
+   * Report the cache size for a specific partition, to indicate how many key-value pairs are
+   * currently stored.
+   *
+   * @param partitionId the partition to which the cache size corresponds
+   * @param size the reported cache size
+   */
+  void reportCacheSize(int partitionId, int size);
+
+  enum CacheResult {
+    /** Entry was found in the cache */
+    HIT,
+    /** Entry was not found in the cache */
+    MISS
+  }
+}

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetrics.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetrics.java
@@ -1,18 +1,9 @@
 /*
- * Copyright Camunda Services GmbH
- *
- * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
- * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
- *
- * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
- * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
- * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
- * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
- *
- * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
- *
- * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.operate.zeebeimport.cache;
 

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
@@ -1,18 +1,9 @@
 /*
- * Copyright Camunda Services GmbH
- *
- * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
- * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
- *
- * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
- * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
- * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
- * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
- *
- * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
- *
- * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.operate.zeebeimport.cache;
 

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
@@ -37,7 +37,7 @@ public class TreePathCacheMetricsImpl implements TreePathCacheMetrics {
           cacheSizes.put(partitionId, cacheSizeRecorder);
           // gauges are registered once
           metrics.registerGauge(
-              Metrics.GAUGE_NAME_FNI_TREE_PATH_CACHE_SIZE,
+              Metrics.GAUGE_NAME_IMPORT_FNI_TREE_PATH_CACHE_SIZE,
               cacheSizeRecorder,
               Number::doubleValue,
               Metrics.TAG_KEY_PARTITION,
@@ -48,7 +48,7 @@ public class TreePathCacheMetricsImpl implements TreePathCacheMetrics {
   @Override
   public void reportCacheResult(final int partitionId, final CacheResult result) {
     metrics.recordCounts(
-        Metrics.COUNTER_NAME_FNI_TREE_PATH_CACHE_RESULT,
+        Metrics.COUNTER_NAME_IMPORT_FNI_TREE_PATH_CACHE_RESULT,
         1,
         Metrics.TAG_KEY_PARTITION,
         Integer.toString(partitionId),
@@ -61,7 +61,7 @@ public class TreePathCacheMetricsImpl implements TreePathCacheMetrics {
       final int partitionId, final Supplier<String> resolving) {
     return metrics
         .getHistogram(
-            Metrics.TIMER_NAME_FNI_CACHE_ACCESS,
+            Metrics.TIMER_NAME_IMPORT_FNI_TREE_PATH_CACHE_ACCESS,
             Metrics.TAG_KEY_PARTITION,
             Integer.toString(partitionId))
         .record(resolving);

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/cache/TreePathCacheMetricsImpl.java
@@ -44,7 +44,7 @@ public class TreePathCacheMetricsImpl implements TreePathCacheMetrics {
   public String recordTimeOfTreePathResolvement(
       final int partitionId, final Supplier<String> resolving) {
     return metrics
-        .getTimer(
+        .getHistogram(
             Metrics.TIMER_NAME_FNI_CACHE_ACCESS,
             Metrics.TAG_KEY_PARTITION,
             Integer.toString(partitionId))

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/ObservableFlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/ObservableFlowNodeInstanceTreePathCacheTest.java
@@ -1,18 +1,9 @@
 /*
- * Copyright Camunda Services GmbH
- *
- * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
- * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
- *
- * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
- * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
- * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
- * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
- *
- * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
- *
- * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
  */
 package io.camunda.operate.zeebeimport.cache;
 

--- a/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/ObservableFlowNodeInstanceTreePathCacheTest.java
+++ b/operate/importer-common/src/test/java/io/camunda/operate/zeebeimport/cache/ObservableFlowNodeInstanceTreePathCacheTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.zeebeimport.cache;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+
+import io.camunda.operate.zeebeimport.cache.TreePathCacheMetrics.CacheResult;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class ObservableFlowNodeInstanceTreePathCacheTest {
+
+  private HashMap<Long, String> spyTreePathResolver;
+  private FlowNodeInstanceTreePathCache treePathCache;
+  private NoopCacheMetrics treePathCacheMetrics;
+
+  @BeforeEach
+  void setup() {
+    // treePathResolver is in this case a simple map, but in production it might be
+    // the ES flow node store to query elastic to find the treePath
+    spyTreePathResolver = spy(new HashMap<>());
+    treePathCacheMetrics = Mockito.spy(new NoopCacheMetrics());
+    treePathCache =
+        new FlowNodeInstanceTreePathCache(
+            List.of(1, 2), 10, spyTreePathResolver::get, treePathCacheMetrics);
+  }
+
+  @Test
+  public void shouldResolveTreePathForRootLevelFNI() {
+    // given
+    // flow scope key and PI key is equal - no need to resolve tree path
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(Long.toString(0xABCD));
+
+    Mockito.verifyNoInteractions(spyTreePathResolver);
+    // the FNI is on root level and the treePath is resolve via PI key
+    // without accessing the cache
+    Mockito.verify(treePathCacheMetrics, times(0)).reportCacheResult(anyInt(), any());
+  }
+
+  @Test
+  public void shouldResolveTreePathFromPreviousRecord() {
+    // given
+    // root fni are added to the cache
+    final var rootFlowNodeInstanceRecord =
+        new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xABCD);
+    final String firstTreePath = treePathCache.resolveTreePath(rootFlowNodeInstanceRecord);
+
+    final var leafFlowNodeInstanceRecord =
+        new FNITreePathCacheCompositeKey(1, 0xFACE, 0xCAFE, 0xABCD);
+
+    // when
+    // fni with flow scope key of previous root FNI
+    final String secondTreePath = treePathCache.resolveTreePath(leafFlowNodeInstanceRecord);
+
+    // then cache should resolve without using the resolver
+    assertThat(secondTreePath)
+        .contains(firstTreePath)
+        .isEqualTo(String.join("/", Long.toString(0xABCD), Long.toString(0xCAFE)));
+
+    Mockito.verifyNoInteractions(spyTreePathResolver);
+    Mockito.verify(treePathCacheMetrics).reportCacheResult(1, CacheResult.HIT);
+  }
+
+  @Test
+  public void shouldTryToResolve() {
+    // given
+    // resolver can't resolve value - returned tree Path is equal to process instance key
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(Long.toString(0xEFDA));
+
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
+    Mockito.verify(treePathCacheMetrics).reportCacheResult(1, CacheResult.MISS);
+  }
+
+  @Test
+  public void shouldResolveTreePath() {
+    // given
+    // resolver can resolve tree path
+    final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
+    spyTreePathResolver.put(0xABCDL, expectedTreePath);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when
+    final String treePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(treePath).isEqualTo(expectedTreePath);
+
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
+    Mockito.verify(treePathCacheMetrics).reportCacheResult(1, CacheResult.MISS);
+  }
+
+  @Test
+  public void shouldNotResolveTreePathTwice() {
+    // given
+    // cache is empty and resolver can resolve tree path
+    final String expectedTreePath = String.join("/", Long.toString(0xABCD), Long.toString(0xEFDA));
+    spyTreePathResolver.put(0xABCDL, expectedTreePath);
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(1, 0xCAFE, 0xABCD, 0xEFDA);
+    final String firstTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // when
+    final String secondTreePath = treePathCache.resolveTreePath(flowNodeInstanceRecord);
+
+    // then
+    assertThat(firstTreePath).isEqualTo(secondTreePath).isEqualTo(expectedTreePath);
+
+    Mockito.verify(spyTreePathResolver, times(1)).get(eq(0xABCDL));
+    Mockito.verify(treePathCacheMetrics).reportCacheResult(1, CacheResult.MISS);
+    Mockito.verify(treePathCacheMetrics).reportCacheResult(1, CacheResult.HIT);
+  }
+
+  @Test
+  public void shouldThrowErrorWhenPartitionIdDoesNotFit() {
+    // given
+    // partition Id doesn't correspond to expected
+    final var flowNodeInstanceRecord = new FNITreePathCacheCompositeKey(3, 0xCAFE, 0xABCD, 0xEFDA);
+
+    // when - then
+    assertThatThrownBy(() -> treePathCache.resolveTreePath(flowNodeInstanceRecord))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Expected to find treePath cache for partitionId 3, but found nothing. Possible partition Ids are: '[1, 2]'.");
+
+    Mockito.verifyNoInteractions(spyTreePathResolver);
+    Mockito.verifyNoInteractions(treePathCacheMetrics);
+  }
+}


### PR DESCRIPTION
## Description
Backport: https://github.com/camunda/camunda/pull/22196

> This PR should allow us to get more insights into the Operate importer treePath Cache. As previously it was mostly a black-box, and unclear to us how much it helps, what it does, etc.

