### PR TITLE
[Backport stable/8.4] fix: merge concurrent resolves for up to 128 hostnames

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -382,6 +382,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
               dnsResolverGroup =
                   new DnsAddressResolverGroup(
                       new DnsNameResolverBuilder(clientGroup.next())
+                          .consolidateCacheSize(128)
                           .dnsQueryLifecycleObserverFactory(
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -217,6 +217,7 @@ public class NettyUnicastService implements ManagedUnicastService {
               dnsAddressResolverGroup =
                   new DnsAddressResolverGroup(
                       new DnsNameResolverBuilder(group.next())
+                          .consolidateCacheSize(128)
                           .dnsQueryLifecycleObserverFactory(
                               new BiDnsQueryLifecycleObserverFactory(
                                   ignored -> metrics,


### PR DESCRIPTION
# Description
Backport of #22410 to `stable/8.4`.

relates to 
original author: @lenaschoenburg