### PR TITLE
fix: use the userKey for the state and response commands to support t…

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserUpdateProcessor.java
@@ -64,9 +64,9 @@ public class UserUpdateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(userKey, UserIntent.UPDATED, updatedUser);
     responseWriter.writeEventOnCommand(userKey, UserIntent.UPDATED, updatedUser, command);
 
-    final long key = keyGenerator.nextKey();
+    final long distributionKey = keyGenerator.nextKey();
     distributionBehavior
-        .withKey(key)
+        .withKey(distributionKey)
         .inQueue(DistributionQueue.IDENTITY.getQueueId())
         .distribute(command);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
@@ -108,10 +108,10 @@ public class UpdateUserTest {
 
     Assertions.assertThat(
             RecordingExporter.userRecords(UserIntent.UPDATED)
-                .filter(record -> record.getKey() == userRecord.getKey())
+                .withUserKey(userRecord.getKey())
                 .limit(1)
-                .getFirst())
-        .isNotNull();
-    ;
+                .getFirst()
+                .getKey())
+        .isEqualTo(userRecord.getKey());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -108,8 +107,11 @@ public class UpdateUserTest {
         .getValue();
 
     Assertions.assertThat(
-            RecordingExporter.userRecords(UserIntent.UPDATED).collect(Collectors.toList()))
-        .allMatch(record -> record.getKey() == userRecord.getKey());
+            RecordingExporter.userRecords(UserIntent.UPDATED)
+                .filter(record -> record.getKey() == userRecord.getKey())
+                .limit(1)
+                .getFirst())
+        .isNotNull();
     ;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserTest.java
@@ -11,8 +11,12 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -78,5 +82,34 @@ public class UpdateUserTest {
             "Expected to update user with username "
                 + username
                 + ", but a user with this username does not exist");
+  }
+
+  @DisplayName("should set the key on follow up commands to the user key")
+  @Test
+  public void shouldSetTheKeyOnFollowUpCommandsToTheUserKey() {
+    final var username = UUID.randomUUID().toString();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    ENGINE
+        .user()
+        .updateUser(userRecord.getKey())
+        .withUsername(userRecord.getValue().getUsername())
+        .withName("Bar Foo")
+        .withEmail("foo@bar.blah")
+        .withPassword("Foo Bar")
+        .update()
+        .getValue();
+
+    Assertions.assertThat(
+            RecordingExporter.userRecords(UserIntent.UPDATED).collect(Collectors.toList()))
+        .allMatch(record -> record.getKey() == userRecord.getKey());
+    ;
   }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserRecordStream.java
@@ -25,4 +25,8 @@ public class UserRecordStream extends ExporterRecordStream<UserRecordValue, User
   public UserRecordStream withUsername(final String username) {
     return valueFilter(v -> v.getUsername().equals(username));
   }
+
+  public UserRecordStream withUserKey(final long userKey) {
+    return valueFilter(v -> v.getUserKey() == userKey);
+  }
 }


### PR DESCRIPTION
## Description
I noticed during testing of a recent change that the key we currently set on state and response followups means updates are not applied correctly in the downstream storage. Instead of updating an existing record following an update, as the key was generated new, the update was stored as a new record with duplicate data.

This PR changes that to be the user key, after this the exporters correctly detect the existing entity and update as expected.
