### PR TITLE
fix: use initial deployment key in metadata of duplicate resources

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -133,7 +133,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
                     .setVersion(
                         processState.getNextProcessVersion(
                             metadata.getBpmnProcessId(), deployment.getTenantId()))
-                    .setDuplicate(false);
+                    .setDuplicate(false)
+                    .setDeploymentKey(deployment.getDeploymentKey());
               }
               stateWriter.appendFollowUpEvent(
                   key,
@@ -202,21 +203,22 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setBpmnProcessId(BufferUtil.wrapString(bpmnProcessId))
           .setChecksum(resourceDigest)
           .setResourceName(deploymentResource.getResourceNameBuffer())
-          .setTenantId(tenantId)
-          .setDeploymentKey(deploymentEvent.getDeploymentKey());
+          .setTenantId(tenantId);
       getOptionalVersionTag(process).ifPresent(processMetadata::setVersionTag);
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);
       if (isDuplicate) {
         processMetadata
-            .setVersion(lastProcess.getVersion())
             .setKey(lastProcess.getKey())
+            .setVersion(lastProcess.getVersion())
+            .setDeploymentKey(lastProcess.getDeploymentKey())
             .setDuplicate(true);
       } else {
         processMetadata
             .setKey(keyGenerator.nextKey())
-            .setVersion(processState.getNextProcessVersion(bpmnProcessId, tenantId));
+            .setVersion(processState.getNextProcessVersion(bpmnProcessId, tenantId))
+            .setDeploymentKey(deploymentEvent.getDeploymentKey());
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -138,7 +138,8 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                               .setDecisionKey(decisionKey)
                               .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
                               .setVersion(decision.getVersion() + 1)
-                              .setDuplicate(false);
+                              .setDuplicate(false)
+                              .setDeploymentKey(deployment.getDeploymentKey());
                         }
                         stateWriter.appendFollowUpEvent(
                             decisionKey,
@@ -283,8 +284,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                   .setDecisionName(decision.getName())
                   .setDecisionRequirementsId(parsedDrg.getId())
                   .setDecisionRequirementsKey(drgRecord.getDecisionRequirementsKey())
-                  .setTenantId(drgRecord.getTenantId())
-                  .setDeploymentKey(deploymentEvent.getDeploymentKey());
+                  .setTenantId(drgRecord.getTenantId());
               getOptionalVersionTag(parsedDrg, decision.getId())
                   .ifPresent(decisionRecord::setVersionTag);
 
@@ -301,17 +301,20 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                           decisionRecord
                               .setDecisionKey(latestDecision.getDecisionKey())
                               .setVersion(latestVersion)
+                              .setDeploymentKey(latestDecision.getDeploymentKey())
                               .setDuplicate(true);
                         } else {
                           decisionRecord
                               .setDecisionKey(newDecisionKey.getAsLong())
-                              .setVersion(latestVersion + 1);
+                              .setVersion(latestVersion + 1)
+                              .setDeploymentKey(deploymentEvent.getDeploymentKey());
                         }
                       },
                       () ->
                           decisionRecord
                               .setDecisionKey(newDecisionKey.getAsLong())
-                              .setVersion(INITIAL_VERSION));
+                              .setVersion(INITIAL_VERSION)
+                              .setDeploymentKey(deploymentEvent.getDeploymentKey()));
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -85,7 +85,8 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
                     .setFormKey(key)
                     .setVersion(
                         formState.getNextFormVersion(metadata.getFormId(), metadata.getTenantId()))
-                    .setDuplicate(false);
+                    .setDuplicate(false)
+                    .setDeploymentKey(deployment.getDeploymentKey());
               }
               writeFormRecord(metadata, resource);
             });
@@ -139,7 +140,6 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     formRecord.setChecksum(checksum);
     formRecord.setResourceName(resource.getResourceName());
     formRecord.setTenantId(tenantId);
-    formRecord.setDeploymentKey(deployment.getDeploymentKey());
     Optional.ofNullable(form.versionTag).ifPresent(formRecord::setVersionTag);
 
     formState
@@ -155,14 +155,20 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
                 formRecord
                     .setFormKey(latestForm.getFormKey())
                     .setVersion(latestVersion)
+                    .setDeploymentKey(latestForm.getDeploymentKey())
                     .setDuplicate(true);
               } else {
                 formRecord
                     .setFormKey(newFormKey.getAsLong())
-                    .setVersion(formState.getNextFormVersion(form.id, tenantId));
+                    .setVersion(formState.getNextFormVersion(form.id, tenantId))
+                    .setDeploymentKey(deployment.getDeploymentKey());
               }
             },
-            () -> formRecord.setFormKey(newFormKey.getAsLong()).setVersion(INITIAL_VERSION));
+            () ->
+                formRecord
+                    .setFormKey(newFormKey.getAsLong())
+                    .setVersion(INITIAL_VERSION)
+                    .setDeploymentKey(deployment.getDeploymentKey()));
   }
 
   private void writeFormRecord(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
@@ -194,10 +194,10 @@ public class MultiResourceDeploymentTest {
                   .getLast())
           .satisfies(
               record -> {
-                assertThat(record.getKey()).isEqualTo(expectedProcessDefinitionKey);
-                assertThat(record.getValue().getProcessDefinitionKey())
-                    .isEqualTo(expectedProcessDefinitionKey);
-                assertThat(record.getValue().getVersion()).isEqualTo(2);
+                Assertions.assertThat(record).hasKey(expectedProcessDefinitionKey);
+                Assertions.assertThat(record.getValue())
+                    .hasProcessDefinitionKey(expectedProcessDefinitionKey)
+                    .hasVersion(2);
               });
     }
 
