### PR TITLE
Fix java client rest connection for long polling jobs

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -42,6 +42,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.hc.client5.http.async.AsyncExecChainHandler;
+import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.config.RequestConfig.Builder;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
@@ -133,14 +134,29 @@ public class HttpClientFactory {
             .setHostnameVerifier(hostnameVerifier)
             .build();
     final PoolingAsyncClientConnectionManager connectionManager =
-        PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+        PoolingAsyncClientConnectionManagerBuilder.create()
+            .setTlsStrategy(tlsStrategy)
+            //            .setDefaultTlsConfig(
+            //                TlsConfig.custom()
+            //                    .setVersionPolicy(HttpVersionPolicy.FORCE_HTTP_1)
+            //                    .setHandshakeTimeout(Timeout.ofSeconds(30L))
+            //                    .build())
+            //            .setMaxConnPerRoute(10)
+            //            .setMaxConnTotal(20)
+            //            .setPoolConcurrencyPolicy(PoolConcurrencyPolicy.LAX)
+            .setDefaultConnectionConfig(
+                ConnectionConfig.custom()
+                    .setSocketTimeout(Timeout.ofSeconds(40L))
+                    .setConnectTimeout(Timeout.ofSeconds(40L))
+                    .build())
+            .build();
 
     final IOReactorConfig ioReactorConfig =
         IOReactorConfig.custom()
             .setSoTimeout(Timeout.ofSeconds(30)) // Overall socket timeout
-            .setSndBufSize(64 * 1024) // Larger send buffer size
-            .setRcvBufSize(64 * 1024) // Larger receive buffer size
-            .setTcpNoDelay(true) // Disable Nagle's algorithm for lower latency
+            //            .setSndBufSize(64 * 1024) // Larger send buffer size
+            //            .setRcvBufSize(64 * 1024) // Larger receive buffer size
+            //            .setTcpNoDelay(true) // Disable Nagle's algorithm for lower latency
             .build();
 
     final HttpAsyncClientBuilder builder =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -68,7 +68,7 @@ public class LongPollingActivateJobsTest {
   // TODO: the REST use case is currently not working, see
   // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {false})
+  @ValueSource(booleans = {true, false})
   public void shouldActivateJobsIfBatchIsTruncated(final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 10;
@@ -110,7 +110,7 @@ public class LongPollingActivateJobsTest {
   // TODO: the REST use case is currently not working, see
   // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {false})
+  @ValueSource(booleans = {true, false})
   public void shouldActivateJobForOpenRequest(final boolean useRest, final TestInfo testInfo)
       throws InterruptedException {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -42,7 +42,7 @@ public class LongPollingActivateJobsTest {
 
   @BeforeEach
   void initClientAndInstances() {
-    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(40)).build();
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
@@ -68,7 +68,7 @@ public class LongPollingActivateJobsTest {
   // TODO: the REST use case is currently not working, see
   // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {true})
   public void shouldActivateJobsIfBatchIsTruncated(final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 10;
@@ -110,7 +110,7 @@ public class LongPollingActivateJobsTest {
   // TODO: the REST use case is currently not working, see
   // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {true})
   public void shouldActivateJobForOpenRequest(final boolean useRest, final TestInfo testInfo)
       throws InterruptedException {
     // given

--- a/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
+++ b/zeebe/qa/integration-tests/src/test/resources/log4j2-test.xml
@@ -17,6 +17,10 @@
     <Logger name="io.atomix.cluster.protocol" level="debug"/>
     <Logger name="io.atomix.raft" level="debug"/>
 
+<!--    <Logger name="org.apache.hc.core5" level="debug"/>-->
+<!--    <logger name="org.apache.http" level="debug"/>-->
+<!--    <Logger name="org.apache.commons.logging.simplelog.log.org.apache.http" level="debug"/>-->
+
     <Root level="info">
       <AppenderRef ref="Console"/>
     </Root>


### PR DESCRIPTION
## Description

Job long-polling may fail (on the TCP level) when done over REST with interleaved job activations or truncated batches of jobs.

This PR aims to adjust the Apache HttpClient used inside the Zeebe java client in order to optimize the communication between the client and the Gateway.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #19883 
