### PR TITLE
refactor: rename decision definition fields

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
@@ -20,22 +20,22 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 public interface DecisionDefinitionFilter extends SearchRequestFilter {
 
   /** Filter by decision key. */
-  DecisionDefinitionFilter decisionKey(final Long value);
+  DecisionDefinitionFilter decisionDefinitionKey(final long value);
 
   /** Filter by dmn decision id. */
-  DecisionDefinitionFilter dmnDecisionId(final String value);
+  DecisionDefinitionFilter decisionDefinitionId(final String value);
 
   /** Filter by dmn decision name. */
-  DecisionDefinitionFilter dmnDecisionName(final String value);
+  DecisionDefinitionFilter decisionDefinitionName(final String value);
 
   /** Filter by version. */
-  DecisionDefinitionFilter version(final Integer value);
+  DecisionDefinitionFilter decisionDefinitionVersion(final int value);
 
   /** Filter by dmn decision requirements id. */
-  DecisionDefinitionFilter dmnDecisionRequirementsId(final String value);
+  DecisionDefinitionFilter decisionRequirementsId(final String value);
 
   /** Filter by decision requirements key. */
-  DecisionDefinitionFilter decisionRequirementsKey(final Long value);
+  DecisionDefinitionFilter decisionRequirementsKey(final long value);
 
   /** Filter by tenant id. */
   DecisionDefinitionFilter tenantId(final String value);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
@@ -20,19 +20,19 @@ import io.camunda.zeebe.client.api.search.query.TypedSearchQueryRequest.SearchRe
 public interface DecisionDefinitionSort extends SearchRequestSort<DecisionDefinitionSort> {
 
   /** Sort by decision key. */
-  DecisionDefinitionSort decisionKey();
+  DecisionDefinitionSort decisionDefinitionKey();
 
   /** Sort by dmn decision id. */
-  DecisionDefinitionSort dmnDecisionId();
+  DecisionDefinitionSort decisionDefinitionId();
 
   /** Sort by dmn decision name. */
-  DecisionDefinitionSort dmnDecisionName();
+  DecisionDefinitionSort decisionDefinitionName();
 
   /** Sort by version. */
-  DecisionDefinitionSort version();
+  DecisionDefinitionSort decisionDefinitionVersion();
 
   /** Sort by dmn decision requirements id. */
-  DecisionDefinitionSort dmnDecisionRequirementsId();
+  DecisionDefinitionSort decisionRequirementsId();
 
   /** Sort by decision requirements key. */
   DecisionDefinitionSort decisionRequirementsKey();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionDefinitionFilterImpl.java
@@ -30,37 +30,37 @@ public class DecisionDefinitionFilterImpl
   }
 
   @Override
-  public DecisionDefinitionFilter decisionKey(final Long value) {
+  public DecisionDefinitionFilter decisionDefinitionKey(final long value) {
     filter.setDecisionDefinitionKey(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter dmnDecisionId(final String value) {
+  public DecisionDefinitionFilter decisionDefinitionId(final String value) {
     filter.setDecisionDefinitionId(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter dmnDecisionName(final String value) {
+  public DecisionDefinitionFilter decisionDefinitionName(final String value) {
     filter.setDecisionDefinitionName(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter version(final Integer value) {
+  public DecisionDefinitionFilter decisionDefinitionVersion(final int value) {
     filter.setVersion(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter dmnDecisionRequirementsId(final String value) {
+  public DecisionDefinitionFilter decisionRequirementsId(final String value) {
     filter.setDecisionRequirementsId(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter decisionRequirementsKey(final Long value) {
+  public DecisionDefinitionFilter decisionRequirementsKey(final long value) {
     filter.setDecisionRequirementsKey(value);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionDefinitionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionDefinitionSortImpl.java
@@ -22,28 +22,28 @@ public class DecisionDefinitionSortImpl extends SearchQuerySortBase<DecisionDefi
     implements DecisionDefinitionSort {
 
   @Override
-  public DecisionDefinitionSort decisionKey() {
-    return field("decisionKey");
+  public DecisionDefinitionSort decisionDefinitionKey() {
+    return field("decisionDefinitionKey");
   }
 
   @Override
-  public DecisionDefinitionSort dmnDecisionId() {
-    return field("dmnDecisionId");
+  public DecisionDefinitionSort decisionDefinitionId() {
+    return field("decisionDefinitionId");
   }
 
   @Override
-  public DecisionDefinitionSort dmnDecisionName() {
-    return field("dmnDecisionName");
+  public DecisionDefinitionSort decisionDefinitionName() {
+    return field("decisionDefinitionName");
   }
 
   @Override
-  public DecisionDefinitionSort version() {
-    return field("version");
+  public DecisionDefinitionSort decisionDefinitionVersion() {
+    return field("decisionDefinitionVersion");
   }
 
   @Override
-  public DecisionDefinitionSort dmnDecisionRequirementsId() {
-    return field("dmnDecisionRequirementsId");
+  public DecisionDefinitionSort decisionRequirementsId() {
+    return field("decisionRequirementsId");
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/SearchDecisionDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/SearchDecisionDefinitionTest.java
@@ -41,12 +41,12 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
         .newDecisionDefinitionQuery()
         .filter(
             f ->
-                f.decisionKey(1L)
-                    .dmnDecisionId("ddi")
-                    .dmnDecisionName("ddm")
+                f.decisionDefinitionKey(1L)
+                    .decisionDefinitionId("ddi")
+                    .decisionDefinitionName("ddm")
                     .decisionRequirementsKey(2L)
-                    .dmnDecisionRequirementsId("ddri")
-                    .version(3)
+                    .decisionRequirementsId("ddri")
+                    .decisionDefinitionVersion(3)
                     .tenantId("t"))
         .send()
         .join();
@@ -70,17 +70,17 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
         .newDecisionDefinitionQuery()
         .sort(
             s ->
-                s.decisionKey()
+                s.decisionDefinitionKey()
                     .asc()
-                    .dmnDecisionId()
+                    .decisionDefinitionId()
                     .asc()
-                    .dmnDecisionName()
+                    .decisionDefinitionName()
                     .desc()
                     .decisionRequirementsKey()
                     .asc()
-                    .dmnDecisionRequirementsId()
+                    .decisionRequirementsId()
                     .asc()
-                    .version()
+                    .decisionDefinitionVersion()
                     .asc()
                     .tenantId()
                     .asc())
@@ -91,17 +91,17 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
     final DecisionDefinitionSearchQueryRequest request =
         gatewayService.getLastRequest(DecisionDefinitionSearchQueryRequest.class);
     assertThat(request.getSort().size()).isEqualTo(7);
-    assertThat(request.getSort().get(0).getField()).isEqualTo("decisionKey");
+    assertThat(request.getSort().get(0).getField()).isEqualTo("decisionDefinitionKey");
     assertThat(request.getSort().get(0).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(1).getField()).isEqualTo("dmnDecisionId");
+    assertThat(request.getSort().get(1).getField()).isEqualTo("decisionDefinitionId");
     assertThat(request.getSort().get(1).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(2).getField()).isEqualTo("dmnDecisionName");
+    assertThat(request.getSort().get(2).getField()).isEqualTo("decisionDefinitionName");
     assertThat(request.getSort().get(2).getOrder()).isEqualTo("desc");
     assertThat(request.getSort().get(3).getField()).isEqualTo("decisionRequirementsKey");
     assertThat(request.getSort().get(3).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(4).getField()).isEqualTo("dmnDecisionRequirementsId");
+    assertThat(request.getSort().get(4).getField()).isEqualTo("decisionRequirementsId");
     assertThat(request.getSort().get(4).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(5).getField()).isEqualTo("version");
+    assertThat(request.getSort().get(5).getField()).isEqualTo("decisionDefinitionVersion");
     assertThat(request.getSort().get(5).getOrder()).isEqualTo("asc");
     assertThat(request.getSort().get(6).getField()).isEqualTo("tenantId");
     assertThat(request.getSort().get(6).getOrder()).isEqualTo("asc");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -94,7 +94,11 @@ class DecisionQueryTest {
   void shouldRetrieveAllDecisionDefinitions() {
     // when
     final var result =
-        zeebeClient.newDecisionDefinitionQuery().sort(b -> b.decisionKey().asc()).send().join();
+        zeebeClient
+            .newDecisionDefinitionQuery()
+            .sort(b -> b.decisionDefinitionKey().asc())
+            .send()
+            .join();
 
     // then
     assertThat(result.items().size()).isEqualTo(3);
@@ -113,7 +117,7 @@ class DecisionQueryTest {
     final var result =
         zeebeClient
             .newDecisionDefinitionQuery()
-            .filter(f -> f.decisionKey(decisionKey))
+            .filter(f -> f.decisionDefinitionKey(decisionKey))
             .send()
             .join();
 
@@ -138,12 +142,12 @@ class DecisionQueryTest {
             .newDecisionDefinitionQuery()
             .filter(
                 f ->
-                    f.decisionKey(decisionKey)
-                        .dmnDecisionId(dmnDecisionId)
+                    f.decisionDefinitionKey(decisionKey)
+                        .decisionDefinitionId(dmnDecisionId)
                         .decisionRequirementsKey(decisionRequirementsKey)
-                        .dmnDecisionName(dmnDecisionName)
-                        .dmnDecisionRequirementsId(dmnDecisionRequirementsId)
-                        .version(version)
+                        .decisionDefinitionName(dmnDecisionName)
+                        .decisionRequirementsId(dmnDecisionRequirementsId)
+                        .decisionDefinitionVersion(version)
                         .tenantId(tenantId))
             .send()
             .join();
@@ -162,8 +166,8 @@ class DecisionQueryTest {
     final var result =
         zeebeClient
             .newDecisionDefinitionQuery()
-            .filter(f -> f.dmnDecisionId(dmnDecisionId))
-            .sort(s -> s.version().desc())
+            .filter(f -> f.decisionDefinitionId(dmnDecisionId))
+            .sort(s -> s.decisionDefinitionVersion().desc())
             .send()
             .join();
 

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -84,7 +84,9 @@ public final class DecisionDefinitionServices
 
   public DecisionDefinitionEntity getByKey(final long decisionKey) {
     final var result =
-        search(decisionDefinitionSearchQuery(q -> q.filter(f -> f.decisionKeys(decisionKey))));
+        search(
+            decisionDefinitionSearchQuery(
+                q -> q.filter(f -> f.decisionDefinitionKeys(decisionKey))));
     if (result.total() < 1) {
       throw new NotFoundException(
           "Decision Definition with decisionKey=%d not found".formatted(decisionKey));

--- a/service/src/main/java/io/camunda/service/search/filter/DecisionDefinitionFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/DecisionDefinitionFilter.java
@@ -16,72 +16,72 @@ import java.util.List;
 import java.util.Objects;
 
 public record DecisionDefinitionFilter(
-    List<Long> decisionKeys,
-    List<String> dmnDecisionIds,
-    List<String> dmnDecisionNames,
-    List<Integer> versions,
-    List<String> dmnDecisionRequirementsIds,
+    List<Long> decisionDefinitionKeys,
+    List<String> decisionDefinitionIds,
+    List<String> decisionDefinitionNames,
+    List<Integer> decisionDefinitionVersions,
+    List<String> decisionRequirementsIds,
     List<Long> decisionRequirementsKeys,
     List<String> tenantIds)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<DecisionDefinitionFilter> {
 
-    private List<Long> decisionKeys;
-    private List<String> dmnDecisionIds;
-    private List<String> dmnDecisionNames;
-    private List<Integer> versions;
-    private List<String> dmnDecisionRequirementsIds;
+    private List<Long> decisionDefinitionKeys;
+    private List<String> decisionDefinitionIds;
+    private List<String> decisionDefinitionNames;
+    private List<Integer> decisionDefinitionVersions;
+    private List<String> decisionRequirementsIds;
     private List<Long> decisionRequirementsKeys;
     private List<String> tenantIds;
 
-    public Builder decisionKeys(final List<Long> values) {
-      this.decisionKeys = addValuesToList(this.decisionKeys, values);
+    public Builder decisionDefinitionKeys(final List<Long> values) {
+      decisionDefinitionKeys = addValuesToList(decisionDefinitionKeys, values);
       return this;
     }
 
-    public Builder decisionKeys(final Long... values) {
-      return decisionKeys(collectValuesAsList(values));
+    public Builder decisionDefinitionKeys(final Long... values) {
+      return decisionDefinitionKeys(collectValuesAsList(values));
     }
 
-    public Builder dmnDecisionIds(final List<String> values) {
-      this.dmnDecisionIds = addValuesToList(this.dmnDecisionIds, values);
+    public Builder decisionDefinitionIds(final List<String> values) {
+      decisionDefinitionIds = addValuesToList(decisionDefinitionIds, values);
       return this;
     }
 
-    public Builder dmnDecisionIds(final String... values) {
-      return dmnDecisionIds(collectValuesAsList(values));
+    public Builder decisionDefinitionIds(final String... values) {
+      return decisionDefinitionIds(collectValuesAsList(values));
     }
 
-    public Builder dmnDecisionNames(final List<String> values) {
-      this.dmnDecisionNames = addValuesToList(this.dmnDecisionNames, values);
+    public Builder decisionDefinitionNames(final List<String> values) {
+      decisionDefinitionNames = addValuesToList(decisionDefinitionNames, values);
       return this;
     }
 
-    public Builder dmnDecisionNames(final String... values) {
-      return dmnDecisionNames(collectValuesAsList(values));
+    public Builder decisionDefinitionNames(final String... values) {
+      return decisionDefinitionNames(collectValuesAsList(values));
     }
 
-    public Builder versions(final List<Integer> values) {
-      this.versions = addValuesToList(this.versions, values);
+    public Builder decisionDefinitionVersions(final List<Integer> values) {
+      decisionDefinitionVersions = addValuesToList(decisionDefinitionVersions, values);
       return this;
     }
 
-    public Builder versions(final Integer... values) {
-      return versions(collectValuesAsList(values));
+    public Builder decisionDefinitionVersions(final Integer... values) {
+      return decisionDefinitionVersions(collectValuesAsList(values));
     }
 
-    public Builder dmnDecisionRequirementsIds(final List<String> values) {
-      this.dmnDecisionRequirementsIds = addValuesToList(this.dmnDecisionRequirementsIds, values);
+    public Builder decisionRequirementsIds(final List<String> values) {
+      decisionRequirementsIds = addValuesToList(decisionRequirementsIds, values);
       return this;
     }
 
-    public Builder dmnDecisionRequirementsIds(final String... values) {
-      return dmnDecisionRequirementsIds(collectValuesAsList(values));
+    public Builder decisionRequirementsIds(final String... values) {
+      return decisionRequirementsIds(collectValuesAsList(values));
     }
 
     public Builder decisionRequirementsKeys(final List<Long> values) {
-      this.decisionRequirementsKeys = addValuesToList(this.decisionRequirementsKeys, values);
+      decisionRequirementsKeys = addValuesToList(decisionRequirementsKeys, values);
       return this;
     }
 
@@ -90,7 +90,7 @@ public record DecisionDefinitionFilter(
     }
 
     public Builder tenantIds(final List<String> values) {
-      this.tenantIds = addValuesToList(this.tenantIds, values);
+      tenantIds = addValuesToList(tenantIds, values);
       return this;
     }
 
@@ -101,11 +101,11 @@ public record DecisionDefinitionFilter(
     @Override
     public DecisionDefinitionFilter build() {
       return new DecisionDefinitionFilter(
-          Objects.requireNonNullElse(decisionKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(dmnDecisionIds, Collections.emptyList()),
-          Objects.requireNonNullElse(dmnDecisionNames, Collections.emptyList()),
-          Objects.requireNonNullElse(versions, Collections.emptyList()),
-          Objects.requireNonNullElse(dmnDecisionRequirementsIds, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionDefinitionKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionDefinitionIds, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionDefinitionNames, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionDefinitionVersions, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionRequirementsIds, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }

--- a/service/src/main/java/io/camunda/service/search/sort/DecisionDefinitionSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/DecisionDefinitionSort.java
@@ -26,27 +26,27 @@ public record DecisionDefinitionSort(List<FieldSorting> orderings) implements So
   public static final class Builder extends SortOption.AbstractBuilder<Builder>
       implements ObjectBuilder<DecisionDefinitionSort> {
 
-    public Builder decisionKey() {
+    public Builder decisionDefinitionKey() {
       currentOrdering = new FieldSorting("key", null);
       return this;
     }
 
-    public Builder dmnDecisionId() {
+    public Builder decisionDefinitionId() {
       currentOrdering = new FieldSorting("decisionId", null);
       return this;
     }
 
-    public Builder dmnDecisionName() {
+    public Builder decisionDefinitionName() {
       currentOrdering = new FieldSorting("name", null);
       return this;
     }
 
-    public Builder version() {
+    public Builder decisionDefinitionVersion() {
       currentOrdering = new FieldSorting("version", null);
       return this;
     }
 
-    public Builder dmnDecisionRequirementsId() {
+    public Builder decisionRequirementsId() {
       currentOrdering = new FieldSorting("decisionRequirementsId", null);
       return this;
     }

--- a/service/src/main/java/io/camunda/service/transformers/filter/DecisionDefinitionFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/DecisionDefinitionFilterTransformer.java
@@ -21,12 +21,12 @@ public final class DecisionDefinitionFilterTransformer
 
   @Override
   public SearchQuery toSearchQuery(final DecisionDefinitionFilter filter) {
-    final var decisionKeysQuery = getDecisionKeysQuery(filter.decisionKeys());
-    final var decisionIdsQuery = getDmnDecisionIdsQuery(filter.dmnDecisionIds());
-    final var dmnDecisionNamesQuery = getDmnDecisionNamesQuery(filter.dmnDecisionNames());
-    final var versionsQuery = getVersionsQuery(filter.versions());
+    final var decisionKeysQuery = getDecisionKeysQuery(filter.decisionDefinitionKeys());
+    final var decisionIdsQuery = getDmnDecisionIdsQuery(filter.decisionDefinitionIds());
+    final var dmnDecisionNamesQuery = getDmnDecisionNamesQuery(filter.decisionDefinitionNames());
+    final var versionsQuery = getVersionsQuery(filter.decisionDefinitionVersions());
     final var decisionRequirementsIdsQuery =
-        getDmnDecisionRequirementsIdsQuery(filter.dmnDecisionRequirementsIds());
+        getDmnDecisionRequirementsIdsQuery(filter.decisionRequirementsIds());
     final var decisionRequirementsKeysQuery =
         getDecisionRequirementsKeysQuery(filter.decisionRequirementsKeys());
     final var tenantIdsQuery = getTenantIdsQuery(filter.tenantIds());
@@ -39,6 +39,11 @@ public final class DecisionDefinitionFilterTransformer
         decisionRequirementsIdsQuery,
         decisionRequirementsKeysQuery,
         tenantIdsQuery);
+  }
+
+  @Override
+  public List<String> toIndices(final DecisionDefinitionFilter filter) {
+    return List.of("operate-decision-8.3.0_alias");
   }
 
   private SearchQuery getDecisionKeysQuery(final List<Long> keys) {
@@ -68,10 +73,5 @@ public final class DecisionDefinitionFilterTransformer
 
   private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {
     return stringTerms("tenantId", tenantIds);
-  }
-
-  @Override
-  public List<String> toIndices(DecisionDefinitionFilter filter) {
-    return List.of("operate-decision-8.3.0_alias");
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/DecisionDefinitionFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/DecisionDefinitionFilterTest.java
@@ -54,7 +54,7 @@ public final class DecisionDefinitionFilterTest {
   public void shouldQueryByDecisionDefinitionKey() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.decisionKeys(123L));
+        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionKeys(123L));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 
@@ -78,7 +78,7 @@ public final class DecisionDefinitionFilterTest {
   public void shouldQueryByDecisionDefinitionName() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.dmnDecisionNames("foo"));
+        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionNames("foo"));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 
@@ -101,7 +101,8 @@ public final class DecisionDefinitionFilterTest {
   @Test
   public void shouldQueryByDecisionDefinitionVersion() {
     // given
-    final var decisionDefinitionFilter = FilterBuilders.decisionDefinition(f -> f.versions(2));
+    final var decisionDefinitionFilter =
+        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionVersions(2));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 
@@ -125,7 +126,7 @@ public final class DecisionDefinitionFilterTest {
   public void shouldQueryByDecisionId() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.dmnDecisionIds("foo"));
+        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionIds("foo"));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 
@@ -149,7 +150,7 @@ public final class DecisionDefinitionFilterTest {
   public void shouldQueryByDecisionRequirementsId() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.dmnDecisionRequirementsIds("567"));
+        FilterBuilders.decisionDefinition(f -> f.decisionRequirementsIds("567"));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 
@@ -219,7 +220,8 @@ public final class DecisionDefinitionFilterTest {
   public void shouldQueryByTenantIdAndDecisionDefinitionName() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.tenantIds("tenant").dmnDecisionNames("foo"));
+        FilterBuilders.decisionDefinition(
+            f -> f.tenantIds("tenant").decisionDefinitionNames("foo"));
     final var searchQuery =
         SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.filter(decisionDefinitionFilter));
 

--- a/service/src/test/java/io/camunda/service/query/sort/DecisionDefinitionSortTest.java
+++ b/service/src/test/java/io/camunda/service/query/sort/DecisionDefinitionSortTest.java
@@ -38,23 +38,23 @@ public class DecisionDefinitionSortTest {
 
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
-        new TestArguments("key", SortOrder.ASC, s -> s.decisionKey().asc()),
-        new TestArguments("decisionId", SortOrder.ASC, s -> s.dmnDecisionId().asc()),
-        new TestArguments("name", SortOrder.DESC, s -> s.dmnDecisionName().desc()),
+        new TestArguments("key", SortOrder.ASC, s -> s.decisionDefinitionKey().asc()),
+        new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionId().asc()),
+        new TestArguments("name", SortOrder.DESC, s -> s.decisionDefinitionName().desc()),
         new TestArguments(
-            "decisionRequirementsId", SortOrder.DESC, s -> s.dmnDecisionRequirementsId().desc()),
+            "decisionRequirementsId", SortOrder.DESC, s -> s.decisionRequirementsId().desc()),
         new TestArguments(
             "decisionRequirementsKey", SortOrder.DESC, s -> s.decisionRequirementsKey().desc()),
         new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
-        new TestArguments("version", SortOrder.ASC, s -> s.version().asc()));
+        new TestArguments("version", SortOrder.ASC, s -> s.decisionDefinitionVersion().asc()));
   }
 
   @ParameterizedTest
   @MethodSource("provideSortParameters")
   public void shouldSortByField(
-      String field,
-      SortOrder sortOrder,
-      Function<DecisionDefinitionSort.Builder, ObjectBuilder<DecisionDefinitionSort>> fn) {
+      final String field,
+      final SortOrder sortOrder,
+      final Function<DecisionDefinitionSort.Builder, ObjectBuilder<DecisionDefinitionSort>> fn) {
     // when
     services.search(SearchQueryBuilders.decisionDefinitionSearchQuery(q -> q.sort(fn)));
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -282,11 +282,11 @@ public final class SearchQueryRequestMapper {
     final var builder = FilterBuilders.decisionDefinition();
 
     if (filter != null) {
-      ofNullable(filter.getDecisionDefinitionKey()).ifPresent(builder::decisionKeys);
-      ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::dmnDecisionIds);
-      ofNullable(filter.getDecisionDefinitionName()).ifPresent(builder::dmnDecisionNames);
-      ofNullable(filter.getVersion()).ifPresent(builder::versions);
-      ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::dmnDecisionRequirementsIds);
+      ofNullable(filter.getDecisionDefinitionKey()).ifPresent(builder::decisionDefinitionKeys);
+      ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::decisionDefinitionIds);
+      ofNullable(filter.getDecisionDefinitionName()).ifPresent(builder::decisionDefinitionNames);
+      ofNullable(filter.getVersion()).ifPresent(builder::decisionDefinitionVersions);
+      ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::decisionRequirementsIds);
       ofNullable(filter.getDecisionRequirementsKey()).ifPresent(builder::decisionRequirementsKeys);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
     }
@@ -439,11 +439,11 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case "decisionKey" -> builder.decisionKey();
-        case "dmnDecisionId" -> builder.dmnDecisionId();
-        case "dmnDecisionName" -> builder.dmnDecisionName();
-        case "version" -> builder.version();
-        case "dmnDecisionRequirementsId" -> builder.dmnDecisionRequirementsId();
+        case "decisionDefinitionKey" -> builder.decisionDefinitionKey();
+        case "decisionDefinitionId" -> builder.decisionDefinitionId();
+        case "decisionDefinitionName" -> builder.decisionDefinitionName();
+        case "decisionDefinitionVersion" -> builder.decisionDefinitionVersion();
+        case "decisionRequirementsId" -> builder.decisionRequirementsId();
         case "decisionRequirementsKey" -> builder.decisionRequirementsKey();
         case "tenantId" -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -163,12 +163,12 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                 .filter(
                     new DecisionDefinitionFilter.Builder()
                         .tenantIds("t")
-                        .decisionKeys(0L)
-                        .dmnDecisionNames("name")
-                        .versions(1)
-                        .dmnDecisionRequirementsIds("drId")
+                        .decisionDefinitionKeys(0L)
+                        .decisionDefinitionNames("name")
+                        .decisionDefinitionVersions(1)
+                        .decisionRequirementsIds("drId")
                         .decisionRequirementsKeys(2L)
-                        .dmnDecisionIds("dId")
+                        .decisionDefinitionIds("dId")
                         .build())
                 .build());
   }
@@ -183,25 +183,25 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
         {
             "sort": [
                 {
-                    "field": "decisionKey",
+                    "field": "decisionDefinitionKey",
                     "order": "asc"
                 },
                 {
-                    "field": "dmnDecisionName",
+                    "field": "decisionDefinitionName",
                     "order": "desc"
                 },
                 {
-                    "field": "version",
+                    "field": "decisionDefinitionVersion",
                     "order": "asc"
                 },
                 {
-                     "field": "dmnDecisionId"
+                     "field": "decisionDefinitionId"
                 },
                 {
                      "field": "decisionRequirementsKey"
                 },
                 {
-                     "field": "dmnDecisionRequirementsId"
+                     "field": "decisionRequirementsId"
                 },
                 {
                      "field": "tenantId"
@@ -228,17 +228,17 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
             new DecisionDefinitionQuery.Builder()
                 .sort(
                     new DecisionDefinitionSort.Builder()
-                        .decisionKey()
+                        .decisionDefinitionKey()
                         .asc()
-                        .dmnDecisionName()
+                        .decisionDefinitionName()
                         .desc()
-                        .version()
+                        .decisionDefinitionVersion()
                         .asc()
-                        .dmnDecisionId()
+                        .decisionDefinitionId()
                         .asc()
                         .decisionRequirementsKey()
                         .asc()
-                        .dmnDecisionRequirementsId()
+                        .decisionRequirementsId()
                         .asc()
                         .tenantId()
                         .asc()


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Continuation of https://github.com/camunda/camunda/pull/22701

- renamed the Decision definition sort fields in the API
- renamed filter and sort fields in the client
- renamed methods and variables names in the service layer

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/22716
