### PR TITLE
Revert "ci: push optimize docker image to infosec registery"

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -42,7 +42,6 @@ jobs:
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize
-      DOCKER_INTERNAL_IMAGE_DOCKER_HUB: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
       DOCKER_LATEST_TAG: latest
     strategy:
       fail-fast: true
@@ -148,21 +147,6 @@ jobs:
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
-
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/271764561088/locations/global/workloadIdentityPools/github/providers/camunda'
-          service_account: 'github-actions-camunda@team-infosec.iam.gserviceaccount.com'
-
-      - name: Login to infosec registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        with:
-          registry: europe-west1-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
 
       - name: Checkout release branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -271,14 +255,12 @@ jobs:
           echo "Tagging optimize release docker image with version ${RELEASE_VERSION}"
           tags=("${DOCKER_IMAGE_TEAM}:${RELEASE_VERSION}")
           tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}")
-          tags+=("${DOCKER_INTERNAL_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}")
 
           # Major and minor versions are always tagged as the latest
           if [ "${MAJOR_OR_MINOR}" = true ] || [ "${DOCKER_LATEST}" = true ]; then
               echo "Tagging optimize release docker image with \`${DOCKER_LATEST_TAG}\`"
               tags+=("${DOCKER_IMAGE_TEAM}:${DOCKER_LATEST_TAG}")
               tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${DOCKER_LATEST_TAG}")
-              tags+=("${DOCKER_INTERNAL_IMAGE_DOCKER_HUB}:${DOCKER_LATEST_TAG}")
           fi
 
           printf -v tag_arguments -- "-t %s " "${tags[@]}"


### PR DESCRIPTION
This reverts commit c09aba4dc2b2872d8139df60d90f7e87ecd58adc.

## Description

We are reverting this commit after verifying that it was causing problems in the Optimize 8 release workflow, blocking this the build for other activities related to the release.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
