### PR TITLE
ci: add 8.6 stable release dry run

### DIFF
--- a/.github/workflows/dispatch-release-8-7.yaml
+++ b/.github/workflows/dispatch-release-8-7.yaml
@@ -1,0 +1,83 @@
+# This workflow builds the release, triggered by our engineering process automation cluster. It creates the release based on the
+# given input.
+#
+name: Repo dispatch Release 8.7
+
+on:
+  repository_dispatch:
+    types: [ trigger_release_8_7 ]
+
+jobs:
+  run-release:
+    name: "Release ${{ github.event.client_payload.releaseVersion }}"
+    uses: ./.github/workflows/camunda-platform-release.yml
+    secrets: inherit
+    with:
+      releaseVersion: ${{ github.event.client_payload.releaseVersion }}
+      nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
+      isLatest: ${{ github.event.client_payload.isLatest }}
+      dryRun: ${{ github.event.client_payload.dryRun }}
+      releaseBranch: ${{ github.event.client_payload.releaseBranch }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  notify-if-failed:
+    name: Send slack notification on failure
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    # if it's a dry run => no slack notification (remove noise in slack due to manual testing)
+    # else => send slack notification as an actual release failed
+    if: ${{ failure() && github.event.client_payload.dryRun == false }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: Release job for ${{ github.event.client_payload.releaseVersion }} failed! :alarm:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: Release job for ${{ github.event.client_payload.releaseVersion }} failed! :alarm:\n"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
## Description

Adjust after 8.6.0 release:
* Add dry run for `stable/8.6`
* Pin 8.6 dispatch workflow to stable branch
* Add 8.7 dispatch workflow

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
