### PR TITLE
ci: disable noisy Docker Build summaries

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -100,6 +100,9 @@ runs:
 
     - name: Build Docker image
       uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: false
+        DOCKER_BUILD_RECORD_UPLOAD: false
       with:
         context: .
         file: ${{ inputs.dockerfile }}

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -93,6 +93,9 @@ jobs:
           driver-opts: network=host
       - name: Build and push to local registry
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: true

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -94,6 +94,9 @@ jobs:
           driver-opts: network=host
       - name: Build and push to local registry
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: true

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -214,6 +214,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Build and push to Zeebe gcr.io registry
         uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
+          DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
           push: true


### PR DESCRIPTION
## Description

This [feature of the docker build GH action](https://docs.docker.com/build/ci/github-actions/build-summary/) was enabled as default in newer major versions. I noticed because I frequently look at pages like https://github.com/camunda/camunda/actions/runs/10884454346 to spot build errors but instead have to scroll through ~10 of nearly identical looking outputs that only yield little value:

![image](https://github.com/user-attachments/assets/52a9457e-a462-428d-a2ca-4d11b2243a65)

We have many jobs in the monorepo CI that build Docker images, sometimes only temporarily to execute some tests against it without ever uploading it anywhere.

This PR proposes to disable this feature again by default (feel free to re-enable it for certain jobs) since the information gain is nearly null but they take up lots of UI space.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
