### PR TITLE
refactor: rename name and version fields for decision definition

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionDefinitionFilter.java
@@ -26,10 +26,10 @@ public interface DecisionDefinitionFilter extends SearchRequestFilter {
   DecisionDefinitionFilter decisionDefinitionId(final String value);
 
   /** Filter by dmn decision name. */
-  DecisionDefinitionFilter decisionDefinitionName(final String value);
+  DecisionDefinitionFilter name(final String value);
 
   /** Filter by version. */
-  DecisionDefinitionFilter decisionDefinitionVersion(final int value);
+  DecisionDefinitionFilter version(final int value);
 
   /** Filter by dmn decision requirements id. */
   DecisionDefinitionFilter decisionRequirementsId(final String value);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionDefinitionSort.java
@@ -26,10 +26,10 @@ public interface DecisionDefinitionSort extends SearchRequestSort<DecisionDefini
   DecisionDefinitionSort decisionDefinitionId();
 
   /** Sort by dmn decision name. */
-  DecisionDefinitionSort decisionDefinitionName();
+  DecisionDefinitionSort name();
 
   /** Sort by version. */
-  DecisionDefinitionSort decisionDefinitionVersion();
+  DecisionDefinitionSort version();
 
   /** Sort by dmn decision requirements id. */
   DecisionDefinitionSort decisionRequirementsId();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionDefinitionFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionDefinitionFilterImpl.java
@@ -42,13 +42,13 @@ public class DecisionDefinitionFilterImpl
   }
 
   @Override
