### PR TITLE
[Backport stable/8.5] ci: use infra self-hosted runners for zeebe-ci.yml/property-tests job

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -268,7 +268,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: gcp-perf-core-16-default
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -268,7 +268,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description
Backport of #22028 to `stable/8.5`.

relates to 
original author: @clementnero