### PR TITLE
Configurable index shards and replicas

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -50,11 +50,17 @@ public class ElasticsearchSchemaManager implements SchemaManager {
             .keySet();
     indexTemplateDescriptors.stream()
         .filter(descriptor -> !existingTemplateNames.contains(descriptor.getTemplateName()))
-        .forEach(descriptor -> createIndexTemplate(descriptor, true));
+        .forEach(
+            descriptor ->
+                elasticsearchClient.createIndexTemplate(
+                    descriptor, getIndexSettings(descriptor.getIndexName()), true));
 
     indexDescriptors.stream()
         .filter(descriptor -> !existingIndexNames.contains(descriptor.getFullQualifiedName()))
-        .forEach(elasticsearchClient::createIndex);
+        .forEach(
+            descriptor ->
+                elasticsearchClient.createIndex(
+                    descriptor, getIndexSettings(descriptor.getIndexName())));
   }
 
   @Override
@@ -65,7 +71,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
       if (descriptor instanceof IndexTemplateDescriptor) {
         LOG.info("Updating template: {}", ((IndexTemplateDescriptor) descriptor).getTemplateName());
-        createIndexTemplate((IndexTemplateDescriptor) descriptor, false);
+        elasticsearchClient.createIndexTemplate(
+            (IndexTemplateDescriptor) descriptor,
+            getIndexSettings(descriptor.getIndexName()),
+            false);
       } else {
         LOG.info(
             "Index alias: {}. New fields will be added {}", descriptor.getAlias(), newProperties);
@@ -102,24 +111,22 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     }
   }
 
-  private void createIndexTemplate(
-      final IndexTemplateDescriptor templateDescriptor, final boolean create) {
+  private IndexSettings getIndexSettings(final String indexName) {
     final var templateReplicas =
         config
             .getReplicasByIndexName()
             .getOrDefault(
-                templateDescriptor.getIndexName(),
-                config.getDefaultSettings().getNumberOfReplicas());
+                indexName, config.getDefaultSettings().getNumberOfReplicas());
     final var templateShards =
         config
             .getShardsByIndexName()
             .getOrDefault(
-                templateDescriptor.getIndexName(), config.getDefaultSettings().getNumberOfShards());
+                indexName, config.getDefaultSettings().getNumberOfShards());
 
     final var settings = new IndexSettings();
     settings.setNumberOfShards(templateShards);
     settings.setNumberOfReplicas(templateReplicas);
 
-    elasticsearchClient.createIndexTemplate(templateDescriptor, settings, create);
+    return settings;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -115,13 +115,11 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     final var templateReplicas =
         config
             .getReplicasByIndexName()
-            .getOrDefault(
-                indexName, config.getDefaultSettings().getNumberOfReplicas());
+            .getOrDefault(indexName, config.getDefaultSettings().getNumberOfReplicas());
     final var templateShards =
         config
             .getShardsByIndexName()
-            .getOrDefault(
-                indexName, config.getDefaultSettings().getNumberOfShards());
+            .getOrDefault(indexName, config.getDefaultSettings().getNumberOfShards());
 
     final var settings = new IndexSettings();
     settings.setNumberOfShards(templateShards);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.Set;
 
 public interface SearchEngineClient {
-  void createIndex(final IndexDescriptor indexDescriptor);
+  void createIndex(final IndexDescriptor indexDescriptor, final IndexSettings settings);
 
   void createIndexTemplate(
       final IndexTemplateDescriptor indexDescriptor,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -211,6 +211,25 @@ public class ElasticsearchEngineClientIT {
   }
 
   @Test
+  void shouldSetReplicasAndShardsFromConfigurationDuringIndexCreation() throws IOException {
+    final var index =
+        SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
+
+    final var settings = new IndexSettings();
+    settings.setNumberOfReplicas(5);
+    settings.setNumberOfShards(10);
+    elsEngineClient.createIndex(index, settings);
+
+    final var indices = elsClient.indices().get(req -> req.index("index_name"));
+
+    assertThat(indices.result().size()).isEqualTo(1);
+    assertThat(indices.result().get("index_name").settings().index().numberOfReplicas())
+        .isEqualTo("5");
+    assertThat(indices.result().get("index_name").settings().index().numberOfShards())
+        .isEqualTo("10");
+  }
+
+  @Test
   void shouldCreateIndexLifeCyclePolicy() throws IOException {
     elsEngineClient.putIndexLifeCyclePolicy("policy_name", "20d");
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -107,7 +107,7 @@ public class ElasticsearchEngineClientIT {
         SchemaTestUtil.mockIndex(qualifiedIndexName, "alias", "index_name", "/mappings.json");
 
     // when
-    elsEngineClient.createIndex(descriptor);
+    elsEngineClient.createIndex(descriptor, new IndexSettings());
 
     // then
     final var index =
@@ -121,7 +121,7 @@ public class ElasticsearchEngineClientIT {
     final var index =
         SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
 
-    elsEngineClient.createIndex(index);
+    elsEngineClient.createIndex(index, new IndexSettings());
 
     final var mappings = elsEngineClient.getMappings("*", MappingSource.INDEX);
 
@@ -198,7 +198,7 @@ public class ElasticsearchEngineClientIT {
     final var index =
         SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
 
-    elsEngineClient.createIndex(index);
+    elsEngineClient.createIndex(index, new IndexSettings());
 
     final Map<String, String> newSettings = Map.of("index.lifecycle.name", "test");
     elsEngineClient.putSettings(List.of(index), newSettings);


### PR DESCRIPTION
## Description

Configuration for replicas and shards now apply to indices (alongside index templates).

**Success Criteria**
- [x] When creating indices with no configuration they inherit default settings defined in `ElasticsearchProperties.IndexSettings`
- [x] When creating indices with specified replica and shard configuration for the index it should be applied. 

## Related issues

closes #23083 
