### PR TITLE
ci: add a new setup-maven-dist composite action to abstract maven install

### DIFF
--- a/.github/actions/setup-maven-dist/action.yaml
+++ b/.github/actions/setup-maven-dist/action.yaml
@@ -1,0 +1,33 @@
+---
+name: Setup Maven Distribution
+
+description: Install Maven using a well-known GitHub action (stCarolas/setup-maven) or the mvnw wrapper.
+
+inputs:
+  maven-version:
+    description: Target Maven version
+    required: true
+  set-mvnw:
+    description: |
+      Update the target version of Maven used by mvnw wrapper.
+      If enabled, stCarolas/setup-maven is skipped.
+    default: "false"
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Maven
+      if: inputs.set-mvnw != 'true'
+      uses: stCarolas/setup-maven@v5
+      with:
+        maven-version: ${{ inputs.maven-version }}
+    - name: Update Maven version used by mvnw wrapper
+      if: inputs.set-mvnw == 'true'
+      shell: bash
+      env:
+        MAVEN_VERSION: ${{ inputs.maven-version }}
+        MAVEN_WRAPPER_PROPERTIES_PATH: .mvn/wrapper/maven-wrapper.properties
+      run: |
+        sed -i "/distributionUrl=/ s/[[:digit:]]\.[[:digit:]]\.[[:digit:]]/${MAVEN_VERSION}/g" "${MAVEN_WRAPPER_PROPERTIES_PATH}"
+        cat "${MAVEN_WRAPPER_PROPERTIES_PATH}"


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674 following this [suggestion](https://github.com/camunda/team-infrastructure/issues/674#issuecomment-2396955014).

This PR introduces a new GitHub composite action, `setup-maven-dist`, which provides two methods to setup Maven:
- `stCarolas/setup-maven` (default option)
- `mvnw` wrapper (set target version in wrapper properties)

This is a first step towards standardizing Maven installations and versions.

Test: https://github.com/camunda/camunda/actions/runs/11328944974/job/31503321238?pr=23323

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
