### PR TITLE
feat: add initial command to scale up partitions

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -76,6 +77,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.AUTHORIZATION, AuthorizationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.ROLE, RoleRecord::new);
     RECORDS_BY_TYPE.put(ValueType.TENANT, TenantRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.SCALE, ScaleRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,7 +46,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.AUTHORIZATION);
+      EnumSet.range(ValueType.JOB, ValueType.SCALE);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.user.UserProcessors;
 import io.camunda.zeebe.engine.processing.usertask.UserTaskProcessor;
+import io.camunda.zeebe.engine.scaling.ScalingProcessors;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -231,6 +232,8 @@ public final class EngineProcessors {
         writers,
         commandDistributionBehavior,
         authCheckBehavior);
+
+    ScalingProcessors.addScalingProcessors(typedRecordProcessors, writers, keyGenerator);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -233,7 +233,8 @@ public final class EngineProcessors {
         commandDistributionBehavior,
         authCheckBehavior);
 
-    ScalingProcessors.addScalingProcessors(typedRecordProcessors, writers, keyGenerator);
+    ScalingProcessors.addScalingProcessors(
+        typedRecordProcessors, writers, keyGenerator, processingState);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -54,6 +54,13 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
       return;
     }
 
+    if (scaleUp.desiredPartitionCount() < 1 || scaleUp.currentPartitionCount() < 1) {
+      final var reason = "Partition count must be at least 1";
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
+      return;
+    }
+
     final var scalingKey = keyGenerator.nextKey();
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
     responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -55,6 +55,7 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
     }
 
     final var scalingKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALING_UP, scaleUp);
     responseWriter.writeEventOnCommand(scalingKey, ScaleIntent.SCALING_UP, scaleUp, command);
 
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, new ScaleRecord());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -9,8 +9,12 @@ package io.camunda.zeebe.engine.scaling;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -18,15 +22,33 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
+  private final RoutingState routingState;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
 
