### PR TITLE
feat: Allow configuring timeouts in cluster topology gossipper

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -617,6 +617,24 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
+      # Configure the parameters used to propagate the dynamic cluster configuration across brokers and gateways
+      # configManager:
+        # Configure the parameters used for gossiping the dynamic cluster configuration.
+        # Note that this is not related to cluster membership gossip.
+        # gossip:
+          # Enable the synchronization of the gossip instead of only relying on gossip
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
+          # enableSync: true
+          # Sets the interval between two synchronization requests to other members of the cluster
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY
+          # syncDelay: 10s
+          # Sets the timeout for the synchronization requests
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCREQUESTTIMEOUT
+          # syncRequestTimeout: 2s
+          # Sets the number of cluster members the configuration is gossiped to.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_GOSSIPFANOUT
+          # gossipFanout: 2
+
       # Configure compression algorithm for all message sent between the brokers and between the broker and
       # the gateway. Available options are NONE, GZIP and SNAPPY.
       # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -495,6 +495,24 @@
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
+      # Configure the parameters used to propagate the dynamic cluster configuration across brokers and gateways
+      # configManager:
+        # Configure the parameters used for gossiping the configuration
+        # Note that this is not related to cluster membership gossip.
+        # gossip:
+          # Enable the synchronization of the gossip instead of only relying on gossip
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
+          # enableSync: true
+          # Sets the interval between two synchronization requests to other members of the cluster
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY
+          # syncDelay: 10s
+          # Sets the timeout for the synchronization requests
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCREQUESTTIMEOUT
+          # syncRequestTimeout: 2s
+          # Sets the number of cluster members the configuration is gossiped to.
+          # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_GOSSIPFANOUT
+          # gossipFanout: 2
+
       # Configure compression algorithm for all message sent between the brokers and between the broker and
       # the gateway. Available options are NONE, GZIP and SNAPPY.
       # This feature is useful when the network latency between the brokers is very high (for example when the brokers are deployed in different data centers).

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -157,6 +157,24 @@
         # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_MEMBERSHIP_SYNCINTERVAL
         # syncInterval: 10s
 
+      # Configure the parameters used to propagate the dynamic cluster configuration across brokers and gateways
+      # configManager:
+        # Configure the parameters used for gossiping the dynamic cluster configuration.
+        # Note that this is not related to cluster membership gossip.
+        # gossip:
+          # Enable the synchronization of the gossip instead of only relying on gossip
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
+          # enableSync: true
+          # Sets the interval between two synchronization requests to other members of the cluster
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY
+          # syncDelay: 10s
+          # Sets the timeout for the synchronization requests
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCREQUESTTIMEOUT
+          # syncRequestTimeout: 2s
+          # Sets the number of cluster members the configuration is gossiped to.
+          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_GOSSIPFANOUT
+          # gossipFanout: 2
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # If this setting is enabled then the certificate and private key must either be provided separately

