### PR TITLE
[Backport release-8.6.0] Validate tenant id in REST process instance creation

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -488,10 +488,21 @@ public class RequestMapper {
   }
 
   public static Either<ProblemDetail, ProcessInstanceCreateRequest> toCreateProcessInstance(
-      final CreateProcessInstanceRequest request) {
-    return getResult(
-        validateCreateProcessInstanceRequest(request),
-        () ->
+      final CreateProcessInstanceRequest request, final boolean multiTenancyEnabled) {
+    final Either<ProblemDetail, String> validationResponse =
+        validateTenantId(request.getTenantId(), multiTenancyEnabled, "Create Process Instance")
+            .flatMap(
+                tenant ->
+                    validateAuthorization(tenant, multiTenancyEnabled, "Create Process Instance")
+                        .map(Either::<ProblemDetail, String>left)
+                        .orElseGet(() -> Either.right(tenant)))
+            .flatMap(
+                tenant ->
+                    validateCreateProcessInstanceRequest(request)
+                        .map(Either::<ProblemDetail, String>left)
+                        .orElseGet(() -> Either.right(tenant)));
+    return validationResponse.map(
+        tenantId ->
             new ProcessInstanceCreateRequest(
                 getLongOrDefault(
                     request, CreateProcessInstanceRequest::getProcessDefinitionKey, -1L),
@@ -499,7 +510,7 @@ public class RequestMapper {
                 getIntOrDefault(
                     request, CreateProcessInstanceRequest::getProcessDefinitionVersion, -1),
                 getMapOrEmpty(request, CreateProcessInstanceRequest::getVariables),
-                request.getTenantId(),
+                tenantId,
                 request.getAwaitCompletion(),
                 request.getRequestTimeout(),
                 request.getOperationReference(),

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -12,6 +12,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceCancelRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceCreateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
+import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.protocol.rest.CancelProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.CreateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceRequest;
@@ -33,10 +34,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class ProcessInstanceController {
 
   private final ProcessInstanceServices processInstanceServices;
+  private final MultiTenancyCfg multiTenancyCfg;
 
   @Autowired
-  public ProcessInstanceController(final ProcessInstanceServices processInstanceServices) {
+  public ProcessInstanceController(
+      final ProcessInstanceServices processInstanceServices,
+      final MultiTenancyCfg multiTenancyCfg) {
     this.processInstanceServices = processInstanceServices;
+    this.multiTenancyCfg = multiTenancyCfg;
   }
 
   @PostMapping(
@@ -44,7 +49,7 @@ public class ProcessInstanceController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createProcessInstance(
       @RequestBody final CreateProcessInstanceRequest request) {
-    return RequestMapper.toCreateProcessInstance(request)
+    return RequestMapper.toCreateProcessInstance(request, multiTenancyCfg.isEnabled())
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createProcessInstance);
   }
 


### PR DESCRIPTION
# Description
Backport of #22743 to `release-8.6.0`.

relates to #21055
original author: @tmetzke