### PR TITLE
[Backport stable/8.5] ci: use infra self-hosted runners (INFRA-671)

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -137,7 +137,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=120
+        -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
         EOF
     - name: Determine if running on GH infra or self-hosted

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -42,7 +42,7 @@ jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}"
     timeout-minutes: 45
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +53,7 @@ jobs:
             maven-modules: "'!zeebe/qa/integration-tests,!zeebe/qa/update-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
             tcc-enabled: 'false'
             tcc-concurrency: 1
           - group: qa-integration
@@ -60,6 +61,7 @@ jobs:
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-16-default
             tcc-enabled: ${{ vars.TCC_ENABLED }}
             tcc-concurrency: 1
           - group: qa-update
@@ -67,6 +69,7 @@ jobs:
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-8-default
             tcc-enabled: ${{ vars.TCC_ENABLED }}
             tcc-concurrency: 2
     env:
@@ -147,8 +150,51 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   unit-tests:
     name: Unit tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          go: false
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -T1C
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Maven Test Build
+        # we use the verify goal here as flaky test extraction is bound to the post-integration-test
+        # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
+        run: >
+          ./mvnw -T2 -B --no-snapshot-updates
+          -D skipITs -D skipChecks -D surefire.rerunFailingTestsCount=3
+          -D junitThreadCount=16
+          -P skip-random-tests,parallel-tests,extract-flaky-tests
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "unit tests"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+  # Zeebe tests requiring strace
+  strace-tests:
+    name: Strace Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install and allow strace tests
@@ -173,22 +219,15 @@ jobs:
         run: >
           ./mvnw -T2 -B --no-snapshot-updates
           -D skipITs -D skipChecks -D surefire.rerunFailingTestsCount=3
-          -D junitThreadCount=16
-          -P skip-random-tests,parallel-tests,extract-flaky-tests
+          -D junitThreadCount=2
+          -P include-strace-tests,extract-flaky-tests
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Normalize artifact name
-        run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
-      - name: Analyze Test Runs
-        if: always()
-        uses: ./.github/actions/analyze-test-runs
-        with:
-          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() }}
         with:
-          name: "unit tests"
+          name: Strace Tests
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -213,7 +252,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: gcp-perf-core-8-default
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64
@@ -315,7 +354,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1559,8 +1559,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.surefire}</version>
           <configuration>
-            <!-- by default, exclude performance tests -->
-            <groups>!performance</groups>
+            <!-- by default, exclude performance and strace tests -->
+            <excludedGroups>performance, strace</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -2098,6 +2098,24 @@
     </profile>
 
     <profile>
+      <!-- Dedicated profile to run ONLY tests requiring strace. -->
+      <id>include-strace-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <groups>strace</groups>
+              <!-- Reset <excludedGroups> as it take precedence over <groups> -->
+              <excludedGroups combine.self="override"></excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <!-- Dedicated profile to run ONLY performance tests. The include config overwrites the default pattern-->
       <id>include-performance-tests</id>
       <build>
@@ -2107,6 +2125,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <groups>performance</groups>
+              <!-- Reset <excludedGroups> as it take precedence over <groups> -->
+              <excludedGroups combine.self="override"></excludedGroups>
             </configuration>
           </plugin>
         </plugins>

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.test.util.STracer;
 import io.camunda.zeebe.test.util.STracer.Syscall;
 import io.camunda.zeebe.test.util.asserts.strace.FSyncTraceAssert;
 import io.camunda.zeebe.test.util.asserts.strace.STracerAssert;
+import io.camunda.zeebe.test.util.junit.StraceTest;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -30,7 +31,6 @@ import org.agrona.IoUtil;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.io.TempDir;
 
 public final class SnapshotChecksumTest {
@@ -134,8 +134,7 @@ public final class SnapshotChecksumTest {
    * This test is only enabled on CI as it relies on strace. You can run it manually directly if
    * your system supports strace. See {@link io.camunda.zeebe.test.util.STracer} for more.
    */
-  @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
-  @Test
+  @StraceTest
   void shouldFlushOnPersist() throws Exception {
     // given
     final var traceFile = temporaryFolder.resolve("traceFile");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/StraceTest.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/StraceTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Marker annotation indicating the following test requires strace to be installed on the machine.
+ * By default, such tests are run only in CI where we can guarantee strace is installed. Of course
+ * the test will also run when running it explicitly via your IDE or command line.
+ *
+ * @see io.camunda.zeebe.test.util.STracer
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Tag("strace")
+@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+@Test
+public @interface StraceTest {}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

Custom backport PR for:
- https://github.com/camunda/camunda/pull/22033
- https://github.com/camunda/camunda/pull/22450
- https://github.com/camunda/camunda/pull/22609
- https://github.com/camunda/camunda/pull/22807

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
