### PR TITLE
feat: add process definition search controller and service infrastucture 

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.service.FlowNodeInstanceServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.MessageServices;
+import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.ResourceServices;
 import io.camunda.service.SignalServices;
@@ -49,6 +50,12 @@ public class CamundaServicesConfiguration {
   @Bean
   public CamundaServices camundaServices() {
     return new CamundaServices(brokerClient, camundaSearchClient);
+  }
+
+  @Bean
+  public ProcessDefinitionServices processDefinitionServices(
+      final CamundaServices camundaServices) {
+    return camundaServices.processDefinitionServices();
   }
 
   @Bean

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -32,6 +32,10 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
         brokerClient, activateJobsHandler, searchClient, transformers, authentication);
   }
 
+  public ProcessDefinitionServices processDefinitionServices() {
+    return new ProcessDefinitionServices(brokerClient, searchClient, transformers, authentication);
+  }
+
   public ProcessInstanceServices processInstanceServices() {
     return new ProcessInstanceServices(brokerClient, searchClient, transformers, authentication);
   }

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.entities.ProcessDefinitionEntity;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.search.query.ProcessDefinitionQuery;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+
+public class ProcessDefinitionServices
+    extends SearchQueryService<
+        ProcessDefinitionServices, ProcessDefinitionQuery, ProcessDefinitionEntity> {
+
+  public ProcessDefinitionServices(
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(brokerClient, searchClient, transformers, authentication);
+  }
+
+  @Override
+  public SearchQueryResult<ProcessDefinitionEntity> search(final ProcessDefinitionQuery query) {
+    return executor.search(query, ProcessDefinitionEntity.class);
+  }
+
+  @Override
+  public ProcessDefinitionServices withAuthentication(final Authentication authentication) {
+    return new ProcessDefinitionServices(brokerClient, searchClient, transformers, authentication);
+  }
+}

--- a/service/src/main/java/io/camunda/service/entities/ProcessDefinitionEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/ProcessDefinitionEntity.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.entities;
+
+public record ProcessDefinitionEntity() {}

