### PR TITLE
ci: revert and use zeebe runners for zeebe-related jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15
-    runs-on: gcp-perf-core-8-default
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -139,7 +139,7 @@ jobs:
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
-    runs-on: gcp-perf-core-16-default
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -203,25 +203,25 @@ jobs:
             maven-modules: "'qa/integration-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-perf-core-8-default
+            runs-on: [ self-hosted, linux, amd64, "16" ]
           - group: modules
             name: "Zeebe Module Integration Tests"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-perf-core-8-default
+            runs-on: [ self-hosted, linux, amd64, "16" ]
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            runs-on: gcp-perf-core-16-default
+            runs-on: [ self-hosted, linux, amd64, "16" ]
           - group: qa-update
             name: "Zeebe QA - Update Tests"
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            runs-on: gcp-perf-core-8-default
+            runs-on: [ self-hosted, linux, amd64, "16" ]
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 25
+    timeout-minutes: 35
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
     name: Java checks
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: [ self-hosted, linux, amd64, "16" ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -29,7 +29,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: gcp-perf-core-8-default
+            runner: [ self-hosted, linux, amd64, "16" ]
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64
@@ -83,7 +83,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: gcp-perf-core-8-default
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: gcp-perf-core-16-default
+    runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Related to https://camunda.slack.com/archives/C071KP5BTHB/p1727859215630489 and compilation failures observed on Infra Self-Hosted runners.

This PRs reverts and uses Zeebe runners for the jobs affected by the compilation failure, as it seems to temporarily fix the issue (root cause is not clear yet).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
