### PR TITLE
ci: setup jave before running any maven commands

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -42,21 +42,21 @@ jobs:
           registry: gcr.io
           username: oauth2accesstoken
           password: ${{ steps.auth.outputs.access_token }}
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - id: image-tag
         name: Calculate image tag
         shell: bash
         run: |
           # Replace dots and slashes with dashes
           branch=${BRANCH/[\/\.]/-}
-          version=$(mvn help:evaluate -q -DforceStdout -D"expression=project.version")
+          version=$(./mvnw help:evaluate -q -DforceStdout -D"expression=project.version")
           echo "image-tag=$version-$branch-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
         env:
           BRANCH: ${{ inputs.branch }}
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
       - uses: ./.github/actions/build-platform-docker


### PR DESCRIPTION
## Description 

The step `Calculate image tag` was failing because it used Java 11. 

```
Caused by: java.lang.UnsupportedClassVersionError: org/eclipse/transformer/maven/TransformerMavenLifecycleParticipant has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.0
```

To fix this, run `setup-zeebe` job before it which sets the java distribution correctly.

## Checklist

## Related issues

closes #22353 
