### PR TITLE
refactor: do not log error when Optimize waits for the DB

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClientFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClientFactory.java
@@ -66,11 +66,19 @@ public class OptimizeElasticsearchClientFactory {
       final TransportOptions requestOptions)
       throws IOException {
     boolean isConnected = false;
+    int connectionAttempts = 0;
     while (!isConnected) {
+      connectionAttempts++;
       try {
         isConnected = getNumberOfClusterNodes(esClient, requestOptions) > 0;
       } catch (final Exception e) {
-        log.error("Can't connect to any Elasticsearch node. Please check the connection!", e);
+        final String errorMessage =
+            "Can't connect to any Elasticsearch node. Please check the connection!";
+        if (connectionAttempts < 10) {
+          log.warn(errorMessage);
+        } else {
+          log.error(errorMessage, e);
+        }
       } finally {
         if (!isConnected) {
           final long sleepTime = backoffCalculator.calculateSleepTime();

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClientFactory.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/OptimizeOpenSearchClientFactory.java
@@ -59,14 +59,19 @@ public class OptimizeOpenSearchClientFactory {
       final OpenSearchClient osClient, final BackoffCalculator backoffCalculator)
       throws IOException {
     boolean isConnected = false;
+    int connectionAttempts = 0;
     while (!isConnected) {
+      connectionAttempts++;
       try {
         isConnected = getNumberOfClusterNodes(osClient) > 0;
       } catch (final Exception e) {
-        log.error(
-            "Can't connect to any OpenSearch node {}. Please check the connection!",
-            osClient.nodes(),
-            e);
+        final String errorMessage =
+            "Can't connect to any OpenSearch node {}. Please check the connection!";
+        if (connectionAttempts < 10) {
+          log.warn(errorMessage, osClient.nodes());
+        } else {
+          log.error(errorMessage, osClient.nodes(), e);
+        }
       } finally {
         if (!isConnected) {
           final long sleepTime = backoffCalculator.calculateSleepTime();


### PR DESCRIPTION
## Description

When Optimize starts, depending on the stack setup, it might need to wait for some time, before the database is ready. With the current code, we are logging these connection attempts as errors, together with the stack trace. Not only this is marking as error something that is expected to happen, but also this is causing a lot of unnecessary noise in the logs, like as follows:

![image](https://github.com/user-attachments/assets/19fb3aaf-4e0c-42b5-b67b-6a90149432a3)

This PR changes the code in a way that the logs are a bit more forgiving during the first 10 attempts of connection, resulting in a cleaner log as well as the error tag being removed in favor of the warning tag. Example of the new log as follows:

![image](https://github.com/user-attachments/assets/10b770a7-84b0-4dbb-a4a8-a8b8a3ede7cd)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
