### PR TITLE
ci: fix to use higher GH API result page size in problems analyze script

### DIFF
--- a/.ci/chatops-commands/ci-problems-analyze.sh
+++ b/.ci/chatops-commands/ci-problems-analyze.sh
@@ -15,12 +15,15 @@ PR_HEAD_SHA=$(gh api -X GET "repos/${OWNER_NAME}/${REPO_NAME}/pulls/${PR_NUMBER}
 # stdout of the script is Markdown available in "result" output (via `echo`) for end users
 # stderr shows the progress of the script while working (via `>&2 echo`), for debugging purposes
 
+# Limitations:
+# * no pagination in GH API calls, over 100 workflows per commit or 100 jobs per workflow wont be recognized
+
 echo "## 🔎 GHA problems for PR #${PR_NUMBER}"
 echo ""
 echo "For most recent commit ${PR_HEAD_SHA}:"
 echo ""
 
-gh api -X GET "repos/${OWNER_NAME}/${REPO_NAME}/actions/runs?sha=${PR_HEAD_SHA}" --jq '.workflow_runs[]' | while read -r workflow_run; do
+gh api -X GET "repos/${OWNER_NAME}/${REPO_NAME}/actions/runs?sha=${PR_HEAD_SHA}&per_page=100" --jq '.workflow_runs[]' | while read -r workflow_run; do
   workflow_run_id=$(echo "${workflow_run}" | jq -r '.id')
   workflow_run_attempt=$(echo "${workflow_run}" | jq -r '.run_attempt')
   >&2 echo "Checking workflow run ${workflow_run_id} attempt ${workflow_run_attempt} for problems..."


### PR DESCRIPTION
## Description

Follow-up to https://github.com/camunda/camunda/pull/22634 as the default page size is 30 entries but we can get 100 even without the effort to implement proper pagination (might result in too long GitHub comments anyways). Not super clean but a Todo for later.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #22204