### PR TITLE
feat: add key to the tasklist-form

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/FormEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/FormEntity.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 
 public class FormEntity extends TenantAwareTasklistEntity<FormEntity> {
 
+  private Long key;
   private String bpmnId;
   private String processDefinitionId;
   private String schema;
@@ -30,13 +31,14 @@ public class FormEntity extends TenantAwareTasklistEntity<FormEntity> {
       final String schema,
       final Long version,
       final String tenantId,
-      final String formKey,
+      final Long formKey,
       final Boolean embedded,
       final Boolean isDeleted) {
     if (embedded) {
       setId(createId(processDefinitionId, bpmnId));
     } else {
-      setId(formKey);
+      setId(String.valueOf(formKey));
+      setKey(formKey);
     }
     this.bpmnId = bpmnId;
     this.processDefinitionId = processDefinitionId;
@@ -125,6 +127,11 @@ public class FormEntity extends TenantAwareTasklistEntity<FormEntity> {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), bpmnId, processDefinitionId, schema, version);
+  }
+
+  @Override
   public boolean equals(final Object o) {
     if (this == o) {
       return true;
@@ -142,12 +149,8 @@ public class FormEntity extends TenantAwareTasklistEntity<FormEntity> {
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(embedded, that.embedded)
         && Objects.equals(isDeleted, that.isDeleted)
-        && Objects.equals(version, that.version);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(super.hashCode(), bpmnId, processDefinitionId, schema, version);
+        && Objects.equals(version, that.version)
+        && Objects.equals(key, that.key);
   }
 
   @Override
@@ -168,6 +171,15 @@ public class FormEntity extends TenantAwareTasklistEntity<FormEntity> {
         + ", isDeleted="
         + isDeleted
         + '}';
+  }
+
+  public Long getKey() {
+    return key;
+  }
+
+  public FormEntity setKey(final Long key) {
+    this.key = key;
+    return this;
   }
 
   public Boolean getIsDeleted() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/FormIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/FormIndex.java
@@ -17,6 +17,7 @@ public class FormIndex extends AbstractIndexDescriptor implements Prio4Backup {
   public static final String INDEX_VERSION = "8.4.0";
 
   public static final String ID = "id";
+  public static final String KEY = "key";
   public static final String BPMN_ID = "bpmnId";
   public static final String PROCESS_DEFINITION_ID = "processDefinitionId";
   public static final String SCHEMA = "schema";

--- a/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-form.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-form.json
@@ -2,6 +2,9 @@
   "mappings": {
     "dynamic": "strict",
     "properties": {
+      "key": {
+        "type": "long"
+      },
       "id": {
         "type": "keyword"
       },

--- a/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-form.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-form.json
@@ -1,6 +1,9 @@
 {
   "dynamic": "strict",
   "properties": {
+    "key": {
+      "type": "long"
+    },
     "id": {
       "type": "keyword"
     },

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/FormZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/FormZeebeRecordProcessorElasticSearch.java
@@ -42,7 +42,7 @@ public class FormZeebeRecordProcessorElasticSearch {
 
   @Autowired private FormIndex formIndex;
 
-  public void processFormRecord(Record record, BulkRequest bulkRequest)
+  public void processFormRecord(final Record record, final BulkRequest bulkRequest)
       throws PersistenceException {
 
     final FormRecordImpl recordValue = (FormRecordImpl) record.getValue();
@@ -71,16 +71,16 @@ public class FormZeebeRecordProcessorElasticSearch {
   }
 
   private void persistForm(
-      Long formKey,
-      String schema,
-      Long version,
-      String tenantId,
-      String formId,
-      boolean isDelete,
-      BulkRequest bulkRequest)
+      final Long formKey,
+      final String schema,
+      final Long version,
+      final String tenantId,
+      final String formId,
+      final boolean isDelete,
+      final BulkRequest bulkRequest)
       throws PersistenceException {
     final FormEntity formEntity =
-        new FormEntity(null, formId, schema, version, tenantId, formKey.toString(), false, false);
+        new FormEntity(null, formId, schema, version, tenantId, formKey, false, false);
 
     try {
       if (isDelete) {
@@ -100,14 +100,14 @@ public class FormZeebeRecordProcessorElasticSearch {
                 .id(ConversionUtils.toStringOrNull(formEntity.getId()))
                 .source(objectMapper.writeValueAsString(formEntity), XContentType.JSON));
       }
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new PersistenceException(
           String.format("Error preparing the form query for the formId: [%s]", formEntity.getId()),
           e);
     }
   }
 
-  public static String bytesToXml(byte[] bytes) {
+  public static String bytesToXml(final byte[] bytes) {
     return new String(bytes, StandardCharsets.UTF_8);
   }
 }

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/FormZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/FormZeebeRecordProcessorOpenSearch.java
@@ -33,7 +33,7 @@ public class FormZeebeRecordProcessorOpenSearch {
 
   @Autowired private FormIndex formIndex;
 
-  public void processFormRecord(Record record, List<BulkOperation> operations)
+  public void processFormRecord(final Record record, final List<BulkOperation> operations)
       throws PersistenceException {
 
     final FormRecordImpl recordValue = (FormRecordImpl) record.getValue();
@@ -62,17 +62,16 @@ public class FormZeebeRecordProcessorOpenSearch {
   }
 
   private void persistForm(
-      Long formKey,
-      String schema,
-      Long version,
-      String tenantId,
-      String formId,
-      boolean isDelete,
-      List<BulkOperation> operations)
+      final Long formKey,
+      final String schema,
+      final Long version,
+      final String tenantId,
+      final String formId,
+      final boolean isDelete,
+      final List<BulkOperation> operations)
       throws PersistenceException {
     final FormEntity formEntity =
-        new FormEntity(
-            null, formId, schema, version, tenantId, formKey.toString(), false, isDelete);
+        new FormEntity(null, formId, schema, version, tenantId, formKey, false, isDelete);
     try {
 
       if (isDelete) {
@@ -101,14 +100,14 @@ public class FormZeebeRecordProcessorOpenSearch {
                                 .document(CommonUtils.getJsonObjectFromEntity(formEntity))))
                 .build());
       }
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new PersistenceException(
           String.format("Error preparing the form query for the formId: [%s]", formEntity.getId()),
           e);
     }
   }
 
-  public static String bytesToXml(byte[] bytes) {
+  public static String bytesToXml(final byte[] bytes) {
     return new String(bytes, StandardCharsets.UTF_8);
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/FormZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/FormZeebeRecordProcessorElasticSearch.java
@@ -80,7 +80,7 @@ public class FormZeebeRecordProcessorElasticSearch {
       final BulkRequest bulkRequest)
       throws PersistenceException {
     final FormEntity formEntity =
-        new FormEntity(null, formId, schema, version, tenantId, formKey.toString(), false, false);
+        new FormEntity(null, formId, schema, version, tenantId, formKey, false, false);
 
     try {
       if (isDelete) {

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/FormZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/FormZeebeRecordProcessorOpenSearch.java
@@ -71,8 +71,7 @@ public class FormZeebeRecordProcessorOpenSearch {
       final List<BulkOperation> operations)
       throws PersistenceException {
     final FormEntity formEntity =
-        new FormEntity(
-            null, formId, schema, version, tenantId, formKey.toString(), false, isDelete);
+        new FormEntity(null, formId, schema, version, tenantId, formKey, false, isDelete);
     try {
 
       if (isDelete) {


### PR DESCRIPTION
## Description

- Add `key` to `tasklist-form` indice
- We wont migrate data now, this is in order to cover the default sorting for V2
- we still going to use `id` for Get Form by Key , once all data is there (but the research only will cover linked forms)
- I added the key as Long, and setup the importers to import the formKey for 8.6.0 

For embeeded form new data, and linked old data, for now, key will be set as a null 

<img width="439" alt="image" src="https://github.com/user-attachments/assets/82a3ae1b-16df-41db-8d54-f9abfeb089e7">


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
