### PR TITLE
fix: configure Keycloak to use file-based DB in Optimize dev setup

### DIFF
--- a/optimize/docker-compose.ccsm-with-optimize.yml
+++ b/optimize/docker-compose.ccsm-with-optimize.yml
@@ -71,7 +71,7 @@ services:
     environment:
       KEYCLOAK_ADMIN_USER: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-mem
+      KEYCLOAK_DATABASE_VENDOR: dev-file
       KEYCLOAK_HTTP_RELATIVE_PATH: /auth
       KEYCLOAK_ENABLE_HEALTH_ENDPOINTS: true
     healthcheck:

--- a/optimize/docker-compose.ccsm-without-optimize.yml
+++ b/optimize/docker-compose.ccsm-without-optimize.yml
@@ -54,7 +54,7 @@ services:
     environment:
       KEYCLOAK_ADMIN_USER: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KEYCLOAK_DATABASE_VENDOR: dev-mem
+      KEYCLOAK_DATABASE_VENDOR: dev-file
       KEYCLOAK_HTTP_RELATIVE_PATH: /auth
       KEYCLOAK_ENABLE_HEALTH_ENDPOINTS: true
     healthcheck:


### PR DESCRIPTION
## Description

This PR fixes a behavior that happens when launching Optimize with one of the docker container development setups. The issue is caused by Keycloak, as it appears to lose its database somehow, when configured to run in-memory.

To reproduce the issue, the following steps could be followed:
* launch the docker containers described by `docker-compose.ccsm-with-optimize.yml` with their current configuration
* wait for all of the applications to start
* visit the Optimize home page and login with the demo credentials
* leave the stack idle for some minutes (20 minutes should be fine)
* visit any page of Optimize, or refresh the current page

As a consequence of doing this, the erroneous behavior can be observed from within the web browser that had Optimize loaded, like this:

<img width="695" alt="image" src="https://github.com/user-attachments/assets/89032c59-535d-4541-bd6c-53019822e57b">

as well as within the logs of the Keycloak container, since they show an error like this:
https://pastebin.com/9ewgp7Gj

The same behavior has been observed by other users as well and has been also investigated by the Bitnami team here:
* https://github.com/bitnami/containers/issues/40909
* https://github.com/keycloak/keycloak/issues/13252

As this apparently happens only when using the in-memory adapter of the DB, the issue can be avoided by used the filesystem-based adapter of the same DB.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
