### PR TITLE
Verify permissions in `AuthorizationAddPermissionsProcessor`

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AddPermissionsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AddPermissionsCommandImpl.java
@@ -97,7 +97,7 @@ public class AddPermissionsCommandImpl
   @Override
   public ZeebeFuture<AddPermissionsResponse> send() {
     final HttpZeebeFuture<AddPermissionsResponse> result = new HttpZeebeFuture<>();
-    httpClient.post(path, jsonMapper.toJson(request), httpRequestConfig.build(), result);
+    httpClient.patch(path, jsonMapper.toJson(request), httpRequestConfig.build(), result);
     return result;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -218,7 +218,12 @@ public final class EngineProcessors {
         typedRecordProcessors, writers, keyGenerator, clock, commandDistributionBehavior);
 
     AuthorizationProcessors.addAuthorizationProcessors(
-        keyGenerator, typedRecordProcessors, processingState, writers, commandDistributionBehavior);
+        keyGenerator,
+        typedRecordProcessors,
+        processingState,
+        writers,
+        commandDistributionBehavior,
+        config);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.engine.processing.identity;
 
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.AuthorizableDistributionProcessor.Authorizable;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor.ProcessingError;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -19,11 +21,13 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public final class AuthorizationAddPermissionProcessor
-    implements DistributedTypedRecordProcessor<AuthorizationRecord> {
+    implements Authorizable<AuthorizationRecord> {
 
   private final KeyGenerator keyGenerator;
   private final AuthorizationState authorizationState;
@@ -43,6 +47,12 @@ public final class AuthorizationAddPermissionProcessor
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
+  }
+
+  @Override
+  public AuthorizationRequest<?> getAuthorizationRequest() {
+    return new AuthorizationRequest<>(
+        AuthorizationResourceType.AUTHORIZATION, PermissionType.UPDATE);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationProcessors.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.AuthorizableDistributionProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -22,11 +24,16 @@ public final class AuthorizationProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
-      final CommandDistributionBehavior distributionBehavior) {
+      final CommandDistributionBehavior distributionBehavior,
+      final EngineConfiguration config) {
     typedRecordProcessors.onCommand(
         ValueType.AUTHORIZATION,
         AuthorizationIntent.ADD_PERMISSION,
-        new AuthorizationAddPermissionProcessor(
-            writers, keyGenerator, processingState, distributionBehavior));
+        new AuthorizableDistributionProcessor<>(
+            processingState,
+            writers,
+            config,
+            new AuthorizationAddPermissionProcessor(
+                writers, keyGenerator, processingState, distributionBehavior)));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRe
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -32,7 +32,7 @@ public class AuthorizationController {
     this.authorizationServices = authorizationServices;
   }
 
-  @PostMapping(
+  @PatchMapping(
       path = "/{ownerKey}",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AuthorizationControllerTest.java
@@ -90,7 +90,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
         .thenReturn(CompletableFuture.completedFuture(authorizationRecord));
 
     webClient
-        .post()
+        .patch()
         .uri("/v2/authorizations/%d".formatted(ownerKey))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
@@ -140,7 +140,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     expectedBody.setInstance(URI.create("/v2/authorizations/%d".formatted(ownerKey)));
 
     webClient
-        .post()
+        .patch()
         .uri("/v2/authorizations/%d".formatted(ownerKey))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
@@ -163,7 +163,7 @@ public class AuthorizationControllerTest extends RestControllerTest {
     expectedBody.setDetail(errorMessage);
 
     webClient
-        .post()
+        .patch()
         .uri("/v2/authorizations/%d".formatted(ownerKey))
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/AuthorizationAddPermissionAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/AuthorizationAddPermissionAuthorizationIT.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class AuthorizationAddPermissionAuthorizationIT {
+
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHORIZED_USERNAME = "foo";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker broker;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    broker =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    broker.start();
+    defaultUserClient = createClientWithAuthorization(broker, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done(), "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            broker,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHORIZED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.AUTHORIZATION, PermissionTypeEnum.UPDATE, List.of("*")));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            broker, defaultUserClient, CONTAINER.getHttpHostAddress(), "bar", "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToAddPermissionsWithDefaultUser() {
+    // given
+    final var userKey =
+        RecordingExporter.userRecords(UserIntent.CREATED)
+            .withUsername(DEFAULT_USERNAME)
+            .getFirst()
+            .getKey();
+
+    // when then
+    final var addPermissionsResponse =
+        defaultUserClient
+            .newAddPermissionsCommand(userKey)
+            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .permission(PermissionTypeEnum.CREATE)
+            .resourceId("*")
+            .send()
+            .join();
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(addPermissionsResponse).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToAddPermissionsWithUser() {
+    // given we use the authorizedUserClient
+    final var userKey =
+        RecordingExporter.userRecords(UserIntent.CREATED)
+            .withUsername(AUTHORIZED_USERNAME)
+            .getFirst()
+            .getKey();
+
+    // when then
+    final var addPermissionsResponse =
+        authorizedUserClient
+            .newAddPermissionsCommand(userKey)
+            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .permission(PermissionTypeEnum.CREATE)
+            .resourceId("*")
+            .send()
+            .join();
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(addPermissionsResponse).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToAddPermissionsIfNoPermissions() {
+    // given we use the unauthorizedUserClient
+    // when
+    final var createFuture =
+        unauthorizedUserClient
+            // We can use any owner key. The authorization check happens before we use it.
+            .newAddPermissionsCommand(1L)
+            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .permission(PermissionTypeEnum.CREATE)
+            .resourceId("*")
+            .send();
+
+    // then
+    assertThatThrownBy(createFuture::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Wraps the `AuthorizationAddPermissionsProcessor` with an authorizable processor. This takes care of verifying the user is permitted before processing the command.

Also adds ITs to verify the behaviour works as expected.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22589
