### PR TITLE
deps: bump protobuf to fix CVE-2024-7254

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
     <version.opensearch-java>2.3.0</version.opensearch-java>
     <version.opensearch.testcontainers>2.0.2</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
-    <version.protobuf>3.22.5</version.protobuf>
+    <version.protobuf>3.25.5</version.protobuf>
     <version.protobuf-common>2.14.3</version.protobuf-common>
     <version.micrometer>1.10.12</version.micrometer>
     <version.rocksdbjni>8.11.4</version.rocksdbjni>


### PR DESCRIPTION
## Description

This PR fixes a DoS issue related to parsing protobuf messages. See: https://github.com/advisories/GHSA-735f-pc8j-v9w8
