### PR TITLE
fix: fix wrong snapshot behavior on success 

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -15,8 +15,7 @@ import java.util.regex.Pattern;
 public class Metadata {
 
   public static final String SNAPSHOT_NAME_PREFIX = "camunda_operate_";
-  private static final String SNAPSHOT_NAME_PATTERN =
-      "{prefix}{version}_part_{index}_of_{count}";
+  private static final String SNAPSHOT_NAME_PATTERN = "{prefix}{version}_part_{index}_of_{count}";
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =
       Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/Metadata.java
@@ -16,7 +16,7 @@ public class Metadata {
 
   public static final String SNAPSHOT_NAME_PREFIX = "camunda_operate_";
   private static final String SNAPSHOT_NAME_PATTERN =
-      "{prefix}{version}_{prefix}{version}_part_{index}_of_{count}{index}_of_{count}";
+      "{prefix}{version}_part_{index}_of_{count}";
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =
       Pattern.compile(SNAPSHOT_NAME_PREFIX + "(\\d*)_.*");

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -342,7 +342,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
           LOGGER.info(String.format("Waiting for snapshot [%s] to finish.", snapshotName));
         }
       } else {
-        return handleSnapshotReceived(currentSnapshot);
+        return snapshotWentWell(currentSnapshot);
       }
     }
     LOGGER.error(
@@ -352,7 +352,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     return false;
   }
 
-  private boolean handleSnapshotReceived(final SnapshotInfo snapshotInfo) {
+  private boolean snapshotWentWell(final SnapshotInfo snapshotInfo) {
     if (snapshotInfo.state() == SUCCESS) {
       LOGGER.info("Snapshot done: " + snapshotInfo.snapshotId());
       return true;
@@ -460,7 +460,11 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
     @Override
     public void onResponse(final CreateSnapshotResponse response) {
-      handleSnapshotReceived(response.getSnapshotInfo());
+      if (snapshotWentWell(response.getSnapshotInfo())) {
+        onSuccess.run();
+      } else {
+        onFailure.run();
+      }
     }
 
     @Override


### PR DESCRIPTION
## Description

- fix the behavior when Create snapshot request returns with response (not with exception):
  - continue with the next snapshot when SUCCESS
  - stop taking backup when FAILED
- fix snapshot name for Operate backups.

closes https://github.com/camunda/camunda/issues/22861 and https://github.com/camunda/camunda/issues/22871