### PR TITLE
Benchmark:  Use different job types

### DIFF
--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -51,7 +51,7 @@
         <zeebe:ioMapping>
           <zeebe:input source="=&#34;dispute_unsuccessful&#34;" target="type" />
         </zeebe:ioMapping>
-        <zeebe:taskDefinition type="customer_notification" />
+        <zeebe:taskDefinition type="inform_about_failed_claim" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0cceqh3</bpmn:incoming>
       <bpmn:outgoing>Flow_1cvob8y</bpmn:outgoing>
@@ -259,7 +259,7 @@
     </bpmn:userTask>
     <bpmn:sendTask id="Activity_1u3hrzx" name="Inform customer about successful claim">
       <bpmn:extensionElements>
-        <zeebe:taskDefinition type="customer_notification" />
+        <zeebe:taskDefinition type="inform_about_successful_claim" />
         <zeebe:ioMapping>
           <zeebe:input source="=&#34;dispute_successful&#34;" target="type" />
         </zeebe:ioMapping>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -210,7 +210,7 @@
         <bpmn:sequenceFlow id="Flow_1f05uvq" sourceRef="Activity_1ys0vez" targetRef="Gateway_1p7bkh1" />
         <bpmn:serviceTask id="Activity_1ys0vez" name="Get vendor info">
           <bpmn:extensionElements>
-            <zeebe:taskDefinition type="dispute_process_request_proof_from_vendor" />
+            <zeebe:taskDefinition type="dispute_process_request_get_vendor_info" />
             <zeebe:properties>
               <zeebe:property name="camundaModeler:exampleOutputJson" value="{&#10;  &#34;vendor_claim_frequency&#34;: 15&#10;}" />
             </zeebe:properties>


### PR DESCRIPTION
## Description

Currently investigating why the benchmarks at some point spiking with a lot of publish messages, and we were realizing that several tasks share the same job type.


Whis caused to send messages multiple times, unnecessarily. The new job type is used to 'get the vendor info', needs to be adjusted on the deployed benchmark config as well.

This doesn't necessarily the problem (not clear yet), but it reduces the amount of not useful work.