### PR TITLE
fix: fix a bug where to /noPermission redirect would not respect the context path

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityController.java
@@ -146,7 +146,7 @@ public class IdentityController {
       HttpServletRequest req, HttpServletResponse res, Throwable t) throws IOException {
     logger.error("Error in authentication callback: ", t);
     cleanup(req);
-    res.sendRedirect(NO_PERMISSION);
+    res.sendRedirect(req.getContextPath() + NO_PERMISSION);
   }
 
   protected void cleanup(HttpServletRequest req) {


### PR DESCRIPTION
…context path

## Description

<!-- Describe the goal and purpose of this PR. -->

When opening operate without permissions while it has a context path set, the `/noPermission` redirect would not respect the request context path and always redirect to root.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
