### PR TITLE
Do not build front end when building Zeebe Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ WORKDIR /zeebe
 ENV MAVEN_OPTS -XX:MaxRAMPercentage=80
 COPY --link . ./
 RUN --mount=type=cache,target=/root/.m2,rw \
-    ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests && \
+    ./mvnw -B -am -pl dist package -T1C -D skipChecks -D skipTests -D skipOptimize -P skipFrontendBuild && \
     mv dist/target/camunda-zeebe .
 
 ### Extract zeebe from distball ###


### PR DESCRIPTION
## Description

This PR speeds up

I quickly tested that it works:

```shell
docker build --target app -t "camunda/zeebe:current-test" --build-arg DIST="build" .
```