### PR TITLE
fix: do not throw Exception when GCS store is not accessible on startup

### DIFF
--- a/zeebe/backup-stores/gcs/pom.xml
+++ b/zeebe/backup-stores/gcs/pom.xml
@@ -83,6 +83,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-testkit</artifactId>
       <scope>test</scope>

--- a/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
+++ b/zeebe/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/ConfigIT.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.backup.gcs;
 
 import com.google.cloud.storage.BucketInfo;
-import io.camunda.zeebe.backup.gcs.GcsBackupStoreException.ConfigurationException.CouldNotAccessBucketException;
 import io.camunda.zeebe.backup.gcs.util.GcsContainer;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.assertj.core.api.Assertions;
@@ -41,7 +40,7 @@ public class ConfigIT {
   }
 
   @Test
-  void shouldFailValidationIfBucketDoesNotExist() {
+  void shouldNotFailValidationIfBucketDoesNotExist() {
     // given
     final var bucketName = RandomStringUtils.randomAlphabetic(12);
     final var config =
@@ -52,8 +51,7 @@ public class ConfigIT {
             .build();
 
     // then
-    Assertions.assertThatThrownBy(() -> GcsBackupStore.validateConfig(config))
-        .isInstanceOf(CouldNotAccessBucketException.class)
-        .hasMessageContaining(config.bucketName());
+    Assertions.assertThatCode(() -> GcsBackupStore.validateConfig(config))
+        .doesNotThrowAnyException();
   }
 }


### PR DESCRIPTION
## Description

In an exception is throw at startup, just log it at warning so that all information necessary if available when reading the logs. Because this error can be transient, it's better to continue anyway the initialization of the broker.
`GcsBackupStoreConfig`  performs validation in the constructor already.
## Related issues
closes #14593