### PR TITLE
deps: fix CVE-2024-38816

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,8 +95,8 @@
     <version.feel-scala>1.16.4</version.feel-scala>
     <version.dmn-scala>1.8.1</version.dmn-scala>
     <version.rest-assured>5.3.2</version.rest-assured>
-    <version.spring>6.0.24</version.spring>
-    <version.spring-boot>3.1.6</version.spring-boot>
+    <version.spring>6.1.13</version.spring>
+    <version.spring-boot>3.1.11</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.4.0</version.kryo>
     <version.failsafe>2.4.4</version.failsafe>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
     <version.feel-scala>1.16.4</version.feel-scala>
     <version.dmn-scala>1.8.1</version.dmn-scala>
     <version.rest-assured>5.3.2</version.rest-assured>
-    <version.spring>6.0.19</version.spring>
+    <version.spring>6.0.24</version.spring>
     <version.spring-boot>3.1.6</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.4.0</version.kryo>


### PR DESCRIPTION
## Description

This PR fixes a high severity CVE: https://spring.io/security/cve-2024-38816

While we shouldn't be affected by this pre-REST API, it's still good to update.
