### PR TITLE
fix: Ambiguous INCOMPLETE snapshot state

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
@@ -10,8 +10,8 @@ package io.camunda.operate.property;
 public class BackupProperties {
 
   private String repositoryName;
-
   private int snapshotTimeout = 0;
+  private Long incompleteCheckTimeoutInSeconds = 5 /* minutes */ * 60L;
 
   public String getRepositoryName() {
     return repositoryName;
@@ -29,5 +29,13 @@ public class BackupProperties {
   public BackupProperties setSnapshotTimeout(final int snapshotTimeout) {
     this.snapshotTimeout = snapshotTimeout;
     return this;
+  }
+
+  public Long getIncompleteCheckTimeoutInSeconds() {
+    return incompleteCheckTimeoutInSeconds;
+  }
+
+  public void setIncompleteCheckTimeoutInSeconds(final Long incompleteCheckTimeoutInSeconds) {
+    this.incompleteCheckTimeoutInSeconds = incompleteCheckTimeoutInSeconds;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -529,10 +529,11 @@ public class BackupControllerIT {
   @Test
   public void shouldReturnIncompleteState() throws IOException {
     final Long backupId = 2L;
-    // we have only 2 out of 3 snapshots
+    // we have only 2 out of 3 snapshots + timeout
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
             "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+    when(snapshotInfo1.startTime()).thenReturn(0L);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
             "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
@@ -711,17 +712,19 @@ public class BackupControllerIT {
             new Metadata().setBackupId(backupId1).setVersion("8.8.8").setPartNo(2).setPartCount(2),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
-    // we have only 2 out of 3 snapshots -> INCOMPLETE
+    // we have only 2 out of 3 snapshots + TIMEOUT -> INCOMPLETE
     final SnapshotInfo snapshotInfo21 =
         createSnapshotInfoMock(
             new Metadata().setBackupId(backupId2).setVersion("8.8.8").setPartNo(1).setPartCount(3),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
+    when(snapshotInfo21.startTime()).thenReturn(0L);
     final SnapshotInfo snapshotInfo22 =
         createSnapshotInfoMock(
             new Metadata().setBackupId(backupId2).setVersion("8.8.8").setPartNo(2).setPartCount(3),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
+    when(snapshotInfo22.startTime()).thenReturn(0L);
     // IN_PROGRESS
     final SnapshotInfo snapshotInfo31 =
         createSnapshotInfoMock(
@@ -820,7 +823,7 @@ public class BackupControllerIT {
   }
 
   private void assertBackupDetails(
-      List<SnapshotInfo> snapshotInfos, GetBackupStateResponseDto backupState) {
+      final List<SnapshotInfo> snapshotInfos, final GetBackupStateResponseDto backupState) {
     assertThat(backupState.getDetails()).hasSize(snapshotInfos.size());
     assertThat(backupState.getDetails())
         .extracting(GetBackupStateResponseDetailDto::getSnapshotName)
@@ -836,27 +839,32 @@ public class BackupControllerIT {
             snapshotInfos.stream().map(si -> si.startTime()).toArray(Long[]::new));
   }
 
-  private SnapshotInfo createSnapshotInfoMock(String name, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final String name, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(null, name, uuid, state, null);
   }
 
-  private SnapshotInfo createSnapshotInfoMock(Metadata metadata, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final Metadata metadata, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(metadata, null, uuid, state, null);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
-      String name, String uuid, SnapshotState state, List<SnapshotShardFailure> failures) {
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     return createSnapshotInfoMock(null, name, uuid, state, failures);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
-      Metadata metadata,
-      String name,
-      String uuid,
-      SnapshotState state,
-      List<SnapshotShardFailure> failures) {
+      final Metadata metadata,
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
     if (metadata != null) {
       when(snapshotInfo.snapshotId())

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
@@ -81,6 +81,7 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
         .setUuid((String) map.get("uuid"))
         .setState(SnapshotState.valueOf((String) map.get("state")))
         .setStartTimeInMillis((Long) map.get("start_time_in_millis"))
+        .setEndTimeInMillis((Long) map.get("end_time_in_millis"))
         .setMetadata(metadata)
         .setFailures(failures);
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/response/OpenSearchSnapshotInfo.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/response/OpenSearchSnapshotInfo.java
@@ -22,6 +22,8 @@ public class OpenSearchSnapshotInfo {
 
   private Long startTimeInMillis;
 
+  private Long endTimeInMillis;
+
   private Map<String, Object> metadata = Map.of();
 
   public String getSnapshot() {
@@ -69,6 +71,15 @@ public class OpenSearchSnapshotInfo {
     return this;
   }
 
+  public Long getEndTimeInMillis() {
+    return endTimeInMillis;
+  }
+
+  public OpenSearchSnapshotInfo setEndTimeInMillis(final Long endTimeInMillis) {
+    this.endTimeInMillis = endTimeInMillis;
+    return this;
+  }
+
   public Map<String, Object> getMetadata() {
     return metadata;
   }
@@ -76,6 +87,12 @@ public class OpenSearchSnapshotInfo {
   public OpenSearchSnapshotInfo setMetadata(final Map<String, Object> metadata) {
     this.metadata = metadata;
     return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        snapshot, uuid, state, failures, startTimeInMillis, endTimeInMillis, metadata);
   }
 
   @Override
@@ -92,12 +109,8 @@ public class OpenSearchSnapshotInfo {
         && Objects.equals(state, that.state)
         && Objects.equals(failures, that.failures)
         && Objects.equals(startTimeInMillis, that.startTimeInMillis)
+        && Objects.equals(endTimeInMillis, that.endTimeInMillis)
         && Objects.equals(metadata, that.metadata);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(snapshot, uuid, state, failures, startTimeInMillis, metadata);
   }
 
   @Override
@@ -116,6 +129,8 @@ public class OpenSearchSnapshotInfo {
         + failures
         + ", startTimeInMillis="
         + startTimeInMillis
+        + ", endTimeInMillis="
+        + endTimeInMillis
         + ", metadata="
         + metadata
         + '}';

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java
@@ -53,13 +53,13 @@ public class BackupService {
   private String[][] indexPatternsOrdered;
 
   public BackupService(
-      @Qualifier("backupThreadPoolExecutor") ThreadPoolTaskExecutor threadPoolTaskExecutor,
-      List<Prio1Backup> prio1BackupIndices,
-      List<Prio2Backup> prio2BackupTemplates,
-      List<Prio3Backup> prio3BackupTemplates,
-      List<Prio4Backup> prio4BackupIndices,
-      OperateProperties operateProperties,
-      BackupRepository repository) {
+      @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor,
+      final List<Prio1Backup> prio1BackupIndices,
+      final List<Prio2Backup> prio2BackupTemplates,
+      final List<Prio3Backup> prio3BackupTemplates,
+      final List<Prio4Backup> prio4BackupIndices,
+      final OperateProperties operateProperties,
+      final BackupRepository repository) {
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.prio1BackupIndices = prio1BackupIndices;
     this.prio2BackupTemplates = prio2BackupTemplates;
@@ -69,7 +69,7 @@ public class BackupService {
     this.operateProperties = operateProperties;
   }
 
-  public void deleteBackup(Long backupId) {
+  public void deleteBackup(final Long backupId) {
     repository.validateRepositoryExists(getRepositoryName());
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
@@ -86,12 +86,12 @@ public class BackupService {
     }
   }
 
-  public TakeBackupResponseDto takeBackup(TakeBackupRequestDto request) {
+  public TakeBackupResponseDto takeBackup(final TakeBackupRequestDto request) {
     repository.validateRepositoryExists(getRepositoryName());
     repository.validateNoDuplicateBackupId(getRepositoryName(), request.getBackupId());
     if (!requestsQueue.isEmpty()) {
       throw new InvalidRequestException("Another backup is running at the moment");
-    }
+    } // TODO remove duplicate
     synchronized (requestsQueue) {
       if (!requestsQueue.isEmpty()) {
         throw new InvalidRequestException("Another backup is running at the moment");
@@ -100,7 +100,7 @@ public class BackupService {
     }
   }
 
-  private TakeBackupResponseDto scheduleSnapshots(TakeBackupRequestDto request) {
+  private TakeBackupResponseDto scheduleSnapshots(final TakeBackupRequestDto request) {
     final String repositoryName = getRepositoryName();
     final int count = getIndexPatternsOrdered().length;
     final List<String> snapshotNames = new ArrayList<>();
@@ -186,7 +186,7 @@ public class BackupService {
     return operateProperties.getVersion().toLowerCase();
   }
 
-  public GetBackupStateResponseDto getBackupState(Long backupId) {
+  public GetBackupStateResponseDto getBackupState(final Long backupId) {
     return repository.getBackupState(getRepositoryName(), backupId);
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -61,8 +61,6 @@ import org.elasticsearch.snapshots.SnapshotShardFailure;
 import org.elasticsearch.transport.TransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -73,13 +71,18 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   private static final String REPOSITORY_MISSING_EXCEPTION_TYPE =
       "type=repository_missing_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
-  @Autowired private RestHighLevelClient esClient;
+  private final RestHighLevelClient esClient;
+  private final ObjectMapper objectMapper;
+  private final OperateProperties operateProperties;
 
-  @Autowired
-  @Qualifier("operateObjectMapper")
-  private ObjectMapper objectMapper;
-
-  @Autowired private OperateProperties operateProperties;
+  public ElasticsearchBackupRepository(
+      final RestHighLevelClient esClient,
+      final ObjectMapper objectMapper,
+      final OperateProperties operateProperties) {
+    this.esClient = esClient;
+    this.objectMapper = objectMapper;
+    this.operateProperties = operateProperties;
+  }
 
   @Override
   public void deleteSnapshot(final String repositoryName, final String snapshotName) {
@@ -157,8 +160,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   public GetBackupStateResponseDto getBackupState(
       final String repositoryName, final Long backupId) {
     final List<SnapshotInfo> snapshots = findSnapshots(repositoryName, backupId);
-    final GetBackupStateResponseDto response = getBackupResponse(backupId, snapshots);
-    return response;
+    return getBackupResponse(backupId, snapshots);
   }
 
   @Override
@@ -252,16 +254,17 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       @Override
       public void onResponse(final AcknowledgedResponse response) {
         LOGGER.debug(
-            "Delete snapshot was acknowledged by Elasticsearch node: " + response.isAcknowledged());
+            "Delete snapshot was acknowledged by Elasticsearch node: {}",
+            response.isAcknowledged());
       }
 
       @Override
       public void onFailure(final Exception e) {
         if (isSnapshotMissingException(e)) {
           // no snapshot with given backupID exists, this is fine, log warning
-          LOGGER.warn("No snapshot found for snapshot deletion: " + e.getMessage());
+          LOGGER.warn("No snapshot found for snapshot deletion: {} ", e.getMessage());
         } else {
-          LOGGER.error("Exception occurred while deleting the snapshot: " + e.getMessage(), e);
+          LOGGER.error("Exception occurred while deleting the snapshot: {}", e.getMessage(), e);
         }
       }
     };
@@ -379,15 +382,15 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         objectMapper.convertValue(snapshots.get(0).userMetadata(), Metadata.class);
     final Integer expectedSnapshotsCount = metadata.getPartCount();
     if (snapshots.size() == expectedSnapshotsCount
-        && snapshots.stream().map(SnapshotInfo::state).allMatch(s -> SUCCESS.equals(s))) {
+        && snapshots.stream().map(SnapshotInfo::state).allMatch(SUCCESS::equals)) {
       response.setState(BackupStateDto.COMPLETED);
     } else if (snapshots.stream()
         .map(SnapshotInfo::state)
         .anyMatch(s -> FAILED.equals(s) || PARTIAL.equals(s))) {
       response.setState(BackupStateDto.FAILED);
-    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(s -> INCOMPATIBLE.equals(s))) {
+    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(INCOMPATIBLE::equals)) {
       response.setState(BackupStateDto.INCOMPATIBLE);
-    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(s -> IN_PROGRESS.equals(s))) {
+    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(IN_PROGRESS::equals)) {
       response.setState(BackupStateDto.IN_PROGRESS);
     } else if (snapshots.size() < expectedSnapshotsCount) {
       response.setState(BackupStateDto.INCOMPLETE);
@@ -484,9 +487,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         }
       } else {
         LOGGER.error(
-            String.format(
-                "Exception while creating snapshot [%s] for backup id [%d].",
-                snapshotRequest.snapshotName(), backupId),
+            "Exception while creating snapshot [{}] for backup id [{}].",
+            snapshotRequest.snapshotName(),
+            backupId,
             ex);
         // No need to continue
         onFailure.run();

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -45,6 +45,7 @@ import java.util.stream.Collectors;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
+import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,6 +37,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,8 +53,7 @@ public class ElasticsearchBackupRepositoryTest {
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private OperateProperties operateProperties;
 
-  @InjectMocks
-  private ElasticsearchBackupRepository backupRepository = spy(new ElasticsearchBackupRepository());
+  @InjectMocks @Spy private ElasticsearchBackupRepository backupRepository;
 
   @Test
   public void testWaitingForSnapshotWithTimeout() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.webapp.elasticsearch.backup;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -20,16 +21,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.BackupProperties;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.webapp.backup.Metadata;
+import io.camunda.operate.webapp.management.dto.BackupStateDto;
+import java.io.IOException;
+import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.SnapshotClient;
+import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.snapshots.SnapshotState;
 import org.junit.jupiter.api.Test;
@@ -46,9 +55,14 @@ public class ElasticsearchBackupRepositoryTest {
   private final String repositoryName = "repo1";
   private final long backupId = 555;
   private final String snapshotName = "camunda_operate_" + backupId + "_8.6_part_1_of_6";
+
+  private final long incompleteCheckTimeoutLengthSeconds =
+      new BackupProperties().getIncompleteCheckTimeoutInSeconds();
+  private final long incompleteCheckTimeoutLength = incompleteCheckTimeoutLengthSeconds * 1000;
+
   @Mock private RestHighLevelClient esClient;
   @Mock private SnapshotClient snapshotClient;
-  @Mock private ObjectMapper objectMapper;
+  @Spy private ObjectMapper objectMapper = new ObjectMapper();
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private OperateProperties operateProperties;
@@ -129,5 +143,139 @@ public class ElasticsearchBackupRepositoryTest {
     }
 
     fail("Expected to continue waiting for snapshotting to finish.");
+  }
+
+  @Test
+  void shouldCreateRepository() {
+    assertThat(backupRepository).isNotNull();
+  }
+
+  @Test
+  void shouldReturnBackupStateCompleted() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up Snapshot details
+    final Map<String, Object> metadata =
+        objectMapper.convertValue(new Metadata().setPartCount(1), Map.class);
+    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = backupRepository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnBackupStateIncomplete() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    final var lastSnapshotInfo = mock(SnapshotInfo.class);
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up operate properties
+    when(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+        .thenReturn(incompleteCheckTimeoutLengthSeconds);
+    // Set up first Snapshot details
+    final Map<String, Object> metadata =
+        objectMapper.convertValue(new Metadata().setPartCount(3), Map.class);
+    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(firstSnapshotInfo.startTime()).thenReturn(23L);
+
+    // Set up last Snapshot details
+    when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(lastSnapshotInfo.endTime()).thenReturn(23L + 6 * 60 * 1_000);
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = backupRepository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+  }
+
+  @Test
+  void shouldReturnBackupStateIncompleteWhenLastSnapshotEndTimeIsTimedOut() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    final var lastSnapshotInfo = mock(SnapshotInfo.class);
+    final long now = Instant.now().toEpochMilli();
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up operate properties
+    when(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+        .thenReturn(incompleteCheckTimeoutLengthSeconds);
+    // Set up first Snapshot details
+    final Map<String, Object> metadata =
+        objectMapper.convertValue(new Metadata().setPartCount(3), Map.class);
+    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(firstSnapshotInfo.startTime()).thenReturn(now - 4_000);
+
+    // Set up last Snapshot details
+    when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(lastSnapshotInfo.startTime()).thenReturn(now - (incompleteCheckTimeoutLength + 4_000));
+    when(lastSnapshotInfo.endTime()).thenReturn(now - (incompleteCheckTimeoutLength + 2_000));
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = backupRepository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+  }
+
+  @Test
+  void shouldReturnBackupStateProgress() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var lastSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    final long now = Instant.now().toEpochMilli();
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up operate properties
+    when(operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds())
+        .thenReturn(incompleteCheckTimeoutLengthSeconds);
+    // Set up Snapshot details
+    final Map<String, Object> metadata =
+        objectMapper.convertValue(new Metadata().setPartCount(3), Map.class);
+    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshotId())
+        .thenReturn(new SnapshotId("first-snapshot-name", "uuid-first"));
+    when(lastSnapshotInfo.snapshotId())
+        .thenReturn(new SnapshotId("last-snapshot-name", "uuid-last"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(firstSnapshotInfo.startTime()).thenReturn(now - 4_000);
+    when(lastSnapshotInfo.startTime()).thenReturn(now - 200);
+    when(lastSnapshotInfo.endTime()).thenReturn(now - 5);
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = backupRepository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.opensearch.client.async.OpenSearchAsyncSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -53,11 +54,14 @@ class OpensearchBackupRepositoryTest {
 
   @Mock private ObjectMapper objectMapper;
 
+  @Mock private OperateProperties operateProperties;
+
   private OpensearchBackupRepository repository;
 
   @BeforeEach
   public void setUp() {
-    repository = new OpensearchBackupRepository(richOpenSearchClient, objectMapper);
+    repository =
+        new OpensearchBackupRepository(richOpenSearchClient, objectMapper, operateProperties);
   }
 
   private void mockAsynchronSnapshotOperations() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.BackupProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.opensearch.client.async.OpenSearchAsyncSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchSnapshotOperations;
@@ -28,7 +29,9 @@ import io.camunda.operate.webapp.backup.BackupService;
 import io.camunda.operate.webapp.backup.Metadata;
 import io.camunda.operate.webapp.management.dto.BackupStateDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -57,11 +60,15 @@ class OpensearchBackupRepositoryTest {
   @Mock private OperateProperties operateProperties;
 
   private OpensearchBackupRepository repository;
+  private final long incompleteCheckTimeoutLength =
+      new BackupProperties().getIncompleteCheckTimeoutInSeconds() * 1000;
+  private long now;
 
   @BeforeEach
   public void setUp() {
     repository =
         new OpensearchBackupRepository(richOpenSearchClient, objectMapper, operateProperties);
+    now = Instant.now().toEpochMilli();
   }
 
   private void mockAsynchronSnapshotOperations() {
@@ -193,7 +200,8 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void getBackupState() {
+  void getBackupStateShouldBeInProgress() {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
     mockSynchronSnapshotOperations();
     mockObjectMapperForMetadata(new Metadata().setPartCount(3));
 
@@ -204,7 +212,40 @@ class OpensearchBackupRepositoryTest {
                     new OpenSearchSnapshotInfo()
                         .setSnapshot("snapshot")
                         .setState(SnapshotState.SUCCESS)
-                        .setStartTimeInMillis(23L))));
+                        .setStartTimeInMillis(now - (incompleteCheckTimeoutLength / 2))
+                        .setEndTimeInMillis(now))));
+
+    final var response = repository.getBackupState("repo", 5L);
+
+    assertThat(response).isNotNull();
+    assertThat(response.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
+    assertThat(response.getBackupId()).isEqualTo(5L);
+    final var snapshotDetails = response.getDetails();
+    assertThat(snapshotDetails).hasSize(1);
+    final var snapshotDetail = snapshotDetails.get(0);
+    assertThat(snapshotDetail.getState()).isEqualTo(SnapshotState.SUCCESS.toString());
+    assertThat(snapshotDetail.getSnapshotName()).isEqualTo("snapshot");
+    assertThat(snapshotDetail.getFailures()).isNull();
+  }
+
+  @Test
+  void getBackupStateShouldBeIncompleteDueToTimeout() {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+
+    final long endtime = now - (incompleteCheckTimeoutLength * 2);
+
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(
+            new OpenSearchGetSnapshotResponse(
+                List.of(
+                    new OpenSearchSnapshotInfo()
+                        .setSnapshot("snapshot")
+                        .setState(SnapshotState.SUCCESS)
+                        .setStartTimeInMillis(endtime - 20)
+                        // end time was double the timeout from now
+                        .setEndTimeInMillis(endtime))));
 
     final var response = repository.getBackupState("repo", 5L);
 
@@ -215,7 +256,6 @@ class OpensearchBackupRepositoryTest {
     assertThat(snapshotDetails).hasSize(1);
     final var snapshotDetail = snapshotDetails.get(0);
     assertThat(snapshotDetail.getState()).isEqualTo(SnapshotState.SUCCESS.toString());
-    assertThat(snapshotDetail.getStartTime().toInstant().toEpochMilli()).isEqualTo(23L);
     assertThat(snapshotDetail.getSnapshotName()).isEqualTo("snapshot");
     assertThat(snapshotDetail.getFailures()).isNull();
   }
@@ -271,5 +311,104 @@ class OpensearchBackupRepositoryTest {
             () -> repository.validateNoDuplicateBackupId("repo", 42L));
     assertThat(exception.getMessage())
         .isEqualTo("A backup with ID [42] already exists. Found snapshots: [test]");
+  }
+
+  @Test
+  void shouldReturnBackupStateIncompleteWhenEndIsInTimeout() throws IOException {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+    final long timeoutTime = now - incompleteCheckTimeoutLength * 2;
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(timeoutTime - 50)
+            .setEndTimeInMillis(timeoutTime - 40);
+    final var lastSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(timeoutTime - 30)
+            .setEndTimeInMillis(timeoutTime - 20);
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(
+            new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo, lastSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+  }
+
+  @Test
+  void shouldReturnBackupStateInProgressWhenStartIsInTimeoutButEndIsNot() throws IOException {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(now - incompleteCheckTimeoutLength)
+            .setEndTimeInMillis(now - 20);
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedWhenSnapshotIsPartialCompleted() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(1));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.PARTIAL)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.FAILED);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedCompleted() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(2));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    final var lastSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(
+            new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo, lastSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedWhenSnapshotIsFailed() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(1));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.FAILED)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.FAILED);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added a timeout property for the maximal time it can take between two parts of a snapshot starting so that the INCOMPLETE state only occurs once the timeout has been exceeded.


PR of the original fix attempt: https://github.com/camunda/camunda/pull/18567

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/operate/issues/5191
