### PR TITLE
feat: support user update in camunda services

### DIFF
--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -15,6 +15,7 @@ import io.camunda.search.security.auth.Authentication;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +41,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
     return new UserServices(brokerClient, userSearchClient, authentication);
   }
 
-  public CompletableFuture<UserRecord> createUser(final CreateUserRequest request) {
+  public CompletableFuture<UserRecord> createUser(final UserDTO request) {
     return sendBrokerRequest(
         new BrokerUserCreateRequest()
             .setUsername(request.username())
@@ -49,5 +50,16 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
             .setPassword(request.password()));
   }
 
-  public record CreateUserRequest(String username, String name, String email, String password) {}
+  public CompletableFuture<UserRecord> updateUser(final UserDTO request) {
+    return sendBrokerRequest(
+        new BrokerUserUpdateRequest()
+            .setUserKey(request.userKey())
+            .setUsername(request.username())
+            .setName(request.name())
+            .setEmail(request.email())
+            .setPassword(request.password()));
+  }
+
+  public record UserDTO(
+      Long userKey, String username, String name, String email, String password) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -45,8 +45,7 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
 
   @Override
   public void processNewCommand(final TypedRecord<UserRecord> command) {
-    final var username = command.getValue().getUsernameBuffer();
-    final var persistedUser = userState.getUser(username);
+    final var persistedUser = userState.getUser(command.getValue().getUserKey());
 
     if (persistedUser.isEmpty()) {
       final var rejectionMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -63,7 +64,10 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(key, UserIntent.UPDATED, updatedUser);
     responseWriter.writeEventOnCommand(key, UserIntent.UPDATED, updatedUser, command);
 
-    distributionBehavior.withKey(key).unordered().distribute(command);
+    distributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.IDENTITY.getQueueId())
+        .distribute(command);
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -36,17 +36,19 @@ public class UpdateUserMultiPartitionTest {
   public void shouldDistributeUserUpdateCommand() {
     final var username = UUID.randomUUID().toString();
 
-    ENGINE
-        .user()
-        .newUser(username)
-        .withName("Foo Bar")
-        .withEmail("foo@bar.com")
-        .withPassword("password")
-        .create();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
 
     ENGINE
         .user()
-        .updateUser(username)
+        .updateUser(userRecord.getKey())
+        .withUsername(userRecord.getValue().getUsername())
         .withName("Bar Foo")
         .withEmail("bar@foo.com")
         .withPassword("password")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -96,5 +97,36 @@ public class UpdateUserMultiPartitionTest {
           .extracting(Record::getIntent)
           .containsSubsequence(UserIntent.UPDATE, UserIntent.UPDATED);
     }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    final var username = UUID.randomUUID().toString();
+    // when
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    ENGINE
+        .user()
+        .updateUser(userRecord.getKey())
+        .withUsername(userRecord.getValue().getUsername())
+        .withName("Bar Foo")
+        .withEmail("bar@foo.com")
+        .withPassword("password")
+        .update();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserPatchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserPatchTest.java
@@ -41,16 +41,23 @@ public class UpdateUserPatchTest {
 
   @Test
   public void shouldUpdateAUserWithTheSpecifiedField() {
-    ENGINE
-        .user()
-        .newUser(baseUser.getUsername())
-        .withName(baseUser.getName())
-        .withEmail(baseUser.getEmail())
-        .withPassword(baseUser.getPassword())
-        .create();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(baseUser.getUsername())
+            .withUsername(baseUser.getUsername())
+            .withName(baseUser.getName())
+            .withEmail(baseUser.getEmail())
+            .withPassword(baseUser.getPassword())
+            .create();
 
     final var updatedUserRecord =
-        ENGINE.user().updateUser(baseUser.getUsername(), updatedUser).update().getValue();
+        ENGINE
+            .user()
+            .updateUser(userRecord.getKey(), updatedUser)
+            .withUsername(baseUser.getUsername())
+            .update()
+            .getValue();
 
     assertThat(updatedUserRecord)
         .isNotNull()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
@@ -29,18 +29,20 @@ public class UpdateUserTest {
   @Test
   public void shouldUpdateAUser() {
     final var username = UUID.randomUUID().toString();
-    ENGINE
-        .user()
-        .newUser(username)
-        .withName("Foo Bar")
-        .withEmail("foo@bar.com")
-        .withPassword("password")
-        .create();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
 
     final var updatedUser =
         ENGINE
             .user()
-            .updateUser(username)
+            .updateUser(userRecord.getKey())
+            .withUsername(userRecord.getValue().getUsername())
             .withName("Bar Foo")
             .withEmail("foo@bar.blah")
             .withPassword("Foo Bar")
@@ -55,14 +57,15 @@ public class UpdateUserTest {
         .hasFieldOrPropertyWithValue("password", "Foo Bar");
   }
 
-  @DisplayName("should reject user update command when username does not exist")
+  @DisplayName("should reject user update command when user key does not exist")
   @Test
-  public void shouldRejectUserUpdateCommandWhenUsernameDoesNotExist() {
+  public void shouldRejectUserUpdateCommandWhenUserKeyDoesNotExist() {
     final var username = UUID.randomUUID().toString();
     final var userNotFoundRejection =
         ENGINE
             .user()
-            .updateUser(username)
+            .updateUser(-1L)
+            .withUsername(username)
             .withName("Foo Bar")
             .withEmail("bar@foo")
             .withPassword("password")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserClient.java
@@ -26,12 +26,12 @@ public final class UserClient {
     return new UserCreationClient(writer, username);
   }
 
-  public UpdateUserClient updateUser(final String username) {
-    return new UpdateUserClient(writer, username);
+  public UpdateUserClient updateUser(final Long userKey) {
+    return new UpdateUserClient(writer, userKey);
   }
 
-  public UpdateUserClient updateUser(final String username, final UserRecord userRecord) {
-    return new UpdateUserClient(writer, username, userRecord);
+  public UpdateUserClient updateUser(final long userKey, final UserRecord userRecord) {
+    return new UpdateUserClient(writer, userKey, userRecord);
   }
 
   public static class UserCreationClient {
@@ -110,17 +110,22 @@ public final class UserClient {
     private final UserRecord userRecord;
     private Function<Long, Record<UserRecordValue>> expectation = SUCCESS_SUPPLIER;
 
-    public UpdateUserClient(final CommandWriter writer, final String username) {
+    public UpdateUserClient(final CommandWriter writer, final long userKey) {
       this.writer = writer;
       userRecord = new UserRecord();
-      userRecord.setUsername(username);
+      userRecord.setUserKey(userKey);
     }
 
     public UpdateUserClient(
-        final CommandWriter writer, final String username, final UserRecord userRecord) {
+        final CommandWriter writer, final long userKey, final UserRecord userRecord) {
       this.writer = writer;
       this.userRecord = userRecord;
-      this.userRecord.setUsername(username);
+      this.userRecord.setUserKey(userKey);
+    }
+
+    public UpdateUserClient withUsername(final String username) {
+      userRecord.setUsername(username);
+      return this;
     }
 
     public UpdateUserClient withName(final String name) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -48,7 +48,7 @@ import io.camunda.service.ProcessInstanceServices.ProcessInstanceMigrateRequest;
 import io.camunda.service.ProcessInstanceServices.ProcessInstanceModifyRequest;
 import io.camunda.service.ResourceServices.DeployResourcesRequest;
 import io.camunda.service.ResourceServices.ResourceDeletionRequest;
-import io.camunda.service.UserServices.CreateUserRequest;
+import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPatchRequest;
@@ -287,12 +287,13 @@ public class RequestMapper {
         () -> new DocumentLinkParams(ZonedDateTime.parse(documentLinkRequest.getExpiresAt())));
   }
 
-  public static Either<ProblemDetail, CreateUserRequest> toCreateUserRequest(
-      final UserRequest request, final PasswordEncoder passwordEncoder) {
+  public static Either<ProblemDetail, UserDTO> toUserDTO(
+      final Long userKey, final UserRequest request, final PasswordEncoder passwordEncoder) {
     return getResult(
         validateUserCreateRequest(request),
         () ->
-            new CreateUserRequest(
+            new UserDTO(
+                userKey,
                 request.getUsername(),
                 request.getName(),
                 request.getEmail(),

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller.usermanagement;
 
 import io.camunda.service.UserServices;
-import io.camunda.service.UserServices.CreateUserRequest;
+import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
@@ -38,7 +38,7 @@ public class UserController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> createUser(
       @RequestBody final UserRequest userRequest) {
-    return RequestMapper.toCreateUserRequest(userRequest, passwordEncoder)
+    return RequestMapper.toUserDTO(null, userRequest, passwordEncoder)
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserController.java
@@ -42,7 +42,7 @@ public class UserController {
         .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createUser);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> createUser(final CreateUserRequest request) {
+  private CompletableFuture<ResponseEntity<Object>> createUser(final UserDTO request) {
     return RequestMapper.executeServiceMethod(
         () ->
             userServices.withAuthentication(RequestMapper.getAuthentication()).createUser(request),

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserControllerTest.java
@@ -16,7 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.exception.CamundaSearchException;
 import io.camunda.search.security.auth.Authentication;
 import io.camunda.service.UserServices;
-import io.camunda.service.UserServices.CreateUserRequest;
+import io.camunda.service.UserServices.UserDTO;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.usermanagement.UserController;
@@ -289,8 +289,8 @@ public class UserControllerTest extends RestControllerTest {
     verifyNoInteractions(userServices);
   }
 
-  private CreateUserRequest validCreateUserRequest() {
-    return new CreateUserRequest("foo", "Foo Bar", "bar@baz.com", "zabraboof");
+  private UserDTO validCreateUserRequest() {
+    return new UserDTO(null, "foo", "Foo Bar", "bar@baz.com", "zabraboof");
   }
 
   private UserRequest validUserWithPasswordRequest() {

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUserUpdateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUserUpdateRequest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerUserUpdateRequest extends BrokerExecuteCommand<UserRecord> {
+  private final UserRecord requestDto = new UserRecord();
+
+  public BrokerUserUpdateRequest() {
+    super(ValueType.USER, UserIntent.UPDATE);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  public BrokerUserUpdateRequest setUserKey(final long userKey) {
+    requestDto.setUserKey(userKey);
+    return this;
+  }
+
+  public BrokerUserUpdateRequest setUsername(final String username) {
+    requestDto.setUsername(username);
+    return this;
+  }
+
+  public BrokerUserUpdateRequest setName(final String name) {
+    requestDto.setName(name);
+    return this;
+  }
+
+  public BrokerUserUpdateRequest setEmail(final String email) {
+    requestDto.setEmail(email);
+    return this;
+  }
+
+  public BrokerUserUpdateRequest setPassword(final String password) {
+    requestDto.setPassword(password);
+    return this;
+  }
+
+  @Override
+  public UserRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected UserRecord toResponseDto(final DirectBuffer buffer) {
+    final var response = new UserRecord();
+    response.wrap(buffer);
+    return response;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR refactors some of the code related to updating a user specifically:
- Use the user key when fetching a user instead of the username
- Distribute the user update command onto the Identity queue

And also adds in:
- A service method to trigger an update user command

I have not added tests at this stage because the existing ITs require the API to be in place with the client for ease.

## Related issues

closes https://github.com/camunda/camunda/issues/21677, closes https://github.com/camunda/camunda/issues/22569
