### PR TITLE
Opensearch BatchRequest should build batch operations and executes them

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
     <version.msgpack>0.9.8</version.msgpack>
     <version.netty>4.1.114.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
-    <version.opensearch>2.9.0</version.opensearch>
+    <version.opensearch>2.14.0</version.opensearch>
     <version.opensearch.testcontainers>2.1.0</version.opensearch.testcontainers>
     <version.prometheus>0.16.0</version.prometheus>
     <version.protobuf>3.25.5</version.protobuf>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -50,6 +50,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
     </dependency>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/OpensearchExporterException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/OpensearchExporterException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.exceptions;
+
+public class OpensearchExporterException extends RuntimeException {
+  public OpensearchExporterException(final String message) {
+    super(message);
+  }
+
+  public OpensearchExporterException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import io.camunda.exporter.exceptions.OpensearchExporterException;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.OpensearchScriptBuilder;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings("rawtypes")
+public class OpensearchBatchRequest implements BatchRequest {
+  public static final int UPDATE_RETRY_COUNT = 3;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchBatchRequest.class);
+  private final OpenSearchClient osClient;
+  private final BulkRequest.Builder bulkRequestBuilder;
+  private final OpensearchScriptBuilder scriptBuilder;
+
+  public OpensearchBatchRequest(
+      final OpenSearchClient osClient,
+      final BulkRequest.Builder bulkRequestBuilder,
+      final OpensearchScriptBuilder scriptBuilder) {
+    this.osClient = osClient;
+    this.bulkRequestBuilder = bulkRequestBuilder;
+    this.scriptBuilder = scriptBuilder;
+  }
+
+  @Override
+  public BatchRequest add(final String index, final ExporterEntity entity) {
+    return addWithId(index, entity.getId(), entity);
+  }
+
+  @Override
+  public BatchRequest addWithId(final String index, final String id, final ExporterEntity entity) {
+    LOGGER.debug("Add index request for index {} id {} and entity {} ", index, id, entity);
+    bulkRequestBuilder.operations(op -> op.index(idx -> idx.index(index).id(id).document(entity)));
+    return this;
+  }
+
+  @Override
+  public BatchRequest addWithRouting(
+      final String index, final ExporterEntity entity, final String routing) {
+    LOGGER.debug(
+        "Add index request with routing {} for index {} and entity {} ", routing, index, entity);
+    bulkRequestBuilder.operations(
+        op ->
+            op.index(idx -> idx.index(index).id(entity.getId()).document(entity).routing(routing)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest upsert(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final Map<String, Object> updateFields) {
+    return upsertWithRouting(index, id, entity, updateFields, null);
+  }
+
+  @Override
+  public BatchRequest upsertWithRouting(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final Map<String, Object> updateFields,
+      final String routing) {
+    LOGGER.debug(
+        "Add upsert request with routing {} for index {} id {} entity {} and update fields {}",
+        routing,
+        index,
+        id,
+        entity,
+        updateFields);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .upsert(entity)
+                        .document(updateFields)
+                        .routing(routing)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest upsertWithScript(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters) {
+    return upsertWithScriptAndRouting(index, id, entity, script, parameters, null);
+  }
+
+  @Override
+  public BatchRequest upsertWithScriptAndRouting(
+      final String index,
+      final String id,
+      final ExporterEntity entity,
+      final String script,
+      final Map<String, Object> parameters,
+      final String routing) {
+    LOGGER.debug(
+        "Add upsert request with routing {} for index {} id {} entity {} and script {} with parameters {} ",
+        routing,
+        index,
+        id,
+        entity,
+        script,
+        parameters);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .upsert(entity)
+                        .script(scriptBuilder.getScriptWithParameters(script, parameters))
+                        .routing(routing)
+                        .retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest update(
+      final String index, final String id, final Map<String, Object> updateFields) {
+    LOGGER.debug(
+        "Add update request for index {} id {} and update fields {}", index, id, updateFields);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .document(updateFields)
+                        .retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest update(final String index, final String id, final ExporterEntity entity) {
+    LOGGER.debug("Add update request for index {} id {} and entity {}", index, id, entity);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index).id(id).document(entity).retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
+  public BatchRequest updateWithScript(
+      final String index,
+      final String id,
+      final String script,
+      final Map<String, Object> parameters) {
+    LOGGER.debug(
+        "Add upsert request with for index {} id {} and script {} with parameters {} ",
+        index,
+        id,
+        script,
+        parameters);
+
+    bulkRequestBuilder.operations(
+        op ->
+            op.update(
+                upd ->
+                    upd.index(index)
+                        .id(id)
+                        .script(scriptBuilder.getScriptWithParameters(script, parameters))
+                        .retryOnConflict(UPDATE_RETRY_COUNT)));
+
+    return this;
+  }
+
+  @Override
+  public void execute() throws PersistenceException {
+    execute(false);
+  }
+
+  @Override
+  public void executeWithRefresh() throws PersistenceException {
+    execute(true);
+  }
+
+  private void execute(final boolean shouldRefresh) throws PersistenceException {
+    if (shouldRefresh) {
+      bulkRequestBuilder.refresh(Refresh.True);
+    }
+    final BulkRequest bulkRequest = bulkRequestBuilder.build();
+    processBulkRequest(bulkRequest);
+  }
+
+  private void processBulkRequest(final BulkRequest bulkRequest) throws PersistenceException {
+    if (bulkRequest.operations().isEmpty()) {
+      return;
+    }
+    try {
+      final BulkResponse bulkItemResponses = osClient.bulk(bulkRequest);
+      final List<BulkResponseItem> items = bulkItemResponses.items();
+      for (final BulkResponseItem responseItem : items) {
+        if (responseItem.error() != null) {
+          LOGGER.warn(
+              String.format(
+                  "%s failed for type [%s] and id [%s]: %s",
+                  responseItem.operationType(),
+                  responseItem.index(),
+                  responseItem.id(),
+                  responseItem.error().reason()),
+              "error on OpenSearch BulkRequest");
+          throw new PersistenceException(
+              "Operation failed: " + responseItem.error().reason(),
+              new OpensearchExporterException(responseItem.error().reason()),
+              Integer.valueOf(responseItem.id()));
+        }
+      }
+    } catch (final IOException | OpenSearchException ex) {
+      throw new PersistenceException(
+          "Error when processing bulk request against OpenSearch: " + ex.getMessage(), ex);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ElasticsearchScriptBuilder.java
@@ -11,12 +11,14 @@ import co.elastic.clients.elasticsearch._types.Script;
 import co.elastic.clients.json.JsonData;
 import jakarta.json.JsonValue;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ElasticsearchScriptBuilder {
   public static final String DEFAULT_SCRIPT_LANG = "painless";
 
   public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
+    Objects.requireNonNull(parameters, "Script Parameters must not be null");
     return new Script.Builder()
         .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
         .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.utils;
 
 import jakarta.json.JsonValue;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.Script;
@@ -17,6 +18,7 @@ public class OpensearchScriptBuilder {
   public static final String DEFAULT_SCRIPT_LANG = "painless";
 
   public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
+    Objects.requireNonNull(parameters, "Script Parameters must not be null");
     return new Script.Builder()
         .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
         .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/OpensearchScriptBuilder.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import jakarta.json.JsonValue;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.Script;
+
+public class OpensearchScriptBuilder {
+  public static final String DEFAULT_SCRIPT_LANG = "painless";
+
+  public Script getScriptWithParameters(final String script, final Map<String, Object> parameters) {
+    return new Script.Builder()
+        .inline(b -> b.source(script).params(jsonParams(parameters)).lang(DEFAULT_SCRIPT_LANG))
+        .build();
+  }
+
+  private Map<String, JsonData> jsonParams(final Map<String, Object> params) {
+    return params.entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> json(e.getValue())));
+  }
+
+  private <A> JsonData json(final A value) {
+    return JsonData.of(value == null ? JsonValue.NULL : value);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.exporter.entities.TestExporterEntity;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.utils.OpensearchScriptBuilder;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.ErrorCause;
+import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.Script;
+import org.opensearch.client.opensearch.core.BulkRequest;
+import org.opensearch.client.opensearch.core.BulkRequest.Builder;
+import org.opensearch.client.opensearch.core.BulkResponse;
+import org.opensearch.client.opensearch.core.bulk.BulkOperation;
+import org.opensearch.client.opensearch.core.bulk.BulkResponseItem;
+import org.opensearch.client.opensearch.core.bulk.IndexOperation;
+
+class OpensearchBatchRequestTest {
+
+  private static final String ID = "id";
+  private static final String INDEX = "index";
+  private OpensearchBatchRequest batchRequest;
+  private OpenSearchClient osClient;
+  private Builder requestBuilder;
+  private OpensearchScriptBuilder scriptBuilder;
+
+  @BeforeEach
+  void setUp() throws IOException {
+    osClient = mock(OpenSearchClient.class);
+    requestBuilder = new Builder();
+    scriptBuilder = mock(OpensearchScriptBuilder.class);
+    batchRequest = new OpensearchBatchRequest(osClient, requestBuilder, scriptBuilder);
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+  }
+
+  @Test
+  void shouldAddABulkOperationWithSpecifiedIndexAndEntity()
+      throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // When
+    batchRequest.add(INDEX, entity);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isIndex()).isTrue();
+    final IndexOperation<TestExporterEntity> index = bulkOperation.index();
+    assertThat(index.index()).isEqualTo(INDEX);
+    assertThat(index.id()).isEqualTo(ID);
+    assertThat(index.document()).isEqualTo(entity);
+  }
+
+  @Test
+  void shouldAddWithRouting() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String routing = "routing";
+
+    // When
+    batchRequest.addWithRouting(INDEX, entity, routing);
+
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isIndex()).isTrue();
+
+    final IndexOperation<TestExporterEntity> index = bulkOperation.index();
+    assertThat(index.index()).isEqualTo(INDEX);
+    assertThat(index.id()).isEqualTo(ID);
+    assertThat(index.routing()).isEqualTo(routing);
+    assertThat(index.document()).isEqualTo(entity);
+  }
+
+  @Test
+  void shouldUpsertEntityWithUpdatedFields() throws IOException, PersistenceException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final Map<String, Object> updateFields = Map.of("id", "id2");
+
+    // When
+    batchRequest.upsert(INDEX, ID, entity, updateFields);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpsertWithRouting() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final Map<String, Object> updateFields = Map.of("id", "id2");
+    final String routing = "routing";
+
+    // When
+    batchRequest.upsertWithRouting(INDEX, ID, entity, updateFields, routing);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.routing()).isEqualTo(routing);
+  }
+
+  @Test
+  void shouldUpsertWithScript() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScript(INDEX, ID, entity, script, params);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpsertWithScriptAndRouting() throws PersistenceException, IOException {
+    // given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+    final String routing = "routing";
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.upsertWithScriptAndRouting(INDEX, ID, entity, script, params, routing);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+    assertThat(update.routing()).isEqualTo(routing);
+  }
+
+  @Test
+  void shouldUpdateWithFields() throws PersistenceException, IOException {
+    final Map<String, Object> updateFields = Map.of("id", "id2");
+
+    // When
+    batchRequest.update(INDEX, ID, updateFields);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpdateWithEntity() throws IOException, PersistenceException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // When
+    batchRequest.update(INDEX, ID, entity);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldUpdateWithScript() throws PersistenceException, IOException {
+    // Given
+    final String script = "script";
+    final Map<String, Object> params = Map.of("id", "id2");
+
+    final Script scriptWithParameters = mock(Script.class);
+    when(scriptBuilder.getScriptWithParameters(script, params)).thenReturn(scriptWithParameters);
+
+    // When
+    batchRequest.updateWithScript(INDEX, ID, script, params);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isUpdate()).isTrue();
+
+    final var update = bulkOperation.update();
+    assertThat(update.index()).isEqualTo(INDEX);
+    assertThat(update.id()).isEqualTo(ID);
+  }
+
+  @Test
+  void shouldExecuteWithMultipleOperationsInBatch() throws PersistenceException, IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+    // When
+    batchRequest.add(INDEX, entity);
+    batchRequest.update(INDEX, ID, entity);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that there are two operations in the bulk request
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(2);
+  }
+
+  @Test
+  void shouldExecuteWithRefresh() throws PersistenceException, IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // When
+    batchRequest.add(INDEX, entity);
+    batchRequest.executeWithRefresh();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+    final BulkRequest request = captor.getValue();
+    assertThat(request.refresh()).isEqualTo(Refresh.True);
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {IOException.class, OpenSearchException.class})
+  void shouldThrowPersistenceExceptionIfBulkRequestFails(final Class<? extends Throwable> throwable)
+      throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // When
+    batchRequest.add(INDEX, entity);
+    when(osClient.bulk(any(BulkRequest.class))).thenThrow(throwable);
+
+    // When
+    final ThrowingCallable callable = () -> batchRequest.execute();
+
+    // Then
+    assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
+    verify(osClient).bulk(any(BulkRequest.class));
+  }
+
+  @Test
+  void shouldThrowPersistenceExceptionIfAResponseItemHasError() throws IOException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    final BulkResponseItem item = mock(BulkResponseItem.class);
+    when(item.id()).thenReturn("1");
+    when(item.error())
+        .thenReturn(new ErrorCause.Builder().type("string_error").reason("error").build());
+
+    final BulkResponse bulkResponse = mock(BulkResponse.class);
+    when(bulkResponse.items()).thenReturn(List.of(item));
+
+    when(osClient.bulk(any(BulkRequest.class))).thenReturn(bulkResponse);
+
+    // When
+    batchRequest.add(INDEX, entity);
+    final ThrowingCallable callable = () -> batchRequest.execute();
+
+    // Then
+    assertThatThrownBy(callable).isInstanceOf(PersistenceException.class);
+    verify(osClient).bulk(any(BulkRequest.class));
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -30,9 +30,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 final class OpensearchClientIT {
+  private static final String PASSWORD = "P@a$5w0rd";
+  private static final String ADMIN_PASSWORD_ENV_VAR = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
+
   @Container
-  private static final OpensearchContainer CONTAINER =
-      TestSupport.createDefaultContainer().withSecurityEnabled();
+  private static final OpensearchContainer<?> CONTAINER =
+      TestSupport.createDefaultContainer()
+          .withSecurityEnabled()
+          .withEnv(ADMIN_PASSWORD_ENV_VAR, PASSWORD);
 
   private static final int PARTITION_ID = 1;
 
@@ -51,7 +56,7 @@ final class OpensearchClientIT {
     config.index.prefix = UUID.randomUUID() + "-test-record";
     config.url = CONTAINER.getHttpHostAddress();
     config.getAuthentication().setUsername(CONTAINER.getUsername());
-    config.getAuthentication().setPassword(CONTAINER.getPassword());
+    config.getAuthentication().setPassword(PASSWORD);
     testClient = new TestClient(config, indexRouter);
     client =
         new OpensearchClient(

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -34,7 +34,7 @@ final class TestSupport {
    */
   static OpensearchContainer<?> createDefaultContainer() {
     return new OpensearchContainer<>(OPENSEARCH_IMAGE)
-        .withEnv("ES_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912")
+        .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912")
         .withEnv("action.auto_create_index", "true");
   }
 


### PR DESCRIPTION
## Description

Implemented BatchRequest for Opensearch.
Exporter handlers should use it to flush their entities into the Batch request, and the ExporterBatchWriter should use execute it to flush all batched requests

## Related issues

closes #21839
