### PR TITLE
ci: set maven cache in build-operate-setup composite action and switch to mvnw wrapper

### DIFF
--- a/.github/actions/build-operate-setup/action.yml
+++ b/.github/actions/build-operate-setup/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     type: number
     default: 21
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "operate"
+    required: false
   nexusUsername:
     required: true
     type: string
@@ -25,12 +29,12 @@ runs:
       with:
         distribution: "adopt"
         java-version: ${{ inputs.javaVersion }}
-        cache: "maven"
 
     - name: Setup Maven
-      uses: stCarolas/setup-maven@v5
+      uses: ./.github/actions/setup-maven-dist
       with:
         maven-version: 3.8.6
+        set-mvnw: true
 
     # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven settings.xml
@@ -44,3 +48,8 @@ runs:
             "password": "${{ inputs.nexusPassword }}"
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+
+    - name: Configure Maven
+      uses: ./.github/actions/setup-maven-cache
+      with:
+        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/build-operate-setup/action.yml
+++ b/.github/actions/build-operate-setup/action.yml
@@ -33,7 +33,7 @@ runs:
     - name: Setup Maven
       uses: ./.github/actions/setup-maven-dist
       with:
-        maven-version: 3.8.6
+        maven-version: 3.9.9
         set-mvnw: true
 
     # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
@@ -53,3 +53,4 @@ runs:
       uses: ./.github/actions/setup-maven-cache
       with:
         maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
+        save-cache: true

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "shared"
     required: false
+  maven-wagon-http-pool:
+    description: Whether to use a connection pool for HTTP connections.
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -34,7 +38,7 @@ runs:
         --batch-mode
         --update-snapshots
         -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=false
+        -D maven.wagon.http.pool=${{ inputs.maven-wagon-http-pool }}
         -D maven.resolver.transport=wagon
         -D maven.wagon.http.retryHandler.class=standard
         -D maven.wagon.http.retryHandler.requestSentEnabled=true

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -13,7 +13,10 @@ inputs:
     description: Whether to use a connection pool for HTTP connections.
     default: "true"
     required: false
-
+  save-cache:
+    description: Whether to cache the Maven repository.
+    default: "false"
+    required: false
 runs:
   using: composite
   steps:
@@ -52,7 +55,7 @@ runs:
         EOF
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
-      if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
+      if: inputs.save-cache == 'true'
       uses: actions/cache@v4
       with:
         # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
@@ -66,7 +69,7 @@ runs:
           ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
-      if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
+      if: inputs.save-cache != 'true'
       uses: actions/cache/restore@v4
       with:
         # This has to match the 'Cache local Maven repository' step above

--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -1,0 +1,33 @@
+---
+name: Setup Maven Distribution
+
+description: Install Maven using a well-known GitHub action (stCarolas/setup-maven) or the mvnw wrapper.
+
+inputs:
+  maven-version:
+    description: Target Maven version
+    required: true
+  set-mvnw:
+    description: |
+      Update the target version of Maven used by mvnw wrapper.
+      If enabled, stCarolas/setup-maven is skipped.
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Maven
+      if: inputs.set-mvnw != 'true'
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - name: Update Maven version used by mvnw wrapper
+      if: inputs.set-mvnw == 'true'
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.maven-version }}
+        MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
+      run: |
+        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -98,7 +98,7 @@ jobs:
       # Build: maven artifacts and Docker images
       - name: Build Maven
         run: |
-          mvn clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging
@@ -149,7 +149,7 @@ jobs:
       - name: Deploy - Nexus SNAPSHOT
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
-          mvn -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -84,13 +84,14 @@ jobs:
       - uses: ./.github/actions/build-operate-setup
         name: Build setup
         with:
+          maven-cache-key-modifier: operate-tests
           nexusUsername: ${{ steps.secrets.outputs.NEXUS_USR }}
           nexusPassword: ${{ steps.secrets.outputs.NEXUS_PSW }}
 
       # Build: all Maven artifacts
       - name: Build Maven
         run: |
-          mvn clean install -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw clean install -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -pl operate -am verify -T1C -B -P spotbugs,skipFrontendBuild -DskipTests -DskipDockerProfile -DskipQaBuild
+      command: ./mvnw -pl operate -am verify -T1C -B -P spotbugs,skipFrontendBuild -DskipTests -DskipDockerProfile -DskipQaBuild
       runner-type: gcp-core-4-default
 
   run-unit-tests:
@@ -60,7 +60,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate/qa/integration-tests verify -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Integration Tests
       runner-type: gcp-core-32-default
 
@@ -80,6 +80,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Opensearch ITs
       runner-type: gcp-core-32-default


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674.

This PR introduces the following changes in `build-operate-setup` composite action:
- use of `setup-maven-cache` composite action to configure maven cache
    - new `operate` and `operate-tests` cache keys (can be refined later if needed)
- switch from `stCarolas/setup-maven` install to the `mvnw` wrapper

Related workflows have been updated accordingly (cache keys + use of `./mvnw` script)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
