### PR TITLE
Remove delimiter from resource identifiers

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class DbAuthorizationState implements AuthorizationState, MutableAuthorizationState {
   private final PersistedAuthorization persistedAuthorization = new PersistedAuthorization();
@@ -121,7 +122,7 @@ public class DbAuthorizationState implements AuthorizationState, MutableAuthoriz
   }
 
   @Override
-  public List<String> getResourceIdentifiers(
+  public Set<String> getResourceIdentifiers(
       final Long ownerKey,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
@@ -134,7 +135,7 @@ public class DbAuthorizationState implements AuthorizationState, MutableAuthoriz
             ownerKeyAndResourceTypeAndPermissionCompositeKey);
 
     return persistedPermissions == null
-        ? Collections.emptyList()
+        ? Collections.emptySet()
         : persistedPermissions.getResourceIdentifiers();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/ResourceIdentifiers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/ResourceIdentifiers.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -31,14 +32,14 @@ public class ResourceIdentifiers extends UnpackedObject implements DbValue {
     return copy;
   }
 
-  public List<String> getResourceIdentifiers() {
+  public Set<String> getResourceIdentifiers() {
     return StreamSupport.stream(resourceIds.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
   }
 
-  public void setResourceIdentifiers(final List<String> permissions) {
+  public void setResourceIdentifiers(final Set<String> permissions) {
     resourceIds.reset();
     permissions.forEach(permission -> resourceIds.add().wrap(BufferUtil.wrapString(permission)));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/AuthorizationState.java
@@ -10,11 +10,11 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface AuthorizationState {
-  List<String> getResourceIdentifiers(
+  Set<String> getResourceIdentifiers(
       Long ownerKey, AuthorizationResourceType resourceType, final PermissionType permissionType);
 
   Optional<AuthorizationOwnerType> getOwnerType(final long ownerKey);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -58,7 +58,7 @@ public class AuthorizationStateTest {
     // then
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(ownerKey, resourceType, permissionType);
-    assertThat(resourceIdentifiers).containsExactly("foo", "bar");
+    assertThat(resourceIdentifiers).containsExactlyInAnyOrder("foo", "bar");
   }
 
   @Test
@@ -77,7 +77,7 @@ public class AuthorizationStateTest {
     // then
     final var resourceIdentifiers =
         authorizationState.getResourceIdentifiers(ownerKey, resourceType, permissionType);
-    assertThat(resourceIdentifiers).containsExactly("foo", "bar", "baz");
+    assertThat(resourceIdentifiers).containsExactlyInAnyOrder("foo", "bar", "baz");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

A decision was made that our resource identifiers will not be stored like 'bpmnProcessId:foo', but instead will be stored as just 'foo'. We won't be verifying permissions of a single resource in multiple ways, so we don't have a need for this delimiter.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22858
