### PR TITLE
Align resource types with permissions document

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -62,7 +62,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .permission()
         .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.JOB)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 
@@ -115,7 +115,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .permission()
         .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.JOB)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 
@@ -141,7 +141,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
         .permission()
         .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
-        .withResourceType(AuthorizationResourceType.JOB)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
         .add();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -50,7 +50,7 @@ public class AddPermissionAuthorizationTest {
             .permission()
             .withAction(PermissionAction.ADD)
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.JOB)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")
             .withPermission(PermissionType.DELETE, "bar")
             .add()
@@ -67,7 +67,7 @@ public class AddPermissionAuthorizationTest {
             PermissionAction.ADD,
             ownerKey,
             AuthorizationOwnerType.USER,
-            AuthorizationResourceType.JOB);
+            AuthorizationResourceType.DEPLOYMENT);
     assertThat(response.getPermissions())
         .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
         .containsExactly(
@@ -87,7 +87,7 @@ public class AddPermissionAuthorizationTest {
             .permission()
             .withAction(PermissionAction.ADD)
             .withOwnerKey(ownerKey)
-            .withResourceType(AuthorizationResourceType.JOB)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")
             .expectRejection()
             .add();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/AuthorizationStateTest.java
@@ -107,7 +107,7 @@ public class AuthorizationStateTest {
     // given
     final var ownerKey = 1L;
     final var resourceType1 = AuthorizationResourceType.DEPLOYMENT;
-    final var resourceType2 = AuthorizationResourceType.JOB;
+    final var resourceType2 = AuthorizationResourceType.PROCESS_DEFINITION;
     final var permissionType = PermissionType.CREATE;
     authorizationState.createOrAddPermission(
         ownerKey, resourceType1, permissionType, List.of("foo"));

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3110,16 +3110,17 @@ components:
           description: The type of resource to add/remove perissions to/from.
           enum:
             - AUTHORIZATION
+            - MAPPING_RULE
             - MESSAGE
-            - JOB
+            - BATCH
             - APPLICATION
+            - SYSTEM
             - TENANT
             - DEPLOYMENT
             - PROCESS_DEFINITION
-            - USER_TASK
             - DECISION_REQUIREMENTS_DEFINITION
             - DECISION_DEFINITION
-            - USER_GROUP
+            - GROUP
             - USER
             - ROLE
         permissions:

--- a/zeebe/protocol/revapi.json
+++ b/zeebe/protocol/revapi.json
@@ -74,6 +74,21 @@
           "code": "java.class.removed",
           "old": "enum io.camunda.zeebe.protocol.record.value.ExecutionListenerEventType",
           "elementKind": "enum"
+        },
+        {
+          "justification": "JOB was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and JOB is not one of them.",
+          "code": "java.field.removed",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.JOB"
+        },
+        {
+          "justification": "USER_GROUP was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_GROUP is not one of them.",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_GROUP",
+          "code": "java.field.removed"
+        },
+        {
+          "justification": "USER_TASK was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_TASK is not one of them.",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK",
+          "code": "java.field.removed"
         }
       ]
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationResourceType.java
@@ -17,16 +17,17 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum AuthorizationResourceType {
   AUTHORIZATION,
+  MAPPING_RULE,
   MESSAGE,
-  JOB,
+  BATCH,
   APPLICATION,
+  SYSTEM,
   TENANT,
   DEPLOYMENT,
   PROCESS_DEFINITION,
-  USER_TASK,
   DECISION_REQUIREMENTS_DEFINITION,
   DECISION_DEFINITION,
-  USER_GROUP,
+  GROUP,
   USER,
   ROLE
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Since implementation some of these resource types have changed. We should align this with the definitive [permissions document](https://docs.google.com/document/d/1ikxw9ARCv-MBwASnj7WhW5uHCndCRk2B35xi-cB2N0M/edit) (internal).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22902 
