### PR TITLE
ci: run Operate frontend build on 8.5 stable branch

### DIFF
--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - stable/operate-8.5
     paths:
       - 'operate/client/**'
       - '!.github/workflows/zeebe-*'


### PR DESCRIPTION
## Description

- enable the Operate Frontend build to run on the 8.5 stable branch (it is part of the release prerequisites)

related to #22523

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
