### PR TITLE
Update base Docker image to latest Ubuntu LTS

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -12,7 +12,7 @@
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "ubuntu:jammy",
+  "org.opencontainers.image.ref.name": "ubuntu:noble",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Camunda Platform",

--- a/.ci/docker/test/zeebe-docker-labels.golden.json
+++ b/.ci/docker/test/zeebe-docker-labels.golden.json
@@ -11,7 +11,7 @@
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",
   "org.opencontainers.image.licenses": "(Apache-2.0 AND LicenseRef-Camunda-License-1.0)",
-  "org.opencontainers.image.ref.name": "ubuntu:jammy",
+  "org.opencontainers.image.ref.name": "ubuntu:noble",
   "org.opencontainers.image.revision": $REVISION,
   "org.opencontainers.image.source": "https://github.com/camunda/camunda",
   "org.opencontainers.image.title": "Zeebe",

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 # Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
 # has trouble with custom versioning schemes
-ARG BASE_IMAGE="ubuntu:jammy"
-ARG BASE_DIGEST="sha256:58b87898e82351c6cf9cf5b9f3c20257bb9e2dcf33af051e12ce532d7f94e3fe"
-ARG JDK_IMAGE="eclipse-temurin:21-jdk-jammy"
-ARG JDK_DIGEST="sha256:c7b6b308fb4d1606571ae3aa9326bacb6146eef4311cf6ea6f5ff53122055f16"
+ARG BASE_IMAGE="ubuntu:noble"
+ARG BASE_DIGEST="sha256:dfc10878be8d8fc9c61cbff33166cb1d1fe44391539243703c72766894fa834a"
+ARG JDK_IMAGE="eclipse-temurin:21-jdk-noble"
+ARG JDK_DIGEST="sha256:48e264b4a3393475e0d778885687adf6012b3ff25f83b6a6bafbcd42a3ffcc65"
 
 # set to "build" to build zeebe from scratch instead of using a distball
 ARG DIST="distball"
@@ -151,7 +151,7 @@ VOLUME ${ZB_HOME}/data
 VOLUME ${ZB_HOME}/logs
 
 RUN groupadd --gid 1001 camunda && \
-    adduser --system --gid 1001 --uid 1001 --home ${ZB_HOME} camunda && \
+    useradd --system --gid 1001 --uid 1001 --home ${ZB_HOME} camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -4,10 +4,10 @@
 # see https://docs.docker.com/build/buildkit/#getting-started
 # Both ubuntu and eclipse-temurin are pinned via digest and not by a strict version tag, as Renovate
 # has trouble with custom versioning schemes
-ARG BASE_IMAGE="ubuntu:jammy"
-ARG BASE_DIGEST="sha256:58b87898e82351c6cf9cf5b9f3c20257bb9e2dcf33af051e12ce532d7f94e3fe"
-ARG JDK_IMAGE="eclipse-temurin:21-jdk-jammy"
-ARG JDK_DIGEST="sha256:c7b6b308fb4d1606571ae3aa9326bacb6146eef4311cf6ea6f5ff53122055f16"
+ARG BASE_IMAGE="ubuntu:noble"
+ARG BASE_DIGEST="sha256:dfc10878be8d8fc9c61cbff33166cb1d1fe44391539243703c72766894fa834a"
+ARG JDK_IMAGE="eclipse-temurin:21-jdk-noble"
+ARG JDK_DIGEST="sha256:48e264b4a3393475e0d778885687adf6012b3ff25f83b6a6bafbcd42a3ffcc65"
 
 # set to "build" to build camunda from scratch instead of using a distball
 ARG DIST="distball"
@@ -150,7 +150,7 @@ VOLUME ${CAMUNDA_HOME}/data
 VOLUME ${CAMUNDA_HOME}/logs
 
 RUN groupadd --gid 1001 camunda && \
-    adduser --system --gid 1001 --uid 1001 --home ${CAMUNDA_HOME} camunda && \
+    useradd --system --gid 1001 --uid 1001 --home ${CAMUNDA_HOME} camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.


### PR DESCRIPTION
## Description

This PR updates the base image of the `camunda/zeebe` and `camunda/camunda` Docker images to the latest Ubuntu LTS. While Jammy is still set to receive security updates, typically many medium/low severity issues are not backported, or take longer to backport. Staying on the rolling end of the LTS cycle will reduce the CVE surface and, consequently, associated support load.

For example, a scan of the latest `ubuntu:jammy` image produces the following vulnerabilities:

```
 trivy image ubuntu:jammy
2024-09-17T09:59:34.167+0200	INFO	Vulnerability scanning is enabled
2024-09-17T09:59:34.167+0200	INFO	Secret scanning is enabled
2024-09-17T09:59:38.407+0200	INFO	Detected OS: ubuntu
2024-09-17T09:59:38.407+0200	INFO	Detecting Ubuntu vulnerabilities...
2024-09-17T09:59:38.411+0200	INFO	Number of language-specific files: 0

ubuntu:jammy (ubuntu 22.04)

Total: 37 (UNKNOWN: 0, LOW: 31, MEDIUM: 6, HIGH: 0, CRITICAL: 0)
```

And for `ubuntu:noble`:

```
❯ trivy image ubuntu:noble
2024-09-17T10:00:14.720+0200	INFO	Vulnerability scanning is enabled
2024-09-17T10:00:14.720+0200	INFO	Secret scanning is enabled
2024-09-17T10:00:16.918+0200	INFO	Detected OS: ubuntu
2024-09-17T10:00:16.918+0200	WARN	This OS version is not on the EOL list: ubuntu 24.04
2024-09-17T10:00:16.918+0200	INFO	Detecting Ubuntu vulnerabilities...
2024-09-17T10:00:16.919+0200	INFO	Number of language-specific files: 0

ubuntu:noble (ubuntu 24.04)

Total: 7 (UNKNOWN: 0, LOW: 4, MEDIUM: 3, HIGH: 0, CRITICAL: 0)
```