-  public DecisionDefinitionFilter decisionDefinitionName(final String value) {
-    filter.setDecisionDefinitionName(value);
+  public DecisionDefinitionFilter name(final String value) {
+    filter.setName(value);
     return this;
   }
 
   @Override
-  public DecisionDefinitionFilter decisionDefinitionVersion(final int value) {
+  public DecisionDefinitionFilter version(final int value) {
     filter.setVersion(value);
     return this;
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/DecisionDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/DecisionDefinitionImpl.java
@@ -32,7 +32,7 @@ public final class DecisionDefinitionImpl implements DecisionDefinition {
   public DecisionDefinitionImpl(final DecisionDefinitionItem item) {
     this(
         item.getDecisionDefinitionId(),
-        item.getDecisionDefinitionName(),
+        item.getName(),
         item.getVersion(),
         item.getDecisionDefinitionKey(),
         item.getDecisionRequirementsId(),

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionDefinitionSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionDefinitionSortImpl.java
@@ -32,13 +32,13 @@ public class DecisionDefinitionSortImpl extends SearchQuerySortBase<DecisionDefi
   }
 
   @Override
-  public DecisionDefinitionSort decisionDefinitionName() {
-    return field("decisionDefinitionName");
+  public DecisionDefinitionSort name() {
+    return field("name");
   }
 
   @Override
-  public DecisionDefinitionSort decisionDefinitionVersion() {
-    return field("decisionDefinitionVersion");
+  public DecisionDefinitionSort version() {
+    return field("version");
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/SearchDecisionDefinitionTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/SearchDecisionDefinitionTest.java
@@ -43,10 +43,10 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
             f ->
                 f.decisionDefinitionKey(1L)
                     .decisionDefinitionId("ddi")
-                    .decisionDefinitionName("ddm")
+                    .name("ddm")
                     .decisionRequirementsKey(2L)
                     .decisionRequirementsId("ddri")
-                    .decisionDefinitionVersion(3)
+                    .version(3)
                     .tenantId("t"))
         .send()
         .join();
@@ -56,7 +56,7 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
         gatewayService.getLastRequest(DecisionDefinitionSearchQueryRequest.class);
     assertThat(request.getFilter().getDecisionDefinitionKey()).isEqualTo(1L);
     assertThat(request.getFilter().getDecisionDefinitionId()).isEqualTo("ddi");
-    assertThat(request.getFilter().getDecisionDefinitionName()).isEqualTo("ddm");
+    assertThat(request.getFilter().getName()).isEqualTo("ddm");
     assertThat(request.getFilter().getDecisionRequirementsKey()).isEqualTo(2L);
     assertThat(request.getFilter().getDecisionRequirementsId()).isEqualTo("ddri");
     assertThat(request.getFilter().getVersion()).isEqualTo(3);
@@ -74,13 +74,13 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
                     .asc()
                     .decisionDefinitionId()
                     .asc()
-                    .decisionDefinitionName()
+                    .name()
                     .desc()
                     .decisionRequirementsKey()
                     .asc()
                     .decisionRequirementsId()
                     .asc()
-                    .decisionDefinitionVersion()
+                    .version()
                     .asc()
                     .tenantId()
                     .asc())
@@ -95,13 +95,13 @@ public final class SearchDecisionDefinitionTest extends ClientRestTest {
     assertThat(request.getSort().get(0).getOrder()).isEqualTo("asc");
     assertThat(request.getSort().get(1).getField()).isEqualTo("decisionDefinitionId");
     assertThat(request.getSort().get(1).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(2).getField()).isEqualTo("decisionDefinitionName");
+    assertThat(request.getSort().get(2).getField()).isEqualTo("name");
     assertThat(request.getSort().get(2).getOrder()).isEqualTo("desc");
     assertThat(request.getSort().get(3).getField()).isEqualTo("decisionRequirementsKey");
     assertThat(request.getSort().get(3).getOrder()).isEqualTo("asc");
     assertThat(request.getSort().get(4).getField()).isEqualTo("decisionRequirementsId");
     assertThat(request.getSort().get(4).getOrder()).isEqualTo("asc");
-    assertThat(request.getSort().get(5).getField()).isEqualTo("decisionDefinitionVersion");
+    assertThat(request.getSort().get(5).getField()).isEqualTo("version");
     assertThat(request.getSort().get(5).getOrder()).isEqualTo("asc");
     assertThat(request.getSort().get(6).getField()).isEqualTo("tenantId");
     assertThat(request.getSort().get(6).getOrder()).isEqualTo("asc");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -145,9 +145,9 @@ class DecisionQueryTest {
                     f.decisionDefinitionKey(decisionKey)
                         .decisionDefinitionId(dmnDecisionId)
                         .decisionRequirementsKey(decisionRequirementsKey)
-                        .decisionDefinitionName(dmnDecisionName)
+                        .name(dmnDecisionName)
                         .decisionRequirementsId(dmnDecisionRequirementsId)
-                        .decisionDefinitionVersion(version)
+                        .version(version)
                         .tenantId(tenantId))
             .send()
             .join();
@@ -167,7 +167,7 @@ class DecisionQueryTest {
         zeebeClient
             .newDecisionDefinitionQuery()
             .filter(f -> f.decisionDefinitionId(dmnDecisionId))
-            .sort(s -> s.decisionDefinitionVersion().desc())
+            .sort(s -> s.version().desc())
             .send()
             .join();
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/transformers/filter/DecisionDefinitionFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/transformers/filter/DecisionDefinitionFilterTransformer.java
@@ -23,8 +23,8 @@ public final class DecisionDefinitionFilterTransformer
   public SearchQuery toSearchQuery(final DecisionDefinitionFilter filter) {
     final var decisionKeysQuery = getDecisionKeysQuery(filter.decisionDefinitionKeys());
     final var decisionIdsQuery = getDmnDecisionIdsQuery(filter.decisionDefinitionIds());
-    final var dmnDecisionNamesQuery = getDmnDecisionNamesQuery(filter.decisionDefinitionNames());
-    final var versionsQuery = getVersionsQuery(filter.decisionDefinitionVersions());
+    final var dmnDecisionNamesQuery = getDmnDecisionNamesQuery(filter.names());
+    final var versionsQuery = getVersionsQuery(filter.versions());
     final var decisionRequirementsIdsQuery =
         getDmnDecisionRequirementsIdsQuery(filter.decisionRequirementsIds());
     final var decisionRequirementsKeysQuery =

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/transformers/filter/DecisionDefinitionQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/transformers/filter/DecisionDefinitionQueryTransformerTest.java
@@ -38,8 +38,7 @@ public final class DecisionDefinitionQueryTransformerTest extends AbstractTransf
   @Test
   public void shouldQueryByDecisionDefinitionName() {
     // given
-    final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionNames("foo"));
+    final var decisionDefinitionFilter = FilterBuilders.decisionDefinition(f -> f.names("foo"));
 
     // when
     final var searchRequest = transformQuery(decisionDefinitionFilter);
@@ -58,8 +57,7 @@ public final class DecisionDefinitionQueryTransformerTest extends AbstractTransf
   @Test
   public void shouldQueryByDecisionDefinitionVersion() {
     // given
-    final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(f -> f.decisionDefinitionVersions(2));
+    final var decisionDefinitionFilter = FilterBuilders.decisionDefinition(f -> f.versions(2));
 
     // when
     final var searchRequest = transformQuery(decisionDefinitionFilter);
@@ -158,8 +156,7 @@ public final class DecisionDefinitionQueryTransformerTest extends AbstractTransf
   public void shouldQueryByTenantIdAndDecisionDefinitionName() {
     // given
     final var decisionDefinitionFilter =
-        FilterBuilders.decisionDefinition(
-            f -> f.tenantIds("tenant").decisionDefinitionNames("foo"));
+        FilterBuilders.decisionDefinition(f -> f.tenantIds("tenant").names("foo"));
 
     // when
     final var searchRequest = transformQuery(decisionDefinitionFilter);

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/transformers/sort/DecisionDefinitionSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/transformers/sort/DecisionDefinitionSortTest.java
@@ -26,13 +26,13 @@ public class DecisionDefinitionSortTest extends AbstractSortTransformerTest {
     return Stream.of(
         new TestArguments("key", SortOrder.ASC, s -> s.decisionDefinitionKey().asc()),
         new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionId().asc()),
-        new TestArguments("name", SortOrder.DESC, s -> s.decisionDefinitionName().desc()),
+        new TestArguments("name", SortOrder.DESC, s -> s.name().desc()),
         new TestArguments(
             "decisionRequirementsId", SortOrder.DESC, s -> s.decisionRequirementsId().desc()),
         new TestArguments(
             "decisionRequirementsKey", SortOrder.DESC, s -> s.decisionRequirementsKey().desc()),
         new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
-        new TestArguments("version", SortOrder.ASC, s -> s.decisionDefinitionVersion().asc()));
+        new TestArguments("version", SortOrder.ASC, s -> s.version().asc()));
   }
 
   @ParameterizedTest

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionDefinitionFilter.java
@@ -18,8 +18,8 @@ import java.util.Objects;
 public record DecisionDefinitionFilter(
     List<Long> decisionDefinitionKeys,
     List<String> decisionDefinitionIds,
-    List<String> decisionDefinitionNames,
-    List<Integer> decisionDefinitionVersions,
+    List<String> names,
+    List<Integer> versions,
     List<String> decisionRequirementsIds,
     List<Long> decisionRequirementsKeys,
     List<String> tenantIds)
@@ -29,8 +29,8 @@ public record DecisionDefinitionFilter(
 
     private List<Long> decisionDefinitionKeys;
     private List<String> decisionDefinitionIds;
-    private List<String> decisionDefinitionNames;
-    private List<Integer> decisionDefinitionVersions;
+    private List<String> names;
+    private List<Integer> versions;
     private List<String> decisionRequirementsIds;
     private List<Long> decisionRequirementsKeys;
     private List<String> tenantIds;
@@ -53,22 +53,22 @@ public record DecisionDefinitionFilter(
       return decisionDefinitionIds(collectValuesAsList(values));
     }
 
-    public Builder decisionDefinitionNames(final List<String> values) {
-      decisionDefinitionNames = addValuesToList(decisionDefinitionNames, values);
+    public Builder names(final List<String> values) {
+      names = addValuesToList(names, values);
       return this;
     }
 
-    public Builder decisionDefinitionNames(final String... values) {
-      return decisionDefinitionNames(collectValuesAsList(values));
+    public Builder names(final String... values) {
+      return names(collectValuesAsList(values));
     }
 
-    public Builder decisionDefinitionVersions(final List<Integer> values) {
-      decisionDefinitionVersions = addValuesToList(decisionDefinitionVersions, values);
+    public Builder versions(final List<Integer> values) {
+      versions = addValuesToList(versions, values);
       return this;
     }
 
-    public Builder decisionDefinitionVersions(final Integer... values) {
-      return decisionDefinitionVersions(collectValuesAsList(values));
+    public Builder versions(final Integer... values) {
+      return versions(collectValuesAsList(values));
     }
 
     public Builder decisionRequirementsIds(final List<String> values) {
@@ -103,8 +103,8 @@ public record DecisionDefinitionFilter(
       return new DecisionDefinitionFilter(
           Objects.requireNonNullElse(decisionDefinitionKeys, Collections.emptyList()),
           Objects.requireNonNullElse(decisionDefinitionIds, Collections.emptyList()),
-          Objects.requireNonNullElse(decisionDefinitionNames, Collections.emptyList()),
-          Objects.requireNonNullElse(decisionDefinitionVersions, Collections.emptyList()),
+          Objects.requireNonNullElse(names, Collections.emptyList()),
+          Objects.requireNonNullElse(versions, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsIds, Collections.emptyList()),
           Objects.requireNonNullElse(decisionRequirementsKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DecisionDefinitionSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DecisionDefinitionSort.java
@@ -36,12 +36,12 @@ public record DecisionDefinitionSort(List<FieldSorting> orderings) implements So
       return this;
     }
 
-    public Builder decisionDefinitionName() {
+    public Builder name() {
       currentOrdering = new FieldSorting("name", null);
       return this;
     }
 
-    public Builder decisionDefinitionVersion() {
+    public Builder version() {
       currentOrdering = new FieldSorting("version", null);
       return this;
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2687,7 +2687,7 @@ components:
         decisionDefinitionId:
           type: string
           description: The DMN id of the decision definition.
-        decisionDefinitionName:
+        name:
           type: string
           description: The DMN name of the decision definition.
         version:
@@ -2915,7 +2915,7 @@ components:
         decisionDefinitionId:
           type: string
           description: The DMN id of the decision definition.
-        decisionDefinitionName:
+        name:
           type: string
           description: The DMN name of the decision definition.
         version:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -318,8 +318,8 @@ public final class SearchQueryRequestMapper {
     if (filter != null) {
       ofNullable(filter.getDecisionDefinitionKey()).ifPresent(builder::decisionDefinitionKeys);
       ofNullable(filter.getDecisionDefinitionId()).ifPresent(builder::decisionDefinitionIds);
-      ofNullable(filter.getDecisionDefinitionName()).ifPresent(builder::decisionDefinitionNames);
-      ofNullable(filter.getVersion()).ifPresent(builder::decisionDefinitionVersions);
+      ofNullable(filter.getName()).ifPresent(builder::names);
+      ofNullable(filter.getVersion()).ifPresent(builder::versions);
       ofNullable(filter.getDecisionRequirementsId()).ifPresent(builder::decisionRequirementsIds);
       ofNullable(filter.getDecisionRequirementsKey()).ifPresent(builder::decisionRequirementsKeys);
       ofNullable(filter.getTenantId()).ifPresent(builder::tenantIds);
@@ -475,8 +475,8 @@ public final class SearchQueryRequestMapper {
       switch (field) {
         case "decisionDefinitionKey" -> builder.decisionDefinitionKey();
         case "decisionDefinitionId" -> builder.decisionDefinitionId();
-        case "decisionDefinitionName" -> builder.decisionDefinitionName();
-        case "decisionDefinitionVersion" -> builder.decisionDefinitionVersion();
+        case "name" -> builder.name();
+        case "version" -> builder.version();
         case "decisionRequirementsId" -> builder.decisionRequirementsId();
         case "decisionRequirementsKey" -> builder.decisionRequirementsKey();
         case "tenantId" -> builder.tenantId();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -253,7 +253,7 @@ public final class SearchQueryResponseMapper {
     return new DecisionDefinitionItem()
         .tenantId(d.tenantId())
         .decisionDefinitionKey(d.key())
-        .decisionDefinitionName(d.name())
+        .name(d.name())
         .version(d.version())
         .decisionDefinitionId(d.decisionId())
         .decisionRequirementsKey(d.decisionRequirementsKey())

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -43,7 +43,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                       "tenantId": "t",
                       "decisionDefinitionKey": 0,
                       "decisionDefinitionId": "dId",
-                      "decisionDefinitionName": "name",
+                      "name": "name",
                       "version": 1,
                       "decisionRequirementsId": "drId",
                       "decisionRequirementsKey": 2
@@ -132,7 +132,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "filter":{
                 "tenantId": "t",
                 "decisionDefinitionKey": 0,
-                "decisionDefinitionName": "name",
+                "name": "name",
                 "version": 1,
                 "decisionRequirementsId": "drId",
                 "decisionRequirementsKey": 2,
@@ -164,8 +164,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                     new DecisionDefinitionFilter.Builder()
                         .tenantIds("t")
                         .decisionDefinitionKeys(0L)
-                        .decisionDefinitionNames("name")
-                        .decisionDefinitionVersions(1)
+                        .names("name")
+                        .versions(1)
                         .decisionRequirementsIds("drId")
                         .decisionRequirementsKeys(2L)
                         .decisionDefinitionIds("dId")
@@ -187,11 +187,11 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                         "order": "asc"
                     },
                     {
-                        "field": "decisionDefinitionName",
+                        "field": "name",
                         "order": "desc"
                     },
                     {
-                        "field": "decisionDefinitionVersion",
+                        "field": "version",
                         "order": "asc"
                     },
                     {
@@ -230,9 +230,9 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
                     new DecisionDefinitionSort.Builder()
                         .decisionDefinitionKey()
                         .asc()
-                        .decisionDefinitionName()
+                        .name()
                         .desc()
-                        .decisionDefinitionVersion()
+                        .version()
                         .asc()
                         .decisionDefinitionId()
                         .asc()
@@ -409,7 +409,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               "tenantId": "t",
               "decisionDefinitionKey": 0,
               "decisionDefinitionId": "dId",
-              "decisionDefinitionName": "name",
+              "name": "name",
               "version": 1,
               "decisionRequirementsId": "drId",
               "decisionRequirementsKey": 2


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
According to the agreed [Naming conventions](https://docs.google.com/document/d/1rS989EESojWRrCMLH7Nscy1UppbgOanvzVeOljCc_iA/edit#heading=h.vy58f5kwk0b4):
```
Other attributes (other than key and id) of entities themselves should go without a prefix to avoid clutter, e.g. version in the process definition entity. In other resources, they have to be referenced with a prefix, e.g. processDefinitionVersion in the process instance entity.
```
For decision definition use:
* `name` instead of `decisionDefinitionName`
* `version` instead of `decisionDefinitionVersion`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/22716
