### PR TITLE
fix: merge concurrent resolves for up to 128 hostnames

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -394,6 +394,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
               dnsResolverGroup =
                   new DnsAddressResolverGroup(
                       new DnsNameResolverBuilder(clientGroup.next())
+                          .consolidateCacheSize(128)
                           .dnsQueryLifecycleObserverFactory(
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -217,6 +217,7 @@ public class NettyUnicastService implements ManagedUnicastService {
               dnsAddressResolverGroup =
                   new DnsAddressResolverGroup(
                       new DnsNameResolverBuilder(group.next())
+                          .consolidateCacheSize(128)
                           .dnsQueryLifecycleObserverFactory(
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,


### PR DESCRIPTION
We make many requests, each of which requires a resolved hostname. To avoid flooding the DNS server with many redundant queries, we can enable request that netty merges the requests to resolve hostnames. A second request will wait for and use the result of the first request.

I've chosen 128 as a magic number because it's a somewhat realistic upper bound on the number of hosts we'd look up (brokers + gateways) and is still low enough to not waste too much memory.

Relates to https://jira.camunda.com/browse/SUPPORT-22744