### PR TITLE
Schema manager rolling update tests

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -898,6 +898,31 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
   @ExperimentalApi("https://github.com/camunda/camunda/issues/20596")
   DecisionInstanceQuery newDecisionInstanceQuery();
 
+  /**
+   * Executes a search request to query decision instances.
+   *
+   * <pre>
+   * long decisionInstanceKey = ...;
+   *
+   * zeebeClient
+   *  .newDecisionInstanceQuery()
+   *  .filter((f) -> f.decisionInstanceKey(decisionInstanceKey))
+   *  .sort((s) -> s.decisionInstanceKey().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. The respective API on compatible clusters is not
+   * enabled by default. Thus, this method doesn't work out of the box with all clusters. Until this
+   * warning is removed, anything described below may not yet have taken effect, and the interface
+   * and its description are subject to change.</strong>
+   *
+   * @return
+   */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/20596")
+  DecisionInstanceQuery newDecisionInstanceQuery();
+
   /*
    * Executes a search request to query decision definitions.
    *

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FormController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FormController.java
@@ -10,10 +10,14 @@ package io.camunda.zeebe.gateway.rest.controller;
 import static io.camunda.zeebe.gateway.rest.Loggers.REST_LOGGER;
 
 import io.camunda.service.FormServices;
+import io.camunda.service.exception.NotFoundException;
 import io.camunda.zeebe.gateway.protocol.rest.FormItem;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,6 +35,7 @@ public class FormController {
   public ResponseEntity<FormItem> getByKey(@PathVariable("formKey") final Long formKey) {
     try {
       return ResponseEntity.ok()
+          .contentType(new MediaType(MediaType.APPLICATION_JSON, StandardCharsets.UTF_8))
           .body(SearchQueryResponseMapper.toFormItem(formServices.getByKey(formKey)));
     } catch (final Exception exc) {
       REST_LOGGER.warn("An exception occurred in get Form by key.", exc);


### PR DESCRIPTION
## Description

Verify schema manager supports rolling updates for the following scenarios:

Scenario 1:

In an update one of the brokers will update with new schemas which will change the resources on ELS to match the new schemas, the other brokers will also eventually update and their schema updates will be idempotent as ELS is already in the state of the new schemas. This represents the normal scenario.

Scenario 2:

In a situation where a exporter has updated and the ELS resources have changed to reflect the new schemas, however there are still old exporters running, and one of these old exporter restarts (calling exporter.open which updates the schema). This will pass validation and no update requests are made to the ELS instance (as there are no new fields to add). Operation will continue as normal. This is the expected (and wanted) behaviour and no further action is needed.


## Related issues

closes #22758
