### PR TITLE
Verify permissions on job complete and job throw error

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -32,14 +32,16 @@ final class DefaultJobCommandPreconditionGuard {
   }
 
   public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
+      final TypedRecord<JobRecord> command,
+      final CommandControl<JobRecord> commandControl,
+      final JobRecord jobFromState) {
     final long jobKey = command.getKey();
     final State jobState = state.getState(jobKey);
 
     preconditionChecker
         .check(jobState, jobKey)
         .ifRightOrLeft(
-            ok -> acceptCommand.accept(command, commandControl),
+            ok -> acceptCommand.accept(command, commandControl, jobFromState),
             violation -> commandControl.reject(violation.getLeft(), violation.getRight()));
 
     return true;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobAcceptFunction.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobAcceptFunction.java
@@ -14,5 +14,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 @FunctionalInterface
 public interface JobAcceptFunction {
 
-  void accept(final TypedRecord<JobRecord> record, final CommandControl<JobRecord> commandControl);
+  void accept(
+      final TypedRecord<JobRecord> record,
+      final CommandControl<JobRecord> commandControl,
+      final JobRecord jobFromState);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
@@ -16,7 +16,7 @@ import java.util.List;
 
 public class JobCommandPreconditionChecker {
 
-  private static final String NO_JOB_FOUND_MESSAGE =
+  public static final String NO_JOB_FOUND_MESSAGE =
       "Expected to %s job with key '%d', but no such job was found";
   private static final String INVALID_JOB_STATE_MESSAGE =
       "Expected to %s job with key '%d', but it is in state '%s'";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -59,7 +59,7 @@ public final class JobCompleteProcessor implements Authorizable<JobRecord, JobRe
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
-              String.format(NO_JOB_FOUND_MESSAGE, command.getIntent(), command.getKey())));
+              String.format(NO_JOB_FOUND_MESSAGE, "complete", command.getKey())));
     }
 
     final var authorizationRequest =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.streamprocessor.AuthorizableCommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
@@ -50,7 +51,10 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.COMPLETE,
-            new JobCompleteProcessor(processingState, jobMetrics, eventHandle))
+            new AuthorizableCommandProcessor<>(
+                processingState,
+                config,
+                new JobCompleteProcessor(processingState, jobMetrics, eventHandle)))
         .onCommand(
             ValueType.JOB,
             JobIntent.FAIL,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -72,11 +72,14 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.THROW_ERROR,
-            new JobThrowErrorProcessor(
+            new AuthorizableCommandProcessor<>(
                 processingState,
-                bpmnBehaviors.eventPublicationBehavior(),
-                keyGenerator,
-                jobMetrics))
+                config,
+                new JobThrowErrorProcessor(
+                    processingState,
+                    bpmnBehaviors.eventPublicationBehavior(),
+                    keyGenerator,
+                    jobMetrics)))
         .onCommand(
             ValueType.JOB,
             JobIntent.TIME_OUT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -8,13 +8,17 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import static io.camunda.zeebe.engine.EngineConfiguration.DEFAULT_MAX_ERROR_MESSAGE_SIZE;
+import static io.camunda.zeebe.engine.processing.job.JobCommandPreconditionChecker.NO_JOB_FOUND_MESSAGE;
 import static io.camunda.zeebe.util.StringUtil.limitString;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventPublicationBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.AuthorizableCommandProcessor.Authorizable;
+import io.camunda.zeebe.engine.processing.streamprocessor.AuthorizableCommandProcessor.Rejection;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
@@ -31,14 +35,16 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 
-public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
+public class JobThrowErrorProcessor implements Authorizable<JobRecord, JobRecord> {
 
   /**
    * Marker element ID. This ID is used to indicate that a given catch event could not be found. The
@@ -46,9 +52,6 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
    * (particularly when no catch event can be found)
    */
   public static final String NO_CATCH_EVENT_FOUND = "NO_CATCH_EVENT_FOUND";
-
-  public static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to cancel job with key '%d', but no such job was found";
 
   public static final String ERROR_REJECTION_MESSAGE =
       "Cannot throw BPMN error from %s job with key '%d', type '%s' and processInstanceKey '%d'";
@@ -86,10 +89,32 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
   }
 
   @Override
+  public Either<Rejection, AuthorizationRequest<JobRecord>> getAuthorizationRequest(
+      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> controller) {
+    final var job = jobState.getJob(command.getKey(), command.getAuthorizations());
+
+    if (job == null) {
+      return Either.left(
+          new Rejection(
+              RejectionType.NOT_FOUND,
+              String.format(NO_JOB_FOUND_MESSAGE, command.getIntent(), command.getKey())));
+    }
+
+    final var authorizationRequest =
+        new AuthorizationRequest<JobRecord>(
+                AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+            .setResource(job)
+            .addResourceId(job.getBpmnProcessId());
+
+    return Either.right(authorizationRequest);
+  }
+
+  @Override
   public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
-    final var jobFromState = jobState.getJob(command.getKey(), command.getAuthorizations());
-    return defaultProcessor.onCommand(command, commandControl, jobFromState);
+      final TypedRecord<JobRecord> command,
+      final CommandControl<JobRecord> commandControl,
+      final JobRecord jobRecord) {
+    return defaultProcessor.onCommand(command, commandControl, jobRecord);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -97,7 +97,7 @@ public class JobThrowErrorProcessor implements Authorizable<JobRecord, JobRecord
       return Either.left(
           new Rejection(
               RejectionType.NOT_FOUND,
-              String.format(NO_JOB_FOUND_MESSAGE, command.getIntent(), command.getKey())));
+              String.format(NO_JOB_FOUND_MESSAGE, "throw an error for", command.getKey())));
     }
 
     final var authorizationRequest =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class JobCompleteAuthorizationIT {
+
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHENTICATED_USERNAME = "foo";
+  public static final String JOB_TYPE = "jobType";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("serviceTask", t -> t.zeebeJobType(JOB_TYPE))
+                .endEvent()
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHENTICATED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe, defaultUserClient, CONTAINER.getHttpHostAddress(), "bar", "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToCompleteJobWithDefaultUser() {
+    // given
+    final var processInstanceKey =
+        defaultUserClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when then
+    final var response = defaultUserClient.newCompleteCommand(jobKey).send().join();
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToCompleteJobWithUser() {
+    // given
+    final var processInstanceKey =
+        defaultUserClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // given we use the authorizedUserClient
+    // when then
+    final var response = authorizedUserClient.newCompleteCommand(jobKey).send().join();
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToCompleteJobIfNoPermissions() {
+    // given
+    final var processInstanceKey =
+        defaultUserClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId(PROCESS_ID)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    final var jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // given we use the unauthorizedUserClient
+    // when
+    final var response = unauthorizedUserClient.newCompleteCommand(jobKey).send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -966,7 +966,7 @@ public class MultiTenancyOverIdentityIT {
           .withThrowableThat()
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to update retries for job with key '%d', but no such job was found"
+              "Command 'COMPLETE' rejected with code 'NOT_FOUND': Expected to complete job with key '%d', but no such job was found"
                   .formatted(activatedJob.getKey()));
     }
   }


### PR DESCRIPTION
## Description

Wraps the `JobCompleteProcessor` with an authorizable processor. This takes care of verifying the user is permitted before processing the command.

Also adds ITs to verify the behaviour works as expected.

I had to touch upon the `JobThrowErrorProcessor` slightly, to make things generic. I moved fetching the Job from state to a different method and passed it along.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22590
