### PR TITLE
build: add name to identity migration configuration

### DIFF
--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -15,6 +15,7 @@
   </parent>
 
   <artifactId>identity-migration</artifactId>
+  <name>Identity Migration</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Description

The Identity migration Maven module needs a name to pass Maven Central release rules when releasing.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

n/a