-  public ScaleUpProcessor(final KeyGenerator keyGenerator, final Writers writers) {
+  public ScaleUpProcessor(
+      final KeyGenerator keyGenerator, final Writers writers, final RoutingState routingState) {
     this.keyGenerator = keyGenerator;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
     stateWriter = writers.state();
+    this.routingState = routingState;
   }
 
   @Override
   public void processRecord(final TypedRecord<ScaleRecord> record) {
-    final var scaleKey = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(scaleKey, ScaleIntent.SCALED_UP, new ScaleRecord());
+    if (!routingState.isInitialized()) {
+      rejectionWriter.appendRejection(
+          record,
+          RejectionType.INVALID_STATE,
+          "Routing state is not initialized, partition scaling is probably disabled.");
+      return;
+    }
+
+    final var scalingKey = keyGenerator.nextKey();
+    responseWriter.writeEventOnCommand(
+        scalingKey, ScaleIntent.SCALING_UP, record.getValue(), record);
+
+    stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, new ScaleRecord());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+
+  public ScaleUpProcessor(final KeyGenerator keyGenerator, final Writers writers) {
+    this.keyGenerator = keyGenerator;
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<ScaleRecord> record) {
+    final var scaleKey = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(scaleKey, ScaleIntent.SCALED_UP, new ScaleRecord());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -27,12 +28,14 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
   private final TypedResponseWriter responseWriter;
 
   public ScaleUpProcessor(
-      final KeyGenerator keyGenerator, final Writers writers, final RoutingState routingState) {
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final ProcessingState processingState) {
     this.keyGenerator = keyGenerator;
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     stateWriter = writers.state();
-    this.routingState = routingState;
+    routingState = processingState.getRoutingState();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -38,10 +38,10 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
   @Override
   public void processRecord(final TypedRecord<ScaleRecord> record) {
     if (!routingState.isInitialized()) {
-      rejectionWriter.appendRejection(
-          record,
-          RejectionType.INVALID_STATE,
-          "Routing state is not initialized, partition scaling is probably disabled.");
+      final var reason =
+          "Routing state is not initialized, partition scaling is probably disabled.";
+      rejectionWriter.appendRejection(record, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectionOnCommand(record, RejectionType.INVALID_STATE, reason);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -47,14 +47,14 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
       return;
     }
 
-    if (scaleUp.desiredPartitionCount() < scaleUp.currentPartitionCount()) {
+    if (scaleUp.getDesiredPartitionCount() < scaleUp.getCurrentPartitionCount()) {
       final var reason = "Desired partition count must be greater than current partition count";
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
       return;
     }
 
-    if (scaleUp.desiredPartitionCount() < 1 || scaleUp.currentPartitionCount() < 1) {
+    if (scaleUp.getDesiredPartitionCount() < 1 || scaleUp.getCurrentPartitionCount() < 1) {
       final var reason = "Partition count must be at least 1";
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaledUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaledUpApplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+
+public class ScaledUpApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+  private final MutableRoutingState routingState;
+
+  public ScaledUpApplier(final MutableRoutingState routingState) {
+    this.routingState = routingState;
+  }
+
+  @Override
+  public void applyState(final long key, final ScaleRecord value) {
+    routingState.arriveAtDesiredState();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+/** Utility class to add all scaling related processors to the {@link TypedRecordProcessors}. */
+public final class ScalingProcessors {
+  private ScalingProcessors() {}
+
+  public static void addScalingProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final KeyGenerator keyGenerator) {
+    typedRecordProcessors.onCommand(
+        ValueType.SCALE, ScaleIntent.SCALE_UP, new ScaleUpProcessor(keyGenerator, writers));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -26,6 +26,6 @@ public final class ScalingProcessors {
     typedRecordProcessors.onCommand(
         ValueType.SCALE,
         ScaleIntent.SCALE_UP,
-        new ScaleUpProcessor(keyGenerator, writers, processingState.getRoutingState()));
+        new ScaleUpProcessor(keyGenerator, writers, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.scaling;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -20,8 +21,11 @@ public final class ScalingProcessors {
   public static void addScalingProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState) {
     typedRecordProcessors.onCommand(
-        ValueType.SCALE, ScaleIntent.SCALE_UP, new ScaleUpProcessor(keyGenerator, writers));
+        ValueType.SCALE,
+        ScaleIntent.SCALE_UP,
+        new ScaleUpProcessor(keyGenerator, writers, processingState.getRoutingState()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
+  final MutableRoutingState routingState;
+
+  public ScalingUpApplier(final MutableRoutingState routingState) {
+    this.routingState = routingState;
+  }
+
+  @Override
+  public void applyState(final long key, final ScaleRecord value) {
+    final var partitionCount = value.desiredPartitionCount();
+    final var partitions =
+        IntStream.rangeClosed(1, partitionCount).boxed().collect(Collectors.toUnmodifiableSet());
+
+    routingState.setDesiredPartitions(partitions);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
@@ -23,7 +23,7 @@ public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRec
 
   @Override
   public void applyState(final long key, final ScaleRecord value) {
-    final var partitionCount = value.desiredPartitionCount();
+    final var partitionCount = value.getDesiredPartitionCount();
     final var partitions =
         IntStream.rangeClosed(1, partitionCount).boxed().collect(Collectors.toUnmodifiableSet());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.scaling.ScaledUpApplier;
 import io.camunda.zeebe.engine.scaling.ScalingUpApplier;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
@@ -457,6 +458,7 @@ public final class EventAppliers implements EventApplier {
 
   private void registerScalingAppliers(final MutableProcessingState state) {
     register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
+    register(ScaleIntent.SCALED_UP, new ScaledUpApplier(state.getRoutingState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.scaling.ScalingUpApplier;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForVersion;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
@@ -113,6 +115,7 @@ public final class EventAppliers implements EventApplier {
     registerAuthorizationAppliers(state);
     registerClockAppliers(state);
     registerRoleAppliers(state);
+    registerScalingAppliers(state);
     return this;
   }
 
@@ -450,6 +453,10 @@ public final class EventAppliers implements EventApplier {
 
   private void registerRoleAppliers(final MutableProcessingState state) {
     register(RoleIntent.CREATED, new RoleCreatedApplier(state.getRoleState()));
+  }
+
+  private void registerScalingAppliers(final MutableProcessingState state) {
+    register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
@@ -18,5 +18,15 @@ public interface MutableRoutingState extends RoutingState {
    */
   void initializeRoutingInfo(int partitionCount);
 
+  /**
+   * Creates a new desired state by copying the current state and using the given partitions.
+   * Message correlation is not modified and only copied from the current state.
+   */
   void setDesiredPartitions(Set<Integer> partitions);
+
+  /**
+   * Copies the desired state to the current state. The desired state must be set via {@link
+   * #setDesiredPartitions(Set)} before calling this method.
+   */
+  void arriveAtDesiredState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoutingState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import java.util.Set;
 
 public interface MutableRoutingState extends RoutingState {
 
@@ -16,4 +17,6 @@ public interface MutableRoutingState extends RoutingState {
    * is already available, this method does nothing.
    */
   void initializeRoutingInfo(int partitionCount);
+
+  void setDesiredPartitions(Set<Integer> partitions);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -74,4 +74,12 @@ public final class DbRoutingState implements MutableRoutingState {
     key.wrapString(DESIRED_KEY);
     columnFamily.upsert(key, desiredRoutingInfo);
   }
+
+  @Override
+  public void arriveAtDesiredState() {
+    key.wrapString(DESIRED_KEY);
+    final var desiredPartitions = columnFamily.get(key);
+    key.wrapString(CURRENT_KEY);
+    columnFamily.update(key, desiredPartitions);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -19,21 +19,19 @@ import java.util.stream.IntStream;
 
 public final class DbRoutingState implements MutableRoutingState {
 
-  /**
-   * This state will later be extended to hold current and <i>desired</i> routing information. This
-   * is the key for the current routing information.
-   */
   private static final String CURRENT_KEY = "CURRENT";
+  private static final String DESIRED_KEY = "DESIRED";
 
   private final ColumnFamily<DbString, PersistedRoutingInfo> columnFamily;
   private final DbString key = new DbString();
   private final PersistedRoutingInfo currentRoutingInfo = new PersistedRoutingInfo();
+  private final PersistedRoutingInfo desiredRoutingInfo = new PersistedRoutingInfo();
 
   public DbRoutingState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     columnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.ROUTING, transactionContext, key, currentRoutingInfo);
+            ZbColumnFamilies.ROUTING, transactionContext, key, new PersistedRoutingInfo());
   }
 
   @Override
@@ -64,5 +62,16 @@ public final class DbRoutingState implements MutableRoutingState {
     currentRoutingInfo.setPartitions(partitions);
     currentRoutingInfo.setMessageCorrelation(new MessageCorrelation.HashMod(partitionCount));
     columnFamily.insert(key, currentRoutingInfo);
+  }
+
+  @Override
+  public void setDesiredPartitions(final Set<Integer> partitions) {
+    final var currentMessageCorrelation = messageCorrelation();
+    desiredRoutingInfo.reset();
+    desiredRoutingInfo.setPartitions(partitions);
+    desiredRoutingInfo.setMessageCorrelation(currentMessageCorrelation);
+
+    key.wrapString(DESIRED_KEY);
+    columnFamily.upsert(key, desiredRoutingInfo);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -112,7 +112,13 @@ public class ScaleUpTest {
     engine.writeRecords(command);
 
     // then
-    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst()).isPresent();
+    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst())
+        .hasValueSatisfying(
+            rejection -> {
+              assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+              assertThat(rejection.getRejectionReason())
+                  .isEqualTo("Partition count must be at least 1");
+            });
   }
 
   @Test
@@ -129,7 +135,14 @@ public class ScaleUpTest {
     engine.writeRecords(command);
 
     // then
-    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst()).isPresent();
+    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst())
+        .hasValueSatisfying(
+            rejection -> {
+              assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+              assertThat(rejection.getRejectionReason())
+                  .isEqualTo(
+                      "Desired partition count must be greater than current partition count");
+            });
   }
 
   private void initRoutingState() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ScaleUpTest {
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void beforeEach() {
+    ((MutableRoutingState) engine.getProcessingState().getRoutingState()).initializeRoutingInfo(1);
+    RecordingExporter.reset();
+    clearInvocations(engine.getCommandResponseWriter());
+  }
+
+  @Test
+  public void shouldRespondToScaleUp() {
+    // given
+    final var command =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.SCALE_UP,
+                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(3));
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    verify(engine.getCommandResponseWriter(), timeout(1000).times(1))
+        .tryWriteResponse(anyInt(), anyLong());
+  }
+
+  @Test
+  public void shouldFinishScaling() {
+    // given
+    final var command =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.SCALE_UP,
+                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(3));
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    assertThat(
+            RecordingExporter.scaleRecords()
+                .limit(r -> r.getIntent() == ScaleIntent.SCALED_UP)
+                .map(Record::getIntent))
+        .containsExactly(ScaleIntent.SCALE_UP, ScaleIntent.SCALING_UP, ScaleIntent.SCALED_UP);
+  }
+
+  @Test
+  public void shouldRejectEmptyScaleUp() {
+    // given
+    final var command = RecordToWrite.command().scale(ScaleIntent.SCALE_UP, new ScaleRecord());
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst()).isPresent();
+  }
+
+  @Test
+  public void shouldRejectScaleDown() {
+    // given
+    final var command =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.SCALE_UP,
+                new ScaleRecord().setCurrentPartitionCount(3).setDesiredPartitionCount(1));
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst()).isPresent();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -117,7 +117,8 @@ public class ScaleUpTest {
             rejection -> {
               assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
               assertThat(rejection.getRejectionReason())
-                  .isEqualTo("Partition count must be at least 1");
+                  .isEqualTo(
+                      "Desired partition count must be greater than current partition count");
             });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -122,6 +122,29 @@ public class ScaleUpTest {
   }
 
   @Test
+  public void shouldRejectScaleUpWithInvalidPartitionCount() {
+    // given
+    initRoutingState();
+    final var command =
+        RecordToWrite.command()
+            .scale(
+                ScaleIntent.SCALE_UP,
+                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(10000));
+
+    // when
+    engine.writeRecords(command);
+
+    // then
+    assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst())
+        .hasValueSatisfying(
+            rejection -> {
+              assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+              assertThat(rejection.getRejectionReason())
+                  .startsWith("Partition count must be at most");
+            });
+  }
+
+  @Test
   public void shouldRejectScaleDown() {
     // given
     initRoutingState();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.routing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class DbRoutingStateTest {
+  @SuppressWarnings("unused")
+  private MutableProcessingState processingState;
+
+  @Test
+  void shouldDefaultToNotInitialized() {
+    // given
+    assertThat(processingState.getRoutingState().isInitialized()).isFalse();
+  }
+
+  @Test
+  void shouldInitializeRoutingInfo() {
+    // given
+    final var routingState = processingState.getRoutingState();
+    final int partitionCount = 3;
+
+    // when
+    routingState.initializeRoutingInfo(partitionCount);
+
+    // then
+    assertThat(routingState.isInitialized()).isTrue();
+    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(routingState.messageCorrelation())
+        .isEqualTo(new RoutingState.MessageCorrelation.HashMod(3));
+  }
+
+  @Test
+  void shouldArriveAtDesiredState() {
+    // given
+    final var routingState = processingState.getRoutingState();
+    routingState.initializeRoutingInfo(1);
+    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1);
+
+    // when
+    routingState.setDesiredPartitions(Set.of(1, 2, 3));
+
+    // then
+    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1);
+    assertThat(routingState.messageCorrelation())
+        .isEqualTo(new RoutingState.MessageCorrelation.HashMod(1));
+
+    // when
+    routingState.arriveAtDesiredState();
+
+    // then
+    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(routingState.messageCorrelation())
+        .isEqualTo(new RoutingState.MessageCorrelation.HashMod(1));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/RecordToWrite.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceCreationRecordValue;
@@ -153,6 +155,12 @@ public final class RecordToWrite implements LogAppendEntry {
         .valueType(ValueType.PROCESS_INSTANCE_MIGRATION)
         .intent(ProcessInstanceMigrationIntent.MIGRATE);
     unifiedRecordValue = (ProcessInstanceMigrationRecord) value;
+    return this;
+  }
+
+  public RecordToWrite scale(final ScaleIntent intent, final ScaleRecord value) {
+    recordMetadata.valueType(ValueType.SCALE).intent(intent);
+    unifiedRecordValue = value;
     return this;
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -133,6 +133,7 @@ final class TestSupport {
             ValueType.NULL_VAL,
             ValueType.PROCESS_INSTANCE_RESULT,
             ValueType.CLOCK,
+            ValueType.SCALE,
             // these are not yet supported
             ValueType.ROLE,
             ValueType.TENANT);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -121,6 +121,7 @@ final class TestSupport {
             ValueType.NULL_VAL,
             ValueType.PROCESS_INSTANCE_RESULT,
             ValueType.CLOCK,
+            ValueType.SCALE,
             // these are not yet supported
             ValueType.ROLE,
             ValueType.TENANT);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.scaling;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
+
+public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue {
+  private final IntegerProperty currentPartitionCountProp =
+      new IntegerProperty("currentPartitionCount", -1);
+  private final IntegerProperty desiredPartitionCountProp =
+      new IntegerProperty("desiredPartitionCount", -1);
+
+  public ScaleRecord() {
+    super(2);
+    declareProperty(currentPartitionCountProp).declareProperty(desiredPartitionCountProp);
+  }
+
+  @Override
+  public int currentPartitionCount() {
+    return currentPartitionCountProp.getValue();
+  }
+
+  @Override
+  public int desiredPartitionCount() {
+    return desiredPartitionCountProp.getValue();
+  }
+
+  public ScaleRecord setCurrentPartitionCount(final int currentPartitionCount) {
+    currentPartitionCountProp.setValue(currentPartitionCount);
+    return this;
+  }
+
+  public ScaleRecord setDesiredPartitionCount(final int desiredPartitionCount) {
+    desiredPartitionCountProp.setValue(desiredPartitionCount);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -13,9 +13,9 @@ import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 
 public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue {
   private final IntegerProperty currentPartitionCountProp =
-      new IntegerProperty("currentPartitionCount", -1);
+      new IntegerProperty("getCurrentPartitionCount", -1);
   private final IntegerProperty desiredPartitionCountProp =
-      new IntegerProperty("desiredPartitionCount", -1);
+      new IntegerProperty("getDesiredPartitionCount", -1);
 
   public ScaleRecord() {
     super(2);
@@ -23,22 +23,22 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
   }
 
   @Override
-  public int currentPartitionCount() {
+  public int getCurrentPartitionCount() {
     return currentPartitionCountProp.getValue();
   }
 
   @Override
-  public int desiredPartitionCount() {
+  public int getDesiredPartitionCount() {
     return desiredPartitionCountProp.getValue();
-  }
-
-  public ScaleRecord setCurrentPartitionCount(final int currentPartitionCount) {
-    currentPartitionCountProp.setValue(currentPartitionCount);
-    return this;
   }
 
   public ScaleRecord setDesiredPartitionCount(final int desiredPartitionCount) {
     desiredPartitionCountProp.setValue(desiredPartitionCount);
+    return this;
+  }
+
+  public ScaleRecord setCurrentPartitionCount(final int currentPartitionCount) {
+    currentPartitionCountProp.setValue(currentPartitionCount);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -54,6 +54,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
@@ -2735,7 +2736,32 @@ final class JsonSerializableToJsonTest {
             "entityKey": -1
           }
           """
-      }
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////// ScaleRecord ////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ScaleRecord (empty)",
+        (Supplier<ScaleRecord>) ScaleRecord::new,
+        """
+        {
+          "currentPartitionCount": -1,
+          "desiredPartitionCount": -1
+        }
+        """
+      },
+      {
+        "ScaleRecord",
+        (Supplier<ScaleRecord>)
+            () -> new ScaleRecord().setCurrentPartitionCount(3).setDesiredPartitionCount(5),
+        """
+        {
+         "currentPartitionCount": 3,
+         "desiredPartitionCount": 5
+        }
+        """
+      },
     };
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -56,6 +56,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -96,6 +97,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRec
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
+import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.EnumSet;
@@ -245,6 +247,7 @@ public final class ValueTypeMapping {
         new Mapping<>(AuthorizationRecordValue.class, AuthorizationIntent.class));
     mapping.put(ValueType.ROLE, new Mapping<>(RoleRecordValue.class, RoleIntent.class));
     mapping.put(ValueType.TENANT, new Mapping<>(TenantRecordValue.class, TenantIntent.class));
+    mapping.put(ValueType.SCALE, new Mapping<>(ScaleRecordValue.class, ScaleIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_CORRELATION;
 
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -64,7 +65,8 @@ public interface Intent {
           ClockIntent.class,
           AuthorizationIntent.class,
           RoleIntent.class,
-          TenantIntent.class);
+          TenantIntent.class,
+          ScaleIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -160,6 +162,8 @@ public interface Intent {
         return RoleIntent.from(intent);
       case TENANT:
         return TenantIntent.from(intent);
+      case SCALE:
+        return ScaleIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -247,6 +251,8 @@ public interface Intent {
         return RoleIntent.valueOf(intent);
       case TENANT:
         return TenantIntent.valueOf(intent);
+      case SCALE:
+        return ScaleIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/ScaleIntent.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent.scaling;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+public enum ScaleIntent implements Intent {
+  SCALE_UP((short) 1, false),
+  SCALING_UP((short) 2, true),
+  SCALED_UP((short) 3, true);
+
+  private final short value;
+  private final boolean isEvent;
+
+  ScaleIntent(final short value, final boolean isEvent) {
+    this.value = value;
+    this.isEvent = isEvent;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return isEvent;
+  }
+
+  public static Intent from(final short intent) {
+    switch (intent) {
+      case 1:
+        return SCALE_UP;
+      case 2:
+        return SCALING_UP;
+      case 3:
+        return SCALED_UP;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.scaling;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableScaleRecordValue.Builder.class)
+public interface ScaleRecordValue extends RecordValue {
+  int currentPartitionCount();
+
+  int desiredPartitionCount();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -22,7 +22,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableScaleRecordValue.Builder.class)
 public interface ScaleRecordValue extends RecordValue {
-  int currentPartitionCount();
+  int getCurrentPartitionCount();
 
-  int desiredPartitionCount();
+  int getDesiredPartitionCount();
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -62,6 +62,7 @@
       <validValue name="TENANT">45</validValue>
 
       <!-- Management records / record not related to process automation -->
+      <validValue name="SCALE">253</validValue>
       <validValue name="CHECKPOINT">254</validValue>
     </enum>
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
@@ -102,6 +103,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.CLOCK, ClockRecord.class);
     registry.put(ValueType.AUTHORIZATION, AuthorizationRecord.class);
     registry.put(ValueType.TENANT, TenantRecord.class);
+    registry.put(ValueType.SCALE, ScaleRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -74,6 +75,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
+import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Iterator;
@@ -453,6 +455,14 @@ public final class RecordingExporter implements Exporter {
 
   public static AuthorizationRecordStream authorizationRecords(final AuthorizationIntent intent) {
     return authorizationRecords().withIntent(intent);
+  }
+
+  public static ScaleRecordStream scaleRecords() {
+    return new ScaleRecordStream(records(ValueType.SCALE, ScaleRecordValue.class));
+  }
+
+  public static ScaleRecordStream scaleRecords(final ScaleIntent intent) {
+    return scaleRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ScaleRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ScaleRecordStream.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
+import java.util.stream.Stream;
+
+public class ScaleRecordStream extends ExporterRecordStream<ScaleRecordValue, ScaleRecordStream> {
+
+  public ScaleRecordStream(final Stream<Record<ScaleRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ScaleRecordStream supply(final Stream<Record<ScaleRecordValue>> wrappedStream) {
+    return new ScaleRecordStream(wrappedStream);
+  }
+}


### PR DESCRIPTION
This adds a new `SCALE_UP` command and the events `SCALING_UP` and `SCALED_UP`.
The command starts the process required to scale up. For now, it only records the _desired_ routing state (i.e. the new number of partitions).
When done, the `SCALED_UP` event updates the _current_ routing state to the _desired_ one, effectively activating the new routing logic. At this point, commands are distributed to all new partitions too.

:thought_balloon: I've chosen to create new packages called `scaling` instead of putting everything next to the usual processing classes. This breaks the convention a bit but should make it much easier to find everything required for scaling and doesn't pollute the already quite big processing packages further.

closes https://github.com/camunda/camunda/issues/23109
