### PR TITLE
Make it possible to skip job retries

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/jobhandling/JobHandlerInvokingSpringBeans.java
@@ -98,6 +98,11 @@ public class JobHandlerInvokingSpringBeans implements JobHandler {
         command.executeAsyncWithMetrics(
             MetricsRecorder.METRIC_NAME_JOB, MetricsRecorder.ACTION_COMPLETED, job.getType());
       }
+    } catch (UnretriableErrorException e) {
+      if (!workerValue.getAutoComplete()) {
+        throw e;
+      }
+      // TODO: Send a fail command and set the retries to 0.
     } catch (final ZeebeBpmnError bpmnError) {
       LOG.trace("Catched BPMN error on {}", job);
       final CommandWrapper command =

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/common/exception/UnretriableErrorException.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/common/exception/UnretriableErrorException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.common.exception;
+
+/**
+ * Exception that can be thrown by a JobWorker if something goes wrong and the job should
+ * not be retried (even if a retry is configured in the process model).
+ */
+public class UnretriableErrorException extends SdkException {
+
+  public UnretriableErrorException(final String message) {
+    super(message);
+  }
+
+  public UnretriableErrorException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+}


### PR DESCRIPTION
## Description

Make it possible to skip the retries configured in the process model. E.g. if the data in the process is "bad" then it doesn't make any sense to try again to execute the job.

This is not a complete feature but just a base for a discussion.