--- a/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
+++ b/dist/src/main/java/io/camunda/application/commons/clustering/DynamicClusterServices.java
@@ -15,10 +15,9 @@ import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.GatewayClusterConfigurationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationCoordinatorSupplier.ClusterClusterConfigurationAwareCoordinatorSupplier;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
-import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.scheduler.ActorScheduler;
-import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
@@ -41,13 +40,12 @@ public class DynamicClusterServices {
   @Bean
   @Profile("!broker")
   public GatewayClusterConfigurationService gatewayClusterTopologyService(
-      final BrokerTopologyManager brokerTopologyManager) {
+      final BrokerTopologyManager brokerTopologyManager, final GatewayCfg gatewayCfg) {
     final var service =
         new GatewayClusterConfigurationService(
             clusterCommunicationService,
             clusterMembershipService,
-            new ClusterConfigurationGossiperConfig(
-                false, Duration.ofSeconds(10), Duration.ofSeconds(1), 2));
+            gatewayCfg.getCluster().getConfigManager().gossip());
     scheduler.submitActor(service).join();
     service.addUpdateListener(brokerTopologyManager);
     return service;

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -201,7 +201,7 @@ final class StandaloneGatewaySecurityTest {
     actorScheduler = actorSchedulerConfiguration.scheduler();
     final var topologyServices = new DynamicClusterServices(actorScheduler, atomixCluster);
     final var topologyManager = topologyServices.brokerTopologyManager();
-    topologyServices.gatewayClusterTopologyService(topologyManager);
+    topologyServices.gatewayClusterTopologyService(topologyManager, gatewayCfg);
 
     final var brokerClientConfiguration =
         new BrokerClientConfiguration(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -13,13 +13,11 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
-import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
-import java.time.Duration;
 
 public class DynamicClusterConfigurationService implements ClusterConfigurationService {
 
@@ -146,16 +144,11 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
         rootDirectory,
         brokerStartupContext.getClusterServices().getCommunicationService(),
         brokerStartupContext.getClusterServices().getMembershipService(),
-        getDefaultClusterConfigurationGossiperConfig(), // TODO: allow user specified config
+        brokerStartupContext.getBrokerConfiguration().getCluster().getConfigManager().gossip(),
         brokerStartupContext
             .getBrokerConfiguration()
             .getExperimental()
             .getFeatures()
             .isEnablePartitionScaling());
-  }
-
-  private ClusterConfigurationGossiperConfig getDefaultClusterConfigurationGossiperConfig() {
-    return new ClusterConfigurationGossiperConfig(
-        true, Duration.ofSeconds(10), Duration.ofSeconds(2), 2);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.util.VisibleForTesting;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -110,6 +111,7 @@ public final class SystemContext {
 
     validateDataConfig(brokerCfg.getData());
 
+    validClusterConfigs(cluster);
     validateExperimentalConfigs(cluster, brokerCfg.getExperimental());
 
     validateExporters(brokerCfg.getExporters());
@@ -117,6 +119,38 @@ public final class SystemContext {
     final var security = brokerCfg.getNetwork().getSecurity();
     if (security.isEnabled()) {
       validateNetworkSecurityConfig(security);
+    }
+  }
+
+  private void validClusterConfigs(final ClusterCfg cluster) {
+    final var gossiper = cluster.getConfigManager().gossip();
+
+    final var errors = new ArrayList<String>(0);
+
+    if (gossiper.enableSync()) {
+      if (!gossiper.syncDelay().isPositive()) {
+        errors.add(
+            String.format(
+                "syncDelay must be positive: configured value = %d ms",
+                gossiper.syncDelay().toMillis()));
+      }
+      if (!gossiper.syncRequestTimeout().isPositive()) {
+        errors.add(
+            String.format(
+                "syncRequestTimeout must be positive: configured value = %d ms",
+                gossiper.syncRequestTimeout().toMillis()));
+      }
+    }
+    if (gossiper.gossipFanout() < 2) {
+      errors.add(
+          String.format(
+              "gossipFanout must be greater than 1: configured value = %d",
+              gossiper.gossipFanout()));
+    }
+
+    if (!errors.isEmpty()) {
+      throw new InvalidConfigurationException(
+          "Invalid ConfigManager configuration: " + String.join(", ", errors), null);
     }
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ClusterCfg.java
@@ -15,6 +15,7 @@ import io.atomix.cluster.messaging.MessagingConfig.CompressionAlgorithm;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -54,6 +55,7 @@ public final class ClusterCfg implements ConfigurationEntry {
   private MembershipCfg membership = new MembershipCfg();
   private RaftCfg raft = new RaftCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
+  private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -191,6 +193,56 @@ public final class ClusterCfg implements ConfigurationEntry {
     this.messageCompression = messageCompression;
   }
 
+  public ConfigManagerCfg getConfigManager() {
+    return configManager;
+  }
+
+  public void setConfigManager(final ConfigManagerCfg configManagerCfg) {
+    configManager = configManagerCfg;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        initialContactPoints,
+        partitionIds,
+        nodeId,
+        partitionsCount,
+        replicationFactor,
+        clusterSize,
+        clusterName,
+        heartbeatInterval,
+        electionTimeout,
+        membership,
+        raft,
+        messageCompression,
+        configManager);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ClusterCfg that = (ClusterCfg) o;
+    return nodeId == that.nodeId
+        && partitionsCount == that.partitionsCount
+        && replicationFactor == that.replicationFactor
+        && clusterSize == that.clusterSize
+        && Objects.equals(initialContactPoints, that.initialContactPoints)
+        && Objects.equals(partitionIds, that.partitionIds)
+        && Objects.equals(clusterName, that.clusterName)
+        && Objects.equals(heartbeatInterval, that.heartbeatInterval)
+        && Objects.equals(electionTimeout, that.electionTimeout)
+        && Objects.equals(membership, that.membership)
+        && Objects.equals(raft, that.raft)
+        && messageCompression == that.messageCompression
+        && Objects.equals(configManager, that.configManager);
+  }
+
   @Override
   public String toString() {
     return "ClusterCfg{"
@@ -219,6 +271,8 @@ public final class ClusterCfg implements ConfigurationEntry {
         + raft
         + ", messageCompression="
         + messageCompression
+        + ", configManagerCfg="
+        + configManager
         + '}';
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ConfigManagerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ConfigManagerCfg.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import java.util.Optional;
+
+public record ConfigManagerCfg(ClusterConfigurationGossiperConfig gossip)
+    implements ConfigurationEntry {
+
+  public ConfigManagerCfg(final ClusterConfigurationGossiperConfig gossip) {
+    this.gossip = Optional.ofNullable(gossip).orElse(ClusterConfigurationGossiperConfig.DEFAULT);
+  }
+
+  public static ConfigManagerCfg defaultConfig() {
+    return new ConfigManagerCfg(null);
+  }
+}

--- a/zeebe/broker/src/test/resources/system/config-manager.yaml
+++ b/zeebe/broker/src/test/resources/system/config-manager.yaml
@@ -1,0 +1,9 @@
+zeebe:
+  broker:
+    cluster:
+      configManager:
+        gossip:
+          enableSync: false
+          syncDelay: 10s
+          syncRequestTimeout: 30s
+          gossipFanout: 10

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
@@ -8,6 +8,29 @@
 package io.camunda.zeebe.dynamic.config.gossip;
 
 import java.time.Duration;
+import java.util.Optional;
 
 public record ClusterConfigurationGossiperConfig(
-    boolean enableSync, Duration syncDelay, Duration syncRequestTimeout, int gossipFanout) {}
+    Boolean enableSync, Duration syncDelay, Duration syncRequestTimeout, Integer gossipFanout) {
+
+  public static final boolean ENABLE_SYNC = true;
+  public static final Duration DEFAULT_SYNC_DELAY = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_SYNC_REQUEST_TIMEOUT = Duration.ofSeconds(2);
+  public static final int DEFAULT_GOSSIP_FANOUT = 2;
+
+  public static final ClusterConfigurationGossiperConfig DEFAULT =
+      new ClusterConfigurationGossiperConfig(
+          ENABLE_SYNC, DEFAULT_SYNC_DELAY, DEFAULT_SYNC_REQUEST_TIMEOUT, DEFAULT_GOSSIP_FANOUT);
+
+  public ClusterConfigurationGossiperConfig(
+      final Boolean enableSync,
+      final Duration syncDelay,
+      final Duration syncRequestTimeout,
+      final Integer gossipFanout) {
+    this.enableSync = enableSync;
+    this.syncDelay = Optional.ofNullable(syncDelay).orElse(DEFAULT_SYNC_DELAY);
+    this.syncRequestTimeout =
+        Optional.ofNullable(syncRequestTimeout).orElse(DEFAULT_SYNC_REQUEST_TIMEOUT);
+    this.gossipFanout = Optional.ofNullable(gossipFanout).orElse(DEFAULT_GOSSIP_FANOUT);
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ClusterCfg.java
@@ -42,6 +42,7 @@ public final class ClusterCfg {
   private MembershipCfg membership = new MembershipCfg();
   private SecurityCfg security = new SecurityCfg();
   private CompressionAlgorithm messageCompression = CompressionAlgorithm.NONE;
+  private ConfigManagerCfg configManager = ConfigManagerCfg.defaultConfig();
 
   public String getMemberId() {
     return memberId;
@@ -156,6 +157,15 @@ public final class ClusterCfg {
     return this;
   }
 
+  public ConfigManagerCfg getConfigManager() {
+    return configManager;
+  }
+
+  public ClusterCfg setConfigManager(final ConfigManagerCfg configManagerCfg) {
+    configManager = configManagerCfg;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -167,7 +177,8 @@ public final class ClusterCfg {
         port,
         membership,
         security,
-        messageCompression);
+        messageCompression,
+        configManager);
   }
 
   @Override
@@ -187,7 +198,8 @@ public final class ClusterCfg {
         && Objects.equals(host, that.host)
         && Objects.equals(membership, that.membership)
         && Objects.equals(security, that.security)
-        && Objects.equals(messageCompression, that.messageCompression);
+        && Objects.equals(messageCompression, that.messageCompression)
+        && Objects.equals(configManager, that.configManager);
   }
 
   @Override
@@ -214,6 +226,8 @@ public final class ClusterCfg {
         + security
         + ", messageCompression="
         + messageCompression
+        + ", configManagerCfg="
+        + configManager
         + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigManagerCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigManagerCfg.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
+import java.util.Optional;
+
+public record ConfigManagerCfg(ClusterConfigurationGossiperConfig gossip) {
+
+  public ConfigManagerCfg(final ClusterConfigurationGossiperConfig gossip) {
+    this.gossip = Optional.ofNullable(gossip).orElse(ClusterConfigurationGossiperConfig.DEFAULT);
+  }
+
+  public static ConfigManagerCfg defaultConfig() {
+    return new ConfigManagerCfg(null);
+  }
+}

--- a/zeebe/gateway/src/test/resources/configuration/gateway.custom.yaml
+++ b/zeebe/gateway/src/test/resources/configuration/gateway.custom.yaml
@@ -14,6 +14,12 @@ zeebe:
       memberId: testMember
       host: 1.2.3.4
       port: 12321
+      configManager:
+        gossip:
+          enableSync: false
+          syncDelay: 5000ms
+          syncRequestTimeout: 30s
+          gossipFanout: 6
 
     threads:
       managementThreads: 100


### PR DESCRIPTION
## Description
ClusterConfigurationGossiperConfig can be configured in both broker & gateway profiles. The current hardcoded configuration is used as default in case it's not configured.

A new namespace in the configuration has been created under `[zeebe.broker|zeebe.gateway].cluster.dynamicConfig`. At the moment it contains only one field `gossip`, but it can be used if we need to extend the configuration.

The configuration is validated using the following criteria:
- syncDelay must be strictly positive
- syncRequestTimeout must be strictly positive
- gossipFanout must be greater or equal than 2
- if enableSync is false, syncDelay & syncRequestTimeout are not validated

❓ Should enableSync be removed? If yes, should we remove directly in this PR?

❓ When the broker is started in standalone mode, the gateway will not start a gossiping the dynamic config as it's already done by the broker, hence I did not add a specific config in the template under `zeebe.broker.gateway.cluster.dynamicConfig`.
Is this correct?

<!-- Describe the goal and purpose of this PR. -->

## Checklist
- [X] Issue created: camunda/camunda-docs#4395

## Related issues

closes #15793
