### PR TITLE
fix: build Optimize before running the schema integrity test

### DIFF
--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install
         uses: ./.github/actions/run-maven
         with:
-          parameters: install -Dskip.fe.build -Dskip.docker -DskipTests -pl optimize -am
+          parameters: -f optimize/pom.xml install -Dskip.fe.build -Dskip.docker -DskipTests -PrunAssembly
       - name: Verify optimize/qa/schema-integrity-tests
         uses: ./.github/actions/run-maven
         with:
@@ -162,7 +162,7 @@ jobs:
       - name: Install
         uses: ./.github/actions/run-maven
         with:
-          parameters: install -Dskip.fe.build -Dskip.docker -DskipTests -pl optimize -am
+          parameters: -f optimize/pom.xml install -Dskip.fe.build -Dskip.docker -DskipTests -PrunAssembly
       - name: Verify optimize/qa/schema-integrity-tests
         uses: ./.github/actions/run-maven
         with:

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -45,7 +45,7 @@
     <previous.optimize.opensearch.version>2.9.0</previous.optimize.opensearch.version>
     <awssdk.version>2.28.13</awssdk.version>
 
-    <jetty.version>12.0.14</jetty.version>
+    <jetty.version>12.0.13</jetty.version>
     <jackson.version>2.18.0</jackson.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <apache.http5-client.version>5.4</apache.http5-client.version>


### PR DESCRIPTION
## Description

One IT is failing because the artifacts needed are not yet in the registry. We need to build them before running the test.
Also, jetty .14 is giving problems at the moment of loading the home page of Optimize. I'm reverting it to .13.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
