### PR TITLE
build: rely on dependency management in process test example

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -878,6 +878,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-spring</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- sibling projects -->
 
       <dependency>

--- a/testing/camunda-process-test-example/pom.xml
+++ b/testing/camunda-process-test-example/pom.xml
@@ -21,8 +21,6 @@
   </licenses>
 
   <properties>
-    <camunda.version>${project.version}</camunda.version>
-
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
 
@@ -37,14 +35,12 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>spring-boot-starter-camunda-sdk</artifactId>
-      <version>${camunda.version}</version>
     </dependency>
 
     <!-- testing (for process test) -->
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-process-test-spring</artifactId>
-      <version>${camunda.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

The Maven release plugin does not support to resolve expressions in properties see https://issues.apache.org/jira/browse/MRELEASE-799 .

This removes the usage of the property with the project.version expression and instead rely on global dependency management for the artifacts in the parent pom.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22503 
