### PR TITLE
fix: fix querying decision instance by evaluationDate

### DIFF
--- a/service/src/main/java/io/camunda/service/search/filter/DateValueFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/DateValueFilter.java
@@ -9,7 +9,6 @@ package io.camunda.service.search.filter;
 
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
-import java.util.Objects;
 
 public final record DateValueFilter(OffsetDateTime after, OffsetDateTime before)
     implements FilterBase {
@@ -31,7 +30,6 @@ public final record DateValueFilter(OffsetDateTime after, OffsetDateTime before)
 
     @Override
     public DateValueFilter build() {
-      Objects.requireNonNullElse(after, before);
       return new DateValueFilter(after, before);
     }
   }

--- a/service/src/main/java/io/camunda/service/search/filter/DecisionInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/DecisionInstanceFilter.java
@@ -20,8 +20,7 @@ import java.util.Objects;
 public record DecisionInstanceFilter(
     List<Long> keys,
     List<DecisionInstanceState> states,
-    DateValueFilter evaluationDateBefore,
-    DateValueFilter evaluationDateAfter,
+    DateValueFilter evaluationDate,
     List<String> evaluationFailures,
     List<Long> processDefinitionKeys,
     List<Long> processInstanceKeys,
@@ -36,8 +35,7 @@ public record DecisionInstanceFilter(
   public static final class Builder implements ObjectBuilder<DecisionInstanceFilter> {
     private List<Long> keys;
     private List<DecisionInstanceState> states;
-    private DateValueFilter evaluationDateBefore;
-    private DateValueFilter evaluationDateAfter;
+    private DateValueFilter evaluationDate;
     private List<String> evaluationFailures;
     private List<Long> processDefinitionKeys;
     private List<Long> processInstanceKeys;
@@ -46,8 +44,6 @@ public record DecisionInstanceFilter(
     private List<String> dmnDecisionNames;
     private List<Integer> decisionVersions;
     private List<DecisionType> decisionTypes;
-    private Boolean evaluated;
-    private Boolean failed;
     private List<String> tenantIds;
 
     public Builder keys(final List<Long> values) {
@@ -68,13 +64,8 @@ public record DecisionInstanceFilter(
       return states(collectValuesAsList(values));
     }
 
-    public Builder evaluationDateBefore(final DateValueFilter evaluationDateBefore) {
-      this.evaluationDateBefore = evaluationDateBefore;
-      return this;
-    }
-
-    public Builder evaluationDateAfter(final DateValueFilter evaluationDateAfter) {
-      this.evaluationDateAfter = evaluationDateAfter;
+    public Builder evaluationDate(final DateValueFilter evaluationDate) {
+      this.evaluationDate = evaluationDate;
       return this;
     }
 
@@ -164,8 +155,7 @@ public record DecisionInstanceFilter(
       return new DecisionInstanceFilter(
           Objects.requireNonNullElse(keys, Collections.emptyList()),
           Objects.requireNonNullElse(states, Collections.emptyList()),
-          evaluationDateBefore,
-          evaluationDateAfter,
+          evaluationDate,
           Objects.requireNonNullElse(evaluationFailures, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),

--- a/service/src/main/java/io/camunda/service/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -11,7 +11,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
-import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.service.entities.DecisionInstanceEntity.DecisionInstanceState;
@@ -35,9 +34,7 @@ public final class DecisionInstanceFilterTransformer
   public SearchQuery toSearchQuery(final DecisionInstanceFilter filter) {
     final var keysQuery = getKeysQuery(filter.keys());
     final var statesQuery = getStatesQuery(filter.states());
-    final var evaluationDateBeforeQuery =
-        getEvaluationDateBeforeQuery(filter.evaluationDateBefore());
-    final var evaluationDateAfterQuery = getEvaluationDateAfterQuery(filter.evaluationDateAfter());
+    final var evaluationDateQuery = getEvaluationDateQuery(filter.evaluationDate());
     final var evaluationFailuresQuery = getEvaluationFailuresQuery(filter.evaluationFailures());
     final var processDefinitionKeysQuery =
         getProcessDefinitionKeysQuery(filter.processDefinitionKeys());
@@ -52,8 +49,7 @@ public final class DecisionInstanceFilterTransformer
     return and(
         keysQuery,
         statesQuery,
-        evaluationDateBeforeQuery,
-        evaluationDateAfterQuery,
+        evaluationDateQuery,
         evaluationFailuresQuery,
         processDefinitionKeysQuery,
         processInstanceKeysQuery,
@@ -78,15 +74,7 @@ public final class DecisionInstanceFilterTransformer
     return stringTerms("state", states != null ? states.stream().map(Enum::name).toList() : null);
   }
 
-  private SearchQuery getEvaluationDateBeforeQuery(final DateValueFilter filter) {
-    if (filter != null) {
-      final var transformer = transformers.getFilterTransformer(DateValueFilter.class);
-      return transformer.apply(new DateFieldFilter("evaluationDate", filter));
-    }
-    return null;
-  }
-
-  private SearchQuery getEvaluationDateAfterQuery(final DateValueFilter filter) {
+  private SearchQuery getEvaluationDateQuery(final DateValueFilter filter) {
     if (filter != null) {
       final var transformer = transformers.getFilterTransformer(DateValueFilter.class);
       return transformer.apply(new DateFieldFilter("evaluationDate", filter));
@@ -128,14 +116,6 @@ public final class DecisionInstanceFilterTransformer
     return stringTerms(
         "decisionType",
         decisionTypes != null ? decisionTypes.stream().map(Enum::name).toList() : null);
-  }
-
-  private SearchQuery getEvaluatedQuery(final Boolean evaluated) {
-    return evaluated != null ? term("evaluated", evaluated) : null;
-  }
-
-  private SearchQuery getFailedQuery(final Boolean failed) {
-    return failed != null ? term("failed", failed) : null;
   }
 
   private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Use single `DateValueFilter` to set evaluationDateBefore and evaluationDateAfter query filters

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
