### PR TITLE
fix: remove base url property

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
@@ -15,8 +15,8 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
-import io.camunda.zeebe.spring.client.properties.common.ApiProperties;
 import io.camunda.zeebe.spring.client.properties.common.AuthProperties;
+import io.camunda.zeebe.spring.client.properties.common.IdentityProperties;
 import io.camunda.zeebe.spring.client.properties.common.ZeebeClientProperties;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -30,7 +30,7 @@ public class CamundaClientProperties {
   private String region;
   @NestedConfigurationProperty private List<String> tenantIds;
   @NestedConfigurationProperty private AuthProperties auth;
-  @NestedConfigurationProperty private ApiProperties identity;
+  @NestedConfigurationProperty private IdentityProperties identity;
   @NestedConfigurationProperty private ZeebeClientProperties zeebe;
 
   public ClientMode getMode() {
@@ -57,11 +57,11 @@ public class CamundaClientProperties {
     this.zeebe = zeebe;
   }
 
-  public ApiProperties getIdentity() {
+  public IdentityProperties getIdentity() {
     return identity;
   }
 
-  public void setIdentity(final ApiProperties identity) {
+  public void setIdentity(final IdentityProperties identity) {
     this.identity = identity;
   }
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -250,7 +250,7 @@ public class ZeebeClientConfigurationProperties {
    * @see ZeebeClientConfiguration#getGatewayAddress()
    */
   @Deprecated
-  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.base-url")
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
   public String getGatewayAddress() {
     if (connectionMode != null && !connectionMode.isEmpty()) {
       LOGGER.info("Using connection mode '{}' to connect to Zeebe", connectionMode);
@@ -406,7 +406,7 @@ public class ZeebeClientConfigurationProperties {
 
   @Deprecated
   @DeprecatedConfigurationProperty(
-      replacement = "camunda.client.zeebe.base-url",
+      replacement = "camunda.client.zeebe.grpc-address",
       reason = "plaintext is determined by the url protocol (http/https) now")
   public Boolean isPlaintextConnectionEnabled() {
     return security.isPlaintext();
@@ -522,7 +522,7 @@ public class ZeebeClientConfigurationProperties {
      * @see ZeebeClientConfiguration#getGatewayAddress()
      */
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.gateway-url")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
     public String getGatewayAddress() {
       return gatewayAddress;
     }
@@ -668,7 +668,7 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     @DeprecatedConfigurationProperty(
-        replacement = "camunda.client.zeebe.base-url",
+        replacement = "camunda.client.zeebe.grpc-address",
         reason = "The zeebe client url is now configured as http/https url")
     public String getBaseUrl() {
       return baseUrl;
@@ -690,7 +690,7 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     @DeprecatedConfigurationProperty(
-        replacement = "camunda.client.zeebe.base-url",
+        replacement = "camunda.client.zeebe.grpc-address",
         reason = "The zeebe client url is now configured as http/https url")
     public int getPort() {
       return port;
@@ -732,7 +732,7 @@ public class ZeebeClientConfigurationProperties {
      */
     @Deprecated
     @DeprecatedConfigurationProperty(
-        replacement = "camunda.client.zeebe.base-url",
+        replacement = "camunda.client.zeebe.grpc-address",
         reason = "The zeebe client url is now configured as http/https url")
     public String getGatewayAddress() {
       return String.format("%s.%s.%s:%d", clusterId, region, baseUrl, port);
@@ -1019,7 +1019,7 @@ public class ZeebeClientConfigurationProperties {
 
     @Deprecated
     @DeprecatedConfigurationProperty(
-        replacement = "camunda.client.zeebe.base-url",
+        replacement = "camunda.client.zeebe.grpc-address",
         reason = "plaintext is determined by the url protocol (http/https) now")
     public Boolean isPlaintext() {
       return plaintext;

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeSelfManagedProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeSelfManagedProperties.java
@@ -62,7 +62,7 @@ public class ZeebeSelfManagedProperties {
     return audience;
   }
 
-  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.base-url")
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
   @Deprecated
   public String getGatewayAddress() {
     return gatewayAddress;

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/IdentityProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/IdentityProperties.java
@@ -16,47 +16,17 @@
 package io.camunda.zeebe.spring.client.properties.common;
 
 import java.net.URL;
-import org.springframework.boot.context.properties.DeprecatedConfigurationProperty;
 
-public class ApiProperties {
-  private Boolean enabled;
-  @Deprecated private URL baseUrl;
+public class IdentityProperties extends ApiProperties {
+  private URL baseUrl;
 
-  private String audience;
-  private String scope;
-
-  public Boolean getEnabled() {
-    return enabled;
-  }
-
-  public void setEnabled(final Boolean enabled) {
-    this.enabled = enabled;
-  }
-
-  @Deprecated
-  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.restAddress")
+  @Override
   public URL getBaseUrl() {
     return baseUrl;
   }
 
-  @Deprecated
+  @Override
   public void setBaseUrl(final URL baseUrl) {
     this.baseUrl = baseUrl;
-  }
-
-  public String getAudience() {
-    return audience;
-  }
-
-  public void setAudience(final String audience) {
-    this.audience = audience;
-  }
-
-  public String getScope() {
-    return scope;
-  }
-
-  public void setScope(final String scope) {
-    this.scope = scope;
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-saas.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-saas.yaml
@@ -8,9 +8,9 @@ camunda:
     zeebe:
       enabled: true
       audience: zeebe.camunda.io
-      base-url: https://${camunda.client.region}.zeebe.camunda.io/${camunda.client.cluster-id}
       grpc-address: https://${camunda.client.cluster-id}.${camunda.client.region}.zeebe.camunda.io
       prefer-rest-over-grpc: false
+      rest-address: https://${camunda.client.region}.zeebe.camunda.io/${camunda.client.cluster-id}
     identity:
       enabled: false
 

--- a/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-self-managed.yaml
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/resources/application-camunda-self-managed.yaml
@@ -7,10 +7,10 @@ camunda:
       issuer: http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token
     zeebe:
       enabled: true
-      base-url: http://localhost:8086
       grpc-address: http://localhost:26500
       audience: zeebe-api
       prefer-rest-over-grpc: false
+      rest-address: http://localhost:8086
     identity:
       enabled: true
       base-url: http://localhost:8084

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSaasTest.java
@@ -37,7 +37,7 @@ public class ZeebeClientPropertiesSaasTest {
   void shouldPopulateBaseUrlsForSaas() {
     assertThat(properties.getZeebe().getGrpcAddress().toString())
         .isEqualTo("https://my-cluster-id.bru-2.zeebe.camunda.io");
-    assertThat(properties.getZeebe().getBaseUrl().toString())
+    assertThat(properties.getZeebe().getRestAddress().toString())
         .isEqualTo("https://bru-2.zeebe.camunda.io/my-cluster-id");
     assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientPropertiesSelfManagedTest.java
@@ -33,7 +33,8 @@ public class ZeebeClientPropertiesSelfManagedTest {
     assertThat(properties.getMode()).isEqualTo(ClientMode.selfManaged);
     assertThat(properties.getZeebe().getGrpcAddress().toString())
         .isEqualTo("http://localhost:26500");
-    assertThat(properties.getZeebe().getBaseUrl().toString()).isEqualTo("http://localhost:8086");
+    assertThat(properties.getZeebe().getRestAddress().toString())
+        .isEqualTo("http://localhost:8086");
     assertThat(properties.getZeebe().isPreferRestOverGrpc()).isEqualTo(false);
     assertThat(properties.getZeebe().getEnabled()).isEqualTo(true);
     assertThat(properties.getZeebe().getAudience()).isEqualTo("zeebe-api");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR deprecates the `baseUrl` property for the zeebeClientProperties so that `restAddress` and `grpcAddress` can be used instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
