### PR TITLE
ci: temporarily increase timeout to allow cache creation on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 20
+    timeout-minutes: 25
     runs-on: [ self-hosted, linux, amd64, "16" ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

This PR unconditionally increases the timeout to fix [this problem](https://camunda.slack.com/archives/C071KP5BTHB/p1726482584788839). This is necessary to get the PR through the merge queue, more granular changes can be implemented later when CI is passing again.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

https://camunda.slack.com/archives/C071KP5BTHB/p1726482584788839
