### PR TITLE
docs: mark clock REST API as alpha feature

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -583,11 +583,16 @@ paths:
     put:
       tags:
         - Clock
-      summary: Pin internal clock
+      summary: Pin internal clock (alpha)
       description: |
         Set a precise, static time for the Zeebe engine’s internal clock.
         When the clock is pinned, it remains at the specified time and does not advance.
         To change the time, the clock must be pinned again with a new timestamp.
+        
+        :::note
+        This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
+        in future releases.
+        :::
       requestBody:
         required: true
         content:
@@ -614,11 +619,15 @@ paths:
     post:
       tags:
         - Clock
-      summary: Reset internal clock
+      summary: Reset internal clock (alpha)
       description: |
         Resets the Zeebe engine’s internal clock to the current system time, enabling it to tick in real-time.
         This operation is useful for returning the clock to
         normal behavior after it has been pinned to a specific time.
+        
+        :::note
+        This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
+        in future releases.
       responses:
         "204":
           description: The clock was successfully reset to the system time.


### PR DESCRIPTION
## Description

Documents the clock REST API as an alpha feature since this is a preview feature that may be subject to change.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22224 
