### PR TITLE
build: revert blocking changes previously applied to the optimize release workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -36,6 +36,9 @@ jobs:
   build:
     name: Execute Release
     runs-on: gcp-core-4-release
+    permissions:
+      contents: 'read'
+      id-token: 'write'
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize
@@ -193,8 +196,10 @@ jobs:
       - name: Remove tag for RC release
         if: env.IS_RC == 'true' || failure()
         run: |
-          git tag -d ${TAG}
-          git push origin :refs/tags/${TAG}
+          if [ $(git tag -l "$TAG") ]; then
+            git tag -d ${TAG}
+            git push origin :refs/tags/${TAG}
+          fi
 
       - name: Create a GitHub release
         if: ${{ env.IS_RC == 'false' && env.DRY_RUN == 'false' }}

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -37,12 +37,11 @@ jobs:
     name: Execute Release
     runs-on: gcp-core-4-release
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize
-      DOCKER_INTERNAL_IMAGE_DOCKER_HUB: europe-west1-docker.pkg.dev/team-infosec/camunda/optimize-8
       DOCKER_LATEST_TAG: latest
     strategy:
       fail-fast: true
@@ -149,21 +148,6 @@ jobs:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
 
-      - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v2'
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/271764561088/locations/global/workloadIdentityPools/github/providers/camunda'
-          service_account: 'github-actions-camunda@team-infosec.iam.gserviceaccount.com'
-
-      - name: Login to infosec registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
-        with:
-          registry: europe-west1-docker.pkg.dev
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-
       - name: Checkout release branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
         with:
@@ -212,10 +196,8 @@ jobs:
       - name: Remove tag for RC release
         if: env.IS_RC == 'true' || failure()
         run: |
-          if [ $(git tag -l "$TAG") ]; then
-            git tag -d ${TAG}
-            git push origin :refs/tags/${TAG}
-          fi
+          git tag -d ${TAG}
+          git push origin :refs/tags/${TAG}
 
       - name: Create a GitHub release
         if: ${{ env.IS_RC == 'false' && env.DRY_RUN == 'false' }}
@@ -271,14 +253,12 @@ jobs:
           echo "Tagging optimize release docker image with version ${RELEASE_VERSION}"
           tags=("${DOCKER_IMAGE_TEAM}:${RELEASE_VERSION}")
           tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}")
-          tags+=("${DOCKER_INTERNAL_IMAGE_DOCKER_HUB}:${RELEASE_VERSION}")
 
           # Major and minor versions are always tagged as the latest
           if [ "${MAJOR_OR_MINOR}" = true ] || [ "${DOCKER_LATEST}" = true ]; then
               echo "Tagging optimize release docker image with \`${DOCKER_LATEST_TAG}\`"
               tags+=("${DOCKER_IMAGE_TEAM}:${DOCKER_LATEST_TAG}")
               tags+=("${DOCKER_IMAGE_DOCKER_HUB}:${DOCKER_LATEST_TAG}")
-              tags+=("${DOCKER_INTERNAL_IMAGE_DOCKER_HUB}:${DOCKER_LATEST_TAG}")
           fi
 
           printf -v tag_arguments -- "-t %s " "${tags[@]}"

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -36,9 +36,6 @@ jobs:
   build:
     name: Execute Release
     runs-on: gcp-core-4-release
-    permissions:
-      contents: "read"
-      id-token: "write"
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize


### PR DESCRIPTION
## Description

This PR reconciles the Optimize 8 release workflow, in the 8.6.0 release branch, with the latest workflow pushed in `main`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
