### PR TITLE
Extended tests for camunda exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -133,6 +133,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.github.docker-java</groupId>
+      <artifactId>docker-java-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -49,18 +49,23 @@ public class CamundaExporterAuthenticationIT {
 
   @Test
   void shouldConnectToElasticsearchWithUsernameAndPassword() {
+    // given
     final var exporter = new CamundaExporter();
 
     final var context =
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
 
+    // when
     exporter.configure(context);
+
+    // then
     assertThatNoException().isThrownBy(() -> exporter.open(controller));
   }
 
   @Test
   void shouldFailToAuthenticateForWrongCredentials() {
+    // given
     final var exporter = new CamundaExporter();
     CONFIG.elasticsearch.getConnect().setPassword("123");
 
@@ -68,7 +73,10 @@ public class CamundaExporterAuthenticationIT {
         new ExporterTestContext()
             .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
 
+    // when
     exporter.configure(context);
+
+    // then
     assertThatThrownBy(() -> exporter.open(controller))
         .isInstanceOf(ElasticsearchException.class)
         .hasMessageContaining("unable to authenticate user");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import io.camunda.exporter.config.ElasticsearchExporterConfiguration;
+import io.camunda.exporter.utils.TestSupport;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class CamundaExporterAuthenticationIT {
+
+  private static final String ELASTIC_PASSWORD = "PASSWORD";
+  private static final ElasticsearchExporterConfiguration CONFIG =
+      new ElasticsearchExporterConfiguration();
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefaultContainer()
+          .withPassword(ELASTIC_PASSWORD)
+          .withEnv("xpack.security.enabled", "true");
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final ExporterTestController controller = new ExporterTestController();
+
+  @BeforeEach
+  void beforeEach() {
+    CONFIG.elasticsearch.getConnect().setUsername("elastic");
+    CONFIG.elasticsearch.getConnect().setPassword(ELASTIC_PASSWORD);
+    CONFIG.elasticsearch.getConnect().setUrl(CONTAINER.getHttpHostAddress());
+    CONFIG.elasticsearch.setCreateSchema(true);
+  }
+
+  @Test
+  void shouldConnectToElasticsearchWithUsernameAndPassword() {
+    final var exporter = new CamundaExporter();
+
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
+
+    exporter.configure(context);
+    assertThatNoException().isThrownBy(() -> exporter.open(controller));
+  }
+
+  @Test
+  void shouldFailToAuthenticateForWrongCredentials() {
+    final var exporter = new CamundaExporter();
+    CONFIG.elasticsearch.getConnect().setPassword("123");
+
+    final var context =
+        new ExporterTestContext()
+            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
+
+    exporter.configure(context);
+    assertThatThrownBy(() -> exporter.open(controller))
+        .isInstanceOf(ElasticsearchException.class)
+        .hasMessageContaining("unable to authenticate user");
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -194,6 +194,78 @@ final class CamundaExporterIT {
   }
 
   @Nested
+  class RollingUpdateTests {
+    @Test
+    void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws IOException {
+      // given
+      config.elasticsearch.setCreateSchema(true);
+
+      final var exporter1 = startExporter();
+      final var exporter2 = startExporter();
+
+      when(index.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
+      when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
+
+      // when
+      exporter1.open(controller);
+      exporter2.open(controller);
+
+      // then
+      final var indices = testClient.indices().get(req -> req.index("*"));
+      final var indexTemplates = testClient.indices().getIndexTemplate(req -> req.name("*"));
+
+      validateMappings(
+          indices.result().get(index.getFullQualifiedName()).mappings(),
+          "mappings-added-property.json");
+      validateMappings(
+          indexTemplates.indexTemplates().stream()
+              .filter(template -> template.name().equals(indexTemplate.getTemplateName()))
+              .findFirst()
+              .orElseThrow()
+              .indexTemplate()
+              .template()
+              .mappings(),
+          "mappings-added-property.json");
+    }
+
+    @Test
+    void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws IOException {
+      // given
+      config.elasticsearch.setCreateSchema(true);
+      final var updatedExporter = startExporter();
+      final var oldExporter = startExporter();
+
+      // when
+      when(index.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
+      when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
+
+      updatedExporter.open(controller);
+
+      when(index.getMappingsClasspathFilename()).thenReturn("mappings.json");
+      when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings.json");
+
+      oldExporter.open(controller);
+
+      // then
+      final var indices = testClient.indices().get(req -> req.index("*"));
+      final var indexTemplates = testClient.indices().getIndexTemplate(req -> req.name("*"));
+
+      validateMappings(
+          indices.result().get(index.getFullQualifiedName()).mappings(),
+          "mappings-added-property.json");
+      validateMappings(
+          indexTemplates.indexTemplates().stream()
+              .filter(template -> template.name().equals(indexTemplate.getTemplateName()))
+              .findFirst()
+              .orElseThrow()
+              .indexTemplate()
+              .template()
+              .mappings(),
+          "mappings-added-property.json");
+    }
+  }
+
+  @Nested
   class SchemaTests {
     @Test
     void shouldCreateAllSchemasIfCreateEnabled() throws IOException {
@@ -451,74 +523,5 @@ final class CamundaExporterIT {
               .toList();
       assertThat(documents).hasSize(1);
     }
-  }
-
-  @Test
-  void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws IOException {
-    // given
-    config.elasticsearch.setCreateSchema(true);
-
-    final var exporter1 = startExporter();
-    final var exporter2 = startExporter();
-
-    when(index.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
-
-    // when
-    exporter1.open(controller);
-    exporter2.open(controller);
-
-    // then
-    final var indices = testClient.indices().get(req -> req.index("*"));
-    final var indexTemplates = testClient.indices().getIndexTemplate(req -> req.name("*"));
-
-    validateMappings(
-        indices.result().get(index.getFullQualifiedName()).mappings(),
-        "mappings-added-property.json");
-    validateMappings(
-        indexTemplates.indexTemplates().stream()
-            .filter(template -> template.name().equals(indexTemplate.getTemplateName()))
-            .findFirst()
-            .orElseThrow()
-            .indexTemplate()
-            .template()
-            .mappings(),
-        "mappings-added-property.json");
-  }
-
-  @Test
-  void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws IOException {
-    // given
-    config.elasticsearch.setCreateSchema(true);
-    final var updatedExporter = startExporter();
-    final var oldExporter = startExporter();
-
-    // when
-    when(index.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings-added-property.json");
-
-    updatedExporter.open(controller);
-
-    when(index.getMappingsClasspathFilename()).thenReturn("mappings.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("mappings.json");
-
-    oldExporter.open(controller);
-
-    // then
-    final var indices = testClient.indices().get(req -> req.index("*"));
-    final var indexTemplates = testClient.indices().getIndexTemplate(req -> req.name("*"));
-
-    validateMappings(
-        indices.result().get(index.getFullQualifiedName()).mappings(),
-        "mappings-added-property.json");
-    validateMappings(
-        indexTemplates.indexTemplates().stream()
-            .filter(template -> template.name().equals(indexTemplate.getTemplateName()))
-            .findFirst()
-            .orElseThrow()
-            .indexTemplate()
-            .template()
-            .mappings(),
-        "mappings-added-property.json");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.exporter.utils;
 
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.PortBinding;
+import com.github.dockerjava.api.model.Ports;
 import java.time.Duration;
 import org.elasticsearch.client.RestClient;
 import org.testcontainers.containers.BindMode;
@@ -42,6 +46,14 @@ public final class TestSupport {
         .withEnv("xpack.security.enabled", "false")
         .withEnv("xpack.watcher.enabled", "false")
         .withEnv("xpack.ml.enabled", "false")
+        .withEnv("discovery.type", "single-node")
+        .withExposedPorts(9200)
+        .withCreateContainerCmdModifier(
+            cmd ->
+                cmd.withHostConfig(
+                    new HostConfig()
+                        .withPortBindings(
+                            new PortBinding(Ports.Binding.bindPort(50000), new ExposedPort(9200)))))
         .withEnv("action.destructive_requires_name", "false");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.exporter.utils;
 
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.PortBinding;
-import com.github.dockerjava.api.model.Ports;
 import java.time.Duration;
 import org.elasticsearch.client.RestClient;
 import org.testcontainers.containers.BindMode;
@@ -46,14 +42,6 @@ public final class TestSupport {
         .withEnv("xpack.security.enabled", "false")
         .withEnv("xpack.watcher.enabled", "false")
         .withEnv("xpack.ml.enabled", "false")
-        .withEnv("discovery.type", "single-node")
-        .withExposedPorts(9200)
-        .withCreateContainerCmdModifier(
-            cmd ->
-                cmd.withHostConfig(
-                    new HostConfig()
-                        .withPortBindings(
-                            new PortBinding(Ports.Binding.bindPort(50000), new ExposedPort(9200)))))
         .withEnv("action.destructive_requires_name", "false");
   }
 }


### PR DESCRIPTION
## Description
Also refactored camunda tests into nested blocks for a logical grouping
ElasticSearch
 - [x] Verify that basic authentication using configured username + password works
 - [x] Verify that record is exported when elastic is not initially reachable, but is reachable later.
 
General exporter behavior
 - [x] Verify periodic flush based on the configuration
 - [x] Verify exporter position is updated after flushing

## Related issues

closes #22854
