### PR TITLE
Raise incident at specific called process depth

### DIFF
--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1258,6 +1258,18 @@
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_AUTHORIZATIONS_ENABLEAUTHORIZATION
           # enableAuthorization: false
 
+        # Allows to configure the maximum depth of child process instances that can be created.
+        # The root process instance is considered depth `1`, and each called instance is considered
+        # to be one level deeper. If a call activity attempts to create a child process instance
+        # that would exceed the configured max depth, an incident is raised at the call activity.
+        # Note that the depth is only tracked for process instances created since 8.3.22, 8.4.18,
+        # 8.5.17, 8.6.12, and 8.7. Any child process instances created before 8.7 (or any of these
+        # patches) will have a depth of 1 rather than the correct depth. For existing child process
+        # instances, the limit is thus applied only from the current child instance onwards.
+        # This setting can also be overridden using the environment variable
+        # ZEEBE_BROKER_EXPERIMENTAL_ENGINE_MAXPROCESSDEPTH
+        # maxProcessDepth: 1000
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -17,6 +17,7 @@ public final class EngineCfg implements ConfigurationEntry {
   private CachesCfg caches = new CachesCfg();
   private JobsCfg jobs = new JobsCfg();
   private ValidatorsCfg validators = new ValidatorsCfg();
+  private int maxProcessDepth = EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -58,6 +59,14 @@ public final class EngineCfg implements ConfigurationEntry {
     this.validators = validators;
   }
 
+  public int getMaxProcessDepth() {
+    return maxProcessDepth;
+  }
+
+  public void setMaxProcessDepth(final int maxProcessDepth) {
+    this.maxProcessDepth = maxProcessDepth;
+  }
+
   @Override
   public String toString() {
     return "EngineCfg{"
@@ -69,6 +78,8 @@ public final class EngineCfg implements ConfigurationEntry {
         + jobs
         + ", validators="
         + validators
+        + ", maxProcessDepth="
+        + maxProcessDepth
         + '}';
   }
 
@@ -82,6 +93,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setProcessCacheCapacity(caches.getProcessCacheCapacity())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
         .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
-        .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize());
+        .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize())
+        .setMaxProcessDepth(getMaxProcessDepth());
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -40,6 +40,8 @@ final class EngineCfgTest {
         .isEqualTo(EngineConfiguration.DEFAULT_PROCESS_CACHE_CAPACITY);
     assertThat(configuration.getValidatorsResultsOutputMaxSize())
         .isEqualTo(EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE);
+    assertThat(configuration.getMaxProcessDepth())
+        .isEqualTo(EngineConfiguration.DEFAULT_MAX_PROCESS_DEPTH);
   }
 
   @Test
@@ -60,5 +62,6 @@ final class EngineCfgTest {
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
     assertThat(configuration.getValidatorsResultsOutputMaxSize()).isEqualTo(2000);
+    assertThat(configuration.getMaxProcessDepth()).isEqualTo(2000);
   }
 }

--- a/zeebe/broker/src/test/resources/system/engine.yaml
+++ b/zeebe/broker/src/test/resources/system/engine.yaml
@@ -14,3 +14,4 @@ zeebe:
           timeoutCheckerBatchLimit: 1000
         validators:
           resultsOutputMaxSize: 2000
+        maxProcessDepth: 2000

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -144,7 +144,8 @@ public final class EngineConfiguration {
     return maxProcessDepth;
   }
 
