### PR TITLE
feat: rename incident to hasIncident in flow node instance api

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/FlownodeInstanceFilter.java
@@ -81,7 +81,7 @@ public interface FlownodeInstanceFilter extends SearchRequestFilter {
    * @param value has the flow node instance an incident
    * @return the updated filter
    */
-  FlownodeInstanceFilter incident(final boolean value);
+  FlownodeInstanceFilter hasIncident(final boolean value);
 
   /**
    * Filters flow node instances by incident key.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/FlownodeInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/FlownodeInstanceFilterImpl.java
@@ -72,8 +72,8 @@ public class FlownodeInstanceFilterImpl
   }
 
   @Override
-  public FlownodeInstanceFilter incident(final boolean value) {
-    filter.setIncident(value);
+  public FlownodeInstanceFilter hasIncident(final boolean value) {
+    filter.hasIncident(value);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/FlowNodeInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/FlowNodeInstanceImpl.java
@@ -40,7 +40,7 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
     flowNodeId = item.getFlowNodeId();
     startDate = item.getStartDate();
     endDate = item.getEndDate();
-    incident = item.getIncident();
+    incident = item.getHasIncident();
     incidentKey = item.getIncidentKey();
     state = item.getState();
     tenantId = item.getTenantId();

--- a/clients/java/src/test/java/io/camunda/zeebe/client/flownodeinstance/FlownodeInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/flownodeinstance/FlownodeInstanceTest.java
@@ -52,7 +52,7 @@ public class FlownodeInstanceTest extends ClientRestTest {
                     .bpmnProcessId("complexProcess")
                     .processInstanceKey(3L)
                     .flowNodeId("flowNodeId")
-                    .incident(true)
+                    .hasIncident(true)
                     .incidentKey(4L)
                     .treePath("processInstanceKey/flowNodeId")
                     .tenantId("<default>"))
@@ -69,7 +69,7 @@ public class FlownodeInstanceTest extends ClientRestTest {
     assertThat(filter.getProcessDefinitionId()).isEqualTo("complexProcess");
     assertThat(filter.getProcessInstanceKey()).isEqualTo(3L);
     assertThat(filter.getFlowNodeId()).isEqualTo("flowNodeId");
-    assertThat(filter.getIncident()).isTrue();
+    assertThat(filter.getHasIncident()).isTrue();
     assertThat(filter.getIncidentKey()).isEqualTo(4L);
     assertThat(filter.getTreePath()).isEqualTo("processInstanceKey/flowNodeId");
     assertThat(filter.getTenantId()).isEqualTo("<default>");

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/FlownodeInstanceFilterTransformer.java
@@ -27,12 +27,12 @@ public class FlownodeInstanceFilterTransformer
         longTerms("key", filter.flowNodeInstanceKeys()),
         longTerms("processInstanceKey", filter.processInstanceKeys()),
         longTerms("processDefinitionKey", filter.processDefinitionKeys()),
-        stringTerms("bpmnProcessId", filter.bpmnProcessIds()),
+        stringTerms("bpmnProcessId", filter.processDefinitionIds()),
         getStateQuery(filter.states()),
         getTypeQuery(filter.types()),
         stringTerms("flowNodeId", filter.flowNodeIds()),
         stringTerms("treePath", filter.treePaths()),
-        filter.incident() != null ? term("incident", filter.incident()) : null,
+        filter.hasIncident() != null ? term("incident", filter.hasIncident()) : null,
         longTerms("incidentKey", filter.incidentKeys()),
         stringTerms("tenantId", filter.tenantIds()));
   }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/FlowNodeInstanceFilterTest.java
@@ -71,7 +71,8 @@ public final class FlowNodeInstanceFilterTest extends AbstractTransformerTest {
 
   @Test
   public void shouldQueryByBpmnProcessId() {
-    final var filter = FilterBuilders.flowNodeInstance(f -> f.bpmnProcessIds("complexProcess"));
+    final var filter =
+        FilterBuilders.flowNodeInstance(f -> f.processDefinitionIds("complexProcess"));
     // when
     final var searchRequest = transformQuery(filter);
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/FlowNodeInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/FlowNodeInstanceSortTest.java
@@ -31,7 +31,7 @@ public class FlowNodeInstanceSortTest extends AbstractSortTransformerTest {
         new FlowNodeInstanceSortTest.TestArguments(
             "processDefinitionKey", SortOrder.ASC, s -> s.processDefinitionKey().asc()),
         new FlowNodeInstanceSortTest.TestArguments(
-            "bpmnProcessId", SortOrder.ASC, s -> s.bpmnProcessId().asc()),
+            "bpmnProcessId", SortOrder.ASC, s -> s.processDefinitionId().asc()),
         new FlowNodeInstanceSortTest.TestArguments(
             "startDate", SortOrder.ASC, s -> s.startDate().asc()),
         new FlowNodeInstanceSortTest.TestArguments(

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FlowNodeInstanceFilter.java
@@ -21,12 +21,12 @@ public record FlowNodeInstanceFilter(
     List<Long> flowNodeInstanceKeys,
     List<Long> processInstanceKeys,
     List<Long> processDefinitionKeys,
-    List<String> bpmnProcessIds,
+    List<String> processDefinitionIds,
     List<FlowNodeState> states,
     List<FlowNodeType> types,
     List<String> flowNodeIds,
     List<String> treePaths,
-    Boolean incident,
+    Boolean hasIncident,
     List<Long> incidentKeys,
     List<String> tenantIds)
     implements FilterBase {
@@ -36,12 +36,12 @@ public record FlowNodeInstanceFilter(
     private List<Long> flowNodeInstanceKeys;
     private List<Long> processInstanceKeys;
     private List<Long> processDefinitionKeys;
-    private List<String> bpmnProcessIds;
+    private List<String> processDefinitionIds;
     private List<FlowNodeState> states;
     private List<FlowNodeType> types;
     private List<String> flowNodeIds;
     private List<String> treePaths;
-    private Boolean incident;
+    private Boolean hasIncident;
     private List<Long> incidentKeys;
     private List<String> tenantIds;
 
@@ -72,13 +72,13 @@ public record FlowNodeInstanceFilter(
       return processDefinitionKeys(collectValuesAsList(values));
     }
 
-    public FlowNodeInstanceFilter.Builder bpmnProcessIds(final List<String> values) {
-      bpmnProcessIds = addValuesToList(bpmnProcessIds, values);
+    public FlowNodeInstanceFilter.Builder processDefinitionIds(final List<String> values) {
+      processDefinitionIds = addValuesToList(processDefinitionIds, values);
       return this;
     }
 
-    public FlowNodeInstanceFilter.Builder bpmnProcessIds(final String... values) {
-      return bpmnProcessIds(collectValuesAsList(values));
+    public FlowNodeInstanceFilter.Builder processDefinitionIds(final String... values) {
+      return processDefinitionIds(collectValuesAsList(values));
     }
 
     public FlowNodeInstanceFilter.Builder states(final List<FlowNodeState> values) {
@@ -117,8 +117,8 @@ public record FlowNodeInstanceFilter(
       return treePaths(collectValuesAsList(values));
     }
 
-    public FlowNodeInstanceFilter.Builder incident(final Boolean value) {
-      incident = value;
+    public FlowNodeInstanceFilter.Builder hasIncident(final Boolean value) {
+      hasIncident = value;
       return this;
     }
 
@@ -146,12 +146,12 @@ public record FlowNodeInstanceFilter(
           Objects.requireNonNullElse(flowNodeInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           Objects.requireNonNullElse(processDefinitionKeys, Collections.emptyList()),
-          Objects.requireNonNullElse(bpmnProcessIds, Collections.emptyList()),
+          Objects.requireNonNullElse(processDefinitionIds, Collections.emptyList()),
           Objects.requireNonNullElse(states, Collections.emptyList()),
           Objects.requireNonNullElse(types, Collections.emptyList()),
           Objects.requireNonNullElse(flowNodeIds, Collections.emptyList()),
           Objects.requireNonNullElse(treePaths, Collections.emptyList()),
-          incident,
+          hasIncident,
           Objects.requireNonNullElse(incidentKeys, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/FlowNodeInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/FlowNodeInstanceSort.java
@@ -41,7 +41,7 @@ public record FlowNodeInstanceSort(List<FieldSorting> orderings) implements Sort
       return this;
     }
 
-    public Builder bpmnProcessId() {
+    public Builder processDefinitionId() {
       currentOrdering = new FieldSorting("bpmnProcessId", null);
       return this;
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2690,7 +2690,7 @@ components:
           description: The process definition key associated to this flow node instance.
           format: int64
         processDefinitionId:
-          description: The bpmn process id associated to this flow node instance.
+          description: The process definition id associated to this flow node instance.
           type: string
         state:
           description: State of flow node instance as defined set of values.
@@ -2737,7 +2737,7 @@ components:
         treePath:
           type: string
           description: The path of keys from process instance to this flow node instance separated by '/'.
-        incident:
+        hasIncident:
           type: boolean
           description: Shows whether this flow node instance has an incident related to.
         incidentKey:
@@ -2772,7 +2772,7 @@ components:
           type: integer
           format: int64
         processDefinitionId:
-          description: The bpmn process id associated to this flow node instance.
+          description: The process definition id associated to this flow node instance.
           type: string
         startDate:
           description: Date when flow node instance started.
@@ -2824,7 +2824,7 @@ components:
             - ACTIVE
             - COMPLETED
             - TERMINATED
-        incident:
+        hasIncident:
           description: Shows whether this flow node instance has an incident. If true also an incidentKey is provided.
           type: boolean
         incidentKey:
@@ -2890,7 +2890,7 @@ components:
           description: The process definition key associated to this incident.
         processDefinitionId:
           type: string
-          description: The bpmn process id associated to this incident.
+          description: The process definition id associated to this incident.
         processInstanceKey:
           type: integer
           format: int64
@@ -2965,7 +2965,7 @@ components:
           description: The process definition key associated to this incident.
         processDefinitionId:
           type: string
-          description: The bpmn process id associated to this incident.
+          description: The process definition id associated to this incident.
         processInstanceKey:
           type: integer
           format: int64

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -377,7 +377,8 @@ public final class SearchQueryRequestMapper {
                   .ifPresent(builder::processInstanceKeys);
               Optional.ofNullable(f.getProcessDefinitionKey())
                   .ifPresent(builder::processDefinitionKeys);
-              Optional.ofNullable(f.getProcessDefinitionId()).ifPresent(builder::bpmnProcessIds);
+              Optional.ofNullable(f.getProcessDefinitionId())
+                  .ifPresent(builder::processDefinitionIds);
               Optional.ofNullable(f.getState())
                   .ifPresent(s -> builder.states(FlowNodeState.valueOf(s.getValue())));
               Optional.ofNullable(f.getType())
@@ -385,7 +386,7 @@ public final class SearchQueryRequestMapper {
                       t -> builder.types(FlowNodeType.fromZeebeBpmnElementType(t.getValue())));
               Optional.ofNullable(f.getFlowNodeId()).ifPresent(builder::flowNodeIds);
               Optional.ofNullable(f.getTreePath()).ifPresent(builder::treePaths);
-              Optional.ofNullable(f.getIncident()).ifPresent(builder::incident);
+              Optional.ofNullable(f.getHasIncident()).ifPresent(builder::hasIncident);
               Optional.ofNullable(f.getIncidentKey()).ifPresent(builder::incidentKeys);
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
             });
@@ -551,7 +552,7 @@ public final class SearchQueryRequestMapper {
         case "flowNodeInstanceKey" -> builder.flowNodeInstanceKey();
         case "processInstanceKey" -> builder.processInstanceKey();
         case "processDefinitionKey" -> builder.processDefinitionKey();
-        case "bpmnProcessId" -> builder.bpmnProcessId();
+        case "processDefinitionId" -> builder.processDefinitionId();
         case "startDate" -> builder.startDate();
         case "endDate" -> builder.endDate();
         case "flowNodeId" -> builder.flowNodeId();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -279,7 +279,7 @@ public final class SearchQueryResponseMapper {
         .processDefinitionId(instance.bpmnProcessId())
         .processInstanceKey(instance.processInstanceKey())
         .incidentKey(instance.incidentKey())
-        .incident(instance.incident())
+        .hasIncident(instance.incident())
         .startDate(instance.startDate())
         .endDate(instance.endDate())
         .state(FlowNodeInstanceItem.StateEnum.fromValue(instance.state().name()))

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -87,7 +87,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                    "treePath":"5/23",
                    "type":"SERVICE_TASK",
                    "state":"ACTIVE",
-                   "incident":true,
+                   "hasIncident":true,
                    "incidentKey":1234,
                    "tenantId":"tenantId"
                  }
@@ -184,7 +184,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                 "flowNodeId": "StartEvent_1",
                 "flowNodeName": "name",
                 "treePath": "2251799813685989/2251799813685996",
-                "incident": true,
+                "hasIncident": true,
                 "incidentKey": 2251799813685320,
                 "tenantId": "default"
               }
@@ -212,12 +212,12 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                         .flowNodeInstanceKeys(2251799813685996L)
                         .processInstanceKeys(2251799813685989L)
                         .processDefinitionKeys(3L)
-                        .bpmnProcessIds("complexProcess")
+                        .processDefinitionIds("complexProcess")
                         .states(FlowNodeState.ACTIVE)
                         .types(FlowNodeType.SERVICE_TASK)
                         .flowNodeIds("StartEvent_1")
                         .treePaths("2251799813685989/2251799813685996")
-                        .incident(true)
+                        .hasIncident(true)
                         .incidentKeys(2251799813685320L)
                         .tenantIds("default")
                         .build())
@@ -236,7 +236,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                  { "field": "flowNodeInstanceKey", "order": "ASC" },
                  { "field": "processInstanceKey", "order": "ASC" },
                  { "field": "processDefinitionKey", "order": "ASC" },
-                 { "field": "bpmnProcessId", "order": "ASC" },
+                 { "field": "processDefinitionId", "order": "ASC" },
                  { "field": "startDate", "order": "DESC" },
                  { "field": "endDate", "order": "DESC" },
                  { "field": "flowNodeId", "order": "ASC" },
@@ -272,7 +272,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                         .asc()
                         .processDefinitionKey()
                         .asc()
-                        .bpmnProcessId()
+                        .processDefinitionId()
                         .asc()
                         .startDate()
                         .desc()


### PR DESCRIPTION
## Description

* Rename `FlowNodeInstance::incident` to `FlowNodeInstance::hasIncident` in order to make clear it is a marker to signal the flow node instance has an incident.

Related to #22716 
