### PR TITLE
Extend gateway cluster endpoint to allow adding partitions and brokers

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -181,22 +181,22 @@ public class ClusterEndpoint {
         return forceRemoveBrokers(dryRun, brokers, partitions);
       }
 
-      if (brokers != null
-          && brokers.getCount() != null
-          && ((brokers.getAdd() != null || !brokers.getAdd().isEmpty())
-              || (brokers.getRemove() != null || !brokers.getRemove().isEmpty()))) {
+      final boolean isScale = brokers != null && brokers.getCount() != null;
+      final boolean shouldAddBrokers =
+          brokers != null && brokers.getAdd() != null && !brokers.getAdd().isEmpty();
+      final boolean shouldRemoveBrokers =
+          brokers != null && brokers.getRemove() != null && !brokers.getRemove().isEmpty();
+      if (isScale && (shouldAddBrokers || shouldRemoveBrokers)) {
         return invalidRequest(
-            "Cannot change brokers count and add/remove brokers at the same time. Specify either the newPartitionCount or brokers to add and remove.");
+            "Cannot change brokers count and add/remove brokers at the same time. Specify either the new brokers count or brokers to add and remove.");
       }
 
       final Optional<Integer> newPartitionCount =
-          partitions != null ? Optional.ofNullable(partitions.getCount()) : Optional.empty();
+          Optional.ofNullable(partitions).map(ClusterConfigPatchRequestPartitions::getCount);
       final Optional<Integer> newReplicationFactor =
-          partitions != null
-              ? Optional.ofNullable(partitions.getReplicationFactor())
-              : Optional.empty();
+          Optional.ofNullable(partitions)
+              .map(ClusterConfigPatchRequestPartitions::getReplicationFactor);
 