--- a/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
@@ -14,6 +14,15 @@ public final class FilterBuilders {
 
   private FilterBuilders() {}
 
+  public static ProcessDefinitionFilter.Builder processDefinition() {
+    return new ProcessDefinitionFilter.Builder();
+  }
+
+  public static ProcessDefinitionFilter processDefinition(
+      final Function<ProcessDefinitionFilter.Builder, ObjectBuilder<ProcessDefinitionFilter>> fn) {
+    return fn.apply(processDefinition()).build();
+  }
+
   public static ProcessInstanceFilter.Builder processInstance() {
     return new ProcessInstanceFilter.Builder();
   }

--- a/service/src/main/java/io/camunda/service/search/filter/ProcessDefinitionFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/ProcessDefinitionFilter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+
+public record ProcessDefinitionFilter() implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<ProcessDefinitionFilter> {
+
+    @Override
+    public ProcessDefinitionFilter build() {
+      return new ProcessDefinitionFilter();
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/ProcessDefinitionQuery.java
+++ b/service/src/main/java/io/camunda/service/search/query/ProcessDefinitionQuery.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.service.search.filter.FilterBuilders;
+import io.camunda.service.search.filter.ProcessDefinitionFilter;
+import io.camunda.service.search.page.SearchQueryPage;
+import io.camunda.service.search.sort.ProcessDefinitionSort;
+import io.camunda.service.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record ProcessDefinitionQuery(
+    ProcessDefinitionFilter filter, ProcessDefinitionSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<ProcessDefinitionFilter, ProcessDefinitionSort> {
+
+  public static ProcessDefinitionQuery of(
+      final Function<ProcessDefinitionQuery.Builder, ObjectBuilder<ProcessDefinitionQuery>> fn) {
+    return fn.apply(new ProcessDefinitionQuery.Builder()).build();
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<ProcessDefinitionQuery.Builder>
+      implements TypedSearchQueryBuilder<
+          ProcessDefinitionQuery,
+          ProcessDefinitionQuery.Builder,
+          ProcessDefinitionFilter,
+          ProcessDefinitionSort> {
+
+    private static final ProcessDefinitionFilter EMPTY_FILTER =
+        FilterBuilders.processDefinition().build();
+    private static final ProcessDefinitionSort EMPTY_SORT =
+        SortOptionBuilders.processDefinition().build();
+
+    private ProcessDefinitionFilter filter;
+    private ProcessDefinitionSort sort;
+
+    @Override
+    protected ProcessDefinitionQuery.Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionQuery.Builder filter(final ProcessDefinitionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionQuery.Builder sort(final ProcessDefinitionSort value) {
+      sort = value;
+      return this;
+    }
+
+    public ProcessDefinitionQuery.Builder filter(
+        final Function<ProcessDefinitionFilter.Builder, ObjectBuilder<ProcessDefinitionFilter>>
+            fn) {
+      return filter(FilterBuilders.processDefinition(fn));
+    }
+
+    public ProcessDefinitionQuery.Builder sort(
+        final Function<ProcessDefinitionSort.Builder, ObjectBuilder<ProcessDefinitionSort>> fn) {
+      return sort(SortOptionBuilders.processDefinition(fn));
+    }
+
+    @Override
+    public ProcessDefinitionQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new ProcessDefinitionQuery(filter, sort, page());
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
@@ -14,6 +14,15 @@ public final class SearchQueryBuilders {
 
   private SearchQueryBuilders() {}
 
+  public static ProcessDefinitionQuery.Builder processDefinitionSearchQuery() {
+    return new ProcessDefinitionQuery.Builder();
+  }
+
+  public static ProcessDefinitionQuery processDefinitionSearchQuery(
+      final Function<ProcessDefinitionQuery.Builder, ObjectBuilder<ProcessDefinitionQuery>> fn) {
+    return fn.apply(processDefinitionSearchQuery()).build();
+  }
+
   public static ProcessInstanceQuery.Builder processInstanceSearchQuery() {
     return new ProcessInstanceQuery.Builder();
   }

--- a/service/src/main/java/io/camunda/service/search/sort/ProcessDefinitionSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/ProcessDefinitionSort.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+
+public record ProcessDefinitionSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static final class Builder
+      extends SortOption.AbstractBuilder<ProcessDefinitionSort.Builder>
+      implements ObjectBuilder<ProcessDefinitionSort> {
+    @Override
+    protected ProcessDefinitionSort.Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessDefinitionSort build() {
+      return new ProcessDefinitionSort(orderings);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
@@ -14,6 +14,15 @@ public final class SortOptionBuilders {
 
   private SortOptionBuilders() {}
 
+  public static ProcessDefinitionSort.Builder processDefinition() {
+    return new ProcessDefinitionSort.Builder();
+  }
+
+  public static ProcessDefinitionSort processDefinition(
+      final Function<ProcessDefinitionSort.Builder, ObjectBuilder<ProcessDefinitionSort>> fn) {
+    return fn.apply(processDefinition()).build();
+  }
+
   public static ProcessInstanceSort.Builder processInstance() {
     return new ProcessInstanceSort.Builder();
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -658,7 +658,7 @@ paths:
       responses:
         "200":
           description: >
-            The Process Definition Search successful response.
+            The process definition search successful response.
           content:
             application/json:
               schema:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -641,7 +641,7 @@ paths:
     post:
       tags:
         - Process definition
-      summary: process definitions (alpha)
+      summary: Search process definitions (alpha)
       description: |
         Search for process definitions based on given criteria.
         :::note

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -665,7 +665,7 @@ paths:
                 $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponse"
         "400":
           description: >
-            The Process Definition Search Query failed.
+            The process definition search query failed.
             More details are provided in the response body.
           content:
             application/problem+json:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -588,7 +588,7 @@ paths:
         Set a precise, static time for the Zeebe engine’s internal clock.
         When the clock is pinned, it remains at the specified time and does not advance.
         To change the time, the clock must be pinned again with a new timestamp.
-        
+
         :::note
         This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
         in future releases.
@@ -624,7 +624,7 @@ paths:
         Resets the Zeebe engine’s internal clock to the current system time, enabling it to tick in real-time.
         This operation is useful for returning the clock to
         normal behavior after it has been pinned to a specific time.
-        
+
         :::note
         This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
         in future releases.
@@ -637,7 +637,47 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-
+  /process-definitions/search:
+    post:
+      tags:
+        - Process definition
+      summary: process definitions (alpha)
+      description: |
+        Search for process definitions based on given criteria.
+        :::note
+        This endpoint is an alpha feature and not enabled on Camunda clusters out of the box.
+        See the [Camunda 8 REST API overview](/apis-tools/camunda-api-rest/camunda-api-rest-overview.md#query-api)
+        for further details.
+        :::
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ProcessDefinitionSearchQueryRequest"
+      responses:
+        "200":
+          description: >
+            The Process Definition Search successful response.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProcessDefinitionSearchQueryResponse"
+        "400":
+          description: >
+            The Process Definition Search Query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          description: >
+            An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /process-instances:
     post:
       tags:
@@ -1893,6 +1933,79 @@ components:
           minimum: 0
           maximum: 100
           default: 50
+    ProcessDefinitionSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        filter:
+          allOf:
+            - $ref: "#/components/schemas/ProcessDefinitionFilterRequest"
+    ProcessDefinitionFilterRequest:
+      type: object
+      properties:
+        processDefinitionKey:
+          description: The key for this process definition.
+          type: integer
+          format: int64
+        processName:
+          description: Name of this process definition.
+          type: string
+        processVersion:
+          description: Version of this process definition.
+          type: integer
+          format: int32
+        processVersionTag:
+          description: Version tag of this process definition.
+          type: integer
+          format: int32
+        bpmnProcessId:
+          description: BPMN process id of this process definition.
+          type: string
+        tenantId:
+          description: Tenant id of this process definition.
+          type: string
+        formKey:
+          description: The key of the form related to this process definition.
+          type: integer
+          format: int64
+    ProcessDefinitionSearchQueryResponse:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessDefinitionItem"
+    ProcessDefinitionItem:
+      type: object
+      properties:
+        processDefinitionKey:
+          description: The key for this process definition.
+          type: integer
+          format: int64
+        processName:
+          description: Name of this process definition.
+          type: string
+        processVersion:
+          description: Version of this process definition.
+          type: integer
+          format: int32
+        processVersionTag:
+          description: Version tag of this process definition.
+          type: integer
+          format: int32
+        bpmnProcessId:
+          description: BPMN process id of this process definition.
+          type: string
+        tenantId:
+          description: Tenant id of this process definition.
+          type: string
+        formKey:
+          description: The key of the form related to this process definition.
+          type: integer
+          format: int64
     ProcessInstanceSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -21,6 +21,7 @@ import io.camunda.service.search.query.DecisionDefinitionQuery;
 import io.camunda.service.search.query.DecisionRequirementsQuery;
 import io.camunda.service.search.query.FlowNodeInstanceQuery;
 import io.camunda.service.search.query.IncidentQuery;
+import io.camunda.service.search.query.ProcessDefinitionQuery;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.TypedSearchQueryBuilder;
@@ -30,6 +31,7 @@ import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.search.sort.DecisionRequirementsSort;
 import io.camunda.service.search.sort.FlowNodeInstanceSort;
 import io.camunda.service.search.sort.IncidentSort;
+import io.camunda.service.search.sort.ProcessDefinitionSort;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOption;
 import io.camunda.service.search.sort.SortOptionBuilders;
@@ -51,6 +53,21 @@ import org.springframework.http.ProblemDetail;
 public final class SearchQueryRequestMapper {
 
   private SearchQueryRequestMapper() {}
+
+  public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
+      final ProcessDefinitionSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.processDefinitionSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            request.getSort(),
+            SortOptionBuilders::processDefinition,
+            SearchQueryRequestMapper::applyProcessDefinitionSortField);
+    final var filter = toProcessDefinitionFilter(request.getFilter());
+    return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processDefinitionSearchQuery);
+  }
 
   public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
       final ProcessInstanceSearchQueryRequest request) {
@@ -157,6 +174,12 @@ public final class SearchQueryRequestMapper {
             SearchQueryRequestMapper::applyIncidentSortField);
     final var filter = toIncidentFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::incidentSearchQuery);
+  }
+
+  private static ProcessDefinitionFilter toProcessDefinitionFilter(
+      final ProcessDefinitionFilterRequest filter) {
+    final var builder = FilterBuilders.processDefinition();
+    return builder.build();
   }
 
   private static ProcessInstanceFilter toProcessInstanceFilter(
@@ -384,6 +407,12 @@ public final class SearchQueryRequestMapper {
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }
+    return validationErrors;
+  }
+
+  private static List<String> applyProcessDefinitionSortField(
+      final String field, final ProcessDefinitionSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
     return validationErrors;
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -21,6 +21,17 @@ public final class SearchQueryResponseMapper {
 
   private SearchQueryResponseMapper() {}
 
+  public static ProcessDefinitionSearchQueryResponse toProcessDefinitionSearchQueryResponse(
+      final SearchQueryResult<ProcessDefinitionEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new ProcessDefinitionSearchQueryResponse()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toProcessDefinitions)
+                .orElseGet(Collections::emptyList));
+  }
+
   public static ProcessInstanceSearchQueryResponse toProcessInstanceSearchQueryResponse(
       final SearchQueryResult<ProcessInstanceEntity> result) {
     final var page = toSearchQueryPageResponse(result);
@@ -115,6 +126,15 @@ public final class SearchQueryResponseMapper {
         .totalItems(result.total())
         .lastSortValues(
             ofNullable(result.sortValues()).map(Arrays::asList).orElseGet(Collections::emptyList));
+  }
+
+  private static List<ProcessDefinitionItem> toProcessDefinitions(
+      final List<ProcessDefinitionEntity> processDefinitions) {
+    return processDefinitions.stream().map(SearchQueryResponseMapper::toProcessDefinition).toList();
+  }
+
+  public static ProcessDefinitionItem toProcessDefinition(final ProcessDefinitionEntity entity) {
+    return new ProcessDefinitionItem();
   }
 
   private static List<ProcessInstanceItem> toProcessInstances(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryController.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.search.query.ProcessDefinitionQuery;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessDefinitionSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import jakarta.validation.ValidationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestQueryController
+@RequestMapping("/v2/process-definitions")
+public class ProcessDefinitionQueryController {
+
+  private final ProcessDefinitionServices processDefinitionServices;
+
+  public ProcessDefinitionQueryController(
+      final ProcessDefinitionServices processDefinitionServices) {
+    this.processDefinitionServices = processDefinitionServices;
+  }
+
+  @PostMapping(
+      path = "/search",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ProcessDefinitionSearchQueryResponse> searchProcessDefinitions(
+      @RequestBody(required = false) final ProcessDefinitionSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toProcessDefinitionQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<ProcessDefinitionSearchQueryResponse> search(
+      final ProcessDefinitionQuery query) {
+    try {
+      final var result =
+          processDefinitionServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .search(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toProcessDefinitionSearchQueryResponse(result));
+    } catch (final ValidationException e) {
+      final var problemDetail =
+          RestErrorMapper.createProblemDetail(
+              HttpStatus.BAD_REQUEST,
+              e.getMessage(),
+              "Validation failed for Process definition Search Query");
+      return RestErrorMapper.mapProblemToResponse(problemDetail);
+    } catch (final Exception e) {
+      final var problemDetail =
+          RestErrorMapper.createProblemDetail(
+              HttpStatus.INTERNAL_SERVER_ERROR,
+              e.getMessage(),
+              "Failed to execute Process definition Search Query");
+      return RestErrorMapper.mapProblemToResponse(problemDetail);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.service.entities.ProcessDefinitionEntity;
+import io.camunda.service.search.query.ProcessDefinitionQuery;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.search.query.SearchQueryResult.Builder;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(
+    value = ProcessDefinitionQueryController.class,
+    properties = "camunda.rest.query.enabled=true")
+public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
+
+  static final String PROCESS_DEFINITION_URL = "/v2/process-definitions/";
+  static final String PROCESS_DEFINITION_SEARCH_URL = PROCESS_DEFINITION_URL + "search";
+
+  static final String EXPECTED_SEARCH_RESPONSE =
+      """
+      {
+          "items": [
+              {
+              }
+          ],
+          "page": {
+              "totalItems": 1,
+              "firstSortValues": [],
+              "lastSortValues": [
+                  "v"
+              ]
+          }
+      }""";
+  static final SearchQueryResult<ProcessDefinitionEntity> SEARCH_QUERY_RESULT =
+      new Builder<ProcessDefinitionEntity>()
+          .total(1L)
+          .items(List.of(new ProcessDefinitionEntity()))
+          .sortValues(new Object[] {"v"})
+          .build();
+
+  @MockBean ProcessDefinitionServices processDefinitionServices;
+
+  @BeforeEach
+  void setupProcessDefinitionServices() {
+    when(processDefinitionServices.withAuthentication(ArgumentMatchers.any(Authentication.class)))
+        .thenReturn(processDefinitionServices);
+  }
+
+  @Test
+  void shouldSearchProcessDefinitionWithEmptyBody() {
+    // given
+    when(processDefinitionServices.search(any(ProcessDefinitionQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_DEFINITION_SEARCH_URL)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(processDefinitionServices).search(new ProcessDefinitionQuery.Builder().build());
+  }
+}


### PR DESCRIPTION
## Description

* Add Process definition QueryController and test
* Add Process definition infrastructure for query, filter and sort
* Add Process definition service infrastructure
* Implementation of filter, sort and CamundaClient follows in later PR's in will also be merged into `operate/c8-process-definition-search-20652` feature branch
* Add OpenAPI description in `rest-api.yaml` (@pepopowitz , @camunda/tech-writers can you review this, please)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
