### PR TITLE
feat: validate deployment-bound resource links at deploy time

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/BpmnDeploymentBindingValidator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.engine.processing.deployment.transform.BpmnElementsWithDeploymentBinding;
+import io.camunda.zeebe.engine.processing.deployment.transform.ValidationErrorFormatter;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import java.io.StringWriter;
+import java.util.List;
+import org.camunda.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
+import org.camunda.bpm.model.xml.impl.validation.ValidationResultsCollectorImpl;
+import org.camunda.bpm.model.xml.validation.ValidationResults;
+
+public class BpmnDeploymentBindingValidator {
+
+  private final ValidationErrorFormatter formatter = new ValidationErrorFormatter();
+  private final ZeebeCalledElementDeploymentBindingValidator calledElementValidator;
+  private final ZeebeCalledDecisionDeploymentBindingValidator calledDecisionValidator;
+  private final ZeebeFormDefinitionDeploymentBindingValidator formDefinitionValidator;
+
+  public BpmnDeploymentBindingValidator(final DeploymentRecord deployment) {
+    calledElementValidator = new ZeebeCalledElementDeploymentBindingValidator(deployment);
+    calledDecisionValidator = new ZeebeCalledDecisionDeploymentBindingValidator(deployment);
+    formDefinitionValidator = new ZeebeFormDefinitionDeploymentBindingValidator(deployment);
+  }
+
+  public String validate(final BpmnElementsWithDeploymentBinding elements) {
+    final var resultsCollector = new ValidationResultsCollectorImpl();
+
+    validateCalledElements(elements.getCalledElements(), resultsCollector);
+    validateCalledDecisions(elements.getCalledDecisions(), resultsCollector);
+    validateFormDefinitions(elements.getFormDefinitions(), resultsCollector);
+
+    final var validationResults = resultsCollector.getResults();
+
+    return validationResults.hasErrors() ? createErrorMessage(validationResults) : null;
+  }
+
+  private void validateCalledElements(
+      final List<ZeebeCalledElement> calledElements,
+      final ValidationResultsCollectorImpl collector) {
+    calledElements.forEach(
+        element -> {
+          collector.setCurrentElement(element);
+          calledElementValidator.validate(element, collector);
+        });
+  }
+
+  private void validateCalledDecisions(
+      final List<ZeebeCalledDecision> calledDecisions,
+      final ValidationResultsCollectorImpl collector) {
+    calledDecisions.forEach(
+        element -> {
+          collector.setCurrentElement(element);
+          calledDecisionValidator.validate(element, collector);
+        });
+  }
+
+  private void validateFormDefinitions(
+      final List<ZeebeFormDefinition> formDefinitions,
+      final ValidationResultsCollectorImpl collector) {
+    formDefinitions.forEach(
+        element -> {
+          collector.setCurrentElement(element);
+          formDefinitionValidator.validate(element, collector);
+        });
+  }
+
+  private String createErrorMessage(final ValidationResults validationResults) {
+    final var writer = new StringWriter();
+    final var results = new ModelValidationResultsImpl(validationResults);
+    results.write(writer, formatter);
+    return writer.toString();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeCalledDecisionDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeCalledDecisionDeploymentBindingValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeCalledDecisionDeploymentBindingValidator
+    implements ModelElementValidator<ZeebeCalledDecision> {
+
+  private final List<DecisionRecordValue> decisionsMetadata;
+
+  public ZeebeCalledDecisionDeploymentBindingValidator(final DeploymentRecord deployment) {
+    decisionsMetadata = deployment.getDecisionsMetadata();
+  }
+
+  @Override
+  public Class<ZeebeCalledDecision> getElementType() {
+    return ZeebeCalledDecision.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeCalledDecision calledDecision,
+      final ValidationResultCollector validationResultCollector) {
+    if (decisionsMetadata.stream()
+        .noneMatch(decision -> calledDecision.getDecisionId().equals(decision.getDecisionId()))) {
+      validationResultCollector.addError(
+          0,
+          "Expected to find decision with id '%s' in current deployment, but not found."
+              .formatted(calledDecision.getDecisionId()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeCalledElementDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeCalledElementDeploymentBindingValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeCalledElementDeploymentBindingValidator
+    implements ModelElementValidator<ZeebeCalledElement> {
+
+  private final List<ProcessMetadataValue> processesMetadata;
+
+  public ZeebeCalledElementDeploymentBindingValidator(final DeploymentRecord deployment) {
+    processesMetadata = deployment.getProcessesMetadata();
+  }
+
+  @Override
+  public Class<ZeebeCalledElement> getElementType() {
+    return ZeebeCalledElement.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeCalledElement calledElement,
+      final ValidationResultCollector validationResultCollector) {
+    if (processesMetadata.stream()
+        .noneMatch(process -> calledElement.getProcessId().equals(process.getBpmnProcessId()))) {
+      validationResultCollector.addError(
+          0,
+          "Expected to find process with id '%s' in current deployment, but not found."
+              .formatted(calledElement.getProcessId()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeFormDefinitionDeploymentBindingValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeFormDefinitionDeploymentBindingValidator.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
+import java.util.List;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeFormDefinitionDeploymentBindingValidator
+    implements ModelElementValidator<ZeebeFormDefinition> {
+
+  private final List<FormMetadataValue> formMetadata;
+
+  public ZeebeFormDefinitionDeploymentBindingValidator(final DeploymentRecord deployment) {
+    formMetadata = deployment.getFormMetadata();
+  }
+
+  @Override
+  public Class<ZeebeFormDefinition> getElementType() {
+    return ZeebeFormDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeFormDefinition formDefinition,
+      final ValidationResultCollector validationResultCollector) {
+    if (formMetadata.stream()
+        .noneMatch(form -> formDefinition.getFormId().equals(form.getFormId()))) {
+      validationResultCollector.addError(
+          0,
+          "Expected to find form with id '%s' in current deployment, but not found."
+              .formatted(formDefinition.getFormId()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnElementsWithDeploymentBinding.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class BpmnElementsWithDeploymentBinding implements DeploymentResourceContext {
+
+  private final List<ZeebeCalledElement> calledElements = new ArrayList<>();
+  private final List<ZeebeCalledDecision> calledDecisions = new ArrayList<>();
+  private final List<ZeebeFormDefinition> formDefinitions = new ArrayList<>();
+
+  public void addFromProcess(final Process process) {
+    process
+        .getFlowElements()
+        .forEach(
+            element -> {
+              switch (element) {
+                case final CallActivity callActivity -> handleCallActivity(callActivity);
+                case final BusinessRuleTask task -> handleBusinessRuleTask(task);
+                case final UserTask task -> handleUserTask(task);
+                default -> {}
+              }
+            });
+  }
+
+  public List<ZeebeCalledElement> getCalledElements() {
+    return calledElements;
+  }
+
+  public List<ZeebeCalledDecision> getCalledDecisions() {
+    return calledDecisions;
+  }
+
+  public List<ZeebeFormDefinition> getFormDefinitions() {
+    return formDefinitions;
+  }
+
+  private void handleCallActivity(final CallActivity callActivity) {
+    Optional.ofNullable(callActivity.getSingleExtensionElement(ZeebeCalledElement.class))
+        .filter(
+            calledElement ->
+                calledElement.getBindingType() == ZeebeBindingType.deployment
+                    && isNotExpression(calledElement.getProcessId()))
+        .ifPresent(calledElements::add);
+  }
+
+  private void handleBusinessRuleTask(final BusinessRuleTask task) {
+    Optional.ofNullable(task.getSingleExtensionElement(ZeebeCalledDecision.class))
+        .filter(
+            calledDecision ->
+                calledDecision.getBindingType() == ZeebeBindingType.deployment
+                    && isNotExpression(calledDecision.getDecisionId()))
+        .ifPresent(calledDecisions::add);
+  }
+
+  private void handleUserTask(final UserTask task) {
+    Optional.ofNullable(task.getSingleExtensionElement(ZeebeFormDefinition.class))
+        .filter(
+            formDefinition ->
+                formDefinition.getBindingType() == ZeebeBindingType.deployment
+                    && isNotExpression(formDefinition.getFormId()))
+        .ifPresent(formDefinitions::add);
+  }
+
+  private boolean isNotExpression(final String s) {
+    return !s.startsWith("=");
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -113,10 +113,9 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
-  public Either<Failure, Void> writeRecords(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
     if (deployment.hasDuplicatesOnly()) {
-      return Either.right(null);
+      return;
     }
     final var checksum = checksumGenerator.apply(resource.getResource());
     deployment.processesMetadata().stream()
@@ -141,7 +140,6 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                   ProcessIntent.CREATED,
                   new ProcessRecord().wrap(metadata, resource.getResource()));
             });
-    return Either.right(null);
   }
 
   private Either<Failure, BpmnModelInstance> readProcessDefinition(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -73,7 +73,9 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
   @Override
   public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+      final DeploymentResource resource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
 
     return readProcessDefinition(resource)
         .flatMap(
@@ -100,7 +102,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                         })
                     .map(
                         ok -> {
-                          createProcessMetadata(deployment, resource, definition);
+                          createProcessMetadata(deployment, resource, definition, context);
                           return null;
                         });
 
@@ -183,7 +185,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   private void createProcessMetadata(
       final DeploymentRecord deploymentEvent,
       final DeploymentResource deploymentResource,
-      final BpmnModelInstance definition) {
+      final BpmnModelInstance definition,
+      final DeploymentResourceContext context) {
     for (final Process process : getExecutableProcesses(definition)) {
       final String bpmnProcessId = process.getId();
       final String tenantId = deploymentEvent.getTenantId();
@@ -217,6 +220,10 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
             .setKey(keyGenerator.nextKey())
             .setVersion(processState.getNextProcessVersion(bpmnProcessId, tenantId))
             .setDeploymentKey(deploymentEvent.getDeploymentKey());
+      }
+
+      if (context instanceof final BpmnElementsWithDeploymentBinding elements) {
+        elements.addFromProcess(process);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceContext.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.transform;
+
+public interface DeploymentResourceContext {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -34,8 +34,6 @@ interface DeploymentResourceTransformer {
    * @param resource the resource to transform
    * @param deployment the deployment record containing the metadata created in {@link
    *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord)}
-   * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
-   *     Either.Left} if the transformation failed
    */
-  Either<Failure, Void> writeRecords(DeploymentResource resource, DeploymentRecord deployment);
+  void writeRecords(DeploymentResource resource, DeploymentRecord deployment);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -20,11 +20,14 @@ interface DeploymentResourceTransformer {
    *
    * @param resource the resource to transform
    * @param deployment the deployment to add the deployed resource to
+   * @param context optional parameter to store additional information
    * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
    *     Either.Left} if the transformation failed
    */
   Either<Failure, Void> createMetadata(
-      final DeploymentResource resource, final DeploymentRecord deployment);
+      final DeploymentResource resource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context);
 
   /**
    * Step 2 of transforming the given resource: The transformer should update the previously created
@@ -33,7 +36,8 @@ interface DeploymentResourceTransformer {
    *
    * @param resource the resource to transform
    * @param deployment the deployment record containing the metadata created in {@link
-   *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord)}
+   *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord,
+   *     DeploymentResourceContext)}
    */
   void writeRecords(DeploymentResource resource, DeploymentRecord deployment);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -68,7 +68,9 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
   @Override
   public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+      final DeploymentResource resource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
 
     final var dmnResource = new ByteArrayInputStream(resource.getResource());
     final var parsedDrg = decisionEngine.parse(dmnResource);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -89,10 +89,9 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   @Override
-  public Either<Failure, Void> writeRecords(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
     if (deployment.hasDuplicatesOnly()) {
-      return Either.right(null);
+      return;
     }
     final var checksum = checksumGenerator.apply(resource.getResource());
     deployment.decisionRequirementsMetadata().stream()
@@ -156,7 +155,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                                 .setDeploymentKey(decision.getDeploymentKey()));
                       });
             });
-    return Either.right(null);
   }
 
   private Either<Failure, ?> checkForDuplicateIds(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -51,7 +51,9 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
 
   @Override
   public Either<Failure, Void> createMetadata(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+      final DeploymentResource resource,
+      final DeploymentRecord deployment,
+      final DeploymentResourceContext context) {
     return parseForm(resource)
         .flatMap(
             form ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -65,10 +65,9 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
-  public Either<Failure, Void> writeRecords(
-      final DeploymentResource resource, final DeploymentRecord deployment) {
+  public void writeRecords(final DeploymentResource resource, final DeploymentRecord deployment) {
     if (deployment.hasDuplicatesOnly()) {
-      return Either.right(null);
+      return;
     }
     final var checksum = checksumGenerator.apply(resource.getResource());
     deployment.formMetadata().stream()
@@ -90,7 +89,6 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
               }
               writeFormRecord(metadata, resource);
             });
-    return Either.right(null);
   }
 
   private Either<Failure, Form> parseForm(final DeploymentResource resource) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
@@ -214,14 +214,21 @@ public class JobBasedUserTaskFormTest {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .userTask("task")
-            .zeebeFormId(FORM_ID_1)
+            // an incident can only occur at run time if the target form ID is an expression;
+            // static IDs are already checked at deploy time
+            .zeebeFormId("=formIdVariable")
             .zeebeFormBindingType(ZeebeBindingType.deployment)
             .endEvent()
             .done();
     final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
 
     // when
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("formIdVariable", FORM_ID_1)
+            .create();
 
     // then
     assertFormIncident(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
@@ -218,7 +218,9 @@ public class NativeUserTaskFormTest {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .userTask("task")
-            .zeebeFormId(FORM_ID_1)
+            // an incident can only occur at run time if the target form ID is an expression;
+            // static IDs are already checked at deploy time
+            .zeebeFormId("=formIdVariable")
             .zeebeFormBindingType(ZeebeBindingType.deployment)
             .zeebeUserTask()
             .endEvent()
@@ -226,7 +228,12 @@ public class NativeUserTaskFormTest {
     final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
 
     // when
-    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("formIdVariable", FORM_ID_1)
+            .create();
 
     // then
     assertFormIncident(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentRejectionTest.java
@@ -14,11 +14,13 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -124,7 +126,8 @@ public class DeploymentRejectionTest {
         .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
         .hasRecordType(RecordType.COMMAND_REJECTION)
         .hasIntent(DeploymentIntent.CREATE)
-        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT)
+        .hasRejectionReason("Expected to deploy at least one resource, but none given");
   }
 
   @Test
@@ -273,5 +276,277 @@ public class DeploymentRejectionTest {
             tuple(ProcessIntent.CREATED, RecordType.EVENT),
             tuple(DeploymentIntent.CREATED, RecordType.EVENT),
             tuple(CommandDistributionIntent.STARTED, RecordType.EVENT));
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfCalledProcessNotIncludedForCallActivityWithBindingTypeDeployment() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "callActivity",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeProcessId("test-process"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.bpmn':
+            - Element: callActivity > extensionElements > calledElement
+                - ERROR: Expected to find process with id 'test-process' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfCalledDecisionNotIncludedForBusinessRuleTaskWithBindingTypeDeployment() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask(
+                "businessRuleTask",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeCalledDecisionId("test-decision")
+                        .zeebeResultVariable("foo"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.bpmn':
+            - Element: businessRuleTask > extensionElements > calledDecision
+                - ERROR: Expected to find decision with id 'test-decision' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void shouldRejectDeploymentIfLinkedFormNotIncludedForUserTaskWithBindingTypeDeployment() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "userTask",
+                builder ->
+                    builder
+                        .zeebeFormBindingType(ZeebeBindingType.deployment)
+                        .zeebeFormId("test-form"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process.bpmn':
+            - Element: userTask > extensionElements > formDefinition
+                - ERROR: Expected to find form with id 'test-form' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfTargetResourceNotIncludedForBindingTypeDeploymentInAnyProcess() {
+    // given
+    final var process1 =
+        Bpmn.createExecutableProcess("process-1")
+            .startEvent()
+            .callActivity(
+                "callActivity1",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeProcessId("test-process-1"))
+            .endEvent()
+            .done();
+    final var process2 =
+        Bpmn.createExecutableProcess("process-2")
+            .startEvent()
+            .callActivity(
+                "callActivity2",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeProcessId("test-process-2"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("process 1.bpmn", process1)
+            .withXmlResource("process 2.bpmn", process2)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .isEqualTo(
+            """
+            Expected to deploy new resources, but encountered the following errors:
+            'process 1.bpmn':
+            - Element: callActivity1 > extensionElements > calledElement
+                - ERROR: Expected to find process with id 'test-process-1' in current deployment, but not found.
+
+            'process 2.bpmn':
+            - Element: callActivity2 > extensionElements > calledElement
+                - ERROR: Expected to find process with id 'test-process-2' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void
+      shouldRejectDeploymentIfTargetResourceNotIncludedForBindingTypeDeploymentInMultipleElements() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "callActivity",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeProcessId("test-process"))
+            .businessRuleTask(
+                "businessRuleTask",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeCalledDecisionId("test-decision")
+                        .zeebeResultVariable("foo"))
+            .endEvent()
+            .done();
+
+    // when
+    final var rejectedDeployment =
+        ENGINE.deployment().withXmlResource("process.bpmn", process).expectRejection().deploy();
+
+    // then
+    Assertions.assertThat(rejectedDeployment)
+        .hasKey(ExecuteCommandResponseDecoder.keyNullValue())
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+    assertThat(rejectedDeployment.getRejectionReason())
+        .startsWith("Expected to deploy new resources, but encountered the following errors:")
+        // the order of the element errors for a particular resource is not deterministic, so the
+        // assertion checks that one of the possible variants is included
+        .containsAnyOf(
+            """
+            'process.bpmn':
+            - Element: businessRuleTask > extensionElements > calledDecision
+                - ERROR: Expected to find decision with id 'test-decision' in current deployment, but not found.
+            - Element: callActivity > extensionElements > calledElement
+                - ERROR: Expected to find process with id 'test-process' in current deployment, but not found.
+            """,
+            """
+            'process.bpmn':
+            - Element: callActivity > extensionElements > calledElement
+                - ERROR: Expected to find process with id 'test-process' in current deployment, but not found.
+            - Element: businessRuleTask > extensionElements > calledDecision
+                - ERROR: Expected to find decision with id 'test-decision' in current deployment, but not found.
+            """);
+  }
+
+  @Test
+  public void shouldNotRejectDeploymentForBindingTypeDeploymentIfTargetIdIsExpression() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "activity",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeProcessIdExpression("processIdVar"))
+            .businessRuleTask(
+                "businessRuleTask",
+                builder ->
+                    builder
+                        .zeebeBindingType(ZeebeBindingType.deployment)
+                        .zeebeCalledDecisionIdExpression("decisionIdVar")
+                        .zeebeResultVariable("foo"))
+            .userTask(
+                "userTask",
+                builder ->
+                    builder
+                        .zeebeFormBindingType(ZeebeBindingType.deployment)
+                        .zeebeFormId("=formIdVar"))
+            .endEvent()
+            .done();
+
+    // when
+    final var deployment = ENGINE.deployment().withXmlResource("process.bpmn", process).deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasIntent(DeploymentIntent.CREATED);
+  }
+
+  @Test
+  public void
+      shouldNotRejectDeploymentIfTargetResourceMissingForBindingTypeDeploymentInNonExecutableProcess() {
+    // given
+    final String resource = "/processes/non-executable-process-deployment-binding.bpmn";
+
+    // when
+    final var deployment = ENGINE.deployment().withXmlClasspathResource(resource).deploy();
+
+    // then
+    Assertions.assertThat(deployment)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.DEPLOYMENT)
+        .hasIntent(DeploymentIntent.CREATED);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -120,13 +120,20 @@ public class BusinessRuleTaskIncidentTest {
             .withXmlResource(
                 processWithBusinessRuleTask(
                     b ->
-                        b.zeebeCalledDecisionId(DECISION_ID)
+                        // an incident can only occur at run time if the target decision ID is an
+                        // expression; static IDs are already checked at deploy time
+                        b.zeebeCalledDecisionIdExpression(DECISION_ID_VARIABLE)
                             .zeebeBindingType(ZeebeBindingType.deployment)
                             .zeebeResultVariable(RESULT_VARIABLE)))
             .deploy();
 
     // when
-    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable(DECISION_ID_VARIABLE, DECISION_ID)
+            .create();
 
     final var taskActivating =
         RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)

--- a/zeebe/engine/src/test/resources/processes/non-executable-process-deployment-binding.bpmn
+++ b/zeebe/engine/src/test/resources/processes/non-executable-process-deployment-binding.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1kgp0v2" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+  <bpmn:collaboration id="Collaboration_15knhs4">
+    <bpmn:participant id="Participant_0j12xdt" name="NonExecutable" processRef="Process_NonExecutable" />
+    <bpmn:participant id="Participant_0wtt8eq" name="Executable" processRef="Process_Executable" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_NonExecutable" isExecutable="false">
+    <bpmn:callActivity id="Activity_0479jw8">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="foo" propagateAllChildVariables="false" bindingType="deployment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1v3y6nm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hfdetm</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0mc4l18">
+      <bpmn:incoming>Flow_1hfdetm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1hfdetm" sourceRef="Activity_0479jw8" targetRef="Event_0mc4l18" />
+    <bpmn:sequenceFlow id="Flow_1v3y6nm" sourceRef="StartEvent_1" targetRef="Activity_0479jw8" />
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1v3y6nm</bpmn:outgoing>
+    </bpmn:startEvent>
+  </bpmn:process>
+  <bpmn:process id="Process_Executable" isExecutable="true">
+    <bpmn:userTask id="Activity_0e1nlla">
+      <bpmn:incoming>Flow_0ehgnzz</bpmn:incoming>
+      <bpmn:outgoing>Flow_18ndycz</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:startEvent id="Event_1f6tis7">
+      <bpmn:outgoing>Flow_0ehgnzz</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_1gk7uow">
+      <bpmn:incoming>Flow_18ndycz</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ehgnzz" sourceRef="Event_1f6tis7" targetRef="Activity_0e1nlla" />
+    <bpmn:sequenceFlow id="Flow_18ndycz" sourceRef="Activity_0e1nlla" targetRef="Event_1gk7uow" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_15knhs4">
+      <bpmndi:BPMNShape id="Participant_0j12xdt_di" bpmnElement="Participant_0j12xdt" isHorizontal="true">
+        <dc:Bounds x="129" y="57" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0mc4l18_di" bpmnElement="Event_0mc4l18">
+        <dc:Bounds x="622" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vj78jg_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pm4fr9_di" bpmnElement="Activity_0479jw8">
+        <dc:Bounds x="370" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1v3y6nm_di" bpmnElement="Flow_1v3y6nm">
+        <di:waypoint x="228" y="170" />
+        <di:waypoint x="370" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hfdetm_di" bpmnElement="Flow_1hfdetm">
+        <di:waypoint x="470" y="170" />
+        <di:waypoint x="622" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0wtt8eq_di" bpmnElement="Participant_0wtt8eq" isHorizontal="true">
+        <dc:Bounds x="129" y="340" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_066yjtd" bpmnElement="Activity_0e1nlla">
+        <dc:Bounds x="380" y="410" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vopqjx_di" bpmnElement="Event_1f6tis7">
+        <dc:Bounds x="202" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_10wu371" bpmnElement="Event_1gk7uow">
+        <dc:Bounds x="622" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0nncof1" bpmnElement="Flow_0ehgnzz">
+        <di:waypoint x="238" y="450" />
+        <di:waypoint x="380" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0dxgrvx" bpmnElement="Flow_18ndycz">
+        <di:waypoint x="480" y="450" />
+        <di:waypoint x="622" y="450" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description
When a BPMN process gets deployed, validate that all linked resources (e.g. a called process in a call activity) are part of the same deployment if the binding type `deployment` is used. If at least one resource is missing, the deployment will be rejected.

## Related issues
closes #19712
closes #19384