### PR TITLE
ci: removal of go actions and zbctl usage

### DIFF
--- a/.ci/scripts/distribution/qa-testbench.sh
+++ b/.ci/scripts/distribution/qa-testbench.sh
@@ -7,11 +7,10 @@
 # Licensed under the Camunda License 1.0. You may not use this file
 # except in compliance with the Camunda License 1.0.
 #
-chmod +x clients/go/cmd/zbctl/dist/zbctl
+curl -LO https://github.com/camunda/camunda/releases/download/8.5.7/zbctl
+chmod +x zbctl
 
-zbctl="clients/go/cmd/zbctl/dist/zbctl"
-
-"${zbctl}" create instance external-tool-integration --variables "${QA_RUN_VARIABLES}"
+./zbctl create instance external-tool-integration --variables "${QA_RUN_VARIABLES}"
 
 businessKey="${BUSINESS_KEY}"
 
@@ -20,7 +19,7 @@ jobKey=""
 
 while true; do
     # activate jobs non-zero exits can be ignored with `<command> || true`
-    "${zbctl}" activate jobs "$businessKey" > activationresponse.txt 2>/dev/null || true
+    ./zbctl activate jobs "$businessKey" > activationresponse.txt 2>/dev/null || true
     jobKey=$(jq -r '.jobs[0].key' < activationresponse.txt)
 
     if [[ -z "$jobKey" || "$jobKey" == "null" ]]; then
@@ -39,7 +38,7 @@ echo "Job variables are: $variables"
 testResult=$(echo "$variables" | jq -r '.aggregatedTestResult')
 echo "Test result is: $testResult"
 
-"${zbctl}" complete job "$jobKey"
+./zbctl complete job "$jobKey"
 
 if [ "$testResult" == "FAILED" ]; then
   echo "Test failed"

--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -1,20 +1,11 @@
-# This action packages the complete Zeebe distribution artifacts. This includes the Go client,
-# zbctl, and the Zeebe distribution TAR ball. This excludes the Docker image. See the build-zeebe-docker
-# for that.
+# This action packages the complete Zeebe distribution artifacts.
+# This excludes the Docker image. See the build-platform-docker for that.
 
 ---
 name: Build Zeebe
 description: Builds & installs the complete Zeebe distribution
 
 inputs:
-  go:
-    description: If false, will not build zbctl; defaults to true
-    default: "true"
-    required: false
-  java:
-    description: If false, will not build the Java distribution; defaults to true
-    default: "true"
-    required: false
   maven-extra-args:
     description: Additional CLI arguments which will be passed to the maven install command as is, e.g. "-am -pl util/"
     default: ""
@@ -28,14 +19,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - if: ${{ inputs.go == 'true' }}
-      name: Build Go
-      shell: bash
-      id: build-go
-      working-directory: clients/go/cmd/zbctl
-      run: ./build.sh
-    - if: ${{ inputs.java == 'true' }}
-      name: Package Zeebe
+    - name: Package Zeebe
       shell: bash
       id: build-java
       run: |

--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -6,10 +6,6 @@ name: Setup Zeebe
 description: Sets up the required stack to build, install, and run Zeebe
 
 inputs:
-  go:
-    description: If true, will set up Golang; defaults to true
-    required: false
-    default: "true"
   java:
     description: If true, will set up Java; defaults to true
     required: false
@@ -115,9 +111,3 @@ runs:
       uses: ./.github/actions/setup-maven-cache
       with:
         maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
-    - if: ${{ inputs.go == 'true' }}
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
-        cache: true
-        cache-dependency-path: 'clients/go/go.sum'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: false
           docker: false
           maven-cache-key-modifier: java-checks
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
@@ -108,7 +107,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: true
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -151,7 +149,6 @@ jobs:
           sudo sysctl -w kernel.yama.ptrace_scope=0
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: false
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          go: false
           maven-extra-args: -T1C -PskipFrontendBuild -D skipOptimize
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
@@ -328,7 +327,6 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild -D skipOptimize
-          go: false
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker
         with:
