### PR TITLE
Create a default user

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1284,6 +1284,12 @@
           # PS: The default value is 12kb. Increasing it to a higher value introduces a risk that it will be throttled by NGINX proxy configs or the zeebe client configs.
           # resultsOutputMaxSize: 12288
 
+        # authorization
+          # Enables authorization checks. If enabled a default user will be created with the credentials demo/demo.
+          # This default user can be used to setup the system. It is recommended to change the password of the default user afterwards.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_AUTHORIZATIONS_ENABLEAUTHORIZATION
+          # enableAuthorization: false
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -879,6 +879,7 @@
       # Using a low interval will result in unnecessary load while idle. We recommend to benchmark any changes to this setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SCHEDULEDTASKCHECKINTERVAL
       # scheduledTaskCheckInterval: 1s
+
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.
@@ -1158,6 +1159,12 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
           # PS: The default value is 12kb. Increasing it to a higher value introduces a risk that it will be throttled by NGINX proxy configs or the zeebe client configs.
           # resultsOutputMaxSize: 12288
+
+        # authorization
+          # Enables authorization checks. If enabled a default user will be created with the credentials demo/demo.
+          # This default user can be used to setup the system. It is recommended to change the password of the default user afterwards.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_AUTHORIZATIONS_ENABLEAUTHORIZATION
+          # enableAuthorization: false
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/AuthorizationsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/AuthorizationsCfg.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public final class AuthorizationsCfg implements ConfigurationEntry {
+
+  private boolean enableAuthorization = EngineConfiguration.DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
+
+  @Override
+  public String toString() {
+    return "AuthorizationCfg{enableAuthorization=%s}".formatted(enableAuthorization);
+  }
+
+  public boolean isEnableAuthorization() {
+    return enableAuthorization;
+  }
+
+  public void setEnableAuthorization(final boolean enableAuthorization) {
+    this.enableAuthorization = enableAuthorization;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration.engine;
 
+import io.camunda.zeebe.broker.system.configuration.AuthorizationsCfg;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
 import io.camunda.zeebe.engine.EngineConfiguration;
@@ -17,6 +18,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private CachesCfg caches = new CachesCfg();
   private JobsCfg jobs = new JobsCfg();
   private ValidatorsCfg validators = new ValidatorsCfg();
+  private AuthorizationsCfg authorizations = new AuthorizationsCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -24,6 +26,7 @@ public final class EngineCfg implements ConfigurationEntry {
     caches.init(globalConfig, brokerBase);
     jobs.init(globalConfig, brokerBase);
     validators.init(globalConfig, brokerBase);
+    authorizations.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -58,6 +61,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.validators = validators;
   }
 
+  public AuthorizationsCfg getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final AuthorizationsCfg authorizations) {
+    this.authorizations = authorizations;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -69,6 +80,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + jobs
         + ", validators="
         + validators
+        + ", authorizations="
+        + authorizations
         + '}';
   }
 
@@ -81,6 +94,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setProcessCacheCapacity(caches.getProcessCacheCapacity())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
-        .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize());
+        .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())
+        .setEnableAuthorization(authorizations.isEnableAuthorization());
   }
 }

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -121,6 +121,11 @@
       <artifactId>feel-engine</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+    </dependency>
