### PR TITLE
fix: make versiontag IT assertion dependent on zeebe version

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/processdefinition/ZeebeProcessDefinitionImportIT.java
@@ -68,7 +68,11 @@ public class ZeebeProcessDefinitionImportIT extends AbstractCCSMIT {
               assertThat(importedDef.getKey()).isEqualTo(deployedProcess.getBpmnProcessId());
               assertThat(importedDef.getVersion())
                   .isEqualTo(String.valueOf(deployedProcess.getVersion()));
-              assertThat(importedDef.getVersionTag()).isEqualTo(ZeebeBpmnModels.VERSION_TAG);
+              if (isZeebeVersionPre86()) {
+                assertThat(importedDef.getVersionTag()).isNull();
+              } else {
+                assertThat(importedDef.getVersionTag()).isEqualTo(ZeebeBpmnModels.VERSION_TAG);
+              }
               assertThat(importedDef.getType()).isEqualTo(DefinitionType.PROCESS);
 
               assertThat(importedDef.getBpmn20Xml()).isEqualTo(Bpmn.convertToString(simpleProcess));


### PR DESCRIPTION
related to zeebe compatibility test failures: https://github.com/camunda/camunda/actions/runs/10857240497

## Description

The versionTag field was only recently added to zeebe records, when the IT run against previous versions this assertion fails since the field will be null for anything pre 8.6.

Test run: https://github.com/camunda/camunda/actions/runs/10879720699

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
