### PR TITLE
Fix realistic benchmark process

### DIFF
--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -57,6 +57,11 @@
       <bpmn:outgoing>Flow_1cvob8y</bpmn:outgoing>
     </bpmn:sendTask>
     <bpmn:subProcess id="Activity_199882v" name="Document Request Process">
+      <bpmn:extensionElements>
+        <zeebe:ioMapping>
+          <zeebe:input source="=null" target="correlationKey" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
       <bpmn:incoming>Flow_15wpx65</bpmn:incoming>
       <bpmn:outgoing>Flow_06bdzt7</bpmn:outgoing>
       <bpmn:startEvent id="Event_1g0dyzc" name="documents required">
@@ -138,6 +143,11 @@
         <bpmn:outgoing>Flow_16in312</bpmn:outgoing>
       </bpmn:startEvent>
       <bpmn:subProcess id="Activity_03cktkd" name="Vendor fraud claim validation">
+        <bpmn:extensionElements>
+          <zeebe:ioMapping>
+            <zeebe:input source="=null" target="correlationKey" />
+          </zeebe:ioMapping>
+        </bpmn:extensionElements>
         <bpmn:incoming>Flow_16in312</bpmn:incoming>
         <bpmn:outgoing>Flow_1y2i3of</bpmn:outgoing>
         <bpmn:multiInstanceLoopCharacteristics>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -131,7 +131,7 @@
       <bpmn:startEvent id="Event_1tf9brs" name="fraud claim investigation started">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
-            <zeebe:output source="=1" target="vendor_claim_frequency" />
+            <zeebe:output source="=5" target="vendor_claim_frequency" />
             <zeebe:output source="=1" target="customer_claim_frequency" />
           </zeebe:ioMapping>
         </bpmn:extensionElements>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/bankCustomerComplaintDisputeHandling.bpmn
@@ -128,11 +128,6 @@
     <bpmn:subProcess id="Activity_02tn153" name="Fraud Claim Investigation">
       <bpmn:incoming>Flow_06bdzt7</bpmn:incoming>
       <bpmn:outgoing>Flow_1jy0gq5</bpmn:outgoing>
-      <bpmn:multiInstanceLoopCharacteristics>
-        <bpmn:extensionElements>
-          <zeebe:loopCharacteristics inputCollection="=disputeDetails.disputePositions" inputElement="disputePosition" />
-        </bpmn:extensionElements>
-      </bpmn:multiInstanceLoopCharacteristics>
       <bpmn:startEvent id="Event_1tf9brs" name="fraud claim investigation started">
         <bpmn:extensionElements>
           <zeebe:ioMapping>
@@ -145,6 +140,11 @@
       <bpmn:subProcess id="Activity_03cktkd" name="Vendor fraud claim validation">
         <bpmn:incoming>Flow_16in312</bpmn:incoming>
         <bpmn:outgoing>Flow_1y2i3of</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=disputeDetails.disputePositions" inputElement="disputePosition" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
         <bpmn:startEvent id="Event_0vl38e2" name="vendor fraud claim validation required">
           <bpmn:extensionElements>
             <zeebe:ioMapping>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
@@ -118,7 +118,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_0mrwftr">
-          <text>&lt;10</text>
+          <text>&lt;1000</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_128ie24">
           <text>-5</text>
@@ -136,7 +136,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_1b2ur4a">
-          <text>[10..100]</text>
+          <text>[1000..10000]</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_0km0sb7">
           <text>5</text>
@@ -154,7 +154,7 @@
           <text></text>
         </inputEntry>
         <inputEntry id="UnaryTests_00ncl7p">
-          <text>&gt;100</text>
+          <text>&gt;10000</text>
         </inputEntry>
         <outputEntry id="LiteralExpression_1ojlycx">
           <text>8</text>

--- a/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
+++ b/zeebe/benchmarks/project/src/main/resources/bpmn/realistic/determineFraudRatingConfidence.dmn
@@ -14,7 +14,7 @@
       </input>
       <input id="InputClause_16ezqsg" label="dispute amount">
         <inputExpression id="LiteralExpression_1ihjohf" typeRef="number">
-          <text>disputePosition.amount</text>
+          <text>disputeDetails.disputeAmount.amount</text>
         </inputExpression>
       </input>
       <output id="Output_1" label="fraud rating score" name="fraud_rating_score" typeRef="number" />


### PR DESCRIPTION
## Description

The process changes we recently did, caused PI didn't complete anymore. This caused at some point the clusters where crash due to their large state. 

![2024-09-17_16-17](https://github.com/user-attachments/assets/d1adb591-f623-4d89-80eb-864504d63da5)


This PR adjusts the process model to make more sense in general to the used workers and calculation.

![2024-09-17_15-15](https://github.com/user-attachments/assets/e0775f14-1d5c-4d80-99ea-b83b779ec136)

Changes:

 * Multi instance on outer sub process doesn't make much sense, as
DMN is executed multiple times, overwriting the respective value.
Reduces also the load.
* To run the right path in the process some variables have been adjusted
  * To calculate a better rating adjust the vendor claim frequency
  * To have a better rating, and cover the bigger dispute imputs we adjust the values
* Add input mappings to the sub processes to avoid concurrent writes
  * Without the definition as input mappings, the variables are created on the root scope, causing to overwrite each other.
<!-- Describe the goal and purpose of this PR. -->


Running with the changes we can see that instances are completed again:

![2024-09-17_16-14](https://github.com/user-attachments/assets/30375ca1-7d47-4a72-aeed-d61c9f891014)

Metrics:

![2024-09-17_18-22](https://github.com/user-attachments/assets/f277193b-bd3e-4fb9-8ae3-a25269b5399c)
![2024-09-17_18-22_1](https://github.com/user-attachments/assets/abb6fa20-248f-4034-aee5-cbb8de81c711)


## Related issues

related #21472 
related [thread](https://camunda.slack.com/archives/C037W9NMATG/p1726587900515399) 
