### PR TITLE
[Backport stable/8.5] ci: use infra self-hosted runners for zeebe-snyk.yml workflow

### DIFF
--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -83,7 +83,7 @@ jobs:
   scan:
     name: Snyk Scan
     # Run on self-hosted to make building Zeebe much faster
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-8-default
     permissions:
       security-events: write # required to upload SARIF files
     steps:


### PR DESCRIPTION
# Description
Backport of #21979 to `stable/8.5`.

relates to 
original author: @clementnero