### PR TITLE
ci: add content write permissions to optimize release workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -37,7 +37,7 @@ jobs:
     name: Execute Release
     runs-on: gcp-core-4-release
     permissions:
-      contents: 'read'
+      contents: 'write'
       id-token: 'write'
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize


### PR DESCRIPTION
## Description
Optimize release workflow is currently failing on the push changes stage with a permission denied error. This PR adds `content` write permission to see if that resolves the issue. See [docs](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
