### PR TITLE
Revert "ci: revert and use zeebe runners for zeebe-related jobs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,8 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
     name: Java checks
-    timeout-minutes: 30
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    timeout-minutes: 15
+    runs-on: gcp-perf-core-8-default
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -139,7 +139,7 @@ jobs:
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
-    timeout-minutes: 35
+    timeout-minutes: 25
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -203,25 +203,25 @@ jobs:
             maven-modules: "'qa/integration-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: [ self-hosted, linux, amd64, "16" ]
+            runs-on: gcp-perf-core-8-default
           - group: modules
             name: "Zeebe Module Integration Tests"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: [ self-hosted, linux, amd64, "16" ]
+            runs-on: gcp-perf-core-8-default
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            runs-on: [ self-hosted, linux, amd64, "16" ]
+            runs-on: gcp-perf-core-16-default
           - group: qa-update
             name: "Zeebe QA - Update Tests"
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-            runs-on: [ self-hosted, linux, amd64, "16" ]
+            runs-on: gcp-perf-core-8-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
-    timeout-minutes: 30
+    timeout-minutes: 20
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -29,7 +29,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: [ self-hosted, linux, amd64, "16" ]
+            runner: gcp-perf-core-8-default
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64
@@ -83,7 +83,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
@@ -129,7 +129,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"


### PR DESCRIPTION
Reverts camunda/camunda#22999

Related to[ INC-1845](https://app.incident.io/camunda/incidents/1845) and [investigation](https://camunda.slack.com/archives/C07QFEUS5C1/p1728043615595609?thread_ts=1727961757.334499&cid=C07QFEUS5C1).

`cyclonedx` maven plugin has been [reverted](https://github.com/camunda/camunda/pull/23070) which now fixes compilation issues with Infra runners. Infra Self-Hosted runners can be used again.

Cache has been disabled (with a test commit) to ensure that GitHub jobs do not encounter compilation errors.

Before merging:
- [x] remove test [commit](https://github.com/camunda/camunda/pull/23086/commits/d3ea352e47845517c10b1f47f663b3255882f2bf)