@@ -664,7 +662,6 @@ jobs:
         id: build-camunda
         with:
           maven-extra-args: -PskipFrontendBuild
-          go: false
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker
         with:

--- a/.github/workflows/update-identity.yml
+++ b/.github/workflows/update-identity.yml
@@ -48,7 +48,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          go: false
           maven-cache-key-modifier: identity-update
       - name: Update identity version in ./parent/pom.xml
         id: update-identity-version

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -133,7 +133,6 @@ jobs:
         id: build-zeebe
         with:
           maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true -am -pl :camunda-zeebe
-          go: false
       - uses: google-github-actions/auth@v2
         id: auth
         with:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -128,7 +128,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-          go: false
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -37,7 +37,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: false
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -45,7 +44,6 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          go: false
           maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
@@ -91,13 +89,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: false
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          go: false
           maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
@@ -141,13 +137,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: false
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         with:
-          go: false
           maven-extra-args: -T1C -PskipFrontendBuild
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -84,9 +84,10 @@ jobs:
       - name: Start Test
         shell: bash
         run: |
-          chmod +x clients/go/cmd/zbctl/dist/zbctl
+          curl -LO https://github.com/camunda/camunda/releases/download/8.5.7/zbctl
+          chmod +x zbctl
           variables=$(echo "${{ inputs.variables }}" | envsubst)
-          clients/go/cmd/zbctl/dist/zbctl create instance ${{ inputs.processId }} --variables "$variables"
+          ./zbctl create instance ${{ inputs.processId }} --variables "$variables"
         env:
           IMAGE: ${{ steps.build-zeebe-docker.outputs.image }}
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,10 +91,8 @@ WORKDIR /zeebe
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} zeebe.tar.gz
 
-# Remove zbctl from the distribution to reduce CVE related maintenance effort w.r.t to containers
 RUN mkdir camunda-zeebe && \
-    tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe && \
-    find . -type f -name 'zbctl*' -delete
+    tar xfvz zeebe.tar.gz --strip 1 -C camunda-zeebe
 
 ### Image containing the zeebe distribution ###
 # hadolint ignore=DL3006

--- a/camunda.Dockerfile
+++ b/camunda.Dockerfile
@@ -91,10 +91,8 @@ WORKDIR /camunda
 ARG DISTBALL="dist/target/camunda-zeebe-*.tar.gz"
 COPY --link ${DISTBALL} camunda.tar.gz
 
-# Remove zbctl from the distribution to reduce CVE related maintenance effort w.r.t to containers
 RUN mkdir camunda-zeebe && \
-    tar xfvz camunda.tar.gz --strip 1 -C camunda-zeebe && \
-    find . -type f -name 'zbctl*' -delete
+    tar xfvz camunda.tar.gz --strip 1 -C camunda-zeebe
 
 ### Image containing the camunda distribution ###
 # hadolint ignore=DL3006

--- a/zeebe/benchmarks/setup/README.md
+++ b/zeebe/benchmarks/setup/README.md
@@ -43,8 +43,8 @@ If you want to use your own or a different Zeebe snapshot then you could do the 
 **Build the docker image:**
 
 ```bash
-# builds the dist with zbctl packed
-clients/go/cmd/zbctl/build.sh && mvn clean install -T1C -DskipTests -pl dist -am
+# builds the dist
+mvn clean install -T1C -DskipTests -pl dist -am
 # builds the a new zeebe docker image
 docker build --build-arg DISTBALL=dist/target/camunda-zeebe-*.tar.gz -t gcr.io/zeebe-io/zeebe:SNAPSHOT-$(date +%Y-%m-%d)-$(git rev-parse --short=8 HEAD) --target app .
 # pushes the image to our docker registry


### PR DESCRIPTION
## Description

This PR removes the go setup and build from our custom actions, as well as the related parameters on the action.

As the testbench workflow from is using zbctl it needs to be downloaded instead.

As a follow-up, once testbench is updated to 8.6.x we can start using the equivalent REST API to create a process instance, see https://github.com/camunda/camunda/issues/22536 .

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22511
