### PR TITLE
ci: use infra self-hosted runners for zeebe-ci.yml/performance-tests job

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -129,7 +129,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

This PR introduces the use of `gcp-perf-core-16-default` runner type for the `zeebe-ci.yml/performance-tests` job.

`gcp-perf-core-16-default` has the same characteristics as the zeebe runners:
- same amount of [resources](https://github.com/camunda/infra-core/blob/stage/camunda-ci/kustomize/base/github-self-hosted-runners/runnersets/types/c2d/manifests/gcp-perf-core-16.yml#L16-L31)
- a RAM-backed filesystem for the `/tmp` directory, needed for some performance tests that require high I/O, see zeebe [runners](https://github.com/zeebe-io/infra/blob/main/gcp/zeebe-io/zeebe-ci-1/runner-amd64-16.yml#L48-L50) and https://github.com/camunda/infra-core/pull/8375

The `zeebe-ci.yml/performance-tests` job has been run several times successfully with dev runners from https://github.com/camunda/infra-core/pull/8375

Before merging:
- [x] Check that https://github.com/camunda/infra-core/pull/8375 is merged
- [x] Remove test [commit](https://github.com/camunda/camunda/pull/22450/commits/9631fe0ad92300aedc75cb1ba1eb57da205aec85)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
