### PR TITLE
Return 502 in REST for closed broker connection 

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -121,7 +121,7 @@ public class RestErrorMapper {
             "Expected to handle REST API request, but the connection was cut prematurely with the broker; "
                 + "the request may or may not have been accepted, and may not be safe to retry";
         REST_GATEWAY_LOGGER.warn(ccMsg, cc);
-        yield createProblemDetail(HttpStatus.GATEWAY_TIMEOUT, ccMsg, cc.getClass().getName());
+        yield createProblemDetail(HttpStatus.BAD_GATEWAY, ccMsg, cc.getClass().getName());
       case final ConnectTimeoutException cte:
         final var cteMsg =
             "Expected to handle REST API request, but a connection timeout exception occurred";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -274,7 +274,7 @@ public class ErrorMapperTest extends RestControllerTest {
   }
 
   @Test
-  public void shouldReturnGatewayTimeoutOnConnectionClosed() {
+  public void shouldReturnBadGatewayOnConnectionClosed() {
     // given
     final var errorMsg = "Oh noes, connection closed!";
     Mockito.when(userTaskServices.completeUserTask(anyLong(), any(), anyString()))
@@ -283,7 +283,7 @@ public class ErrorMapperTest extends RestControllerTest {
     final var request = new UserTaskCompletionRequest();
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(
-            HttpStatus.GATEWAY_TIMEOUT,
+            HttpStatus.BAD_GATEWAY,
             "Expected to handle REST API request, but the connection was cut prematurely with the broker; "
                 + "the request may or may not have been accepted, and may not be safe to retry");
     expectedBody.setTitle(ConnectionClosed.class.getName());
@@ -298,7 +298,7 @@ public class ErrorMapperTest extends RestControllerTest {
         .body(Mono.just(request), UserTaskCompletionRequest.class)
         .exchange()
         .expectStatus()
-        .isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+        .isEqualTo(HttpStatus.BAD_GATEWAY)
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)


### PR DESCRIPTION
## Description

If the connection to the broker is closed for the gateway, the REST gateway returns a 502 status instead of a 504.

## Related issues

closes #22540 