### PR TITLE
ci: set maven cache in build-tasklist-setup composite action and switch to mvnw wrapper

### DIFF
--- a/.github/actions/build-tasklist-setup/action.yml
+++ b/.github/actions/build-tasklist-setup/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     type: number
     default: 21
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "tasklist"
+    required: false
   nexusUsername:
     required: true
     type: string
@@ -25,12 +29,12 @@ runs:
       with:
         distribution: "adopt"
         java-version: ${{ inputs.javaVersion }}
-        cache: "maven"
 
     - name: Setup Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: ./.github/actions/setup-maven-dist
       with:
         maven-version: 3.8.6
+        set-mvnw: true
 
     # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven settings.xml
@@ -44,3 +48,8 @@ runs:
             "password": "${{ inputs.nexusPassword }}"
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+
+    - name: Configure Maven
+      uses: ./.github/actions/setup-maven-cache
+      with:
+        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "shared"
     required: false
+  maven-wagon-http-pool:
+    description: Whether to use a connection pool for HTTP connections.
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -34,7 +38,7 @@ runs:
         --batch-mode
         --update-snapshots
         -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=false
+        -D maven.wagon.http.pool=${{ inputs.maven-wagon-http-pool }}
         -D maven.resolver.transport=wagon
         -D maven.wagon.http.retryHandler.class=standard
         -D maven.wagon.http.retryHandler.requestSentEnabled=true

--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -1,0 +1,33 @@
+---
+name: Setup Maven Distribution
+
+description: Install Maven using a well-known GitHub action (stCarolas/setup-maven) or the mvnw wrapper.
+
+inputs:
+  maven-version:
+    description: Target Maven version
+    required: true
+  set-mvnw:
+    description: |
+      Update the target version of Maven used by mvnw wrapper.
+      If enabled, stCarolas/setup-maven is skipped.
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Maven
+      if: inputs.set-mvnw != 'true'
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - name: Update Maven version used by mvnw wrapper
+      if: inputs.set-mvnw == 'true'
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.maven-version }}
+        MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
+      run: |
+        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -96,7 +96,7 @@ jobs:
       # Build backend
       - name: Build backend
         run: |
-          mvn -T1C clean deploy -B -PskipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -T1C clean deploy -B -PskipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging
@@ -147,7 +147,7 @@ jobs:
       - name: Deploy - Nexus SNAPSHOT
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
-          mvn -f tasklist org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -PskipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -f tasklist org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -PskipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -78,16 +78,17 @@ jobs:
       - uses: ./.github/actions/build-tasklist-setup
         name: Build setup
         with:
+          maven-cache-key-modifier: tasklist-tests
           nexusUsername: ${{ steps.secrets.outputs.NEXUS_USR }}
           nexusPassword: ${{ steps.secrets.outputs.NEXUS_PSW }}
 
       - name: Build backend
-        run: mvn -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
+        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
 
       # Run integration tests in parallel
       - name: Run Integration Tests
         run: |
-          mvn -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
+          ./mvnw -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
 
       # Sanitize the branch name to replace non alphanumeric characters with `-`
       - id: sanitize


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674.

This PR introduces the following changes in `build-tasklist-setup` composite action:
- use of `setup-maven-cache` composite action to configure maven cache
    - new `tasklist` and `tasklist-tests` cache keys (can be refined later if needed)
- switch from `stCarolas/setup-maven` install to the `mvnw` wrapper

Related workflows have been updated accordingly (cache keys + use of `./mvnw` script)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