+
     <!-- TEST DEPENDENCIES -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -26,6 +26,7 @@ public final class EngineConfiguration {
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
+  public static final boolean DEFAULT_ENABLE_AUTHORIZATION_CHECKS = false;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
@@ -37,6 +38,8 @@ public final class EngineConfiguration {
   private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
 
   private int validatorsResultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+
+  private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -111,6 +114,15 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setValidatorsResultsOutputMaxSize(final int maxSize) {
     validatorsResultsOutputMaxSize = maxSize;
+    return this;
+  }
+
+  public boolean isEnableAuthorization() {
+    return enableAuthorization;
+  }
+
+  public EngineConfiguration setEnableAuthorization(final boolean enableAuthorization) {
+    this.enableAuthorization = enableAuthorization;
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -203,7 +203,12 @@ public final class EngineProcessors {
         typedRecordProcessors, processingState, bpmnBehaviors, writers);
 
     UserProcessors.addUserProcessors(
-        keyGenerator, typedRecordProcessors, processingState, writers, commandDistributionBehavior);
+        keyGenerator,
+        typedRecordProcessors,
+        processingState,
+        writers,
+        commandDistributionBehavior,
+        config);
 
     ClockProcessors.addClockProcessors(
         typedRecordProcessors, writers, keyGenerator, clock, commandDistributionBehavior);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/DefaultUserCreator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/DefaultUserCreator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import static java.util.Optional.*;
+
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.UserType;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import org.slf4j.Logger;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public final class DefaultUserCreator implements StreamProcessorLifecycleAware, Task {
+  public static final String DEFAULT_USER_USERNAME = "demo";
+  public static final String DEFAULT_USER_PASSWORD = "demo";
+  public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
+  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
+  private final MutableProcessingState processingState;
+  private final BCryptPasswordEncoder passwordEncoder;
+
+  public DefaultUserCreator(final MutableProcessingState processingState) {
+    this.processingState = processingState;
+    passwordEncoder = new BCryptPasswordEncoder();
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    if (context.getPartitionId() != Protocol.DEPLOYMENT_PARTITION) {
+      // We should only create users on the deployment partition. The command will be distributed to
+      // the other partitions using our command distribution mechanism.
+      LOG.debug(
+          "Skipping default user creation on partition {} as it is not the deployment partition",
+          context.getPartitionId());
+      return;
+    }
+
+    // We use a timestamp of 0L to ensure this is runs immediately once the stream processor is
+    // started,
+    context.getScheduleService().runAtAsync(0L, this);
+  }
+
+  @Override
+  public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    ofNullable(processingState.getUserState().getUser(DEFAULT_USER_USERNAME))
+        .ifPresentOrElse(
+            user -> {
+              LOG.debug("Default user already exists, skipping creation");
+            },
+            () -> {
+              final var defaultUser =
+                  new UserRecord()
+                      .setUsername(DEFAULT_USER_USERNAME)
+                      .setName(DEFAULT_USER_USERNAME)
+                      .setEmail(DEFAULT_USER_EMAIL)
+                      .setPassword(passwordEncoder.encode(DEFAULT_USER_PASSWORD))
+                      .setUserType(UserType.DEFAULT);
+
+              taskResultBuilder.appendCommandRecord(UserIntent.CREATE, defaultUser);
+              LOG.info(
+                  "Created default user with username '{}' and password '{}'",
+                  DEFAULT_USER_USERNAME,
+                  DEFAULT_USER_PASSWORD);
+            });
+
+    return taskResultBuilder.build();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/DefaultUserCreator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/DefaultUserCreator.java
@@ -11,6 +11,7 @@ import static java.util.Optional.*;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -29,13 +30,13 @@ public final class DefaultUserCreator implements StreamProcessorLifecycleAware, 
   public static final String DEFAULT_USER_PASSWORD = "demo";
   public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private final MutableProcessingState processingState;
+  private final UserState userState;
   private final EngineConfiguration config;
   private final BCryptPasswordEncoder passwordEncoder;
 
   public DefaultUserCreator(
       final MutableProcessingState processingState, final EngineConfiguration config) {
-    this.processingState = processingState;
+    userState = processingState.getUserState();
     this.config = config;
     passwordEncoder = new BCryptPasswordEncoder();
   }
@@ -64,7 +65,7 @@ public final class DefaultUserCreator implements StreamProcessorLifecycleAware, 
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    ofNullable(processingState.getUserState().getUser(DEFAULT_USER_USERNAME))
+    ofNullable(userState.getUser(DEFAULT_USER_USERNAME))
         .ifPresentOrElse(
             user -> {
               LOG.debug("Default user already exists, skipping creation");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -21,7 +22,8 @@ public class UserProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
-      final CommandDistributionBehavior distributionBehavior) {
+      final CommandDistributionBehavior distributionBehavior,
+      final EngineConfiguration config) {
     typedRecordProcessors
         .onCommand(
             ValueType.USER,
@@ -31,6 +33,6 @@ public class UserProcessors {
             ValueType.USER,
             UserIntent.UPDATE,
             new UserUpdateProcessor(keyGenerator, processingState, writers, distributionBehavior))
-        .withListener(new DefaultUserCreator(processingState));
+        .withListener(new DefaultUserCreator(processingState, config));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -22,13 +22,15 @@ public class UserProcessors {
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior) {
-    typedRecordProcessors.onCommand(
-        ValueType.USER,
-        UserIntent.CREATE,
-        new UserCreateProcessor(keyGenerator, processingState, writers, distributionBehavior));
-    typedRecordProcessors.onCommand(
-        ValueType.USER,
-        UserIntent.UPDATE,
-        new UserUpdateProcessor(keyGenerator, processingState, writers, distributionBehavior));
+    typedRecordProcessors
+        .onCommand(
+            ValueType.USER,
+            UserIntent.CREATE,
+            new UserCreateProcessor(keyGenerator, processingState, writers, distributionBehavior))
+        .onCommand(
+            ValueType.USER,
+            UserIntent.UPDATE,
+            new UserUpdateProcessor(keyGenerator, processingState, writers, distributionBehavior))
+        .withListener(new DefaultUserCreator(processingState));
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-template.json
@@ -35,6 +35,9 @@
             },
             "password": {
               "type": "keyword"
+            },
+            "userType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-template.json
@@ -35,6 +35,9 @@
             },
             "password": {
               "type": "keyword"
+            },
+            "userType": {
+              "type": "keyword"
             }
           }
         }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -94,6 +94,7 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
 public class RequestMapper {
@@ -273,7 +274,7 @@ public class RequestMapper {
   }
 
   public static Either<ProblemDetail, CreateUserRequest> toCreateUserRequest(
-      final UserRequest request) {
+      final UserRequest request, final PasswordEncoder passwordEncoder) {
     return getResult(
         validateUserCreateRequest(request),
         () ->
@@ -281,7 +282,7 @@ public class RequestMapper {
                 request.getUsername(),
                 request.getName(),
                 request.getEmail(),
-                request.getPassword()));
+                passwordEncoder.encode(request.getPassword())));
   }
 
   public static <BrokerResponseT> CompletableFuture<ResponseEntity<Object>> executeServiceMethod(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createUser(
       @RequestBody final UserRequest userRequest) {
-    return RequestMapper.toCreateUserRequest(userRequest)
+    return RequestMapper.toCreateUserRequest(userRequest, passwordEncoder)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -10,10 +10,12 @@ package io.camunda.zeebe.protocol.impl.record.value.user;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
@@ -23,14 +25,17 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty emailProp = new StringProperty("email", "");
   private final StringProperty passwordProp = new StringProperty("password", "");
+  private final EnumProperty<UserType> userTypeProp =
+      new EnumProperty<>("userType", UserType.class, UserType.REGULAR);
 
   public UserRecord() {
-    super(5);
+    super(6);
     declareProperty(userKeyProp)
         .declareProperty(usernameProp)
         .declareProperty(nameProp)
         .declareProperty(emailProp)
-        .declareProperty(passwordProp);
+        .declareProperty(passwordProp)
+        .declareProperty(userTypeProp);
   }
 
   public void wrap(final UserRecord record) {
@@ -39,6 +44,7 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
     nameProp.setValue(record.getNameBuffer());
     emailProp.setValue(record.getEmailBuffer());
     passwordProp.setValue(record.getPasswordBuffer());
+    userTypeProp.setValue(record.getUserType());
   }
 
   public UserRecord copy() {
@@ -47,6 +53,7 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
     copy.nameProp.setValue(BufferUtil.cloneBuffer(getNameBuffer()));
     copy.emailProp.setValue(BufferUtil.cloneBuffer(getEmailBuffer()));
     copy.passwordProp.setValue(BufferUtil.cloneBuffer(getPasswordBuffer()));
+    copy.userTypeProp.setValue(getUserType());
     return copy;
   }
 
@@ -108,6 +115,16 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
   @Override
   public String getPassword() {
     return bufferAsString(passwordProp.getValue());
+  }
+
+  @Override
+  public UserType getUserType() {
+    return userTypeProp.getValue();
+  }
+
+  public UserRecord setUserType(final UserType userType) {
+    userTypeProp.setValue(userType);
+    return this;
   }
 
   public UserRecord setPassword(final String password) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -73,6 +73,7 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.protocol.record.value.VariableDocumentUpdateSemantic;
 import io.camunda.zeebe.test.util.JsonUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -2508,14 +2509,16 @@ final class JsonSerializableToJsonTest {
                     .setUsername("foobar")
                     .setName("Foo Bar")
                     .setEmail("foo@bar")
-                    .setPassword("f00b4r"),
+                    .setPassword("f00b4r")
+                    .setUserType(UserType.DEFAULT),
         """
         {
           "userKey": 1,
           "username": "foobar",
           "name": "Foo Bar",
           "email": "foo@bar",
-          "password": "f00b4r"
+          "password": "f00b4r",
+          "userType": "DEFAULT"
         }
         """
       },
@@ -2537,7 +2540,8 @@ final class JsonSerializableToJsonTest {
           "username": "foobar",
           "name": "Foo Bar",
           "email": "foo@bar",
-          "password": "f00b4r"
+          "password": "f00b4r",
+          "userType": "REGULAR"
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserType.java
@@ -15,23 +15,9 @@
  */
 package io.camunda.zeebe.protocol.record.value;
 
-import io.camunda.zeebe.protocol.record.ImmutableProtocol;
-import io.camunda.zeebe.protocol.record.RecordValue;
-import org.immutables.value.Value;
-
-@Value.Immutable
-@ImmutableProtocol(builder = ImmutableUserRecordValue.Builder.class)
-public interface UserRecordValue extends RecordValue {
-
-  Long getUserKey();
-
-  String getUsername();
-
-  String getName();
-
-  String getEmail();
-
-  String getPassword();
-
-  UserType getUserType();
+public enum UserType {
+  // The default user is automatically created and has full access to the system.
+  DEFAULT,
+  // Regular users are created manually and need to be granted permissions to access the system.
+  REGULAR
 }

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -462,6 +462,12 @@
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-crypto</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/DefaultUserCreatorIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/DefaultUserCreatorIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.processing;
+
+import static io.camunda.zeebe.protocol.record.RecordValueAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.engine.processing.user.DefaultUserCreator;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.UserType;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@ZeebeIntegration
+final class DefaultUserCreatorIT {
+
+  private static BCryptPasswordEncoder passwordEncoder;
+  @AutoCloseResource private ZeebeClient client;
+  @AutoCloseResource private TestStandaloneBroker broker;
+
+  @BeforeAll
+  static void beforeAll() {
+    passwordEncoder = new BCryptPasswordEncoder();
+  }
+
+  @Test
+  void shouldCreateDefaultUser() throws InterruptedException {
+    // given a broker with authorization enabled
+    createBroker(true, 1);
+
+    // then default user should be created
+    final var createdUser =
+        RecordingExporter.userRecords(UserIntent.CREATED)
+            .withUsername(DefaultUserCreator.DEFAULT_USER_USERNAME)
+            .getFirst()
+            .getValue();
+
+    assertThat(createdUser)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("username", DefaultUserCreator.DEFAULT_USER_USERNAME)
+        .hasFieldOrPropertyWithValue("name", DefaultUserCreator.DEFAULT_USER_USERNAME)
+        .hasFieldOrPropertyWithValue("email", DefaultUserCreator.DEFAULT_USER_EMAIL)
+        .hasFieldOrPropertyWithValue("userType", UserType.DEFAULT);
+    final var passwordMatches =
+        passwordEncoder.matches(
+            DefaultUserCreator.DEFAULT_USER_PASSWORD, createdUser.getPassword());
+    assertTrue(passwordMatches);
+  }
+
+  @Test
+  void shouldNotCreateDefaultUserWhenAuthorizationsDisabled() {
+    // given a broker with authorization disabled
+    createBroker(false, 1);
+
+    // then default user should not be created
+    // We send a clock reset command so we have a record we can limit our RecordingExporter on
+    client.newClockResetCommand().send().join();
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ClockIntent.RESET)
+                .withIntent(UserIntent.CREATE)
+                .toList())
+        .describedAs("No user CREATE command must be written")
+        .isEmpty();
+  }
+
+  @Test
+  void shouldOnlyCreateDefaultUserOnDeploymentPartition() {
+    // given a broker with authorization disabled
+    createBroker(true, 2);
+
+    // then default user should not be created
+    // We send a clock reset command so we have a record we can limit our RecordingExporter on
+    client.newClockResetCommand().send().join();
+
+    final var userCreateRecords =
+        RecordingExporter.records()
+            .limit(r -> r.getIntent() == ClockIntent.RESET)
+            .userRecords()
+            .withIntent(UserIntent.CREATED)
+            .toList();
+
+    Assertions.assertThat(userCreateRecords)
+        .describedAs("One partition should CREATE user and distribute it to the other")
+        .hasSize(2);
+
+    final var firstRecord = userCreateRecords.getFirst();
+    final var secondRecord = userCreateRecords.getLast();
+
+    Assertions.assertThat(firstRecord.getPartitionId()).isEqualTo(Protocol.DEPLOYMENT_PARTITION);
+    Assertions.assertThat(Protocol.decodePartitionId(firstRecord.getValue().getUserKey()))
+        .describedAs("User key should be generated on the deployment partition")
+        .isEqualTo(Protocol.DEPLOYMENT_PARTITION);
+
+    Assertions.assertThat(secondRecord.getPartitionId())
+        .isNotEqualTo(Protocol.DEPLOYMENT_PARTITION);
+    Assertions.assertThat(Protocol.decodePartitionId(secondRecord.getValue().getUserKey()))
+        .describedAs(
+            "User key should be generated on the deployment partition and distributed to this partition")
+        .isEqualTo(Protocol.DEPLOYMENT_PARTITION);
+
+    Assertions.assertThat(firstRecord.getValue()).isEqualTo(secondRecord.getValue());
+  }
+
+  @Test
+  void shouldNotCreateDefaultUserOnRestart(@TempDir final Path tempDir) {
+    // given a broker with authorization enabled
+    createBroker(true, 1, tempDir);
+
+    RecordingExporter.userRecords(UserIntent.CREATED).limit(1).await();
+
+    // when broker is restarted
+    final var partitions = PartitionsActuator.of(broker);
+    partitions.takeSnapshot();
+    Awaitility.await("Snapshot is taken")
+        .atMost(Duration.ofSeconds(60))
+        .until(
+            () ->
+                Optional.ofNullable(partitions.query().get(1).snapshotId())
+                    .flatMap(FileBasedSnapshotId::ofFileName),
+            Optional::isPresent)
+        .orElseThrow();
+    broker.stop();
+    broker.start().awaitCompleteTopology();
+
+    // then default user should be created once
+    // We send a clock reset command so we have a record we can limit our RecordingExporter on
+    client.newClockResetCommand().send().join();
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ClockIntent.RESET)
+                .withIntent(UserIntent.CREATE)
+                .toList())
+        .describedAs("Only one user CREATE command must be written")
+        .hasSize(1);
+  }
+
+  private void createBroker(
+      final boolean authorizationsEnabled, final int partitionCount, final Path tempDir) {
+    broker =
+        new TestStandaloneBroker()
+            .withBrokerConfig(
+                cfg ->
+                    cfg.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(authorizationsEnabled))
+            .withBrokerConfig(cfg -> cfg.getCluster().setPartitionsCount(partitionCount))
+            .withRecordingExporter(true);
+
+    if (tempDir != null) {
+      broker.withWorkingDirectory(tempDir);
+    }
+
+    broker.start().awaitCompleteTopology(1, partitionCount, 1, Duration.ofSeconds(30));
+    client = broker.newClientBuilder().build();
+  }
+
+  private void createBroker(final boolean authorizationsEnabled, final int partitionCount) {
+    createBroker(authorizationsEnabled, partitionCount, null);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -373,7 +373,7 @@ public final class ZeebeAssertHelper {
     final UserRecordValue user =
         RecordingExporter.userRecords()
             .withIntent(UserIntent.CREATED)
-            .withUsernameKey(username)
+            .withUsername(username)
             .getFirst()
             .getValue();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -123,4 +123,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new UserTaskRecordStream(
         filter(r -> r.getValueType() == ValueType.USER_TASK).map(Record.class::cast));
   }
+
+  public UserRecordStream userRecords() {
+    return new UserRecordStream(
+        filter(r -> r.getValueType() == ValueType.USER).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
@@ -431,6 +432,10 @@ public final class RecordingExporter implements Exporter {
 
   public static UserRecordStream userRecords() {
     return new UserRecordStream(records(ValueType.USER, UserRecordValue.class));
+  }
+
+  public static UserRecordStream userRecords(final UserIntent intent) {
+    return userRecords().withIntent(intent);
   }
 
   public static ClockRecordStream clockRecords() {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserRecordStream.java
@@ -22,7 +22,7 @@ public class UserRecordStream extends ExporterRecordStream<UserRecordValue, User
     return new UserRecordStream(wrappedStream);
   }
 
-  public UserRecordStream withUsernameKey(final String usernameKey) {
-    return valueFilter(v -> v.getUsername().equals(usernameKey));
+  public UserRecordStream withUsername(final String username) {
+    return valueFilter(v -> v.getUsername().equals(username));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a scheduled task upon broker start. This task is only scheduled a single time and is responsible for creating the default user. This user will only be created once, and only on the Deployment partition. It's created via a command and will be distributed to other partitions accordingly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21421
