### PR TITLE
[Backport stable/8.3] ci: use infra self-hosted runners (INFRA-671)

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -137,7 +137,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
-        -D aether.syncContext.named.time=120
+        -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
         EOF
     - name: Determine if running on GH infra or self-hosted

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -30,7 +30,7 @@ jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}"
     timeout-minutes: 20
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -41,12 +41,14 @@ jobs:
             maven-modules: "'!qa/integration-tests,!qa/update-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
             tcc-enabled: 'false'
           - group: qa-integration
             name: "QA Integration Tests"
             maven-modules: "qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-16-default
             tcc-enabled: 'false'
             tcc-concurrency: 4
           - group: qa-update
@@ -54,6 +56,7 @@ jobs:
             maven-modules: "qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-8-default
             tcc-enabled: 'false'
             tcc-concurrency: 3
     env:
@@ -128,12 +131,10 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   unit-tests:
     name: Unit tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Install strace tests
-        run: sudo apt-get -qq update && sudo apt-get install -y strace
       - uses: ./.github/actions/setup-zeebe
         with:
           go: false
@@ -156,8 +157,6 @@ jobs:
           -P skip-random-tests,parallel-tests,extract-flaky-tests
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Normalize artifact name
-        run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Duplicate Test Check
         uses: ./.github/actions/check-duplicate-tests
         with:
@@ -191,7 +190,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: gcp-perf-core-8-default
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64
@@ -290,7 +289,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/671.

Custom backport PR for:
- https://github.com/camunda/camunda/pull/22033
- https://github.com/camunda/camunda/pull/22450
- https://github.com/camunda/camunda/pull/22609
- https://github.com/camunda/camunda/pull/22807

Strace-related tests are not executed on CI for `stable/8.3`, therefore no need to extract them into a separate job.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