-      final boolean isScale = brokers != null && brokers.getCount() != null;
       if (isScale) {
         final var scaleRequest =
             new ClusterScaleRequest(

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -183,7 +183,8 @@ public class ClusterEndpoint {
 
       if (brokers != null
           && brokers.getCount() != null
-          && (!brokers.getAdd().isEmpty() || !brokers.getRemove().isEmpty())) {
+          && ((brokers.getAdd() != null || !brokers.getAdd().isEmpty())
+              || (brokers.getRemove() != null || !brokers.getRemove().isEmpty()))) {
         return invalidRequest(
             "Cannot change brokers count and add/remove brokers at the same time. Specify either the newPartitionCount or brokers to add and remove.");
       }
@@ -242,14 +243,18 @@ public class ClusterEndpoint {
       final boolean dryRun,
       final ClusterConfigPatchRequestBrokers brokers,
       final ClusterConfigPatchRequestPartitions partitions) {
-    if (brokers != null) {
-      if (brokers.getCount() != null) {
-        return invalidRequest("Cannot force change the broker count.");
-      }
-      if (!brokers.getAdd().isEmpty()) {
-        return invalidRequest("Cannot force add brokers");
-      }
+
+    if (brokers == null) {
+      return invalidRequest("Must provide a set of brokers to force remove.");
     }
+
+    if (brokers.getCount() != null) {
+      return invalidRequest("Cannot force change the broker count.");
+    }
+    if (brokers.getAdd() != null && !brokers.getAdd().isEmpty()) {
+      return invalidRequest("Cannot force add brokers");
+    }
+
     if (partitions != null) {
       if (partitions.getCount() != null) {
         return invalidRequest("Cannot force change the partition count.");
@@ -259,7 +264,7 @@ public class ClusterEndpoint {
       }
     }
 
-    if (brokers != null && brokers.getRemove().isEmpty()) {
+    if (brokers.getRemove() == null || brokers.getRemove().isEmpty()) {
       return invalidRequest("Must provide a set of brokers to force remove.");
     }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -11,6 +11,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import feign.FeignException;
 import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestBrokers;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequestPartitions;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -19,6 +22,7 @@ import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 
@@ -204,7 +208,86 @@ final class ClusterEndpointIT {
         .withBrokersCount(BROKER_COUNT)
         .withPartitionsCount(PARTITION_COUNT)
         .withReplicationFactor(replicationFactor)
+        .withBrokerConfig(
+            b -> b.brokerConfig().getExperimental().getFeatures().setEnablePartitionScaling(true))
         .build()
         .start();
+  }
+
+  @Nested
+  final class ClusterPatchRequest {
+    @Test
+    void shouldRequestClusterScale() {
+      try (final var cluster = createCluster(1)) {
+        // given
+        cluster.awaitCompleteTopology();
+        final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+        // when
+        final var request =
+            new ClusterConfigPatchRequest()
+                .brokers(new ClusterConfigPatchRequestBrokers().count(2))
+                .partitions(
+                    new ClusterConfigPatchRequestPartitions().count(2).replicationFactor(2));
+        final var response = actuator.patchCluster(request, false, false);
+        // then
+        assertThat(response.getExpectedTopology())
+            .describedAs("ClusterSize is increased to 2")
+            .hasSize(2);
+        assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
+            .describedAs("Each broker has 2 partitions")
+            .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size())
+            .isEqualTo(2);
+
+        assertThat(response.getPlannedChanges()).isNotEmpty();
+      }
+    }
+
+    @Test
+    void shouldRequestClusterPatch() {
+      try (final var cluster = createCluster(1)) {
+        // given
+        cluster.awaitCompleteTopology();
+        final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+        // when
+        final var request =
+            new ClusterConfigPatchRequest()
+                .brokers(new ClusterConfigPatchRequestBrokers().add(List.of(1)))
+                .partitions(
+                    new ClusterConfigPatchRequestPartitions().count(2).replicationFactor(2));
+        final var response = actuator.patchCluster(request, false, false);
+        // then
+        assertThat(response.getExpectedTopology())
+            .describedAs("ClusterSize is increased to 2")
+            .hasSize(2);
+        assertThat(response.getExpectedTopology().getFirst().getPartitions().size())
+            .describedAs("Each broker has 2 partitions")
+            .isEqualTo(response.getExpectedTopology().getLast().getPartitions().size())
+            .isEqualTo(2);
+
+        assertThat(response.getPlannedChanges()).isNotEmpty();
+      }
+    }
+
+    @Test
+    void shouldRequestForceRemoveBroker() {
+      // create cluster with two brokers
+      try (final var cluster = createCluster(2)) {
+        // given
+        cluster.awaitCompleteTopology();
+        cluster.brokers().get(MemberId.from("1")).close();
+        final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+        // when - force remove broker 1
+        final var request =
+            new ClusterConfigPatchRequest()
+                .brokers(new ClusterConfigPatchRequestBrokers().remove(List.of(1)));
+        final var response = actuator.patchCluster(request, false, true);
+
+        // then
+        assertThat(response.getExpectedTopology()).hasSize(1);
+      }
+    }
   }
 }

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -48,6 +48,11 @@
 
     <dependency>
       <groupId>io.github.openfeign</groupId>
+      <artifactId>feign-httpclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.openfeign</groupId>
       <artifactId>feign-jackson</artifactId>
     </dependency>
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -18,6 +18,7 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
@@ -70,6 +71,8 @@ public interface ClusterActuator {
         .encoder(new JacksonEncoder(List.of(new Jdk8Module(), new JavaTimeModule())))
         .decoder(new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule())))
         .retryer(Retryer.NEVER_RETRY)
+        // The default http client do not support http PATCH
+        .client(new feign.httpclient.ApacheHttpClient())
         .target(target);
   }
 
@@ -182,4 +185,18 @@ public interface ClusterActuator {
   @RequestLine("POST /brokers/{brokerId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PlannedOperationsResponse addBrokerInvalidType(@Param final String brokerId);
+
+  /**
+   * Scales the given brokers up or down and reassigns partitions to the new brokers.
+   *
+   * @param dryRun if true, changes are not applied but only simulated.
+   * @param force if true, the brokers that are not specified will be forcely removed.
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("PATCH ?dryRun={dryRun}&force={force}")
+  @Headers({"Content-Type: application/json", "accept: application/json"})
+  PlannedOperationsResponse patchCluster(
+      @RequestBody final ClusterConfigPatchRequest request,
+      @Param boolean dryRun,
+      @Param boolean force);
 }


### PR DESCRIPTION
## Description

This PR adds the endpoint for a cluster patch request that allows to change cluster size, partition count and replication factor in a single request. 

Examples:
Request o change the number of brokers, as well as number of partitions and replication factor. 
```
 curl -X 'PATCH' \
  'http://localhost:9600/actuator/cluster' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "brokers" : {
    "count" : 4,
  },
  "partitions" : {
    "replicationFactor" : 1,
    "count" : 4
  }
}'
```
Request to add or remove specific brokers, instead of providing a new cluster size.
```
curl -X 'PATCH' \
  'http://localhost:9600/actuator/cluster' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "brokers" : {
    "add" : [ 4 ],
    "remove" : [ 2 ]
  },
  "partitions" : {
    "replicationFactor" : 1,
    "count" : 4
  }
}'
```

We can also change just one of the parameters - partition count, replication factor or the brokers in a single request. 
In addition, the to force remove a set of brokers, we can provide `brokers.remove` in the input and set the request parameter `?force=true` 

## Related issues

closes #21480 
