### PR TITLE
fix: Throw IllegalArgumentException when non-existing exporters are configured

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -14,16 +14,21 @@ import static org.mockito.Mockito.mock;
 import io.atomix.cluster.AtomixCluster;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.configuration.backup.BackupStoreCfg.BackupStoreType;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg.NodeCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
 import java.io.File;
 import java.security.cert.CertificateException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -325,6 +330,31 @@ final class SystemContextTest {
     assertThatCode(() -> initSystemContext(brokerCfg))
         .isInstanceOf(InvalidConfigurationException.class)
         .hasMessageContaining("Failed configuring backup store S3");
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/12678")
+  void shouldThrowExceptionWithInvalidExporters() {
+    // given
+    final var brokerCfg = new BrokerCfg();
+    final List<String> exportersNames = Arrays.asList("unknown", "oops", "nope");
+    final Map<String, ExporterCfg> exporters = HashMap.newHashMap(exportersNames.size());
+
+    for (final String exporterName : exportersNames) {
+      final ExporterCfg exporterCfg = new ExporterCfg();
+      exporterCfg.setClassName(null);
+      exporterCfg.setJarPath("unknown".equals(exporterName) ? null : exporterName);
+      final Map<String, Object> args = HashMap.newHashMap(1);
+      args.put("any_arg", 1);
+      exporterCfg.setArgs(args);
+      exporters.put(exporterName, exporterCfg);
+    }
+    brokerCfg.setExporters(exporters);
+
+    // then
+    assertThatCode(() -> initSystemContext(brokerCfg))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Expected to find a 'className' configured for the exporter. Couldn't find a valid one for the following exporters ");
   }
 
   private SystemContext initSystemContext(final BrokerCfg brokerCfg) {


### PR DESCRIPTION
Validates configured exporters and throws exception in case there are any invalid exporters (i.e. without a defined `className`)

## Description

We now verify if the configured exporters exist during the configuration validation step in `SystemContext`.


## Related issues

closes #12678 
