### PR TITLE
refactor: rename key to userTaskKey

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -28,7 +28,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
    * @param value the key of the user task
    * @return the updated filter
    */
-  UserTaskFilter key(final Long value);
+  UserTaskFilter userTaskKey(final Long value);
 
   /**
    * Filters user tasks by the specified state.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 public interface UserTask {
 
-  Long getKey();
+  Long getUserTaskKey();
 
   /** State of the task */
   String getState();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
@@ -35,8 +35,8 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   }
 
   @Override
-  public UserTaskFilter key(final Long value) {
-    filter.setKey(value);
+  public UserTaskFilter userTaskKey(final Long value) {
+    filter.setUserTaskKey(value);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 public class UserTaskImpl implements UserTask {
 
-  private final Long key;
+  private final Long userTaskKey;
   private final String state;
   private final String assignee;
   private final String elementId;
@@ -44,7 +44,7 @@ public class UserTaskImpl implements UserTask {
   private final Integer priority;
 
   public UserTaskImpl(final UserTaskItem item) {
-    key = item.getKey();
+    userTaskKey = item.getUserTaskKey();
     state = item.getState();
     assignee = item.getAssignee();
     elementId = item.getElementId();
@@ -67,8 +67,8 @@ public class UserTaskImpl implements UserTask {
   }
 
   @Override
-  public Long getKey() {
-    return key;
+  public Long getUserTaskKey() {
+    return userTaskKey;
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
@@ -61,12 +61,12 @@ public final class SearchUserTaskTest extends ClientRestTest {
   @Test
   void shouldSearchUserTaskByKey() {
     // when
-    client.newUserTaskQuery().filter(f -> f.key(12345L)).send().join();
+    client.newUserTaskQuery().filter(f -> f.userTaskKey(12345L)).send().join();
 
     // then
     final UserTaskSearchQueryRequest request =
         gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
-    assertThat(request.getFilter().getKey()).isEqualTo(12345L);
+    assertThat(request.getFilter().getUserTaskKey()).isEqualTo(12345L);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -137,7 +137,7 @@ class UserTaskQueryTest {
         camundaClient.newUserTaskQuery().filter(f -> f.assignee("demo")).send().join();
     assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().getFirst().getAssignee()).isEqualTo("demo");
-    assertThat(result.items().getFirst().getKey()).isEqualTo(userTaskKeyTaskAssigned);
+    assertThat(result.items().getFirst().getUserTaskKey()).isEqualTo(userTaskKeyTaskAssigned);
   }
 
   @Test
@@ -193,7 +193,7 @@ class UserTaskQueryTest {
   public void shouldValidatePagination() {
     final var result = camundaClient.newUserTaskQuery().page(p -> p.limit(1)).send().join();
     assertThat(result.items().size()).isEqualTo(1);
-    final var key = result.items().getFirst().getKey();
+    final var key = result.items().getFirst().getUserTaskKey();
     // apply searchAfter
     final var resultAfter =
         camundaClient
@@ -203,7 +203,7 @@ class UserTaskQueryTest {
             .join();
 
     assertThat(resultAfter.items().size()).isEqualTo(5);
-    final var keyAfter = resultAfter.items().getFirst().getKey();
+    final var keyAfter = resultAfter.items().getFirst().getUserTaskKey();
     // apply searchBefore
     final var resultBefore =
         camundaClient
@@ -212,7 +212,7 @@ class UserTaskQueryTest {
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(1);
-    assertThat(resultBefore.items().getFirst().getKey()).isEqualTo(key);
+    assertThat(resultBefore.items().getFirst().getUserTaskKey()).isEqualTo(key);
   }
 
   @Test
@@ -357,7 +357,7 @@ class UserTaskQueryTest {
             () -> {
               final var result = camundaClient.newUserTaskQuery().send().join();
               assertThat(result.items().size()).isEqualTo(6);
-              userTaskKeyTaskAssigned = result.items().getFirst().getKey();
+              userTaskKeyTaskAssigned = result.items().getFirst().getUserTaskKey();
             });
 
     camundaClient

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -92,7 +92,7 @@ public final class UserTaskServices
   public UserTaskEntity getByKey(final Long key) {
     final SearchQueryResult<UserTaskEntity> result =
         executor.search(
-            SearchQueryBuilders.userTaskSearchQuery().filter(f -> f.keys(key)).build(),
+            SearchQueryBuilders.userTaskSearchQuery().filter(f -> f.userTaskKeys(key)).build(),
             UserTaskEntity.class);
     if (result.total() < 1) {
       throw new NotFoundException(String.format("User Task with key %d not found", key));

--- a/service/src/main/java/io/camunda/service/search/filter/UserTaskFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/UserTaskFilter.java
@@ -16,7 +16,7 @@ import java.util.List;
 import java.util.Objects;
 
 public final record UserTaskFilter(
-    List<Long> keys,
+    List<Long> userTaskKeys,
     List<String> elementIds,
     List<String> bpmnProcessIds,
     List<String> assignees,
@@ -31,7 +31,7 @@ public final record UserTaskFilter(
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<UserTaskFilter> {
-    private List<Long> keys;
+    private List<Long> userTaskKeys;
     private List<String> elementIds;
     private List<String> bpmnProcessIds;
     private List<String> assignees;
@@ -44,12 +44,12 @@ public final record UserTaskFilter(
     private List<VariableValueFilter> variableFilters;
     private String type;
 
-    public Builder keys(final Long... values) {
-      return keys(collectValuesAsList(values));
+    public Builder userTaskKeys(final Long... values) {
+      return userTaskKeys(collectValuesAsList(values));
     }
 
-    public Builder keys(final List<Long> values) {
-      keys = addValuesToList(keys, values);
+    public Builder userTaskKeys(final List<Long> values) {
+      userTaskKeys = addValuesToList(userTaskKeys, values);
       return this;
     }
 
@@ -147,7 +147,7 @@ public final record UserTaskFilter(
     @Override
     public UserTaskFilter build() {
       return new UserTaskFilter(
-          Objects.requireNonNullElse(keys, Collections.emptyList()),
+          Objects.requireNonNullElse(userTaskKeys, Collections.emptyList()),
           Objects.requireNonNullElse(elementIds, Collections.emptyList()),
           Objects.requireNonNullElse(bpmnProcessIds, Collections.emptyList()),
           Objects.requireNonNullElse(assignees, Collections.emptyList()),

--- a/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
@@ -34,7 +34,7 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
 
   @Override
   public SearchQuery toSearchQuery(final UserTaskFilter filter) {
-    final var userTaskKeysQuery = getUserTaskKeysQuery(filter.keys());
+    final var userTaskKeysQuery = getUserTaskKeysQuery(filter.userTaskKeys());
 
     final var processInstanceKeysQuery = getProcessInstanceKeysQuery(filter.processInstanceKeys());
     final var processDefinitionKeyQuery =

--- a/service/src/test/java/io/camunda/service/query/filter/UserTaskFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserTaskFilterTest.java
@@ -144,7 +144,7 @@ public class UserTaskFilterTest {
   @Test
   public void shouldQueryByUserTaskKey() {
     // given
-    final var userTaskFilter = FilterBuilders.userTask((f) -> f.keys(4503599627370497L));
+    final var userTaskFilter = FilterBuilders.userTask((f) -> f.userTaskKeys(4503599627370497L));
     final var searchQuery =
         SearchQueryBuilders.userTaskSearchQuery((q) -> q.filter(userTaskFilter));
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2238,7 +2238,7 @@ components:
       description: User task filter request.
       type: object
       properties:
-        key:
+        userTaskKey:
           type: integer
           format: int64
         state:
@@ -2275,7 +2275,7 @@ components:
     UserTaskItem:
       type: object
       properties:
-        key:
+        userTaskKey:
           type: integer
           format: int64
         state:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -348,7 +348,7 @@ public final class SearchQueryRequestMapper {
     Optional.ofNullable(filter)
         .ifPresent(
             f -> {
-              Optional.ofNullable(f.getKey()).ifPresent(builder::keys);
+              Optional.ofNullable(f.getUserTaskKey()).ifPresent(builder::keys);
               Optional.ofNullable(f.getState()).ifPresent(builder::states);
               Optional.ofNullable(f.getBpmnDefinitionId()).ifPresent(builder::bpmnProcessIds);
               Optional.ofNullable(f.getElementId()).ifPresent(builder::elementIds);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -348,7 +348,7 @@ public final class SearchQueryRequestMapper {
     Optional.ofNullable(filter)
         .ifPresent(
             f -> {
-              Optional.ofNullable(f.getUserTaskKey()).ifPresent(builder::keys);
+              Optional.ofNullable(f.getUserTaskKey()).ifPresent(builder::userTaskKeys);
               Optional.ofNullable(f.getState()).ifPresent(builder::states);
               Optional.ofNullable(f.getBpmnDefinitionId()).ifPresent(builder::bpmnProcessIds);
               Optional.ofNullable(f.getElementId()).ifPresent(builder::elementIds);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -266,7 +266,7 @@ public final class SearchQueryResponseMapper {
   public static UserTaskItem toUserTask(final UserTaskEntity t) {
     return new UserTaskItem()
         .tenantIds(t.tenantId())
-        .key(t.key())
+        .userTaskKey(t.key())
         .processInstanceKey(t.processInstanceId())
         .processDefinitionKey(t.processDefinitionId())
         .elementInstanceKey(t.flowNodeInstanceId())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -44,7 +44,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
           "items": [
               {
                   "tenantIds": "t",
-                  "key": 0,
+                  "userTaskKey": 0,
                   "processInstanceKey": 1,
                   "processDefinitionKey": 2,
                   "elementInstanceKey": 3,
@@ -78,7 +78,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
       """
       {
                   "tenantIds": "t",
-                  "key": 0,
+                  "userTaskKey": 0,
                   "processInstanceKey": 1,
                   "processDefinitionKey": 2,
                   "elementInstanceKey": 3,


### PR DESCRIPTION
## Description

Rename the field `key` to `userTaskKey` on Search User Tasks

## Related issues

closes #https://github.com/camunda/camunda/issues/22708
