### PR TITLE
feat(spec): add example requests to endpoints with mutually-exclusive request fields

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -708,6 +708,18 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/CreateProcessInstanceRequest"
+            examples:
+              "By process decision key":
+                summary: "Create a process instance by processDefinitionKey."
+                value:
+                  processDefinitionKey: 12345
+                  variables: {}
+              "By BPMN process ID":
+                summary: "Create a process instance by bpmnProcessID and version."
+                value:
+                  bpmnProcessId: "1234-5678"
+                  version: 1
+                  variables: {}
       responses:
         "200":
           description: The process instance was created.
@@ -1281,6 +1293,17 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/EvaluateDecisionRequest"
+            examples:
+              "By decision key":
+                summary: "Evaluate the decision by decisionKey."
+                value:
+                  decisionKey: 12345
+                  variables: {}
+              "By decision ID":
+                summary: "Evaluate the decision by decisionId."
+                value:
+                  decisionId: "1234-5678"
+                  variables: {}
       responses:
         "200":
           description: The decision was evaluated.


### PR DESCRIPTION
## Description

Adds valid example requests to the C8 API spec for two endpoints, each of which accepts mutually exclusive fields in requests:

* POST /process-instances
* POST /decisions/evaluation

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Original issue was discussed in https://github.com/camunda/camunda-docs/pull/4308#discussion_r1765350148.