### PR TITLE
Validate tenant id in REST process instance creation

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -12,6 +12,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceRequest;
@@ -33,10 +34,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ProcessInstanceController {
 
   private final ProcessInstanceServices processInstanceServices;
+  private final MultiTenancyCfg multiTenancyCfg;
 
   @Autowired
-  public ProcessInstanceController(final ProcessInstanceServices processInstanceServices) {
+  public ProcessInstanceController(
+      final ProcessInstanceServices processInstanceServices,
+      final MultiTenancyCfg multiTenancyCfg) {
     this.processInstanceServices = processInstanceServices;
+    this.multiTenancyCfg = multiTenancyCfg;
   }
 
   @PostMapping(
@@ -44,7 +49,7 @@ public class ProcessInstanceController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createProcessInstance(
       @RequestBody final CreateProcessInstanceRequest request) {
-    return RequestMapper.toCreateProcessInstance(request)
+    return RequestMapper.toCreateProcessInstance(request, multiTenancyCfg.isEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createProcessInstance);
   }
 


### PR DESCRIPTION
## Description

In the REST API, validate the provided tenant id in the process instance creation endpoint.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #21055 
