### PR TITLE
Schema manager rolling update tests

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -141,7 +141,7 @@ public class CamundaExporter implements Exporter {
     if (configuration.elasticsearch.getRetention().isEnabled()) {
       searchEngineClient.putIndexLifeCyclePolicy(
           configuration.elasticsearch.getRetention().getPolicyName(),
-          configuration.elasticsearch.getRetention().getMininumAge());
+          configuration.elasticsearch.getRetention().getMinimumAge());
 
       final var lifecycleUpdate =
           Map.of(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -163,9 +163,7 @@ public class CamundaExporter implements Exporter {
 
   private Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexTemplates(
       final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
-    final var currentTemplates =
-        searchEngineClient.getMappings(
-            configuration.elasticsearch.getIndexPrefix() + "*", MappingSource.INDEX_TEMPLATE);
+    final var currentTemplates = searchEngineClient.getMappings("*", MappingSource.INDEX_TEMPLATE);
 
     return schemaValidator.validateIndexMappings(
         currentTemplates,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ElasticsearchProperties.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ElasticsearchProperties.java
@@ -98,7 +98,7 @@ public class ElasticsearchProperties {
 
   public static final class RetentionConfiguration {
     private boolean enabled = false;
-    private String mininumAge = "30d";
+    private String minimumAge = "30d";
     private String policyName;
 
     public boolean isEnabled() {
@@ -109,12 +109,12 @@ public class ElasticsearchProperties {
       this.enabled = enabled;
     }
 
-    public String getMininumAge() {
-      return mininumAge;
+    public String getMinimumAge() {
+      return minimumAge;
     }
 
-    public void setMininumAge(final String mininumAge) {
-      this.mininumAge = mininumAge;
+    public void setMinimumAge(final String minimumAge) {
+      this.minimumAge = minimumAge;
     }
 
     public String getPolicyName() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -44,10 +44,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @Override
   public void initialiseResources() {
     final var existingTemplateNames =
-        elasticsearchClient
-            .getMappings(
-                elasticsearchProperties.getIndexPrefix() + "*", MappingSource.INDEX_TEMPLATE)
-            .keySet();
+        elasticsearchClient.getMappings("*", MappingSource.INDEX_TEMPLATE).keySet();
     final var existingIndexNames =
         elasticsearchClient
             .getMappings(elasticsearchProperties.getIndexPrefix() + "*", MappingSource.INDEX)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -73,7 +73,7 @@ final class CamundaExporterIT {
   @BeforeAll
   public void beforeAll() {
     config.elasticsearch.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-    config.elasticsearch.setIndexPrefix("");
+    config.elasticsearch.setIndexPrefix("camunda-record");
     config.bulk.setSize(1); // force flushing on the first record
 
     testClient = new ElasticsearchConnector(config.elasticsearch.getConnect()).createClient();
@@ -101,7 +101,12 @@ final class CamundaExporterIT {
             "template_name",
             "mappings.json");
 
-    index = SchemaTestUtil.mockIndex("qualified_name", "alias", "index_name", "mappings.json");
+    index =
+        SchemaTestUtil.mockIndex(
+            config.elasticsearch.getIndexPrefix() + "qualified_name",
+            "alias",
+            "index_name",
+            "mappings.json");
   }
 
   private Context getContext() {


### PR DESCRIPTION
## Description

Verify schema manager supports rolling updates for the following scenarios:

Scenario 1:

In an update one of the brokers will update with new schemas which will change the resources on ELS to match the new schemas, the other brokers will also eventually update and their schema updates will be idempotent as ELS is already in the state of the new schemas. This represents the normal scenario.

Scenario 2:

In a situation where a exporter has updated and the ELS resources have changed to reflect the new schemas, however there are still old exporters running, and one of these old exporter restarts (calling exporter.open which updates the schema). This will pass validation and no update requests are made to the ELS instance (as there are no new fields to add). Operation will continue as normal. This is the expected (and wanted) behaviour and no further action is needed.


## Related issues

closes #22758
