### PR TITLE
ci: instrument zeebe-snyk.yml to observe build status

### DIFF
--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -207,3 +207,12 @@ jobs:
             ## Result Links
             - [Snyk projects](https://app.snyk.io/org/team-zeebe/projects)
           EOF
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

As discussed in https://github.com/camunda/team-infrastructure/issues/671#issuecomment-2345997788, this PR instruments the `zeebe-snyk.yml` workflow to get metrics on build status.

I did not overwrite default values for `job_name`, `user_reason` and `user_description`, because I am not familiar with monorepo best practices and there is no particular information to report.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
