### PR TITLE
refactor: Remove reference to actor/scheduler in LogStream class

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -76,7 +76,6 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         .withLogName("logStream-" + context.getRaftPartition().name())
         .withPartitionId(context.getPartitionId())
         .withMaxFragmentSize(context.getMaxFragmentSize())
-        .withActorSchedulingService(context.getActorSchedulingService())
         .withClock(context.getStreamClock())
         .withRequestLimit(
             flowControlCfg.getRequest() != null

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -162,7 +162,6 @@ public final class TestStreams {
             .withLogStorage(logStorage)
             .withPartitionId(partitionId)
             .withClock(clock)
-            .withActorSchedulingService(actorScheduler)
             .build();
 
     logStreamConsumer.accept(logStream);

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -94,13 +94,6 @@
 
     <!-- Test dependencies -->
     <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-scheduler</artifactId>
-      <classifier>tests</classifier>
-      <type>test-jar</type>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
-import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import java.time.InstantSource;
 import java.util.Objects;
 
@@ -20,19 +19,11 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private static final int MINIMUM_FRAGMENT_SIZE = 4 * 1024;
   private int maxFragmentSize = 1024 * 1024 * 4;
   private int partitionId = -1;
-  private ActorSchedulingService actorSchedulingService;
   private LogStorage logStorage;
   private String logName;
   private InstantSource clock;
   private Limit requestLimit;
   private RateLimit writeRateLimit;
-
-  @Override
-  public LogStreamBuilder withActorSchedulingService(
-      final ActorSchedulingService actorSchedulingService) {
-    this.actorSchedulingService = actorSchedulingService;
-    return this;
-  }
 
   @Override
   public LogStreamBuilder withMaxFragmentSize(final int maxFragmentSize) {
@@ -85,7 +76,6 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   }
 
   private void validate() {
-    Objects.requireNonNull(actorSchedulingService, "Must specify a actor scheduler");
     Objects.requireNonNull(logStorage, "Must specify a log storage");
     Objects.requireNonNull(clock, "Must specify a clock source");
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -10,19 +10,10 @@ package io.camunda.zeebe.logstreams.log;
 import com.netflix.concurrency.limits.Limit;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
-import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import java.time.InstantSource;
 
 /** Builder pattern for the {@link LogStream} */
 public interface LogStreamBuilder {
-
-  /**
-   * The actor scheduler to use for the {@link LogStream} and its child actors
-   *
-   * @param actorSchedulingService the scheduler to use
-   * @return this builder
-   */
-  LogStreamBuilder withActorSchedulingService(ActorSchedulingService actorSchedulingService);
 
   /**
    * The maximum fragment size read from the shared write buffer; this should be aligned with the

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import org.agrona.DirectBuffer;
@@ -226,7 +227,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldWriteEventWithTimestampFromClock() {
     // given
-    logStreamRule.getClock().setCurrentTime(123456789L);
+    logStreamRule.getClock().delegate = () -> Instant.ofEpochMilli(123456789L);
     final long position = tryWrite(TestEntry.ofDefaults());
 
     // when

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -11,13 +11,14 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
-import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.junit.rules.ExternalResource;
 
 public final class LogStreamRule extends ExternalResource {
-  private final ControlledActorClock clock = new ControlledActorClock();
+  private final ControlledClock clock = new ControlledClock();
   private final boolean shouldStartByDefault;
 
   private final Consumer<LogStreamBuilder> streamBuilder;
@@ -116,7 +117,16 @@ public final class LogStreamRule extends ExternalResource {
     return logStream;
   }
 
-  public ControlledActorClock getClock() {
+  public ControlledClock getClock() {
     return clock;
+  }
+
+  public static final class ControlledClock implements InstantSource {
+    public InstantSource delegate;
+
+    @Override
+    public Instant instant() {
+      return delegate == null ? Instant.now() : delegate.instant();
+    }
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -11,9 +11,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
-import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
-import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import java.util.function.Consumer;
 import org.agrona.CloseHelper;
 import org.junit.rules.ExternalResource;
@@ -27,7 +25,6 @@ public final class LogStreamRule extends ExternalResource {
   private LogStreamReader logStreamReader;
   private LogStreamWriter logStreamWriter;
   private LogStreamBuilder builder;
-  private ActorSchedulerRule actorSchedulerRule;
   private ListLogStorage listLogStorage;
 
   private LogStreamRule(final boolean shouldStart, final Consumer<LogStreamBuilder> streamBuilder) {
@@ -45,9 +42,6 @@ public final class LogStreamRule extends ExternalResource {
 
   @Override
   protected void before() {
-    actorSchedulerRule = new ActorSchedulerRule(clock);
-    actorSchedulerRule.before();
-
     if (shouldStartByDefault) {
       createLogStream();
     }
@@ -56,20 +50,15 @@ public final class LogStreamRule extends ExternalResource {
   @Override
   protected void after() {
     stopLogStream();
-
-    actorSchedulerRule.after();
   }
 
   public void createLogStream() {
-    final ActorScheduler actorScheduler = actorSchedulerRule.get();
-
     if (listLogStorage == null) {
       listLogStorage = new ListLogStorage();
     }
 
     builder =
         LogStream.builder()
-            .withActorSchedulingService(actorScheduler)
             .withPartitionId(0)
             .withLogName("logStream-0")
             .withLogStorage(listLogStorage)
@@ -91,8 +80,7 @@ public final class LogStreamRule extends ExternalResource {
   }
 
   private void openLogStream() {
-    logStream =
-        SyncLogStream.builder(builder).withActorSchedulingService(actorSchedulerRule.get()).build();
+    logStream = SyncLogStream.builder(builder).build();
     listLogStorage.setPositionListener(logStream::setLastWrittenPosition);
   }
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
-import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import java.time.InstantSource;
 
 public final class SyncLogStreamBuilder implements LogStreamBuilder {
@@ -24,13 +23,6 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
 
   SyncLogStreamBuilder(final LogStreamBuilder delegate) {
     this.delegate = delegate;
-  }
-
-  @Override
-  public SyncLogStreamBuilder withActorSchedulingService(
-      final ActorSchedulingService actorSchedulingService) {
-    delegate.withActorSchedulingService(actorSchedulingService);
-    return this;
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
@@ -44,13 +44,10 @@ public final class ControlledActorClock implements ActorClock {
 
   public void setCurrentTime(final long currentTime) {
     this.currentTime = currentTime;
-    if (usesPointInTime()) {
-      update();
-    }
   }
 
   public void setCurrentTime(final Instant currentTime) {
-    setCurrentTime(currentTime.toEpochMilli());
+    this.currentTime = currentTime.toEpochMilli();
   }
 
   private boolean usesPointInTime() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
@@ -44,10 +44,13 @@ public final class ControlledActorClock implements ActorClock {
 
   public void setCurrentTime(final long currentTime) {
     this.currentTime = currentTime;
+    if (usesPointInTime()) {
+      update();
+    }
   }
 
   public void setCurrentTime(final Instant currentTime) {
-    this.currentTime = currentTime.toEpochMilli();
+    setCurrentTime(currentTime.toEpochMilli());
   }
 
   private boolean usesPointInTime() {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -161,7 +161,6 @@ public final class StreamPlatform {
             .withLogStorage(logStorage)
             .withClock(clock)
             .withPartitionId(partitionId)
-            .withActorSchedulingService(actorScheduler)
             .build();
 
     logStorage.setPositionListener(logStream::setLastWrittenPosition);


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
First part of https://github.com/camunda/camunda/issues/22832. Removed reference to ActorSchedulingService from LogStream & LogStreamBuilder.

ControlledActorClock is removed from class LogStreamRule.


## Related issues
related to #22832