-  public void setMaxProcessDepth(final int maxProcessDepth) {
+  public EngineConfiguration setMaxProcessDepth(final int maxProcessDepth) {
     this.maxProcessDepth = maxProcessDepth;
+    return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -28,6 +28,8 @@ public final class EngineConfiguration {
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
   public static final boolean DEFAULT_ENABLE_AUTHORIZATION_CHECKS = false;
 
+  public static final int DEFAULT_CALL_ACTIVITY_MAX_DEPTH = 1000;
+
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
   private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
@@ -41,6 +43,8 @@ public final class EngineConfiguration {
   private int validatorsResultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
 
   private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
+
+  private int defaultCallActivityMaxDepth = DEFAULT_CALL_ACTIVITY_MAX_DEPTH;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -134,5 +138,13 @@ public final class EngineConfiguration {
   public EngineConfiguration setEnableAuthorization(final boolean enableAuthorization) {
     this.enableAuthorization = enableAuthorization;
     return this;
+  }
+
+  public int getDefaultCallActivityMaxDepth() {
+    return defaultCallActivityMaxDepth;
+  }
+
+  public void setDefaultCallActivityMaxDepth(final int defaultCallActivityMaxDepth) {
+    this.defaultCallActivityMaxDepth = defaultCallActivityMaxDepth;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -28,7 +28,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
   public static final boolean DEFAULT_ENABLE_AUTHORIZATION_CHECKS = false;
 
-  public static final int DEFAULT_CALL_ACTIVITY_MAX_DEPTH = 1000;
+  public static final int DEFAULT_MAX_PROCESS_DEPTH = 1000;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
@@ -44,7 +44,7 @@ public final class EngineConfiguration {
 
   private boolean enableAuthorization = DEFAULT_ENABLE_AUTHORIZATION_CHECKS;
 
-  private int defaultCallActivityMaxDepth = DEFAULT_CALL_ACTIVITY_MAX_DEPTH;
+  private int maxProcessDepth = DEFAULT_MAX_PROCESS_DEPTH;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -140,11 +140,11 @@ public final class EngineConfiguration {
     return this;
   }
 
-  public int getDefaultCallActivityMaxDepth() {
-    return defaultCallActivityMaxDepth;
+  public int getMaxProcessDepth() {
+    return maxProcessDepth;
   }
 
-  public void setDefaultCallActivityMaxDepth(final int defaultCallActivityMaxDepth) {
-    this.defaultCallActivityMaxDepth = defaultCallActivityMaxDepth;
+  public void setMaxProcessDepth(final int maxProcessDepth) {
+    this.maxProcessDepth = maxProcessDepth;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -81,7 +81,8 @@ public final class BpmnProcessors {
         writers, typedRecordProcessors, processingState, authCheckBehavior);
 
     final var bpmnStreamProcessor =
-        new BpmnStreamProcessor(bpmnBehaviors, processingState, writers, processEngineMetrics);
+        new BpmnStreamProcessor(
+            bpmnBehaviors, processingState, writers, processEngineMetrics, config);
     addBpmnStepProcessor(typedRecordProcessors, bpmnStreamProcessor);
 
     addMessageStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -99,7 +99,7 @@ public final class BpmnElementProcessors {
     processors.put(
         BpmnElementType.CALL_ACTIVITY,
         new CallActivityProcessor(
-            bpmnBehaviors, stateTransitionBehavior, config.getDefaultCallActivityMaxDepth()));
+            bpmnBehaviors, stateTransitionBehavior, config.getMaxProcessDepth()));
     processors.put(
         BpmnElementType.AD_HOC_SUB_PROCESS,
         new AdHocSubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.container.AdHocSubProcessProcessor;
@@ -43,7 +44,8 @@ public final class BpmnElementProcessors {
 
   public BpmnElementProcessors(
       final BpmnBehaviors bpmnBehaviors,
-      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+      final BpmnStateTransitionBehavior stateTransitionBehavior,
+      final EngineConfiguration config) {
     // tasks
     processors.put(
         BpmnElementType.SERVICE_TASK,
@@ -96,7 +98,8 @@ public final class BpmnElementProcessors {
         new MultiInstanceBodyProcessor(bpmnBehaviors, stateTransitionBehavior));
     processors.put(
         BpmnElementType.CALL_ACTIVITY,
-        new CallActivityProcessor(bpmnBehaviors, stateTransitionBehavior));
+        new CallActivityProcessor(
+            bpmnBehaviors, stateTransitionBehavior, config.getDefaultCallActivityMaxDepth()));
     processors.put(
         BpmnElementType.AD_HOC_SUB_PROCESS,
         new AdHocSubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
@@ -65,7 +66,8 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
       final BpmnBehaviors bpmnBehaviors,
       final MutableProcessingState processingState,
       final Writers writers,
-      final ProcessEngineMetrics processEngineMetrics) {
+      final ProcessEngineMetrics processEngineMetrics,
+      final EngineConfiguration config) {
     processState = processingState.getProcessState();
 
     rejectionWriter = writers.rejection();
@@ -78,7 +80,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             processEngineMetrics,
             this::getContainerProcessor,
             writers);
-    processors = new BpmnElementProcessors(bpmnBehaviors, stateTransitionBehavior);
+    processors = new BpmnElementProcessors(bpmnBehaviors, stateTransitionBehavior, config);
     stateBehavior = bpmnBehaviors.stateBehavior();
     jobBehavior = bpmnBehaviors.jobBehavior();
     eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -67,7 +67,26 @@ public final class CallActivityProcessor
   @Override
   public Either<Failure, ?> onActivate(
       final ExecutableCallActivity element, final BpmnElementContext context) {
-    return variableMappingBehavior.applyInputMappings(context, element);
+    return variableMappingBehavior
+        .applyInputMappings(context, element)
+        .flatMap(
+            ok -> {
+              final var processInstance =
+                  stateBehavior.getElementInstance(context.getProcessInstanceKey());
+              final int calledProcessDepth = processInstance.getCalledProcessDepth();
+              if (calledProcessDepth >= 1000) {
+                return Either.left(
+                    new Failure(
+                        """
+                        The call activity has reached the maximum depth of 1000. \
+                        This is likely due to a recursive call. \
+                        Cancel the root process instance if this was unintentional. \
+                        Otherwise, consider increasing the maximum depth, \
+                        or use process instance modification to adjust the process instance.""",
+                        ErrorType.CALLED_ELEMENT_ERROR));
+              }
+              return Either.right(null);
+            });
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -45,12 +45,12 @@ public final class CallActivityProcessor
   private final BpmnVariableMappingBehavior variableMappingBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
   private final BpmnJobBehavior jobBehavior;
-  private final int maxCallActivityDepth;
+  private final int maxProcessDepth;
 
   public CallActivityProcessor(
       final BpmnBehaviors bpmnBehaviors,
       final BpmnStateTransitionBehavior stateTransitionBehavior,
-      final int maxCallActivityDepth) {
+      final int maxProcessDepth) {
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     this.stateTransitionBehavior = stateTransitionBehavior;
     stateBehavior = bpmnBehaviors.stateBehavior();
@@ -59,7 +59,7 @@ public final class CallActivityProcessor
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
     jobBehavior = bpmnBehaviors.jobBehavior();
-    this.maxCallActivityDepth = maxCallActivityDepth;
+    this.maxProcessDepth = maxProcessDepth;
   }
 
   @Override
@@ -76,8 +76,8 @@ public final class CallActivityProcessor
             ok -> {
               final var processInstance =
                   stateBehavior.getElementInstance(context.getProcessInstanceKey());
-              final int calledProcessDepth = processInstance.getCalledProcessDepth();
-              if (calledProcessDepth >= maxCallActivityDepth) {
+              final int processDepth = processInstance.getProcessDepth();
+              if (processDepth >= maxProcessDepth) {
                 return Either.left(
                     new Failure(
                         """
@@ -86,7 +86,7 @@ public final class CallActivityProcessor
                         Cancel the root process instance if this was unintentional. \
                         Otherwise, consider increasing the maximum depth, \
                         or use process instance modification to adjust the process instance."""
-                            .formatted(maxCallActivityDepth),
+                            .formatted(maxProcessDepth),
                         ErrorType.CALLED_ELEMENT_ERROR));
               }
               return Either.right(null);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -186,6 +186,10 @@ public final class CallActivityProcessor
     transitionToTerminated(element, callActivityContext);
   }
 
+  /**
+   * Returns a failure if the process depth of the called instance is about to exceed the maximum
+   * allowed depth. Otherwise, returns a right.
+   */
   private Either<Failure, Void> validateProcessDepth(final BpmnElementContext context) {
     final var processInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
     final int processDepth = processInstance.getProcessDepth();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -189,7 +189,7 @@ public final class CallActivityProcessor
   private Either<Failure, Void> validateProcessDepth(final BpmnElementContext context) {
     final var processInstance = stateBehavior.getElementInstance(context.getProcessInstanceKey());
     final int processDepth = processInstance.getProcessDepth();
-    final var isExceedingMaxDepth = processDepth >= maxProcessDepth;
+    final var isExceedingMaxDepth = (processDepth + 1) > maxProcessDepth;
     if (isExceedingMaxDepth) {
       final var message = MAX_DEPTH_EXCEEDED_MESSAGE.formatted(maxProcessDepth);
       return Either.left(new Failure(message, ErrorType.CALLED_ELEMENT_ERROR));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -191,7 +191,13 @@ public final class EventAppliers implements EventApplier {
 
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATING,
-        new ProcessInstanceElementActivatingApplier(
+        1,
+        new ProcessInstanceElementActivatingV1Applier(
+            elementInstanceState, processState, eventScopeInstanceState));
+    register(
+        ProcessInstanceIntent.ELEMENT_ACTIVATING,
+        2,
+        new ProcessInstanceElementActivatingV2Applier(
             elementInstanceState, processState, eventScopeInstanceState));
     register(
         ProcessInstanceIntent.ELEMENT_ACTIVATED,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -137,7 +137,7 @@ final class ProcessInstanceElementActivatingApplier
         final var parentProcessInstance =
             elementInstanceState.getInstance(
                 elementInstance.getValue().getParentProcessInstanceKey());
-        elementInstance.setCalledProcessDept(parentProcessInstance.getCalledProcessDepth() + 1);
+        elementInstance.setProcessDepth(parentProcessInstance.getProcessDepth() + 1);
         elementInstanceState.updateInstance(elementInstance);
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -57,11 +57,12 @@ final class ProcessInstanceElementActivatingApplier
     cleanupSequenceFlowsTaken(value);
 
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    elementInstanceState.newInstance(
-        flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    final var elementInstance =
+        elementInstanceState.newInstance(
+            flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
     if (flowScopeInstance == null) {
-      applyRootProcessState(elementInstanceKey, value);
+      applyRootProcessState(elementInstance, value);
       return;
     }
 
@@ -122,7 +123,7 @@ final class ProcessInstanceElementActivatingApplier
   }
 
   private void applyRootProcessState(
-      final long elementInstanceKey, final ProcessInstanceRecord value) {
+      final ElementInstance elementInstance, final ProcessInstanceRecord value) {
     final var parentElementInstance =
         elementInstanceState.getInstance(value.getParentElementInstanceKey());
     if (parentElementInstance != null) {
@@ -130,8 +131,14 @@ final class ProcessInstanceElementActivatingApplier
       // it should always be a call-activity, but let's try to be safe
       final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
       if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
-        parentElementInstance.setCalledChildInstanceKey(elementInstanceKey);
+        parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
         elementInstanceState.updateInstance(parentElementInstance);
+
+        final var parentProcessInstance =
+            elementInstanceState.getInstance(
+                elementInstance.getValue().getParentProcessInstanceKey());
+        elementInstance.setCalledProcessDept(parentProcessInstance.getCalledProcessDepth() + 1);
+        elementInstanceState.updateInstance(elementInstance);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableExclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableInclusiveGateway;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.instance.EventTrigger;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+
+/** Applies state changes for `ProcessInstance:Element_Activating` */
+final class ProcessInstanceElementActivatingV1Applier
+    implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
+  private final MutableEventScopeInstanceState eventScopeInstanceState;
+
+  public ProcessInstanceElementActivatingV1Applier(
+      final MutableElementInstanceState elementInstanceState,
+      final ProcessState processState,
+      final MutableEventScopeInstanceState eventScopeInstanceState) {
+    this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
+    this.eventScopeInstanceState = eventScopeInstanceState;
+  }
+
+  @Override
+  public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+
+    createEventScope(elementInstanceKey, value);
+    final var numberOfTakenSequenceFlows =
+        elementInstanceState.getNumberOfTakenSequenceFlows(
+            value.getFlowScopeKey(), value.getElementIdBuffer());
+    cleanupSequenceFlowsTaken(value);
+
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+    final var elementInstance =
+        elementInstanceState.newInstance(
+            flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    if (flowScopeInstance == null) {
+      applyRootProcessState(elementInstance, value);
+      return;
+    }
+
+    final var flowScopeElementType = flowScopeInstance.getValue().getBpmnElementType();
+    final var currentElementType = value.getBpmnElementType();
+
+    decrementActiveSequenceFlow(
+        value,
+        flowScopeInstance,
+        flowScopeElementType,
+        currentElementType,
+        numberOfTakenSequenceFlows);
+
+    if (currentElementType == BpmnElementType.START_EVENT
+        && flowScopeElementType == BpmnElementType.EVENT_SUB_PROCESS) {
+      final EventTrigger flowScopeEventTrigger =
+          eventScopeInstanceState.peekEventTrigger(flowScopeInstance.getParentKey());
+      moveVariablesToNewEventScope(
+          flowScopeEventTrigger, flowScopeInstance.getParentKey(), elementInstanceKey);
+    }
+
+    manageMultiInstance(elementInstanceKey, flowScopeInstance, flowScopeElementType);
+  }
+
+  private void cleanupSequenceFlowsTaken(final ProcessInstanceRecord value) {
+    if (value.getBpmnElementType() == BpmnElementType.PARALLEL_GATEWAY
+        || value.getBpmnElementType() == BpmnElementType.INCLUSIVE_GATEWAY) {
+
+      final var gateway =
+          processState.getFlowElement(
+              value.getProcessDefinitionKey(),
+              value.getTenantId(),
+              value.getElementIdBuffer(),
+              ExecutableFlowNode.class);
+      // before a parallel or inclusive gateway is activated, all incoming sequence flows of the
+      // gateway must
+      // be taken at least once. decrement the number of the taken sequence flows for each incoming
+      // sequence flow but keep the remaining numbers for the next activation of the gateway.
+      // (Tetris principle)
+      elementInstanceState.decrementNumberOfTakenSequenceFlows(
+          value.getFlowScopeKey(), gateway.getId());
+    }
+  }
+
+  private void moveVariablesToNewEventScope(
+      final EventTrigger eventTrigger, final long oldEventScopeKey, final long newEventScopeKey) {
+    // In order to pass the variables of the event trigger to the element instance, we need to
+    // create a new event trigger, using the element instance key as the event scope key.
+    if (eventTrigger != null) {
+      eventScopeInstanceState.triggerEvent(
+          newEventScopeKey,
+          eventTrigger.getEventKey(),
+          eventTrigger.getElementId(),
+          eventTrigger.getVariables(),
+          eventTrigger.getProcessInstanceKey());
+      eventScopeInstanceState.deleteTrigger(oldEventScopeKey, eventTrigger.getEventKey());
+    }
+  }
+
+  private void applyRootProcessState(
+      final ElementInstance elementInstance, final ProcessInstanceRecord value) {
+    final var parentElementInstance =
+        elementInstanceState.getInstance(value.getParentElementInstanceKey());
+    if (parentElementInstance != null) {
+      // this check is not really necessary: if parentElementInstance exists,
+      // it should always be a call-activity, but let's try to be safe
+      final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
+      if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
+        parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
+        elementInstanceState.updateInstance(parentElementInstance);
+
+        final var parentProcessInstance =
+            elementInstanceState.getInstance(
+                elementInstance.getValue().getParentProcessInstanceKey());
+        elementInstance.setProcessDepth(parentProcessInstance.getProcessDepth() + 1);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+
+  private void decrementActiveSequenceFlow(
+      final ProcessInstanceRecord value,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType,
+      final BpmnElementType currentElementType,
+      final int numberOfTakenSequenceFlows) {
+    // remove active sequence flows to this element
+    processState
+        .getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class)
+        .getIncoming()
+        .stream()
+        .map(ExecutableSequenceFlow::getId)
+        .forEach(flowScopeInstance::removeActiveSequenceFlowId);
+    elementInstanceState.updateInstance(flowScopeInstance);
+
+    // We don't want to decrement the active sequence flow for elements which have no incoming
+    // sequence flow and for interrupting event sub processes we reset the count completely.
+    // Furthermore some elements are special and need to be handled separately.
+    switch (currentElementType) {
+      case START_EVENT:
+      case BOUNDARY_EVENT:
+        break;
+      case INTERMEDIATE_CATCH_EVENT:
+        decrementIntermediateCatchEventSequenceFlow(value, flowScopeInstance);
+        break;
+      case PARALLEL_GATEWAY:
+        decrementParallelGatewaySequenceFlow(value, flowScopeInstance);
+        break;
+      case INCLUSIVE_GATEWAY:
+        decrementInclusiveGatewaySequenceFlow(flowScopeInstance, numberOfTakenSequenceFlows);
+        break;
+      case EVENT_SUB_PROCESS:
+        decrementEventSubProcessSequenceFlow(value, flowScopeInstance);
+        break;
+      default:
+        if (flowScopeElementType != BpmnElementType.MULTI_INSTANCE_BODY) {
+          flowScopeInstance.decrementActiveSequenceFlows();
+          elementInstanceState.updateInstance(flowScopeInstance);
+        }
+        break;
+    }
+  }
+
+  private void decrementIntermediateCatchEventSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // If we are an intermediate catch event and our previous element is an event based gateway,
+    // then we don't want to decrement the active flow, since based on the BPMN spec we DON'T take
+    // the sequence flow.
+
+    final var executableCatchEventElement =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableCatchEventElement.class);
+
+    // When the catch event is of the link catch event type,
+    // the catch event has no incoming sequence flow
+    final List<ExecutableSequenceFlow> incoming = executableCatchEventElement.getIncoming();
+    if (!incoming.isEmpty()) {
+      final var incomingSequenceFlow = executableCatchEventElement.getIncoming().get(0);
+      final var previousElement = incomingSequenceFlow.getSource();
+      if (previousElement.getElementType() != BpmnElementType.EVENT_BASED_GATEWAY) {
+        flowScopeInstance.decrementActiveSequenceFlows();
+        elementInstanceState.updateInstance(flowScopeInstance);
+      }
+    }
+  }
+
+  private void decrementParallelGatewaySequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // Parallel gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the incoming count.
+
+    final var executableFlowNode =
+        processState.getFlowElement(
+            value.getProcessDefinitionKey(),
+            value.getTenantId(),
+            value.getElementIdBuffer(),
+            ExecutableFlowNode.class);
+    final var size = executableFlowNode.getIncoming().size();
+    IntStream.range(0, size).forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementInclusiveGatewaySequenceFlow(
+      final ElementInstance flowScopeInstance, final int numberOfTakenSequenceFlows) {
+    // Inclusive gateways can have more than one incoming sequence flow, we need to decrement the
+    // active sequence flows based on the satisfied incoming sequence flows.
+
+    IntStream.range(0, numberOfTakenSequenceFlows)
+        .forEach(i -> flowScopeInstance.decrementActiveSequenceFlows());
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private void decrementEventSubProcessSequenceFlow(
+      final ProcessInstanceRecord value, final ElementInstance flowScopeInstance) {
+    // For interrupting event sub processes we need to reset the active sequence flows, because
+    // we might have interrupted multiple sequence flows.
+    // For non interrupting we do nothing, since we had no incoming sequence flow.
+
+    final var executableFlowElementContainer = getExecutableFlowElementContainer(value);
+    final var executableStartEvent = executableFlowElementContainer.getStartEvents().get(0);
+    if (executableStartEvent.isInterrupting()) {
+      flowScopeInstance.resetActiveSequenceFlows();
+    }
+    elementInstanceState.updateInstance(flowScopeInstance);
+  }
+
+  private ExecutableFlowElementContainer getExecutableFlowElementContainer(
+      final ProcessInstanceRecord value) {
+    return processState.getFlowElement(
+        value.getProcessDefinitionKey(),
+        value.getTenantId(),
+        value.getElementIdBuffer(),
+        ExecutableFlowElementContainer.class);
+  }
+
+  private void manageMultiInstance(
+      final long elementInstanceKey,
+      final ElementInstance flowScopeInstance,
+      final BpmnElementType flowScopeElementType) {
+    if (flowScopeElementType == BpmnElementType.MULTI_INSTANCE_BODY) {
+      // update the loop counter of the multi-instance body (starting by 1)
+      flowScopeInstance.incrementMultiInstanceLoopCounter();
+      // update the numberOfInstances of the multi-instance body
+      flowScopeInstance.incrementNumberOfElementInstances();
+      elementInstanceState.updateInstance(flowScopeInstance);
+
+      // set the loop counter of the inner instance
+      final var loopCounter = flowScopeInstance.getMultiInstanceLoopCounter();
+      elementInstanceState.updateInstance(
+          elementInstanceKey, instance -> instance.setMultiInstanceLoopCounter(loopCounter));
+    }
+  }
+
+  private void createEventScope(
+      final long elementInstanceKey, final ProcessInstanceRecord elementRecord) {
+    Class<? extends ExecutableFlowNode> flowElementClass = ExecutableFlowNode.class;
+
+    // in the case of the multi instance body, it shares the same element ID as that of its
+    // contained activity; this means when doing a processState.getFlowElement, you don't know which
+    // you will get, and the boundary events will only be bound to the multi instance
+    if (elementRecord.getBpmnElementType() == BpmnElementType.MULTI_INSTANCE_BODY) {
+      flowElementClass = ExecutableMultiInstanceBody.class;
+    }
+
+    final var flowElement =
+        processState.getFlowElement(
+            elementRecord.getProcessDefinitionKey(),
+            elementRecord.getTenantId(),
+            elementRecord.getElementIdBuffer(),
+            flowElementClass);
+
+    if (flowElement instanceof final ExecutableCatchEventSupplier eventSupplier
+        && !eventSupplier.getEvents().isEmpty()) {
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey,
+          eventSupplier.getInterruptingElementIds(),
+          eventSupplier.getBoundaryElementIds());
+    } else if (flowElement instanceof ExecutableJobWorkerElement
+        || flowElement instanceof ExecutableActivity
+        || flowElement instanceof ExecutableExclusiveGateway
+        || flowElement instanceof ExecutableInclusiveGateway) {
+      // executable elements without events
+      eventScopeInstanceState.createInstance(
+          elementInstanceKey, Collections.emptySet(), Collections.emptySet());
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV1Applier.java
@@ -57,12 +57,11 @@ final class ProcessInstanceElementActivatingV1Applier
     cleanupSequenceFlowsTaken(value);
 
     final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    final var elementInstance =
-        elementInstanceState.newInstance(
-            flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    elementInstanceState.newInstance(
+        flowScopeInstance, elementInstanceKey, value, ProcessInstanceIntent.ELEMENT_ACTIVATING);
 
     if (flowScopeInstance == null) {
-      applyRootProcessState(elementInstance, value);
+      applyRootProcessState(elementInstanceKey, value);
       return;
     }
 
@@ -123,7 +122,7 @@ final class ProcessInstanceElementActivatingV1Applier
   }
 
   private void applyRootProcessState(
-      final ElementInstance elementInstance, final ProcessInstanceRecord value) {
+      final long elementInstanceKey, final ProcessInstanceRecord value) {
     final var parentElementInstance =
         elementInstanceState.getInstance(value.getParentElementInstanceKey());
     if (parentElementInstance != null) {
@@ -131,14 +130,8 @@ final class ProcessInstanceElementActivatingV1Applier
       // it should always be a call-activity, but let's try to be safe
       final var parentElementType = parentElementInstance.getValue().getBpmnElementType();
       if (parentElementType == BpmnElementType.CALL_ACTIVITY) {
-        parentElementInstance.setCalledChildInstanceKey(elementInstance.getKey());
+        parentElementInstance.setCalledChildInstanceKey(elementInstanceKey);
         elementInstanceState.updateInstance(parentElementInstance);
-
-        final var parentProcessInstance =
-            elementInstanceState.getInstance(
-                elementInstance.getValue().getParentProcessInstanceKey());
-        elementInstance.setProcessDepth(parentProcessInstance.getProcessDepth() + 1);
-        elementInstanceState.updateInstance(elementInstance);
       }
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingV2Applier.java
@@ -31,14 +31,14 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 /** Applies state changes for `ProcessInstance:Element_Activating` */
-final class ProcessInstanceElementActivatingApplier
+final class ProcessInstanceElementActivatingV2Applier
     implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
   private final ProcessState processState;
   private final MutableEventScopeInstanceState eventScopeInstanceState;
 
-  public ProcessInstanceElementActivatingApplier(
+  public ProcessInstanceElementActivatingV2Applier(
       final MutableElementInstanceState elementInstanceState,
       final ProcessState processState,
       final MutableEventScopeInstanceState eventScopeInstanceState) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -53,10 +53,17 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new ObjectProperty<>("taskListenerIndicesRecord", new TaskListenerIndicesRecord());
 
   /**
-   * This value is added in 8.7, any child process instances created before 8.7 will have a depth of
-   * 0.
+   * Expresses the current depth of the process instance in the called process tree.
+   *
+   * <p>A root process instance has depth 1. Each child instance has the depth of its parent
+   * incremented by 1.
    *
    * @since 8.7
+   * @apiNote This value is added in 8.7, any child process instances created before 8.7 will have a
+   *     depth of 1 rather than a correct value. Child instances created on or after 8.7 will have a
+   *     depth of 1 + the depth of the parent instance. Therefore, child instances created on or
+   *     after 8.7 that are part of a root process instance created prior to 8.7, will not have a
+   *     correct depth.
    */
   private final IntegerProperty processDepth = new IntegerProperty("processDepth", 1);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -77,7 +77,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(activeSequenceFlowIdsProp)
         .declareProperty(userTaskKeyProp)
         .declareProperty(executionListenerIndexProp)
-        .declareProperty(taskListenerIndicesRecordProp);
+        .declareProperty(taskListenerIndicesRecordProp)
+        .declareProperty(calledProcessDepthProp);
   }
 
   public ElementInstance(
@@ -313,5 +314,9 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
 
   public int getCalledProcessDepth() {
     return calledProcessDepthProp.getValue();
+  }
+
+  public void setCalledProcessDept(final int depth) {
+    calledProcessDepthProp.setValue(depth);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -58,8 +58,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    *
    * @since 8.7
    */
-  private final IntegerProperty calledProcessDepthProp =
-      new IntegerProperty("calledProcessDepth", 0);
+  private final IntegerProperty processDepth = new IntegerProperty("processDepth", 1);
 
   public ElementInstance() {
     super(15);
@@ -78,7 +77,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(userTaskKeyProp)
         .declareProperty(executionListenerIndexProp)
         .declareProperty(taskListenerIndicesRecordProp)
-        .declareProperty(calledProcessDepthProp);
+        .declareProperty(processDepth);
   }
 
   public ElementInstance(
@@ -312,11 +311,11 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     return activeSequenceFlowIdsProp.stream().map(StringValue::getValue).toList();
   }
 
-  public int getCalledProcessDepth() {
-    return calledProcessDepthProp.getValue();
+  public int getProcessDepth() {
+    return processDepth.getValue();
   }
 
-  public void setCalledProcessDept(final int depth) {
-    calledProcessDepthProp.setValue(depth);
+  public void setProcessDepth(final int depth) {
+    processDepth.setValue(depth);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -52,6 +52,15 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final ObjectProperty<TaskListenerIndicesRecord> taskListenerIndicesRecordProp =
       new ObjectProperty<>("taskListenerIndicesRecord", new TaskListenerIndicesRecord());
 
+  /**
+   * This value is added in 8.7, any child process instances created before 8.7 will have a depth of
+   * 0.
+   *
+   * @since 8.7
+   */
+  private final IntegerProperty calledProcessDepthProp =
+      new IntegerProperty("calledProcessDepth", -1);
+
   public ElementInstance() {
     super(15);
     declareProperty(parentKeyProp)
@@ -300,5 +309,9 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    */
   public List<DirectBuffer> getActiveSequenceFlowIds() {
     return activeSequenceFlowIdsProp.stream().map(StringValue::getValue).toList();
+  }
+
+  public int getCalledProcessDepth() {
+    return calledProcessDepthProp.getValue();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -58,12 +58,13 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    * <p>A root process instance has depth 1. Each child instance has the depth of its parent
    * incremented by 1.
    *
-   * @since 8.7
-   * @apiNote This value is added in 8.7, any child process instances created before 8.7 will have a
-   *     depth of 1 rather than a correct value. Child instances created on or after 8.7 will have a
-   *     depth of 1 + the depth of the parent instance. Therefore, child instances created on or
-   *     after 8.7 that are part of a root process instance created prior to 8.7, will not have a
-   *     correct depth.
+   * @since 8.3.22, 8.4.18, 8.5.17, 8.6.12, and 8.7
+   * @apiNote This property is added in 8.7 and backported to 8.6.12, 8.5.17, 8.4.18, and 8.3.22.
+   *     Any child process instances created before 8.7 (or any of these patches) will have a depth
+   *     of 1 rather than a correct value. Child instances created before the property existed will
+   *     have a depth of 1 + the depth of the parent instance. Therefore, child instances created on
+   *     or after the property was added that are part of a root process instance created prior to
+   *     the property existed, will not have a correct depth.
    */
   private final IntegerProperty processDepth = new IntegerProperty("processDepth", 1);
 
@@ -287,15 +288,15 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     executionListenerIndexProp.reset();
   }
 
-  public Integer getTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public Integer getTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     return taskListenerIndicesRecordProp.getValue().getTaskListenerIndex(eventType);
   }
 
-  public void incrementTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public void incrementTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     taskListenerIndicesRecordProp.getValue().incrementTaskListenerIndex(eventType);
   }
 
-  public void resetTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public void resetTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     taskListenerIndicesRecordProp.getValue().resetTaskListenerIndex(eventType);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -59,7 +59,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    * @since 8.7
    */
   private final IntegerProperty calledProcessDepthProp =
-      new IntegerProperty("calledProcessDepth", -1);
+      new IntegerProperty("calledProcessDepth", 0);
 
   public ElementInstance() {
     super(15);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -61,7 +61,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty processDepth = new IntegerProperty("processDepth", 1);
 
   public ElementInstance() {
-    super(15);
+    super(16);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -39,7 +39,15 @@ import org.junit.Test;
 
 public final class CallActivityTest {
 
-  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  public static final boolean ENABLE_STRAIGHT_THROUGH_PROCESSING_LOOP_DETECTOR = false;
+
+  @ClassRule
+  public static final EngineRule ENGINE =
+      EngineRule.singlePartition()
+          .withFeatureFlags(
+              featureFlags ->
+                  featureFlags.setEnableStraightThroughProcessingLoopDetector(
+                      ENABLE_STRAIGHT_THROUGH_PROCESSING_LOOP_DETECTOR));
 
   private static final String PROCESS_ID_PARENT = "wf-parent";
   private static final String PROCESS_ID_CHILD = "wf-child";
@@ -1191,6 +1199,44 @@ public final class CallActivityTest {
             parentInstance.getProcessDefinitionKey(),
             childInstance.getProcessDefinitionKey())
         .hasOnlyCallingElementPath(ca1Index, ca2Index);
+  }
+
+  @Test
+  public void shouldLimitDescendantDepth() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess("Loop")
+                .startEvent()
+                .exclusiveGateway("failsafe")
+                .defaultFlow()
+                .callActivity(
+                    "go_deeper",
+                    b ->
+                        b.zeebeProcessId("Loop")
+                            .zeebeInputExpression("depth + 1", "depth")
+                            .zeebePropagateAllParentVariables(false))
+                .endEvent("done")
+                .moveToLastExclusiveGateway()
+                .conditionExpression("depth > 1000")
+                .userTask("inspect_failure")
+                .endEvent("failed")
+                .done())
+        .deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId("Loop").withVariable("depth", 1).create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that incident is raised due to the depth limit")
+        .hasErrorMessage("Oh noo, Durin dug too deep!");
   }
 
   private void deployDefaultParentAndChildProcess() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1221,7 +1221,7 @@ public final class CallActivityTest {
                             .zeebePropagateAllParentVariables(false))
                 .endEvent("done")
                 .moveToLastExclusiveGateway()
-                .conditionExpression("depth > 1010")
+                .conditionExpression("depth > %d".formatted(CUSTOM_CALL_ACTIVITY_DEPTH + 1))
                 .userTask("inspect_failure")
                 .endEvent("failed")
                 .done())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1233,7 +1233,6 @@ public final class CallActivityTest {
         ENGINE.processInstance().ofBpmnProcessId("Loop").withVariable("depth", 1).create();
 
     // then
-    RecordingExporter.setMaximumWaitTime(10_000);
     Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst().getValue())
         .describedAs("Expect that incident is raised due to the depth limit")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -39,11 +39,14 @@ import org.junit.Test;
 
 public final class CallActivityTest {
 
+  public static final int CUSTOM_CALL_ACTIVITY_DEPTH = 10;
   public static final boolean ENABLE_STRAIGHT_THROUGH_PROCESSING_LOOP_DETECTOR = false;
 
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
+          .withEngineConfig(
+              config -> config.setDefaultCallActivityMaxDepth(CUSTOM_CALL_ACTIVITY_DEPTH))
           .withFeatureFlags(
               featureFlags ->
                   featureFlags.setEnableStraightThroughProcessingLoopDetector(
@@ -1230,15 +1233,17 @@ public final class CallActivityTest {
         ENGINE.processInstance().ofBpmnProcessId("Loop").withVariable("depth", 1).create();
 
     // then
+    RecordingExporter.setMaximumWaitTime(10_000);
     Assertions.assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst().getValue())
         .describedAs("Expect that incident is raised due to the depth limit")
         .hasErrorMessage(
             """
-        The call activity has reached the maximum depth of 1000. This is likely due to a recursive call. \
+        The call activity has reached the maximum depth of %d. This is likely due to a recursive call. \
         Cancel the root process instance if this was unintentional. Otherwise, consider increasing the \
         maximum depth, or use process instance modification to adjust the process instance.\
-        """);
+        """
+                .formatted(CUSTOM_CALL_ACTIVITY_DEPTH));
   }
 
   private void deployDefaultParentAndChildProcess() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1242,6 +1242,15 @@ public final class CallActivityTest {
         maximum depth, or use process instance modification to adjust the process instance.\
         """
                 .formatted(CUSTOM_CALL_ACTIVITY_DEPTH));
+
+    Assertions.assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withName("depth")
+                .withScopeKey(incident.getElementInstanceKey())
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that we cannot call the call activity with a depth greater than 10")
+        .hasValue("%d".formatted(CUSTOM_CALL_ACTIVITY_DEPTH + 1));
   }
 
   private void deployDefaultParentAndChildProcess() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1219,7 +1219,7 @@ public final class CallActivityTest {
                             .zeebePropagateAllParentVariables(false))
                 .endEvent("done")
                 .moveToLastExclusiveGateway()
-                .conditionExpression("depth > 1000")
+                .conditionExpression("depth > 1010")
                 .userTask("inspect_failure")
                 .endEvent("failed")
                 .done())
@@ -1231,12 +1231,14 @@ public final class CallActivityTest {
 
     // then
     Assertions.assertThat(
-            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .getFirst()
-                .getValue())
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst().getValue())
         .describedAs("Expect that incident is raised due to the depth limit")
-        .hasErrorMessage("Oh noo, Durin dug too deep!");
+        .hasErrorMessage(
+            """
+        The call activity has reached the maximum depth of 1000. This is likely due to a recursive call. \
+        Cancel the root process instance if this was unintentional. Otherwise, consider increasing the \
+        maximum depth, or use process instance modification to adjust the process instance.\
+        """);
   }
 
   private void deployDefaultParentAndChildProcess() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -1228,19 +1228,21 @@ public final class CallActivityTest {
         .deploy();
 
     // when
-    final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId("Loop").withVariable("depth", 1).create();
+    ENGINE.processInstance().ofBpmnProcessId("Loop").withVariable("depth", 1).create();
 
     // then
-    Assertions.assertThat(
-            RecordingExporter.incidentRecords(IncidentIntent.CREATED).getFirst().getValue())
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withElementId("go_deeper")
+            .getFirst()
+            .getValue();
+    Assertions.assertThat(incident)
         .describedAs("Expect that incident is raised due to the depth limit")
         .hasErrorMessage(
             """
-        The call activity has reached the maximum depth of %d. This is likely due to a recursive call. \
-        Cancel the root process instance if this was unintentional. Otherwise, consider increasing the \
-        maximum depth, or use process instance modification to adjust the process instance.\
-        """
+            The call activity has reached the maximum depth of %d. This is likely due to a recursive call. \
+            Cancel the root process instance if this was unintentional. Otherwise, consider increasing the \
+            maximum depth, or use process instance modification to adjust the process instance."""
                 .formatted(CUSTOM_CALL_ACTIVITY_DEPTH));
 
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
@@ -407,6 +408,7 @@ public final class CallActivityTest {
     ENGINE
         .deployment()
         .withXmlResource("wf-parent.bpmn", parentProcess(c -> c.zeebeInputExpression("x", "y")))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -434,6 +436,7 @@ public final class CallActivityTest {
             "wf-parent.bpmn",
             parentProcess(
                 c -> c.zeebeInputExpression("x", "y").zeebePropagateAllParentVariables(true)))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -465,6 +468,7 @@ public final class CallActivityTest {
             "wf-parent.bpmn",
             parentProcess(
                 c -> c.zeebeInputExpression("x", "y").zeebePropagateAllParentVariables(false)))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -496,6 +500,7 @@ public final class CallActivityTest {
         .deployment()
         .withXmlResource(
             "wf-parent.bpmn", parentProcess(c -> c.zeebePropagateAllParentVariables(false)))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -593,6 +598,7 @@ public final class CallActivityTest {
         .withXmlResource(
             "wf-parent.bpmn",
             parentProcess(callActivity -> callActivity.zeebeProcessIdExpression("processId")))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -799,6 +805,7 @@ public final class CallActivityTest {
         .withXmlResource(
             "wf-parent.bpmn",
             parentProcess(callActivity -> callActivity.zeebeInputExpression("x", "y")))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     final var processInstanceKey =
@@ -831,6 +838,8 @@ public final class CallActivityTest {
                 .startEvent()
                 .callActivity("call", c -> c.zeebeProcessId(PROCESS_ID_PARENT))
                 .done())
+        .withXmlResource("wf-parent.bpmn", parentProcess(AbstractBpmnModelElementBuilder::done))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     final var rootInstanceKey = ENGINE.processInstance().ofBpmnProcessId("root").create();
@@ -865,6 +874,7 @@ public final class CallActivityTest {
         .withXmlResource(
             "wf-parent.bpmn",
             parentProcess(c -> c.zeebeInputExpression("assert(x, x != null)", "y")))
+        .withXmlResource("wf-child.bpmn", childProcess(jobType, ServiceTaskBuilder::done))
         .deploy();
 
     // when
@@ -896,7 +906,11 @@ public final class CallActivityTest {
     processBuilder.startEvent("timer-start").timerWithCycle("R/PT1H").endEvent();
     processBuilder.startEvent("message-start").message("start").endEvent();
 
-    ENGINE.deployment().withXmlResource("wf-child.bpmn", processBuilder.done()).deploy();
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-parent.bpmn", parentProcess(AbstractBpmnModelElementBuilder::done))
+        .withXmlResource("wf-child.bpmn", processBuilder.done())
+        .deploy();
 
     // when
     final var processInstanceKey =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -45,8 +45,7 @@ public final class CallActivityTest {
   @ClassRule
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
-          .withEngineConfig(
-              config -> config.setDefaultCallActivityMaxDepth(CUSTOM_CALL_ACTIVITY_DEPTH))
+          .withEngineConfig(config -> config.setMaxProcessDepth(CUSTOM_CALL_ACTIVITY_DEPTH))
           .withFeatureFlags(
               featureFlags ->
                   featureFlags.setEnableStraightThroughProcessingLoopDetector(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.db.DbKey;
 import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.EngineProcessors;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
@@ -107,6 +108,7 @@ public final class EngineRule extends ExternalResource {
   private final FeatureFlags featureFlags = FeatureFlags.createDefaultForTests();
   private ArrayList<TestInterPartitionCommandSender> interPartitionCommandSenders;
   private Consumer<SecurityConfiguration> securityConfigModifier = cfg -> {};
+  private Consumer<EngineConfiguration> engineConfigModifier = cfg -> {};
 
   private EngineRule(final int partitionCount) {
     this(partitionCount, null);
@@ -194,6 +196,11 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
+  public EngineRule withEngineConfig(final Consumer<EngineConfiguration> modifier) {
+    engineConfigModifier = engineConfigModifier.andThen(modifier);
+    return this;
+  }
+
   private void startProcessors(final StreamProcessorMode mode, final boolean awaitOpening) {
     interPartitionCommandSenders = new ArrayList<>();
 
@@ -206,6 +213,7 @@ public final class EngineRule extends ExternalResource {
               partitionId,
               (recordProcessorContext) -> {
                 securityConfigModifier.accept(recordProcessorContext.getSecurityConfig());
+                engineConfigModifier.accept(recordProcessorContext.getConfig());
                 return EngineProcessors.createEngineProcessors(
                         recordProcessorContext,
                         partitionCount,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This is the effort we made during our mob programming session. We added a test case with a failsafe to ensure the process instance doesn't overload the test engine. We also added a simple implementation to check the called process depth.

Still to do:
- actually increment the depth
- make the depth configurable
- consider how to deal with existing child instances
- configure the depth in the test for performance

## Related issues

closes #16410
