### PR TITLE
ci: set maven cache in optimize composite actions and switch to mvnw wrapper

### DIFF
--- a/.github/actions/run-maven/maven.sh
+++ b/.github/actions/run-maven/maven.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn $PARAMETERS -T $THREADS -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+./mvnw $PARAMETERS -T $THREADS -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "shared"
     required: false
+  maven-wagon-http-pool:
+    description: Whether to use a connection pool for HTTP connections.
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -34,7 +38,7 @@ runs:
         --batch-mode
         --update-snapshots
         -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=false
+        -D maven.wagon.http.pool=${{ inputs.maven-wagon-http-pool }}
         -D maven.resolver.transport=wagon
         -D maven.wagon.http.retryHandler.class=standard
         -D maven.wagon.http.retryHandler.requestSentEnabled=true

--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -1,0 +1,33 @@
+---
+name: Setup Maven Distribution
+
+description: Install Maven using a well-known GitHub action (stCarolas/setup-maven) or the mvnw wrapper.
+
+inputs:
+  maven-version:
+    description: Target Maven version
+    required: true
+  set-mvnw:
+    description: |
+      Update the target version of Maven used by mvnw wrapper.
+      If enabled, stCarolas/setup-maven is skipped.
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Maven
+      if: inputs.set-mvnw != 'true'
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - name: Update Maven version used by mvnw wrapper
+      if: inputs.set-mvnw == 'true'
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.maven-version }}
+        MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
+      run: |
+        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Java distribution to be used
     required: false
     default: 'temurin'
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "optimize"
+    required: false
   maven-version:
     description: Maven version to be used
     required: false
@@ -36,11 +40,11 @@ runs:
     with:
       java-version: ${{ inputs.java-version }}
       distribution: ${{ inputs.distribution }}
-      cache: "maven"
   - name: Setup Maven
-    uses: stCarolas/setup-maven@v5
+    uses: ./.github/actions/setup-maven-dist
     with:
       maven-version: ${{ inputs.maven-version }}
+      set-mvnw: true
   - name: 'Create settings.xml'
     uses: s4u/maven-settings-action@7802f6aec16c9098b4798ad1f1d8ac75198194bd # v3.0.0
     with:
@@ -52,6 +56,10 @@ runs:
           "password": "${{ steps.secrets.outputs.NEXUS_PASSWORD }}"
         }]
       mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+  - name: Configure Maven
+    uses: ./.github/actions/setup-maven-cache
+    with:
+      maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
   # workaround, maven has troubles creating a subdirectory of a non existing directory
   - shell: bash
     run: mkdir -p ${{ github.workspace }}/optimize/backend/target/classes/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Test
         uses: ./.github/actions/run-maven

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
@@ -130,6 +131,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
@@ -209,6 +211,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry
@@ -290,6 +293,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry
@@ -373,6 +377,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
           java-version: 21
           distribution: zulu
@@ -75,7 +76,7 @@ jobs:
       working-directory: ./optimize/client
       run: yarn install
     - name: 'build backend & frontend'
-      run: mvn clean install -DskipTests -Dskip.docker -pl optimize/backend -am
+      run: ./mvnw clean install -DskipTests -Dskip.docker -pl optimize/backend -am
     - name: 'start backend'
       working-directory: ./optimize/client
       run: |

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Install firefox deps
@@ -108,7 +109,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: mvn clean install -T1C -DskipTests -Dskip.docker -pl optimize/backend -am -P skipFrontendBuild
+        run: ./mvnw clean install -T1C -DskipTests -Dskip.docker -pl optimize/backend -am -P skipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Prepare release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DpushChanges=false \
             -DskipTests=true \
             -DignoreSnapshots=true \
@@ -201,7 +201,7 @@ jobs:
 
       - name: Perform release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DlocalCheckout=true \
             -DskipTests=true \
             -B \

--- a/.github/workflows/optimize-zeebe-compatibility.yml
+++ b/.github/workflows/optimize-zeebe-compatibility.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
           java-version: ${{ steps.pom-info.outputs.java_version }}
       - name: Login to Harbor registry


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674.

This PR introduces the following changes:
- `setup-maven` composite action:
    - use of `setup-maven-cache` composite action to configure maven cache
        - new `optimize` and `optiomize-tests` cache keys (can be refined later if needed)
    - switch from `stCarolas/setup-maven` install to the `mvnw` wrapper
- `run-maven` composite action
    - use the `mvnw` wrapper

Related workflows have been updated accordingly (cache keys + use of `./mvnw` script)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
