### PR TITLE
feat: improve java client exceptional completion

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpZeebeFuture.java
@@ -60,7 +60,7 @@ public class HttpZeebeFuture<RespT> extends CompletableFuture<RespT> implements 
     try {
       return super.get(timeout, unit);
     } catch (final ExecutionException e) {
-      throw new ClientException(e);
+      throw unwrapExecutionException(e);
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new ClientException("Failed: interrupted while awaiting response", e);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
 import io.camunda.zeebe.client.util.ClientRestTest;
 import io.camunda.zeebe.client.util.RestGatewayPaths;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 public final class ExceptionHandlingRestTest extends ClientRestTest {
@@ -34,6 +35,20 @@ public final class ExceptionHandlingRestTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newTopologyRequest().useRest().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  public void shouldProvideProblemExceptionOnFailedRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getTopologyUrl(),
+        () -> new ProblemDetail().title("Invalid request").status(400));
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newTopologyRequest().useRest().send().join(1L, TimeUnit.SECONDS))
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayPaths;
+import org.junit.jupiter.api.Test;
+
+public final class ExceptionHandlingRestTest extends ClientRestTest {
+
+  @Test
+  public void shouldProvideProblemExceptionOnFailedRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayPaths.getTopologyUrl(),
+        () -> new ProblemDetail().title("Invalid request").status(400));
+
+    // when / then
+    assertThatThrownBy(() -> client.newTopologyRequest().useRest().send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid request");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ExceptionHandlingRestTest.java
@@ -40,7 +40,7 @@ public final class ExceptionHandlingRestTest extends ClientRestTest {
   }
 
   @Test
-  public void shouldProvideProblemExceptionOnFailedRequest() {
+  public void shouldProvideProblemExceptionOnFailedRequestWithTimeout() {
     // given
     gatewayService.errorOnRequest(
         RestGatewayPaths.getTopologyUrl(),

--- a/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -171,7 +171,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
 
     // when
     assertThatThrownBy(() -> client.newTopologyRequest().send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
@@ -220,7 +220,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     // when
     assertThatThrownBy(
             () -> client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Invalid request");
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/user/CreateUserTest.java
@@ -133,7 +133,7 @@ public class CreateUserTest extends ClientRestTest {
                     .password(PASSWORD)
                     .send()
                     .join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/AssignUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/AssignUserTaskTest.java
@@ -98,7 +98,7 @@ public final class AssignUserTaskTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskAssignCommand(123L).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/CompleteUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/CompleteUserTaskTest.java
@@ -74,7 +74,7 @@ public final class CompleteUserTaskTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskCompleteCommand(123L).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UnassignUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UnassignUserTaskTest.java
@@ -48,7 +48,7 @@ public final class UnassignUserTaskTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskUnassignCommand(123L).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
@@ -264,7 +264,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskUpdateCommand(123L).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 
@@ -293,7 +293,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskUpdateCommand(123L).priority(120).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Priority field must be an integer between 0 and 100. Provided: 120");
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -30,7 +30,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
-import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
@@ -180,13 +179,11 @@ class DecisionQueryTest {
   void shouldReturn404ForNotFoundDecisionKey() {
     // when
     final long decisionKey = new Random().nextLong();
-    final var exception =
+    final var problemException =
         assertThrows(
-            CompletionException.class,
+            ProblemException.class,
             () -> zeebeClient.newDecisionDefinitionGetXmlRequest(decisionKey).send().join());
     // then
-    assertThat(exception.getCause()).isInstanceOf(ProblemException.class);
-    final var problemException = (ProblemException) exception.getCause();
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
         .isEqualTo("DecisionDefinition with decisionKey=%d cannot be found".formatted(decisionKey));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -89,7 +89,7 @@ public class AddPermissionsTest {
 
     // then
     assertThatThrownBy(future::join)
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("title: NOT_FOUND")
         .hasMessageContaining("status: 404")
         .hasMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
@@ -114,7 +114,7 @@ class AssignUserTaskTest {
                     .allowOverride(false)
                     .send()
                     .join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'");
   }
 
@@ -122,7 +122,7 @@ class AssignUserTaskTest {
   void shouldRejectIfMissingAssignee() {
     // when / then
     assertThatThrownBy(() -> client.newUserTaskAssignCommand(userTaskKey).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }
 
@@ -131,7 +131,7 @@ class AssignUserTaskTest {
     // when / then
     assertThatThrownBy(
             () -> client.newUserTaskAssignCommand(userTaskKey).allowOverride(false).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ClockTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ClockTest.java
@@ -78,8 +78,8 @@ class ClockTest {
   void shouldRejectPinOperationIfNoTimestampProvided() {
     // when / then
     assertThatThrownBy(() -> client.newClockPinCommand().send().join())
-        .hasCauseInstanceOf(ProblemException.class)
-        .extracting(e -> (ProblemException) e.getCause())
+        .isInstanceOf(ProblemException.class)
+        .extracting(e -> (ProblemException) e)
         .satisfies(
             e -> {
               assertThat(e.getMessage()).startsWith("Failed with code 400: 'Bad Request'");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteUserTaskTest.java
@@ -90,7 +90,7 @@ class CompleteUserTaskTest {
 
     // when / then
     assertThatThrownBy(() -> client.newUserTaskCompleteCommand(userTaskKey).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CorrelateMessageTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CorrelateMessageTest.java
@@ -179,7 +179,7 @@ class CorrelateMessageTest {
 
     //     then
     assertThatThrownBy(responseFuture::join)
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("title: NOT_FOUND")
         .hasMessageContaining("status: 404")
         .hasMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CreateUserTest.java
@@ -83,7 +83,7 @@ class CreateUserTest {
                     .password("password")
                     .send()
                     .join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 409: 'Conflict'")
         .hasMessageContaining("a user with this username already exists");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UpdateUserTaskTest.java
@@ -226,7 +226,7 @@ class UpdateUserTaskTest {
   void shouldRejectIfMissingUpdateData() {
     // when / then
     assertThatThrownBy(() -> client.newUserTaskUpdateCommand(userTaskKey).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'");
   }
 
@@ -235,7 +235,7 @@ class UpdateUserTaskTest {
     // when / then
     assertThatThrownBy(
             () -> client.newUserTaskUpdateCommand(userTaskKey).dueDate("foo").send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining("The provided due date 'foo' cannot be parsed as a date");
   }
@@ -245,7 +245,7 @@ class UpdateUserTaskTest {
     // when / then
     assertThatThrownBy(
             () -> client.newUserTaskUpdateCommand(userTaskKey).followUpDate("foo").send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining("The provided follow-up date 'foo' cannot be parsed as a date");
   }
@@ -261,7 +261,7 @@ class UpdateUserTaskTest {
                     .followUpDate("foo")
                     .send()
                     .join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining("The provided due date 'bar' cannot be parsed as a date")
         .hasMessageContaining("The provided follow-up date 'foo' cannot be parsed as a date");

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
@@ -57,7 +57,7 @@ public class FilterIT {
   void shouldFailWithFirstFilterThrowingException() {
     // when / then
     assertThatThrownBy(() -> client.newTopologyRequest().useRest().send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("No topology interactions while testing");
   }
 
@@ -65,7 +65,7 @@ public class FilterIT {
   void shouldFailWithSecondFilterThrowingException() {
     // when / then
     assertThatThrownBy(() -> client.newUserTaskCompleteCommand(12345).send().join())
-        .hasCauseInstanceOf(ProblemException.class)
+        .isInstanceOf(ProblemException.class)
         .hasMessageContaining("No user task interactions while testing");
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Improve the Zeebe Java client handling of failures during REST API calls.

With the addition of REST API support for the Java client, we added a new `HttpZeebeFuture` that extends `CompletableFuture`. We directly use the `CompletableFuture#join()` there, and it throws `CompletionExceptions`. In contrast, when using gRPC, the java client calls `CompletableFuture#get()` instead, and it throws `ExecutionExceptions` when a request fails.

We unwrap `ExecutionExceptions`, but don't touch `CompletionExceptions`.

This PR aligns the behavior and handling of exceptional REST API calls with gRPC calls in the Zeebe Java client.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21173 
