### PR TITLE
feat: Implemented ExporterFactories feature #22446

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/DefaultExporterFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/DefaultExporterFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.repo;
+
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.util.ReflectUtil;
+import org.slf4j.Logger;
+
+class DefaultExporterFactory implements ExporterFactory {
+
+  private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+  private final Class<? extends Exporter> exporterClass;
+  private final String id;
+
+  public DefaultExporterFactory(final String id, final Class<? extends Exporter> exporterClass) {
+    this.id = id;
+    this.exporterClass = exporterClass;
+  }
+
+  @Override
+  public String exporterId() {
+    return id;
+  }
+
+  @Override
+  public Exporter newInstance() throws ExporterInstantiationException {
+    LOG.info("Use default exporter factory to create instance of {}", exporterClass);
+    try {
+      return ReflectUtil.newInstance(exporterClass);
+    } catch (final Exception e) {
+      throw new ExporterInstantiationException(id, e);
+    }
+  }
+
+  @Override
+  public boolean isSameTypeAs(final ExporterFactory other) {
+    return other instanceof DefaultExporterFactory
+        && ((DefaultExporterFactory) other).exporterClass.equals(exporterClass);
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.repo;
+
+import io.camunda.zeebe.exporter.api.Exporter;
+
+public interface ExporterFactory {
+
+  /**
+   * @return The ID of the exporter, e.g. "rdbms" or "elasticsearch"
+   */
+  String exporterId();
+
+  /**
+   * @return Returns a new instance of the Exporter
+   */
+  Exporter newInstance() throws ExporterInstantiationException;
+
+  /**
+   * @return true if the other factory produces the same exporter type
+   */
+  boolean isSameTypeAs(ExporterFactory other);
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -11,14 +11,18 @@ import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.context.ExporterContext;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.camunda.zeebe.util.jar.ExternalJarRepository;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.InstantSource;
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 public final class ExporterRepository {
@@ -28,12 +32,18 @@ public final class ExporterRepository {
   private final Map<String, ExporterDescriptor> exporters;
 
   public ExporterRepository() {
-    this(new HashMap<>(), new ExternalJarRepository());
+    this(new ArrayList<>());
+  }
+
+  public ExporterRepository(final List<ExporterDescriptor> exporters) {
+    this(exporters, new ExternalJarRepository());
   }
 
   public ExporterRepository(
-      final Map<String, ExporterDescriptor> exporters, final ExternalJarRepository jarRepository) {
-    this.exporters = exporters;
+      final List<ExporterDescriptor> exporters, final ExternalJarRepository jarRepository) {
+    this.exporters =
+        exporters.stream()
+            .collect(Collectors.toMap(ExporterDescriptor::getId, Function.identity()));
     this.jarRepository = jarRepository;
   }
 
@@ -41,12 +51,8 @@ public final class ExporterRepository {
     return Collections.unmodifiableMap(exporters);
   }
 
-  public ExporterDescriptor load(final String id, final Class<? extends Exporter> exporterClass)
-      throws ExporterLoadException {
-    return load(id, exporterClass, null);
-  }
-
-  public ExporterDescriptor load(
+  @VisibleForTesting
+  public ExporterDescriptor validateAndAddExporterDescriptor(
       final String id,
       final Class<? extends Exporter> exporterClass,
       final Map<String, Object> args)
@@ -85,7 +91,7 @@ public final class ExporterRepository {
       throw new ExporterLoadException(id, "cannot load specified class", e);
     }
 
-    return load(id, exporterClass, config.getArgs());
+    return validateAndAddExporterDescriptor(id, exporterClass, config.getArgs());
   }
 
   private void validate(final ExporterDescriptor descriptor) throws ExporterLoadException {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/SimpleBrokerStartTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker;
 
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
@@ -62,7 +63,7 @@ public final class SimpleBrokerStartTest {
                       mock(ActorScheduler.class),
                       mock(AtomixCluster.class),
                       mock(BrokerClient.class));
-              new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE);
+              new Broker(systemContext, TEST_SPRING_BROKER_BRIDGE, emptyList());
             });
 
     // then

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.repo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
+import io.camunda.zeebe.broker.exporter.util.TestExporterFactory;
+import org.junit.jupiter.api.Test;
+
+class ExporterDescriptorTest {
+
+  @Test
+  void shouldCheckIfIsSameTypeForSameExporter() {
+    // GIVEN we have a descriptor and a factory
+    final ExporterDescriptor exporterDescriptor1 =
+        new ExporterDescriptor(TestExporterFactory.EXPORTER_ID, new TestExporterFactory());
+
+    // AND we have another descriptor and a factory
+    final ExporterDescriptor exporterDescriptor2 =
+        new ExporterDescriptor(TestExporterFactory.EXPORTER_ID, new TestExporterFactory());
+
+    // THEN we should get a true
+    assertThat(exporterDescriptor1.isSameTypeAs(exporterDescriptor2)).isTrue();
+  }
+
+  @Test
+  void shouldCheckIfIsNotSameTypeForSameExporter() {
+    // GIVEN we have a descriptor and a factory
+    final ExporterDescriptor exporterDescriptor1 =
+        new ExporterDescriptor(TestExporterFactory.EXPORTER_ID, new TestExporterFactory());
+
+    // AND we have another descriptor and a factory
+    final ExporterDescriptor exporterDescriptor2 =
+        new ExporterDescriptor("otherExporter", ControlledTestExporter.class, null);
+
+    // THEN we should get a true
+    assertThat(exporterDescriptor1.isSameTypeAs(exporterDescriptor2)).isFalse();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -120,7 +120,10 @@ final class ExporterContainerTest {
       runtime = new ExporterContainerRuntime(storagePath);
 
       final var descriptor =
-          runtime.getRepository().load(EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
       exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
       exporter = (FakeExporter) exporterContainer.getExporter();
     }
@@ -553,7 +556,10 @@ final class ExporterContainerTest {
       runtime = new ExporterContainerRuntime(storagePath);
 
       descriptor =
-          runtime.getRepository().load(EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
+          runtime
+              .getRepository()
+              .validateAndAddExporterDescriptor(
+                  EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
     }
 
     @Test
@@ -694,7 +700,7 @@ final class ExporterContainerTest {
       descriptor =
           runtime
               .getRepository()
-              .load(
+              .validateAndAddExporterDescriptor(
                   "fakeExporterWithMetrics", FakeExporterWithMetrics.class, Map.of("key", "value"));
 
       final var meterRegistry = new SimpleMeterRegistry();
@@ -707,7 +713,7 @@ final class ExporterContainerTest {
 
       // when
       // then
-      assertThat(meterRegistry.getMeters().get(0).getId().getName())
+      assertThat(meterRegistry.getMeters().getFirst().getId().getName())
           .isEqualTo(REGISTERED_COUNTER_NAME);
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/TestExporterFactory.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/util/TestExporterFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.util;
+
+import io.camunda.zeebe.broker.exporter.repo.ExporterFactory;
+import io.camunda.zeebe.broker.exporter.repo.ExporterInstantiationException;
+import io.camunda.zeebe.exporter.api.Exporter;
+
+public class TestExporterFactory implements ExporterFactory {
+
+  public static final String EXPORTER_ID = "controlled";
+
+  @Override
+  public String exporterId() {
+    return EXPORTER_ID;
+  }
+
+  @Override
+  public Exporter newInstance() throws ExporterInstantiationException {
+    return new ControlledTestExporter();
+  }
+
+  @Override
+  public boolean isSameTypeAs(final ExporterFactory other) {
+    return other instanceof TestExporterFactory;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -222,9 +222,9 @@ class ExporterDirectorPartitionTransitionStepTest {
     final Map<String, ExporterDescriptor> exporters =
         Map.of(
             enabledExporterId,
-            new ExporterDescriptor(enabledExporterId, null, null),
+            new ExporterDescriptor(enabledExporterId),
             disabledExporterId,
-            new ExporterDescriptor(disabledExporterId, null, null));
+            new ExporterDescriptor(disabledExporterId));
     when(exporterRepository.getExporters()).thenReturn(exporters);
     transitionContext.setDynamicPartitionConfig(exporterConfig);
   }


### PR DESCRIPTION
- This is an alternative way to create new instances of exporters

## Description

When zeebe creates exporters, it now first looks if there is an ExporterFactory in the spring context for the exporter id. 
If yes, it uses newInstance on this factory. This makes it possible to pass spring beans to the exporter during creation. 
If no, the old default behaviour is to simply create the exporter by the provided className.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22446
