### PR TITLE
feat: add migration support for event sub processes and receive tasks

### DIFF
--- a/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
@@ -8,7 +8,7 @@
 
 import {zeebeGrpcApi} from '../api/zeebe-grpc';
 
-const {deployProcesses, createInstances} = zeebeGrpcApi;
+const {deployProcesses, createSingleInstance} = zeebeGrpcApi;
 
 const setup = async () => {
   const {deployments: deploymentsV1} = await deployProcesses([
@@ -34,15 +34,19 @@ const setup = async () => {
   }
 
   return {
-    processV1Instances: await createInstances(
-      'orderProcessMigration',
-      deploymentsV1[0].process.version,
-      10,
-      {
-        key1: 'myFirstCorrelationKey',
-        key2: 'mySecondCorrelationKey',
-        key3: 'myThirdCorrelationkey',
-      },
+    processV1Instances: await Promise.all(
+      [...new Array(10)].map((_, index) =>
+        createSingleInstance(
+          'orderProcessMigration',
+          deploymentsV1[0]!.process.version,
+
+          {
+            key1: 'myFirstCorrelationKey',
+            key2: 'mySecondCorrelationKey',
+            key3: `myCorrelationKey${index}`,
+          },
+        ),
+      ),
     ),
     processV1: deploymentsV1[0].process,
     processV2: deploymentsV2[0].process,

--- a/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
@@ -11,6 +11,7 @@ import {test} from '../test-fixtures';
 import {expect} from '@playwright/test';
 import {SETUP_WAITING_TIME} from './constants';
 import {config} from '../config';
+import {zeebeGrpcApi} from '../api/zeebe-grpc';
 
 let initialData: Awaited<ReturnType<typeof setup>>;
 
@@ -25,6 +26,38 @@ test.beforeAll(async ({request}) => {
           {
             data: {
               filter: {
+                processDefinitionKey:
+                  initialData.processV1.processDefinitionKey,
+              },
+            },
+          },
+        );
+
+        return await response.json();
+      },
+      {timeout: SETUP_WAITING_TIME},
+    )
+    .toHaveProperty('total', 10);
+
+  await Promise.all(
+    [...new Array(10)].map((_, index) =>
+      zeebeGrpcApi.zeebe.publishMessage({
+        name: 'Message_4',
+        correlationKey: `myCorrelationKey${index}`,
+      }),
+    ),
+  );
+
+  // Wait until all processes received their messages and all tokens moved to Task E
+  await expect
+    .poll(
+      async () => {
+        const response = await request.post(
+          `${config.endpoint}/v1/flownode-instances/search`,
+          {
+            data: {
+              filter: {
+                flowNodeId: 'TaskE',
                 processDefinitionKey:
                   initialData.processV1.processDefinitionKey,
               },
@@ -80,7 +113,7 @@ test.describe.serial('Process Instance Migration', () => {
     await processesPage.migrationModal.confirmButton.click();
 
     // Expect auto mapping for each flow node
-    await expect(page.getByLabel(/target flow node for/i)).toHaveCount(13);
+    await expect(page.getByLabel(/target flow node for/i)).toHaveCount(18);
 
     await expect(
       page.getByLabel(/target flow node for check payment/i),
@@ -121,6 +154,21 @@ test.describe.serial('Process Instance Migration', () => {
     await expect(
       page.getByLabel(/target flow node for timer intermediate catch/i),
     ).toHaveValue('TimerIntermediateCatch');
+    await expect(
+      page.getByLabel(/target flow node for message event sub process/i),
+    ).toHaveValue('MessageEventSubProcess');
+    await expect(
+      page.getByLabel(/target flow node for timer event sub process/i),
+    ).toHaveValue('TimerEventSubProcess');
+    await expect(page.getByLabel(/target flow node for task e/i)).toHaveValue(
+      'TaskE',
+    );
+    await expect(page.getByLabel(/target flow node for task f/i)).toHaveValue(
+      'TaskF',
+    );
+    await expect(
+      page.getByLabel(/target flow node for message receive task/i),
+    ).toHaveValue('MessageReceiveTask');
 
     // Expect pre-selected process and version
     await expect(migrationView.targetProcessComboBox).toHaveValue(
@@ -192,6 +240,42 @@ test.describe.serial('Process Instance Migration', () => {
     ).toContainText(/4 results/i);
 
     await commonPage.collapseOperationsPanel();
+  });
+
+  test('Migrated event sub processes', async ({
+    commonPage,
+    processesPage,
+    processesPage: {filtersPanel},
+  }) => {
+    const {processV2} = initialData;
+    await processesPage.navigateToProcesses({
+      searchParams: {
+        active: 'true',
+      },
+    });
+    await commonPage.expandOperationsPanel();
+
+    const migrateOperationEntry = commonPage.operationsList
+      .getByRole('listitem')
+      .first();
+
+    const operationId = await migrateOperationEntry
+      .getByRole('link')
+      .innerText();
+
+    await processesPage.navigateToProcesses({
+      searchParams: {
+        active: 'true',
+        process: processV2.bpmnProcessId,
+        version: processV2.version.toString(),
+        operationId,
+        flowNodeId: 'TaskE',
+      },
+    });
+
+    await expect(
+      processesPage.processInstancesTable.getByRole('heading'),
+    ).toContainText(/6 results/i);
   });
 
   /**
@@ -290,6 +374,34 @@ test.describe.serial('Process Instance Migration', () => {
     await migrationView.mapFlowNode({
       sourceFlowNodeName: 'Timer intermediate catch',
       targetFlowNodeName: 'Timer intermediate catch 2',
+    });
+
+    /**
+     * Map event sub processes with containing tasks
+     */
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Message event sub process',
+      targetFlowNodeName: 'Message event sub process 2',
+    });
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Timer event sub process',
+      targetFlowNodeName: 'Timer event sub process 2',
+    });
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Task E',
+      targetFlowNodeName: 'Task E2',
+    });
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Task F',
+      targetFlowNodeName: 'Task F2',
+    });
+
+    /**
+     * Map message receive task
+     */
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Message receive task',
+      targetFlowNodeName: 'Message receive task 2',
     });
 
     await migrationView.nextButton.click();
@@ -419,6 +531,29 @@ test.describe.serial('Process Instance Migration', () => {
     await processInstancePage.diagram.clickFlowNode('Task C2'); // deselect Task C2
 
     /**
+     * Expect that the correlation key and message have been migrated from Message receive task to Message receive task 2
+     */
+    await processInstancePage.diagram.clickFlowNode('Message receive task 2');
+    await processInstancePage.diagram.showMetaData();
+    await page.waitForTimeout(500); // wait until metadata modal is fully rendered
+    await expect(
+      processInstancePage.metadataModal.getByText(
+        '"correlationKey": "myFirstCorrelationKey"',
+      ),
+    ).toBeVisible();
+    await expect(
+      processInstancePage.metadataModal.getByText(
+        '"messageName": "Message_5",',
+      ),
+    ).toBeVisible();
+
+    await processInstancePage.metadataModal
+      .getByRole('button', {name: /close/i})
+      .click();
+
+    await processInstancePage.diagram.clickFlowNode('Message receive task 2'); // deselect task
+
+    /**
      * Expect that the correlation key has been updated if source and target message event have the same message id
      */
     await processInstancePage.diagram.clickEvent('Message intermediate catch');
@@ -433,6 +568,10 @@ test.describe.serial('Process Instance Migration', () => {
         '"messageName": "Message_3",',
       ),
     ).toBeVisible();
+    await page.waitForTimeout(500); // wait until metadata modal is fully rendered
+    await processInstancePage.metadataModal
+      .getByRole('button', {name: /close/i})
+      .click();
   });
 
   test('Migrated date tag', async ({processesPage, processInstancePage}) => {

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -53,6 +53,7 @@
       <bpmn:outgoing>Flow_0vrcdpx</bpmn:outgoing>
       <bpmn:outgoing>Flow_143wmxd</bpmn:outgoing>
       <bpmn:outgoing>Flow_08ahq87</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1jeea8a</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0qko2kt" sourceRef="Gateway_2" targetRef="EndEvent_1" />
     <bpmn:endEvent id="Event_2">
@@ -85,10 +86,6 @@
       <bpmn:incoming>Flow_0vrcdpx</bpmn:incoming>
       <bpmn:outgoing>Flow_18qdbnx</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
-      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
-      <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
-    </bpmn:boundaryEvent>
     <bpmn:boundaryEvent id="TimerInterrupting" name="Timer interrupting" attachedToRef="TaskB">
       <bpmn:outgoing>Flow_1ym4tee</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_04oq8h5">
@@ -112,6 +109,7 @@
       <bpmn:incoming>Flow_0yq74mw</bpmn:incoming>
       <bpmn:incoming>Flow_0e569q0</bpmn:incoming>
       <bpmn:incoming>Flow_1wxn661</bpmn:incoming>
+      <bpmn:incoming>Flow_17dl770</bpmn:incoming>
       <bpmn:outgoing>Flow_0qko2kt</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1o99cpi" sourceRef="TaskB" targetRef="TimerIntermediateCatch" />
@@ -151,6 +149,69 @@
     <bpmn:sequenceFlow id="Flow_0e569q0" sourceRef="TaskA" targetRef="Gateway_2" />
     <bpmn:sequenceFlow id="Flow_08ahq87" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_1wxn661" sourceRef="MessageIntermediateCatch" targetRef="Gateway_2" />
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_13rtwuo">
+        <bpmn:incoming>Flow_006eqia</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE" />
+      <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE" targetRef="Event_13rtwuo" />
+      <bpmn:serviceTask id="TaskE" name="Task E">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1f7mn63</bpmn:incoming>
+        <bpmn:outgoing>Flow_006eqia</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_2u2g7tt" />
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0lk89tk">
+        <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF" />
+      <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF" targetRef="Event_0lk89tk" />
+      <bpmn:serviceTask id="TaskF" name="Task F">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0eemr1n</bpmn:incoming>
+        <bpmn:outgoing>Flow_1rrwh6x</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="TimerStartEvent" name="Timer start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_0eemr1n</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1e0y77m">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1jeea8a" sourceRef="Gateway_1" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_17dl770" sourceRef="MessageReceiveTask" targetRef="Gateway_2" />
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_14us09o">
+      <bpmn:incoming>Flow_1jeea8a</bpmn:incoming>
+      <bpmn:outgoing>Flow_17dl770</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:subProcess id="ErrorEventSubProcess" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:startEvent id="ErrorStartEvent" name="Error start event">
+        <bpmn:outgoing>Flow_0vpdnw8</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_189rgdh" />
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_00hyyoh" name="Task G">
+        <bpmn:incoming>Flow_0vpdnw8</bpmn:incoming>
+        <bpmn:outgoing>Flow_08cj9mr</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_0vpdnw8" sourceRef="ErrorStartEvent" targetRef="Activity_00hyyoh" />
+      <bpmn:endEvent id="Event_1mvw93n">
+        <bpmn:incoming>Flow_08cj9mr</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_08cj9mr" sourceRef="Activity_00hyyoh" targetRef="Event_1mvw93n" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="MessageInterrupting" name="Message interrupting" attachedToRef="TaskA">
+      <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
+    </bpmn:boundaryEvent>
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -173,6 +234,16 @@
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:message id="Message_2530hhv" name="Message_3">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_2u2g7tt" name="Message_4">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key3" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_14us09o" name="Message_5">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=key1" />
     </bpmn:extensionElements>
@@ -209,9 +280,6 @@
       <bpmndi:BPMNShape id="Gateway_1p3ovhb_di" bpmnElement="Gateway_1">
         <dc:Bounds x="305" y="113" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bflyvp_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="945" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
         <dc:Bounds x="562" y="585" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -230,17 +298,14 @@
       <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
         <dc:Bounds x="440" y="792" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1bflyvp_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="945" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
         <dc:Bounds x="562" y="1055" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
         <dc:Bounds x="440" y="952" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
-        <dc:Bounds x="742" y="654" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="715" y="698" width="90" height="27" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
         <dc:Bounds x="722" y="382" width="36" height="36" />
@@ -248,16 +313,95 @@
           <dc:Bounds x="696" y="425" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
-        <dc:Bounds x="492" y="532" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
+        <dc:Bounds x="742" y="654" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="442" y="559" width="56" height="27" />
+          <dc:Bounds x="715" y="698" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
-        <dc:Bounds x="492" y="694" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1090" y="290" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="1352" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="1210" y="350" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="1130" y="372" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="417" y="726" width="86" height="14" />
+          <dc:Bounds x="1112" y="415" width="73" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="1166" y="390" />
+        <di:waypoint x="1210" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="1310" y="390" />
+        <di:waypoint x="1352" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1090" y="540" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="1352" y="622" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="1210" y="600" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="1130" y="622" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1107" y="665" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="1166" y="640" />
+        <di:waypoint x="1210" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="1310" y="640" />
+        <di:waypoint x="1352" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="440" y="1150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1aznn99_di" bpmnElement="ErrorEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1090" y="790" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03dewb3_di" bpmnElement="ErrorStartEvent">
+        <dc:Bounds x="1130" y="872" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1109" y="915" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00hyyoh_di" bpmnElement="Activity_00hyyoh">
+        <dc:Bounds x="1220" y="850" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mvw93n_di" bpmnElement="Event_1mvw93n">
+        <dc:Bounds x="1382" y="872" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0vpdnw8_di" bpmnElement="Flow_0vpdnw8">
+        <di:waypoint x="1166" y="890" />
+        <di:waypoint x="1220" y="890" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08cj9mr_di" bpmnElement="Flow_08cj9mr">
+        <di:waypoint x="1320" y="890" />
+        <di:waypoint x="1382" y="890" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="492" y="1014" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="442" y="1049" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
@@ -266,10 +410,16 @@
           <dc:Bounds x="434" y="889" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
-        <dc:Bounds x="492" y="1014" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
+        <dc:Bounds x="492" y="694" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="442" y="1049" width="56" height="27" />
+          <dc:Bounds x="417" y="726" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="492" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="442" y="559" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -395,6 +545,16 @@
       <bpmndi:BPMNEdge id="Flow_1wxn661_di" bpmnElement="Flow_1wxn661">
         <di:waypoint x="758" y="400" />
         <di:waypoint x="970" y="400" />
+        <di:waypoint x="970" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jeea8a_di" bpmnElement="Flow_1jeea8a">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="1190" />
+        <di:waypoint x="440" y="1190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17dl770_di" bpmnElement="Flow_17dl770">
+        <di:waypoint x="540" y="1190" />
+        <di:waypoint x="970" y="1190" />
         <di:waypoint x="970" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -111,6 +111,7 @@
       <bpmn:outgoing>Flow_1rzqxuo</bpmn:outgoing>
       <bpmn:outgoing>Flow_1bdhdkt</bpmn:outgoing>
       <bpmn:outgoing>Flow_13205bp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10qe08j</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_05ul9v8" sourceRef="Gateway_1" targetRef="TaskA" />
     <bpmn:sequenceFlow id="Flow_0jjil6z" sourceRef="Gateway_1" targetRef="TaskB" />
@@ -141,6 +142,7 @@
       <bpmn:incoming>Flow_1bvocj3</bpmn:incoming>
       <bpmn:incoming>Flow_0qh5pp6</bpmn:incoming>
       <bpmn:incoming>Flow_0lwoyt0</bpmn:incoming>
+      <bpmn:incoming>Flow_170beuy</bpmn:incoming>
       <bpmn:outgoing>Flow_1xou7mm</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1bvocj3" sourceRef="TimerIntermediateCatch" targetRef="Gateway_2" />
@@ -159,10 +161,54 @@
     <bpmn:sequenceFlow id="Flow_0qh5pp6" sourceRef="TaskA" targetRef="Gateway_2" />
     <bpmn:sequenceFlow id="Flow_13205bp" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch" />
     <bpmn:sequenceFlow id="Flow_0lwoyt0" sourceRef="MessageIntermediateCatch" targetRef="Gateway_2" />
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_13rtwuo">
+        <bpmn:incoming>Flow_006eqia</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskE" name="Task E">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1f7mn63</bpmn:incoming>
+        <bpmn:outgoing>Flow_006eqia</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_0cooija" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE" targetRef="Event_13rtwuo" />
+      <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0lk89tk">
+        <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskF" name="Task F">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0eemr1n</bpmn:incoming>
+        <bpmn:outgoing>Flow_1rrwh6x</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="TimerStartEvent" name="Timer start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_0eemr1n</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1e0y77m">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF" targetRef="Event_0lk89tk" />
+      <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF" />
+    </bpmn:subProcess>
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_19ff1sq">
+      <bpmn:incoming>Flow_10qe08j</bpmn:incoming>
+      <bpmn:outgoing>Flow_170beuy</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_10qe08j" sourceRef="Gateway_1" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_170beuy" sourceRef="MessageReceiveTask" targetRef="Gateway_2" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
-      <zeebe:subscription correlationKey="=key" />
+      <zeebe:subscription correlationKey="=key1" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmn:message id="Message_1xpzcw8" name="Message_1">
@@ -178,6 +224,21 @@
   <bpmn:message id="Message_0qjep2d" name="Message_3">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=key2" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_2u2g7tt" name="Message_4">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_19ff1sq" name="Message_5">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_0cooija" name="Message_7">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key3" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -212,12 +273,6 @@
       <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
         <dc:Bounds x="840" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0qdsa34_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="285" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1c7u8wl_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="975" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
         <dc:Bounds x="522" y="612" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -239,14 +294,14 @@
       <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
         <dc:Bounds x="400" y="819" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0qdsa34_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="285" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
         <dc:Bounds x="400" y="979" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
-        <dc:Bounds x="742" y="681" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="718" y="724" width="90" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_1c7u8wl_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="975" y="113" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
         <dc:Bounds x="662" y="402" width="36" height="36" />
@@ -254,16 +309,70 @@
           <dc:Bounds x="635" y="446" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
-        <dc:Bounds x="452" y="559" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
+        <dc:Bounds x="742" y="681" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="402" y="586" width="56" height="27" />
+          <dc:Bounds x="718" y="724" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
-        <dc:Bounds x="452" y="721" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="400" y="1150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1080" y="240" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="1342" y="322" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="1200" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="1120" y="322" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="377" y="753" width="86" height="14" />
+          <dc:Bounds x="1104" y="365" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="1300" y="340" />
+        <di:waypoint x="1342" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="1156" y="340" />
+        <di:waypoint x="1200" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1080" y="490" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="1342" y="572" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="1200" y="550" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="1120" y="572" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1097" y="615" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="1300" y="590" />
+        <di:waypoint x="1342" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="1156" y="590" />
+        <di:waypoint x="1200" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="452" y="1041" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="402" y="1076" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
@@ -272,10 +381,16 @@
           <dc:Bounds x="394" y="916" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
-        <dc:Bounds x="452" y="1041" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
+        <dc:Bounds x="452" y="721" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="402" y="1076" width="56" height="27" />
+          <dc:Bounds x="377" y="753" width="86" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="452" y="559" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="402" y="586" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
@@ -405,6 +520,16 @@
       <bpmndi:BPMNEdge id="Flow_0lwoyt0_di" bpmnElement="Flow_0lwoyt0">
         <di:waypoint x="698" y="420" />
         <di:waypoint x="1000" y="420" />
+        <di:waypoint x="1000" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10qe08j_di" bpmnElement="Flow_10qe08j">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="1190" />
+        <di:waypoint x="400" y="1190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_170beuy_di" bpmnElement="Flow_170beuy">
+        <di:waypoint x="500" y="1190" />
+        <di:waypoint x="1000" y="1190" />
         <di:waypoint x="1000" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -138,6 +138,7 @@
       <bpmn:outgoing>Flow_0fyja5s</bpmn:outgoing>
       <bpmn:outgoing>Flow_1478njt</bpmn:outgoing>
       <bpmn:outgoing>Flow_0kfelct</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00bezny</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_2">
       <bpmn:incoming>Flow_0hxjz3q</bpmn:incoming>
@@ -146,6 +147,7 @@
       <bpmn:incoming>Flow_0s3pyc8</bpmn:incoming>
       <bpmn:incoming>Flow_1j5fksj</bpmn:incoming>
       <bpmn:incoming>Flow_0aheimq</bpmn:incoming>
+      <bpmn:incoming>Flow_16drwmj</bpmn:incoming>
       <bpmn:outgoing>Flow_1ibxab9</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0lyxcbw" sourceRef="TaskB2" targetRef="TimerIntermediateCatch2" />
@@ -167,6 +169,50 @@
     <bpmn:sequenceFlow id="Flow_0kfelct" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch2" />
     <bpmn:sequenceFlow id="Flow_1j5fksj" sourceRef="MessageIntermediateCatch2" targetRef="Gateway_2" />
     <bpmn:sequenceFlow id="Flow_0aheimq" sourceRef="TaskA2" targetRef="Gateway_2" />
+    <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0lk89tk">
+        <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskF2" name="Task F2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0eemr1n</bpmn:incoming>
+        <bpmn:outgoing>Flow_1rrwh6x</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="TimerStartEvent" name="Timer start event 2" isInterrupting="false">
+        <bpmn:outgoing>Flow_0eemr1n</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1e0y77m">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskF2" targetRef="Event_0lk89tk" />
+      <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskF2" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="MessageEventSubProcess2" name="Message event sub process 2" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_13rtwuo">
+        <bpmn:incoming>Flow_006eqia</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskE2" name="Task E2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1f7mn63</bpmn:incoming>
+        <bpmn:outgoing>Flow_006eqia</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_312oin4" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskE2" targetRef="Event_13rtwuo" />
+      <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskE2" />
+    </bpmn:subProcess>
+    <bpmn:receiveTask id="MessageReceiveTask2" name="Message receive task 2" messageRef="Message_1r6tus3">
+      <bpmn:incoming>Flow_00bezny</bpmn:incoming>
+      <bpmn:outgoing>Flow_16drwmj</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_00bezny" sourceRef="Gateway_1" targetRef="MessageReceiveTask2" />
+    <bpmn:sequenceFlow id="Flow_16drwmj" sourceRef="MessageReceiveTask2" targetRef="Gateway_2" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -186,6 +232,26 @@
   <bpmn:message id="Message_2sap3jl" name="Message_3">
     <bpmn:extensionElements>
       <zeebe:subscription correlationKey="=key3" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_19ff1sq" name="Message_5">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1ls8ug4" name="Message_4">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key2" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_312oin4" name="Message_6">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key3" />
+    </bpmn:extensionElements>
+  </bpmn:message>
+  <bpmn:message id="Message_1r6tus3" name="Message_7">
+    <bpmn:extensionElements>
+      <zeebe:subscription correlationKey="=key1" />
     </bpmn:extensionElements>
   </bpmn:message>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -274,6 +340,60 @@
           <dc:Bounds x="745" y="725" width="90" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask2">
+        <dc:Bounds x="360" y="1150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2" isExpanded="true">
+        <dc:Bounds x="1230" y="460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="1492" y="542" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
+        <dc:Bounds x="1350" y="520" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="1270" y="542" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1247" y="585" width="83" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="1450" y="560" />
+        <di:waypoint x="1492" y="560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="1306" y="560" />
+        <di:waypoint x="1350" y="560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2" isExpanded="true">
+        <dc:Bounds x="1230" y="210" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="1492" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
+        <dc:Bounds x="1350" y="270" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="1270" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1254" y="335" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="1450" y="310" />
+        <di:waypoint x="1492" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="1306" y="310" />
+        <di:waypoint x="1350" y="310" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting2">
         <dc:Bounds x="412" y="1041" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -429,6 +549,16 @@
       <bpmndi:BPMNEdge id="Flow_0aheimq_di" bpmnElement="Flow_0aheimq">
         <di:waypoint x="460" y="537" />
         <di:waypoint x="1130" y="537" />
+        <di:waypoint x="1130" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00bezny_di" bpmnElement="Flow_00bezny">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="1190" />
+        <di:waypoint x="360" y="1190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16drwmj_di" bpmnElement="Flow_16drwmj">
+        <di:waypoint x="460" y="1190" />
+        <di:waypoint x="1130" y="1190" />
         <di:waypoint x="1130" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -30,6 +30,11 @@ const {
   TimerNonInterrupting,
   MessageIntermediateCatch,
   TimerIntermediateCatch,
+  TaskX,
+  TaskY,
+  MessageEventSubProcess,
+  TimerEventSubProcess,
+  MessageReceiveTask,
 } = elements;
 
 /**
@@ -56,9 +61,14 @@ describe('MigrationView/BottomPanel', () => {
     expect(screen.getByText(TimerNonInterrupting.name)).toBeInTheDocument();
     expect(screen.getByText(MessageIntermediateCatch.name)).toBeInTheDocument();
     expect(screen.getByText(TimerIntermediateCatch.name)).toBeInTheDocument();
+    expect(screen.getByText(TaskX.name)).toBeInTheDocument();
+    expect(screen.getByText(TaskY.name)).toBeInTheDocument();
+    expect(screen.getByText(MessageEventSubProcess.name)).toBeInTheDocument();
+    expect(screen.getByText(TimerEventSubProcess.name)).toBeInTheDocument();
+    expect(screen.getByText(MessageReceiveTask.name)).toBeInTheDocument();
 
-    // expect table to have 1 header + 11 content rows
-    expect(screen.getAllByRole('row')).toHaveLength(12);
+    // expect table to have 1 header + 16 content rows
+    expect(screen.getAllByRole('row')).toHaveLength(17);
   });
 
   it.each([
@@ -70,6 +80,9 @@ describe('MigrationView/BottomPanel', () => {
     {source: MessageInterrupting, target: MessageNonInterrupting},
     {source: MessageIntermediateCatch, target: MessageIntermediateCatch},
     {source: TimerIntermediateCatch, target: TimerIntermediateCatch},
+    {source: MessageEventSubProcess, target: MessageEventSubProcess},
+    {source: TimerEventSubProcess, target: TimerEventSubProcess},
+    {source: TaskX, target: TaskX},
   ])(
     'should allow $source.type -> $target.type mapping',
     async ({source, target}) => {
@@ -117,6 +130,7 @@ describe('MigrationView/BottomPanel', () => {
     {source: MessageIntermediateCatch, target: MessageInterrupting},
     {source: TimerInterrupting, target: TimerIntermediateCatch},
     {source: MessageIntermediateCatch, target: TimerIntermediateCatch},
+    {source: MessageEventSubProcess, target: TimerEventSubProcess},
   ])(
     'should not allow $source.type -> $target.type mapping',
     async ({source, target}) => {
@@ -180,6 +194,21 @@ describe('MigrationView/BottomPanel', () => {
     const comboboxMessageIntermediateCatch = await screen.findByLabelText(
       new RegExp(`target flow node for ${MessageIntermediateCatch.name}`, 'i'),
     );
+    const comboboxMessageEventSubProcess = await screen.findByLabelText(
+      new RegExp(`target flow node for ${MessageEventSubProcess.name}`, 'i'),
+    );
+    const comboboxTimerEventSubProcess = await screen.findByLabelText(
+      new RegExp(`target flow node for ${TimerEventSubProcess.name}`, 'i'),
+    );
+    const comboboxTaskX = await screen.findByLabelText(
+      new RegExp(`target flow node for ${TaskX.name}`, 'i'),
+    );
+    const comboboxTaskY = await screen.findByLabelText(
+      new RegExp(`target flow node for ${TaskY.name}`, 'i'),
+    );
+    const comboboxMessageReceiveTask = await screen.findByLabelText(
+      new RegExp(`target flow node for ${MessageReceiveTask.name}`, 'i'),
+    );
 
     screen.getByRole('button', {name: /fetch target process/i}).click();
 
@@ -189,6 +218,8 @@ describe('MigrationView/BottomPanel', () => {
 
     // Expect auto-mapping (same id, same bpmn type)
     expect(comboboxCheckPayment).toHaveValue(checkPayment.id);
+    expect(comboboxTaskX).toHaveValue(TaskX.id);
+    expect(comboboxMessageReceiveTask).toHaveValue(MessageReceiveTask.id);
 
     // Expect auto-mapping (same id, same bpmn type)
     expect(comboboxShipArticles).toHaveValue(shipArticles.id);
@@ -203,6 +234,12 @@ describe('MigrationView/BottomPanel', () => {
     expect(comboboxMessageIntermediateCatch).toHaveValue(
       comboboxMessageIntermediateCatch.id,
     );
+
+    // Expect auto-mapping (same event sub process type)
+    expect(comboboxMessageEventSubProcess).toHaveValue(
+      MessageEventSubProcess.id,
+    );
+    expect(comboboxTimerEventSubProcess).toHaveValue(TimerEventSubProcess.id);
 
     // Expect no auto-mapping (flow node does not exist in target)
     expect(comboboxShippingSubProcess).toHaveValue('');
@@ -219,6 +256,10 @@ describe('MigrationView/BottomPanel', () => {
 
     // Expect no auto-mapping (different bpmn type)
     expect(comboboxRequestForPayment).toHaveValue('');
+
+    // Expect no auto-mapping (different id)
+    expect(comboboxTaskY).toHaveValue('');
+    expect(comboboxTaskY).toBeEnabled();
   });
 
   it('should add tags for unmapped flow nodes', async () => {
@@ -232,25 +273,44 @@ describe('MigrationView/BottomPanel', () => {
       name: new RegExp(`target flow node for ${requestForPayment.name}`, 'i'),
     });
 
-    const rowCheckPayment = screen.getByText(checkPayment.name).closest('tr');
-    const rowShippingSubProcess = screen
-      .getByText(shippingSubProcess.name)
+    const rowCheckPayment = screen
+      .getByText(getMatcherFunction(checkPayment.name))
       .closest('tr');
-    const rowShipArticles = screen.getByText(shipArticles.name).closest('tr');
+    const rowShippingSubProcess = screen
+      .getByText(getMatcherFunction(shippingSubProcess.name))
+      .closest('tr');
+    const rowShipArticles = screen
+      .getByText(getMatcherFunction(shipArticles.name))
+      .closest('tr');
     const rowRequestForPayment = screen
-      .getByText(requestForPayment.name)
+      .getByText(getMatcherFunction(requestForPayment.name))
       .closest('tr');
     const rowMessageInterrupting = screen
-      .getByText(MessageInterrupting.name)
+      .getByText(getMatcherFunction(MessageInterrupting.name))
       .closest('tr');
     const rowTimerInterrupting = screen
-      .getByText(TimerInterrupting.name)
+      .getByText(getMatcherFunction(TimerInterrupting.name))
       .closest('tr');
     const rowMessageNonInterrupting = screen
-      .getByText(MessageNonInterrupting.name)
+      .getByText(getMatcherFunction(MessageNonInterrupting.name))
       .closest('tr');
     const rowTimerNonInterrupting = screen
-      .getByText(TimerNonInterrupting.name)
+      .getByText(getMatcherFunction(TimerNonInterrupting.name))
+      .closest('tr');
+    const rowTaskY = screen
+      .getByText(getMatcherFunction(TaskY.name))
+      .closest('tr');
+    const rowMessageEventSubProcess = screen
+      .getByText(getMatcherFunction(MessageEventSubProcess.name))
+      .closest('tr');
+    const rowTimerEventSubProcess = screen
+      .getByText(getMatcherFunction(TimerEventSubProcess.name))
+      .closest('tr');
+    const rowTaskX = screen
+      .getByText(getMatcherFunction(TaskX.name))
+      .closest('tr');
+    const rowMessageReceiveTask = screen
+      .getByText(getMatcherFunction(MessageReceiveTask.name))
       .closest('tr');
 
     await waitFor(() => {
@@ -271,8 +331,17 @@ describe('MigrationView/BottomPanel', () => {
       within(rowTimerNonInterrupting!).queryByText(/not mapped/i),
     ).not.toBeInTheDocument();
     expect(
-      within(rowShippingSubProcess!).getByText(/not mapped/i),
-    ).toBeInTheDocument();
+      within(rowMessageEventSubProcess!).queryByText(/not mapped/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rowTimerEventSubProcess!).queryByText(/not mapped/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rowTaskX!).queryByText(/not mapped/i),
+    ).not.toBeInTheDocument();
+    expect(
+      within(rowMessageReceiveTask!).queryByText(/not mapped/i),
+    ).not.toBeInTheDocument();
 
     // expect to have "not mapped" tag (not auto-mapped)
     expect(
@@ -284,6 +353,10 @@ describe('MigrationView/BottomPanel', () => {
     expect(
       within(rowTimerInterrupting!).getByText(/not mapped/i),
     ).toBeInTheDocument();
+    expect(
+      within(rowShippingSubProcess!).getByText(/not mapped/i),
+    ).toBeInTheDocument();
+    expect(within(rowTaskY!).getByText(/not mapped/i)).toBeInTheDocument();
 
     // expect tag not to be visible after selecting a target flow node
     await user.selectOptions(comboboxRequestForPayment, checkPayment.name);
@@ -313,7 +386,7 @@ describe('MigrationView/BottomPanel', () => {
     ).toBeVisible();
 
     // Expect all 11 rows to be visible (+1 header row)
-    expect(await screen.findAllByRole('row')).toHaveLength(12);
+    expect(await screen.findAllByRole('row')).toHaveLength(17);
 
     // Toggle on unmapped flow nodes
     await user.click(screen.getByLabelText(/show only not mapped/i));
@@ -334,9 +407,21 @@ describe('MigrationView/BottomPanel', () => {
     expect(
       screen.queryByText(getMatcherFunction(MessageIntermediateCatch.name)),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(getMatcherFunction(MessageEventSubProcess.name)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(getMatcherFunction(TimerEventSubProcess.name)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(getMatcherFunction(TaskX.name)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(getMatcherFunction(MessageReceiveTask.name)),
+    ).not.toBeInTheDocument();
 
     // Expect 6 not mapped rows (+1 header row)
-    expect(await screen.findAllByRole('row')).toHaveLength(7);
+    expect(await screen.findAllByRole('row')).toHaveLength(8);
 
     // Expect the following rows to be visible (because they're not mapped)
     expect(
@@ -357,6 +442,9 @@ describe('MigrationView/BottomPanel', () => {
     expect(
       screen.getByText(getMatcherFunction(TimerIntermediateCatch.name)),
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(getMatcherFunction(TaskY.name)),
+    ).toBeInTheDocument();
 
     expect(screen.getByLabelText(/show only not mapped/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/show only not mapped/i)).toBeVisible();
@@ -365,6 +453,6 @@ describe('MigrationView/BottomPanel', () => {
     await user.click(screen.getByLabelText(/show only not mapped/i));
 
     // Expect all rows to be visible again
-    expect(await screen.findAllByRole('row')).toHaveLength(12);
+    expect(await screen.findAllByRole('row')).toHaveLength(17);
   });
 });

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/mocks.tsx
@@ -69,6 +69,31 @@ const elements = {
     name: 'Timer intermediate catch',
     type: 'timerIntermediateCatch',
   },
+  TaskX: {
+    id: 'TaskX',
+    name: 'Task X',
+    type: 'serviceTask',
+  },
+  TaskY: {
+    id: 'TaskY',
+    name: 'Task Y',
+    type: 'serviceTask',
+  },
+  MessageEventSubProcess: {
+    id: 'MessageEventSubProcess',
+    name: 'Message event sub process',
+    type: 'eventSubProcess',
+  },
+  TimerEventSubProcess: {
+    id: 'TimerEventSubProcess',
+    name: 'Timer event sub process',
+    type: 'eventSubProcess',
+  },
+  MessageReceiveTask: {
+    id: 'MessageReceiveTask',
+    name: 'Message receive task',
+    type: 'receiveTask',
+  },
 };
 
 type Props = {

--- a/operate/client/src/modules/bpmn-js/utils/getEventSubProcessType.ts
+++ b/operate/client/src/modules/bpmn-js/utils/getEventSubProcessType.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {hasType} from './hasType';
+import {isEventSubProcess} from './isEventSubProcess';
+
+const getEventSubProcessType = ({
+  businessObject,
+}: {
+  businessObject: BusinessObject;
+}) => {
+  if (isEventSubProcess({businessObject})) {
+    const startEvent = businessObject.flowElements?.find((businessObject) => {
+      return hasType({businessObject, types: ['bpmn:StartEvent']});
+    });
+
+    return startEvent?.eventDefinitions?.[0]?.$type;
+  }
+};
+
+export {getEventSubProcessType};

--- a/operate/client/src/modules/bpmn-js/utils/isEventSubProcess.ts
+++ b/operate/client/src/modules/bpmn-js/utils/isEventSubProcess.ts
@@ -6,14 +6,35 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
+import {BusinessObject, EventType} from 'bpmn-js/lib/NavigatedViewer';
 import {hasType} from './hasType';
+import {hasEventType} from './hasEventType';
 
-const isEventSubProcess = (businessObject: BusinessObject) => {
-  return (
+const isEventSubProcess = ({
+  businessObject,
+  eventTypes,
+}: {
+  businessObject: BusinessObject;
+  eventTypes?: EventType[];
+}) => {
+  if (
     hasType({businessObject, types: ['bpmn:SubProcess']}) &&
     businessObject.triggeredByEvent === true
-  );
+  ) {
+    if (eventTypes !== undefined) {
+      /**
+       * if event type is provided: check for event type
+       */
+      return businessObject.flowElements?.some((businessObject) => {
+        return (
+          hasType({businessObject, types: ['bpmn:StartEvent']}) &&
+          hasEventType({businessObject, types: eventTypes})
+        );
+      });
+    }
+
+    return true;
+  }
 };
 
 export {isEventSubProcess};

--- a/operate/client/src/modules/components/FlowNodeIcon/index.tsx
+++ b/operate/client/src/modules/components/FlowNodeIcon/index.tsx
@@ -264,7 +264,7 @@ const getSVGComponent = (
     case 'bpmn:IntermediateThrowEvent':
       return FlowNodeEventIntermediateThrow;
     case 'bpmn:SubProcess':
-      return isEventSubProcess(businessObject)
+      return isEventSubProcess({businessObject})
         ? FlowNodeEventSubprocess
         : FlowNodeTaskSubProcess;
   }

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
   <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -60,6 +60,7 @@
       <bpmn:outgoing>Flow_073q9ji</bpmn:outgoing>
       <bpmn:outgoing>Flow_0ditevp</bpmn:outgoing>
       <bpmn:outgoing>Flow_0xpveg6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0q96oby</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_0wzi4n5">
       <bpmn:incoming>Flow_1c5723c</bpmn:incoming>
@@ -67,6 +68,7 @@
       <bpmn:incoming>Flow_0qwbw29</bpmn:incoming>
       <bpmn:incoming>Flow_1m8j611</bpmn:incoming>
       <bpmn:incoming>Flow_0cxvor3</bpmn:incoming>
+      <bpmn:incoming>Flow_1k3ci9e</bpmn:incoming>
       <bpmn:outgoing>Flow_0xq0gk6</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:task id="TaskA" name="Task A">
@@ -166,6 +168,65 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_13rtwuo">
+        <bpmn:incoming>Flow_006eqia</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskX" name="Task X">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1f7mn63</bpmn:incoming>
+        <bpmn:outgoing>Flow_006eqia</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_0so1os3" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskX" targetRef="Event_13rtwuo" />
+      <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskX" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0lk89tk">
+        <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskY" name="Task Y">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0eemr1n</bpmn:incoming>
+        <bpmn:outgoing>Flow_1rrwh6x</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="TimerStartEvent" name="Timer start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_0eemr1n</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1e0y77m">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskY" targetRef="Event_0lk89tk" />
+      <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskY" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_08wf7gf" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_1ngtou5" name="Error start event">
+        <bpmn:outgoing>Flow_0vpdnw8</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_189rgdh" />
+      </bpmn:startEvent>
+      <bpmn:task id="TaskZ" name="Task Z">
+        <bpmn:incoming>Flow_0vpdnw8</bpmn:incoming>
+        <bpmn:outgoing>Flow_08cj9mr</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:endEvent id="Event_1mvw93n">
+        <bpmn:incoming>Flow_08cj9mr</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0vpdnw8" sourceRef="Event_1ngtou5" targetRef="TaskZ" />
+      <bpmn:sequenceFlow id="Flow_08cj9mr" sourceRef="TaskZ" targetRef="Event_1mvw93n" />
+    </bpmn:subProcess>
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_0so1os3">
+      <bpmn:incoming>Flow_0q96oby</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k3ci9e</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_0q96oby" sourceRef="Gateway_1fr6z3f" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_1k3ci9e" sourceRef="MessageReceiveTask" targetRef="Gateway_0wzi4n5" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -193,6 +254,12 @@
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
         <dc:Bounds x="300" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="1712" y="118" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
         <dc:Bounds x="469" y="113" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -201,31 +268,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
         <dc:Bounds x="444" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="1712" y="118" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d5b5q4_di" bpmnElement="confirmDelivery">
-        <dc:Bounds x="1550" y="96" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
-        <dc:Bounds x="1455" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1c8bfdt_di" bpmnElement="MessageIntermediateCatch">
-        <dc:Bounds x="1342" y="120" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1318" y="163" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1uf8pjm_di" bpmnElement="TimerIntermediateCatch">
-        <dc:Bounds x="1342" y="282" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1318" y="325" width="90" height="27" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zhf45a_di" bpmnElement="shippingSubProcess" isExpanded="true">
         <dc:Bounds x="610" y="38" width="350" height="200" />
@@ -251,6 +293,9 @@
       <bpmndi:BPMNShape id="BPMNShape_1o28q8h" bpmnElement="Gateway_1fr6z3f">
         <dc:Bounds x="1015" y="113" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
+        <dc:Bounds x="1455" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1fyji1z" bpmnElement="TaskA">
         <dc:Bounds x="1150" y="98" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -267,10 +312,6 @@
         <dc:Bounds x="1150" y="580" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1mdt1zr_di" bpmnElement="TaskE">
-        <dc:Bounds x="1150" y="751" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_11gdqkh" bpmnElement="Event_1q5nldo">
         <dc:Bounds x="1272" y="213" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -285,6 +326,105 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1xyc01u_di" bpmnElement="Event_1xyc01u">
         <dc:Bounds x="1272" y="863" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mdt1zr_di" bpmnElement="TaskE">
+        <dc:Bounds x="1150" y="751" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d5b5q4_di" bpmnElement="confirmDelivery">
+        <dc:Bounds x="1550" y="96" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1c8bfdt_di" bpmnElement="MessageIntermediateCatch">
+        <dc:Bounds x="1342" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1318" y="163" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1uf8pjm_di" bpmnElement="TimerIntermediateCatch">
+        <dc:Bounds x="1342" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1318" y="325" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="610" y="300" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="872" y="382" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskX">
+        <dc:Bounds x="730" y="360" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="650" y="382" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="634" y="425" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="830" y="400" />
+        <di:waypoint x="872" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="686" y="400" />
+        <di:waypoint x="730" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="610" y="550" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="872" y="632" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskY">
+        <dc:Bounds x="730" y="610" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="650" y="632" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="627" y="675" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="830" y="650" />
+        <di:waypoint x="872" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="686" y="650" />
+        <di:waypoint x="730" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1aznn99_di" bpmnElement="Activity_08wf7gf" isExpanded="true">
+        <dc:Bounds x="610" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03dewb3_di" bpmnElement="Event_1ngtou5">
+        <dc:Bounds x="650" y="882" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="629" y="925" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00hyyoh_di" bpmnElement="TaskZ">
+        <dc:Bounds x="740" y="860" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mvw93n_di" bpmnElement="Event_1mvw93n">
+        <dc:Bounds x="902" y="882" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0vpdnw8_di" bpmnElement="Flow_0vpdnw8">
+        <di:waypoint x="686" y="900" />
+        <di:waypoint x="740" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08cj9mr_di" bpmnElement="Flow_08cj9mr">
+        <di:waypoint x="840" y="900" />
+        <di:waypoint x="902" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="1150" y="950" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1me1qfe_di" bpmnElement="EscalationInterrupting">
         <dc:Bounds x="1192" y="813" width="36" height="36" />
@@ -398,11 +538,6 @@
         <di:waypoint x="1480" y="620" />
         <di:waypoint x="1480" y="163" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qwbw29_di" bpmnElement="Flow_0qwbw29">
-        <di:waypoint x="1250" y="791" />
-        <di:waypoint x="1480" y="791" />
-        <di:waypoint x="1480" y="163" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_1up7i5i" bpmnElement="Flow_14ee2ym">
         <di:waypoint x="1220" y="196" />
         <di:waypoint x="1220" y="231" />
@@ -423,11 +558,6 @@
         <di:waypoint x="1220" y="701" />
         <di:waypoint x="1272" y="701" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1iklgns_di" bpmnElement="Flow_1iklgns">
-        <di:waypoint x="1210" y="849" />
-        <di:waypoint x="1210" y="881" />
-        <di:waypoint x="1272" y="881" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1o2at6f_di" bpmnElement="Flow_1o2at6f">
         <di:waypoint x="960" y="138" />
         <di:waypoint x="1015" y="138" />
@@ -436,6 +566,16 @@
         <di:waypoint x="1505" y="138" />
         <di:waypoint x="1550" y="138" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qwbw29_di" bpmnElement="Flow_0qwbw29">
+        <di:waypoint x="1250" y="791" />
+        <di:waypoint x="1480" y="791" />
+        <di:waypoint x="1480" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iklgns_di" bpmnElement="Flow_1iklgns">
+        <di:waypoint x="1210" y="849" />
+        <di:waypoint x="1210" y="881" />
+        <di:waypoint x="1272" y="881" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1m8j611_di" bpmnElement="Flow_1m8j611">
         <di:waypoint x="1378" y="138" />
         <di:waypoint x="1455" y="138" />
@@ -443,6 +583,16 @@
       <bpmndi:BPMNEdge id="Flow_0cxvor3_di" bpmnElement="Flow_0cxvor3">
         <di:waypoint x="1378" y="300" />
         <di:waypoint x="1480" y="300" />
+        <di:waypoint x="1480" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0q96oby_di" bpmnElement="Flow_0q96oby">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="990" />
+        <di:waypoint x="1150" y="990" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k3ci9e_di" bpmnElement="Flow_1k3ci9e">
+        <di:waypoint x="1250" y="990" />
+        <di:waypoint x="1480" y="990" />
         <di:waypoint x="1480" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -42,10 +42,12 @@
       <bpmn:incoming>Flow_0jjk1nl</bpmn:incoming>
       <bpmn:outgoing>Flow_19ap3af</bpmn:outgoing>
       <bpmn:outgoing>Flow_1u8201x</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0k6h50o</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_0wzi4n5">
       <bpmn:incoming>Flow_10w6zi2</bpmn:incoming>
       <bpmn:incoming>Flow_1j1rioa</bpmn:incoming>
+      <bpmn:incoming>Flow_0w9awk1</bpmn:incoming>
       <bpmn:outgoing>Flow_0r0cpho</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:task id="TaskA" name="Task A">
@@ -85,6 +87,65 @@
       <bpmn:messageEventDefinition id="MessageEventDefinition_1kk3ypa" messageRef="Message_2tsgt52" />
     </bpmn:intermediateCatchEvent>
     <bpmn:sequenceFlow id="Flow_1j1rioa" sourceRef="MessageIntermediateCatch" targetRef="Gateway_0wzi4n5" />
+    <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_13rtwuo">
+        <bpmn:incoming>Flow_006eqia</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskX" name="Task X">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1f7mn63</bpmn:incoming>
+        <bpmn:outgoing>Flow_006eqia</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="MessageStartEvent" name="Message start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_1f7mn63</bpmn:outgoing>
+        <bpmn:messageEventDefinition id="MessageEventDefinition_047sqmx" messageRef="Message_0so1os3" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_006eqia" sourceRef="TaskX" targetRef="Event_13rtwuo" />
+      <bpmn:sequenceFlow id="Flow_1f7mn63" sourceRef="MessageStartEvent" targetRef="TaskX" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="TimerEventSubProcess" name="Timer event sub process" triggeredByEvent="true">
+      <bpmn:endEvent id="Event_0lk89tk">
+        <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="TaskYY" name="Task YY">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0eemr1n</bpmn:incoming>
+        <bpmn:outgoing>Flow_1rrwh6x</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:startEvent id="TimerStartEvent" name="Timer start event" isInterrupting="false">
+        <bpmn:outgoing>Flow_0eemr1n</bpmn:outgoing>
+        <bpmn:timerEventDefinition id="TimerEventDefinition_1e0y77m">
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1rrwh6x" sourceRef="TaskYY" targetRef="Event_0lk89tk" />
+      <bpmn:sequenceFlow id="Flow_0eemr1n" sourceRef="TimerStartEvent" targetRef="TaskYY" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Activity_08wf7gf" name="Error event sub process" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_1ngtou5" name="Error start event">
+        <bpmn:outgoing>Flow_0vpdnw8</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_189rgdh" />
+      </bpmn:startEvent>
+      <bpmn:task id="TaskZ" name="Task Z">
+        <bpmn:incoming>Flow_0vpdnw8</bpmn:incoming>
+        <bpmn:outgoing>Flow_08cj9mr</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:endEvent id="Event_1mvw93n">
+        <bpmn:incoming>Flow_08cj9mr</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0vpdnw8" sourceRef="Event_1ngtou5" targetRef="TaskZ" />
+      <bpmn:sequenceFlow id="Flow_08cj9mr" sourceRef="TaskZ" targetRef="Event_1mvw93n" />
+    </bpmn:subProcess>
+    <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_0so1os3">
+      <bpmn:incoming>Flow_0k6h50o</bpmn:incoming>
+      <bpmn:outgoing>Flow_0w9awk1</bpmn:outgoing>
+    </bpmn:receiveTask>
+    <bpmn:sequenceFlow id="Flow_0k6h50o" sourceRef="Gateway_1fr6z3f" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_0w9awk1" sourceRef="MessageReceiveTask" targetRef="Gateway_0wzi4n5" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -112,6 +173,12 @@
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
         <dc:Bounds x="300" y="98" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="1302" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
         <dc:Bounds x="469" y="113" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -127,6 +194,9 @@
       <bpmndi:BPMNShape id="BPMNShape_1o28q8h" bpmnElement="Gateway_1fr6z3f">
         <dc:Bounds x="775" y="113" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
+        <dc:Bounds x="1195" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1fyji1z" bpmnElement="TaskA">
         <dc:Bounds x="910" y="98" width="100" height="80" />
         <bpmndi:BPMNLabel />
@@ -141,20 +211,90 @@
         <dc:Bounds x="910" y="289" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="1302" y="120" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="270" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_03hi8di" bpmnElement="Gateway_0wzi4n5">
-        <dc:Bounds x="1195" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1c8bfdt_di" bpmnElement="MessageIntermediateCatch">
         <dc:Bounds x="1082" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1058" y="163" width="90" height="27" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="319" y="380" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="581" y="462" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskX">
+        <dc:Bounds x="439" y="440" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="359" y="462" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="343" y="505" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="539" y="480" />
+        <di:waypoint x="581" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="395" y="480" />
+        <di:waypoint x="439" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="319" y="630" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="581" y="712" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskYY">
+        <dc:Bounds x="439" y="690" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="359" y="712" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="336" y="755" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="539" y="730" />
+        <di:waypoint x="581" y="730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="395" y="730" />
+        <di:waypoint x="439" y="730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1aznn99_di" bpmnElement="Activity_08wf7gf" isExpanded="true">
+        <dc:Bounds x="319" y="880" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_03dewb3_di" bpmnElement="Event_1ngtou5">
+        <dc:Bounds x="359" y="962" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="338" y="1005" width="79" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00hyyoh_di" bpmnElement="TaskZ">
+        <dc:Bounds x="449" y="940" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1mvw93n_di" bpmnElement="Event_1mvw93n">
+        <dc:Bounds x="611" y="962" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0vpdnw8_di" bpmnElement="Flow_0vpdnw8">
+        <di:waypoint x="395" y="980" />
+        <di:waypoint x="449" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08cj9mr_di" bpmnElement="Flow_08cj9mr">
+        <di:waypoint x="549" y="980" />
+        <di:waypoint x="611" y="980" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="910" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1kb9m92" bpmnElement="TimerNonInterrupting">
         <dc:Bounds x="962" y="351" width="36" height="36" />
@@ -243,6 +383,16 @@
       <bpmndi:BPMNEdge id="Flow_1j1rioa_di" bpmnElement="Flow_1j1rioa">
         <di:waypoint x="1118" y="138" />
         <di:waypoint x="1195" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k6h50o_di" bpmnElement="Flow_0k6h50o">
+        <di:waypoint x="800" y="163" />
+        <di:waypoint x="800" y="520" />
+        <di:waypoint x="910" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w9awk1_di" bpmnElement="Flow_0w9awk1">
+        <di:waypoint x="1010" y="520" />
+        <di:waypoint x="1220" y="520" />
+        <di:waypoint x="1220" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/modules/stores/processInstanceMigrationMapping.test.ts
+++ b/operate/client/src/modules/stores/processInstanceMigrationMapping.test.ts
@@ -26,6 +26,13 @@ import {waitFor} from '@testing-library/react';
  * - TimerNonInterrupting (event)
  * - MessageIntermediateCatch (event)
  * - TimerIntermediateCatch (event)
+ * - MessageEventSubProcess
+ * - TimerEventSubProcess
+ * - ErrorEventSubProcess
+ * - MessageStartEvent
+ * - TimerStartEvent
+ * - ErrorStartEvent
+ * - MessageReceiveTask
  *
  * orderProcess_v2.bpmn contains:
  * - checkPayment (service task)
@@ -34,6 +41,13 @@ import {waitFor} from '@testing-library/react';
  * - MessageInterrupting (event)
  * - TimerNonInterrupting (event)
  * - MessageIntermediateCatch (event)
+ * - MessageEventSubProcess (sub process)
+ * - TimerEventSubProcess (sub process)
+ * - ErrorEventSubProcess (sub process)
+ * - MessageStartEvent
+ * - TimerStartEvent
+ * - ErrorStartEvent
+ * - MessageReceiveTask
  */
 describe('processInstanceMigrationMappingStore', () => {
   afterEach(() => {
@@ -80,6 +94,22 @@ describe('processInstanceMigrationMappingStore', () => {
         id: 'MessageIntermediateCatch',
         type: 'bpmn:IntermediateCatchEvent',
       },
+      {
+        id: 'MessageEventSubProcess',
+        type: 'bpmn:SubProcess',
+      },
+      {
+        id: 'TaskX',
+        type: 'bpmn:ServiceTask',
+      },
+      {
+        id: 'TimerEventSubProcess',
+        type: 'bpmn:SubProcess',
+      },
+      {
+        id: 'MessageReceiveTask',
+        type: 'bpmn:ReceiveTask',
+      },
     ]);
 
     expect(isAutoMappable('checkPayment')).toBe(true);
@@ -87,11 +117,17 @@ describe('processInstanceMigrationMappingStore', () => {
     expect(isAutoMappable('MessageInterrupting')).toBe(true);
     expect(isAutoMappable('TimerNonInterrupting')).toBe(true);
     expect(isAutoMappable('MessageIntermediateCatch')).toBe(true);
+    expect(isAutoMappable('MessageEventSubProcess')).toBe(true);
+    expect(isAutoMappable('TimerEventSubProcess')).toBe(true);
+    expect(isAutoMappable('TaskX')).toBe(true);
 
     expect(isAutoMappable('requestForPayment')).toBe(false);
     expect(isAutoMappable('TimerInterrupting')).toBe(false);
     expect(isAutoMappable('MessageNonInterrupting')).toBe(false);
     expect(isAutoMappable('TimerIntermediateCatch')).toBe(false);
+    expect(isAutoMappable('ErrorEventSubProcess')).toBe(false);
+    expect(isAutoMappable('TaskY')).toBe(false);
+    expect(isAutoMappable('TaskZ')).toBe(false);
 
     expect(isAutoMappable('unknownFlowNodeId')).toBe(false);
     expect(isAutoMappable('')).toBe(false);
@@ -123,6 +159,14 @@ describe('processInstanceMigrationMappingStore', () => {
             id: 'checkPayment',
             name: 'Check payment',
           },
+          {
+            id: 'TaskX',
+            name: 'Task X',
+          },
+          {
+            id: 'TaskYY',
+            name: 'Task YY',
+          },
         ],
       },
       {
@@ -134,6 +178,14 @@ describe('processInstanceMigrationMappingStore', () => {
           {
             id: 'checkPayment',
             name: 'Check payment',
+          },
+          {
+            id: 'TaskX',
+            name: 'Task X',
+          },
+          {
+            id: 'TaskYY',
+            name: 'Task YY',
           },
         ],
       },
@@ -233,6 +285,82 @@ describe('processInstanceMigrationMappingStore', () => {
           name: 'Timer intermediate catch',
         },
         selectableTargetFlowNodes: [],
+      },
+      {
+        sourceFlowNode: {
+          id: 'MessageEventSubProcess',
+          name: 'Message event sub process',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'MessageEventSubProcess',
+            name: 'Message event sub process',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'TaskX',
+          name: 'Task X',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'checkPayment',
+            name: 'Check payment',
+          },
+          {
+            id: 'TaskX',
+            name: 'Task X',
+          },
+          {
+            id: 'TaskYY',
+            name: 'Task YY',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'TimerEventSubProcess',
+          name: 'Timer event sub process',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'TimerEventSubProcess',
+            name: 'Timer event sub process',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'TaskY',
+          name: 'Task Y',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'checkPayment',
+            name: 'Check payment',
+          },
+          {
+            id: 'TaskX',
+            name: 'Task X',
+          },
+          {
+            id: 'TaskYY',
+            name: 'Task YY',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'MessageReceiveTask',
+          name: 'Message receive task',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'MessageReceiveTask',
+            name: 'Message receive task',
+          },
+        ],
       },
     ]);
   });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
@@ -37,6 +37,11 @@ describe('stores/processXml/processXml.list', () => {
       'confirmDelivery',
       'MessageIntermediateCatch',
       'TimerIntermediateCatch',
+      'MessageEventSubProcess',
+      'TaskX',
+      'TimerEventSubProcess',
+      'TaskY',
+      'MessageReceiveTask',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
@@ -37,6 +37,11 @@ describe('stores/processXml/processXml.list', () => {
       'confirmDelivery',
       'MessageIntermediateCatch',
       'TimerIntermediateCatch',
+      'MessageEventSubProcess',
+      'TaskX',
+      'TimerEventSubProcess',
+      'TaskY',
+      'MessageReceiveTask',
     ]);
   });
 
@@ -64,6 +69,11 @@ describe('stores/processXml/processXml.list', () => {
       'confirmDelivery',
       'MessageIntermediateCatch',
       'TimerIntermediateCatch',
+      'MessageEventSubProcess',
+      'TaskX',
+      'TimerEventSubProcess',
+      'TaskY',
+      'MessageReceiveTask',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
+++ b/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
@@ -52,19 +52,10 @@ const isMigratableFlowNode = (businessObject: BusinessObject) => {
       businessObject,
     })
   ) {
-    if (
-      isEventSubProcess({
-        businessObject,
-        eventTypes: [
-          'bpmn:MessageEventDefinition',
-          'bpmn:TimerEventDefinition',
-        ],
-      })
-    ) {
-      return true; // message and timer event sub processes
-    } else {
-      return false; // any other event sub process
-    }
+    return isEventSubProcess({
+      businessObject,
+      eventTypes: ['bpmn:MessageEventDefinition', 'bpmn:TimerEventDefinition'],
+    });
   }
 
   return hasType({

--- a/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
+++ b/operate/client/src/modules/stores/processXml/utils/isMigratableFlowNode.ts
@@ -9,6 +9,7 @@
 import {BusinessObject} from 'bpmn-js/lib/NavigatedViewer';
 import {hasEventType} from 'modules/bpmn-js/utils/hasEventType';
 import {hasType} from 'modules/bpmn-js/utils/hasType';
+import {isEventSubProcess} from 'modules/bpmn-js/utils/isEventSubProcess';
 
 const isMigratableFlowNode = (businessObject: BusinessObject) => {
   /**
@@ -43,6 +44,29 @@ const isMigratableFlowNode = (businessObject: BusinessObject) => {
     return true;
   }
 
+  /**
+   * Check event sub processes
+   */
+  if (
+    isEventSubProcess({
+      businessObject,
+    })
+  ) {
+    if (
+      isEventSubProcess({
+        businessObject,
+        eventTypes: [
+          'bpmn:MessageEventDefinition',
+          'bpmn:TimerEventDefinition',
+        ],
+      })
+    ) {
+      return true; // message and timer event sub processes
+    } else {
+      return false; // any other event sub process
+    }
+  }
+
   return hasType({
     businessObject,
     types: [
@@ -50,6 +74,7 @@ const isMigratableFlowNode = (businessObject: BusinessObject) => {
       'bpmn:UserTask',
       'bpmn:SubProcess',
       'bpmn:CallActivity',
+      'bpmn:ReceiveTask',
     ],
   });
 };


### PR DESCRIPTION
## Description

- add getEventSubProcessType util function
- add migration support for message and timer event sub processes
- add migration support for receive tasks
- extend unit/integration and e2e test coverage

The big file diff is mostly because of changes in bpmn mock data files.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20818 
