### PR TITLE
Schema json files now supports settings

### DIFF
--- a/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -5,6 +5,7 @@
 			"analysis": {
 				"normalizer": {
 					"case_insensitive": {
+            "type": "custom",
 						"filter": "lowercase"
 					}
 				}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -166,6 +166,35 @@ public class ElasticsearchEngineClientIT {
   }
 
   @Test
+  void shouldCreateIndexTemplateIfSourceFileContainsSettings() throws IOException {
+    final var template =
+        SchemaTestUtil.mockIndexTemplate(
+            "index_name",
+            "index_pattern.*",
+            "alias",
+            List.of(),
+            "template_name",
+            "mappings-and-settings.json");
+
+    elsEngineClient.createIndexTemplate(template, new IndexSettings(), true);
+
+    final var createdTemplate =
+        elsClient.indices().getIndexTemplate(req -> req.name("template_name")).indexTemplates();
+
+    assertThat(createdTemplate.size()).isEqualTo(1);
+    assertThat(
+            createdTemplate
+                .getFirst()
+                .indexTemplate()
+                .template()
+                .settings()
+                .index()
+                .refreshInterval()
+                .time())
+        .isEqualTo("2s");
+  }
+
+  @Test
   void shouldUpdateSettingsWithPutSettingsRequest() throws IOException {
     final var index =
         SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "mappings.json");

--- a/zeebe/exporters/camunda-exporter/src/test/resources/mappings-and-settings.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/mappings-and-settings.json
@@ -1,0 +1,18 @@
+{
+  "settings": {
+    "index": {
+      "refresh_interval": "2s"
+    }
+  },
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text"
+      },
+      "world": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

The json files which contain the contents for index templates now support a setting fields which will be reflected in the created index template. This does not conflict with the default replicas/shards settings for templates.

## Related issues

closes #22804 