### PR TITLE
feat: add support for oidc authentication

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -81,6 +81,16 @@
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>oauth2-oidc-sdk</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -78,5 +78,9 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-client</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaOidcUserService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+@Service
+@Profile("auth-oidc")
+public class CamundaOidcUserService extends OidcUserService {
+
+  public CamundaOidcUserService() {}
+
+  @Override
+  public OidcUser loadUser(final OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+    return super.loadUser(userRequest);
+  }
+}

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -133,6 +133,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-store-azure</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.nimbusds</groupId>
+          <artifactId>oauth2-oidc-sdk</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -542,11 +548,6 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-oauth2-client</artifactId>
     </dependency>
 
   </dependencies>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -544,6 +544,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-oauth2-client</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -30,6 +30,7 @@ public enum Profile {
 
   // authentication profiles
   AUTH_BASIC("auth-basic"),
+  AUTH_OIDC("auth-oidc"),
   IDENTITY_AUTH("identity-auth"),
   SSO_AUTH("sso-auth"),
   DEFAULT_AUTH_PROFILE("auth"),
@@ -49,7 +50,8 @@ public enum Profile {
   }
 
   public static Set<Profile> getAuthProfiles() {
-    return Set.of(AUTH_BASIC, DEFAULT_AUTH_PROFILE, IDENTITY_AUTH, LDAP_AUTH_PROFILE, SSO_AUTH);
+    return Set.of(
+        AUTH_BASIC, AUTH_OIDC, DEFAULT_AUTH_PROFILE, IDENTITY_AUTH, LDAP_AUTH_PROFILE, SSO_AUTH);
   }
 
   public static Set<Profile> getWebappProfiles() {

--- a/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
@@ -14,6 +14,6 @@ import org.springframework.context.annotation.Profile;
 
 @ComponentScan(basePackages = {"io.camunda.authentication"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.authentication"})
-@Profile("auth-basic")
+@Profile("auth-basic|auth-oidc")
 @ConditionalOnRestGatewayEnabled
 public class AuthenticationConfiguration {}

--- a/dist/src/main/resources/application-auth-oidc.yaml
+++ b/dist/src/main/resources/application-auth-oidc.yaml
@@ -1,0 +1,17 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          oidcclient:
+            client-id:
+            client-secret:
+            authorization-grant-type: authorization_code
+            redirect-uri:
+            provider: oidcclient
+            scope:
+              - "openid"
+              - "profile"
+        provider:
+          oidcclient:
+            issuer-uri:


### PR DESCRIPTION
## Description

Camunda supports OIDC authentication via the profile auth-oidc.

Where possible we should support existing configuration options documented in https://docs.camunda.io/docs/next/self-managed/setup/guides/connect-to-an-oidc-provider/?optionsType=env.

## Related issues

closes #19741 
