### PR TITLE
build: use camunda release gh credentials in optimize release workflow

### DIFF
--- a/.github/workflows/optimize-create-release-branch.yml
+++ b/.github/workflows/optimize-create-release-branch.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Configure GitHub user
         run: |
-          git config --global user.name "optimize-release"
-          git config --global user.email "ci@optimize.camunda.cloud"
+          git config --global user.email "github-actions[release]"
+          git config --global user.name "github-actions[release]@users.noreply.github.com"
 
       - name: Create release branch
         run: |

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -156,8 +156,8 @@ jobs:
 
       - name: Configure GitHub user
         run: |
-          git config --global user.name "optimize-release"
-          git config --global user.email "ci@optimize.camunda.cloud"
+          git config --global user.email "github-actions[release]"
+          git config --global user.name "github-actions[release]@users.noreply.github.com"
 
       - name: Prepare release
         run: |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Optimize release workflows were using made up credentials in git config. That causes proclems with CLA and most likely with 403 errors when pushing release changes to release branch.

To make life easy I took the settings from `camunda-platform-release.yml` workflow

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
