### PR TITLE
[Backport stable/optimize-8.6] ci: add new version to zeebe compatibility test

### DIFF
--- a/.github/workflows/optimize-zeebe-compatibility.yml
+++ b/.github/workflows/optimize-zeebe-compatibility.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        zeebe-version: [8.2.0, 8.3.0, 8.4.0, 8.5.0, latest, snapshot]
+        zeebe-version: [8.3.0, 8.4.0, 8.5.0, 8.6.0, latest, snapshot]
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       # Parses the pom within less than second and exposes every value as an output of the step


### PR DESCRIPTION
# Description
Backport of #23131 to `stable/optimize-8.6`.

relates to 
original author: @misiekhardcore