### PR TITLE
[CPT] docs: Link from the README to the docs

### DIFF
--- a/testing/README.md
+++ b/testing/README.md
@@ -5,3 +5,6 @@ Camunda's testing libraries for processes and process applications.
 - [Camunda Process Test for Java](camunda-process-test-java)
 - [Camunda Process Test for Spring](camunda-process-test-spring)
 
+Read more about the libraries and how to get started in our documentation: https://docs.camunda.io/docs/apis-tools/testing/getting-started/.
+
+Check out the [example project](camunda-process-test-example) to see the library in action.

--- a/testing/camunda-process-test-example/README.md
+++ b/testing/camunda-process-test-example/README.md
@@ -1,4 +1,7 @@
 # Camunda-Process-Test-Example
 
-An example project to demonstrate the usage of Camunda Process Test.
+An example project to demonstrate the usage of Camunda Process Test (Spring) for a demo Spring Boot process application.
 
+The test cases are located in the package [src/test/java/io/camunda](src/test/java/io/camunda). You can run the tests locally in your IDE with a JUnit 5 test runner.
+
+Read more about the library and how to use it in our documentation: https://docs.camunda.io/docs/apis-tools/testing/getting-started/.

--- a/testing/camunda-process-test-java/README.md
+++ b/testing/camunda-process-test-java/README.md
@@ -2,4 +2,18 @@
 
 Camunda's new testing library for processes and process applications with Java.
 
-Work in progress!
+## Install
+
+Add the following dependency to your Maven project:
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-process-test-java</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+## Usage
+
+Read more about the usage of the library and how to get started in our documentation: https://docs.camunda.io/docs/apis-tools/testing/getting-started/.

--- a/testing/camunda-process-test-spring/README.md
+++ b/testing/camunda-process-test-spring/README.md
@@ -2,4 +2,18 @@
 
 Camunda's new testing library for processes and process applications with Spring.
 
-Work in progress!
+## Install
+
+Add the following dependency to your Maven project:
+
+```xml
+<dependency>
+  <groupId>io.camunda</groupId>
+  <artifactId>camunda-process-test-spring</artifactId>
+  <scope>test</scope>
+</dependency>
+```
+
+## Usage
+
+Read more about the usage of the library and how to get started in our documentation: https://docs.camunda.io/docs/apis-tools/testing/getting-started/.


### PR DESCRIPTION
## Description

Extend the testing READMEs and link to the documentation.

Note that the links don't work until we publish the documentation for 8.6.

## Related issues