@@ -210,10 +210,10 @@ public class MultiResourceDeploymentTest {
                   .getLast())
           .satisfies(
               record -> {
-                assertThat(record.getKey()).isEqualTo(expectedDecisionRequirementsKey);
-                assertThat(record.getValue().getDecisionRequirementsKey())
-                    .isEqualTo(expectedDecisionRequirementsKey);
-                assertThat(record.getValue().getDecisionRequirementsVersion()).isEqualTo(2);
+                Assertions.assertThat(record).hasKey(expectedDecisionRequirementsKey);
+                Assertions.assertThat(record.getValue())
+                    .hasDecisionRequirementsKey(expectedDecisionRequirementsKey)
+                    .hasDecisionRequirementsVersion(2);
               });
     }
 
@@ -226,11 +226,11 @@ public class MultiResourceDeploymentTest {
                   .getLast())
           .satisfies(
               record -> {
-                assertThat(record.getKey()).isEqualTo(expectedDecisionKey);
-                assertThat(record.getValue().getDecisionKey()).isEqualTo(expectedDecisionKey);
-                assertThat(record.getValue().getDecisionRequirementsKey())
-                    .isEqualTo(expectedDecisionRequirementsKey);
-                assertThat(record.getValue().getVersion()).isEqualTo(2);
+                Assertions.assertThat(record).hasKey(expectedDecisionKey);
+                Assertions.assertThat(record.getValue())
+                    .hasDecisionKey(expectedDecisionKey)
+                    .hasDecisionRequirementsKey(expectedDecisionRequirementsKey)
+                    .hasVersion(2);
               });
     }
 
@@ -238,9 +238,8 @@ public class MultiResourceDeploymentTest {
       assertThat(RecordingExporter.formRecords().withIntent(FormIntent.CREATED).limit(2).getLast())
           .satisfies(
               record -> {
-                assertThat(record.getKey()).isEqualTo(expectedFormKey);
-                assertThat(record.getValue().getFormKey()).isEqualTo(expectedFormKey);
-                assertThat(record.getValue().getVersion()).isEqualTo(2);
+                Assertions.assertThat(record).hasKey(expectedFormKey);
+                Assertions.assertThat(record.getValue()).hasFormKey(expectedFormKey).hasVersion(2);
               });
     }
   }
@@ -292,10 +291,7 @@ public class MultiResourceDeploymentTest {
                   Assertions.assertThat(metadata)
                       .hasVersion(1)
                       .isDuplicate()
-                      .extracting(
-                          ProcessMetadataValue::getProcessDefinitionKey,
-                          InstanceOfAssertFactories.LONG)
-                      .isEqualTo(processV1.getProcessDefinitionKey()));
+                      .hasProcessDefinitionKey(processV1.getProcessDefinitionKey()));
       assertThat(secondDeployment.getDecisionRequirementsMetadata())
           .singleElement()
           .satisfies(
@@ -303,10 +299,7 @@ public class MultiResourceDeploymentTest {
                   Assertions.assertThat(metadata)
                       .hasDecisionRequirementsVersion(1)
                       .isDuplicate()
-                      .extracting(
-                          DecisionRequirementsMetadataValue::getDecisionRequirementsKey,
-                          InstanceOfAssertFactories.LONG)
-                      .isEqualTo(drgV1.getDecisionRequirementsKey()));
+                      .hasDecisionRequirementsKey(drgV1.getDecisionRequirementsKey()));
       assertThat(secondDeployment.getDecisionsMetadata())
           .singleElement()
           .satisfies(
@@ -314,11 +307,8 @@ public class MultiResourceDeploymentTest {
                   Assertions.assertThat(metadata)
                       .hasVersion(1)
                       .isDuplicate()
-                      .extracting(
-                          DecisionRecordValue::getDecisionKey,
-                          DecisionRecordValue::getDecisionRequirementsKey)
-                      .containsExactly(
-                          decisionV1.getDecisionKey(), drgV1.getDecisionRequirementsKey()));
+                      .hasDecisionKey(decisionV1.getDecisionKey())
+                      .hasDecisionRequirementsKey(drgV1.getDecisionRequirementsKey()));
       assertThat(secondDeployment.getFormMetadata())
           .singleElement()
           .satisfies(
@@ -326,8 +316,7 @@ public class MultiResourceDeploymentTest {
                   Assertions.assertThat(metadata)
                       .hasVersion(1)
                       .isDuplicate()
-                      .extracting(FormMetadataValue::getFormKey)
-                      .isEqualTo(formV1.getFormKey()));
+                      .hasFormKey(formV1.getFormKey()));
 
       final long recordsCountAfter =
           RecordingExporter.records()


### PR DESCRIPTION
## Description
For resource versions marked as duplicates, use the deployment key of the deployment they were initially deployed with in the metadata that is added to the current deployment record.

## Related issues
closes #22473