### PR TITLE
Do not assign ILM to main indices.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -143,13 +143,6 @@ public class CamundaExporter implements Exporter {
       searchEngineClient.putIndexLifeCyclePolicy(
           configuration.elasticsearch.getRetention().getPolicyName(),
           configuration.elasticsearch.getRetention().getMinimumAge());
-
-      final var lifecycleUpdate =
-          Map.of(
-              "index.lifecycle.name", configuration.elasticsearch.getRetention().getPolicyName());
-
-      searchEngineClient.putSettings(
-          provider.getIndexDescriptors().stream().toList(), lifecycleUpdate);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -406,22 +406,6 @@ final class CamundaExporterIT {
 
       assertThat(policies.get("not_created_policy")).isNull();
     }
-
-    @Test
-    void shouldSetLifecyclePolicyOnCreatedIndices() throws IOException {
-      config.elasticsearch.setCreateSchema(true);
-      config.elasticsearch.getRetention().setEnabled(true);
-      config.elasticsearch.getRetention().setPolicyName("policy_name");
-
-      startExporter();
-
-      final var createdIndex =
-          testClient.indices().get(req -> req.index(index.getFullQualifiedName())).result();
-
-      assertThat(
-              createdIndex.get(index.getFullQualifiedName()).settings().index().lifecycle().name())
-          .isEqualTo("policy_name");
-    }
   }
 
   @Nested


### PR DESCRIPTION
## Description

Do not assign ILM polices to main indices, this will only be done by the archiver, by default we do not want to lose any information.

Success Criteria:
- [x] Do not assign ILM to main indices.

## Related issues

relates to #22668 
