### PR TITLE
feat: provide isolate CompositeMeterRegistry for each ExporterContainer

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -13,17 +13,20 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.EnsureUtil;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
 import java.time.InstantSource;
 import org.slf4j.Logger;
 
-public final class ExporterContext implements Context {
+public final class ExporterContext implements Context, AutoCloseable {
 
   private static final RecordFilter DEFAULT_FILTER = new AcceptAllRecordsFilter();
 
   private final Logger logger;
   private final Configuration configuration;
   private final int partitionId;
-  private final MeterRegistry meterRegistry;
+  private final CompositeMeterRegistry meterRegistry;
+  private final MeterRegistry underlyingMetricRegistry;
   private final InstantSource clock;
 
   private RecordFilter filter = DEFAULT_FILTER;
@@ -37,7 +40,18 @@ public final class ExporterContext implements Context {
     this.logger = logger;
     this.configuration = configuration;
     this.partitionId = partitionId;
-    this.meterRegistry = meterRegistry;
+    underlyingMetricRegistry = meterRegistry;
+    this.meterRegistry = new CompositeMeterRegistry();
+    // meterRegistry is null in tests
+    if (meterRegistry != null) {
+      this.meterRegistry.add(meterRegistry);
+    }
+    this.meterRegistry
+        .config()
+        .commonTags(
+            Tags.of(
+                "partition", Integer.toString(partitionId),
+                "exporterId", configuration.getId()));
     this.clock = clock;
   }
 
@@ -74,6 +88,18 @@ public final class ExporterContext implements Context {
   public void setFilter(final RecordFilter filter) {
     EnsureUtil.ensureNotNull("filter", filter);
     this.filter = filter;
+  }
+
+  @Override
+  public void close() {
+    // Clear the registry, so the metrics created are deleted:
+    // it must be done before removing the parent registry
+    meterRegistry.clear();
+    // remove the parentMeterRegistry so it's not closed when we close the composite.
+    if (underlyingMetricRegistry != null) {
+      meterRegistry.remove(underlyingMetricRegistry);
+    }
+    meterRegistry.close();
   }
 
   private static final class AcceptAllRecordsFilter implements RecordFilter {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -55,7 +55,6 @@ public class ExecutionLatencyMetrics {
       final long creationTimeMs, final long completionTimeMs) {
     Timer.builder("zeebe.process.instance.execution.time")
         .description("The execution time of processing a complete process instance")
-        .tag("partition", Integer.toString(partitionId))
         .sla(PROCESS_INSTANCE_EXECUTION_BUCKETS)
         .register(meterRegistry)
         .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
@@ -64,7 +63,6 @@ public class ExecutionLatencyMetrics {
   public void observeJobLifeTime(final long creationTimeMs, final long completionTimeMs) {
     Timer.builder("zeebe.job.life.time")
         .description("The life time of an job")
-        .tag("partition", Integer.toString(partitionId))
         .sla(JOB_LIFE_TIME_BUCKETS)
         .register(meterRegistry)
         .record(completionTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
@@ -73,7 +71,6 @@ public class ExecutionLatencyMetrics {
   public void observeJobActivationTime(final long creationTimeMs, final long activationTimeMs) {
     Timer.builder("zeebe.job.activation.time")
         .description("The time until an job was activated")
-        .tag("partition", Integer.toString(partitionId))
         .sla(JOB_ACTIVATION_TIME_BUCKETS)
         .register(meterRegistry)
         .record(activationTimeMs - creationTimeMs, TimeUnit.MILLISECONDS);
@@ -99,7 +96,7 @@ public class ExecutionLatencyMetrics {
             () -> collection.get(partitionId).get())
         .description(
             "The current cached instances for counting their execution latency. If only short-lived instances are handled this can be seen or observed as the current active instance count.")
-        .tags("type", type, "partition", Integer.toString(partitionId))
+        .tags("type", type)
         .register(meterRegistry);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -253,5 +253,10 @@ final class ExporterContainer implements Controller {
     } catch (final Exception e) {
       context.getLogger().error("Error on close", e);
     }
+    try {
+      context.close();
+    } catch (final Exception e) {
+      context.getLogger().error("Error on context.close", e);
+    }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/context/ExporterContextTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.context;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ExporterContextTest {
+  private static final Logger LOG = LoggerFactory.getLogger(ExporterContextTest.class);
+  private static final InstantSource FIXED_INSTANT_SOURCE =
+      InstantSource.fixed(Instant.ofEpochMilli(123456789));
+
+  public ExporterContext makeExporterContext(
+      final int partitionId, final String exporterId, final MeterRegistry underlying) {
+    return new ExporterContext(
+        LOG,
+        new ExporterTestConfiguration<>(exporterId, Collections.emptyMap()),
+        partitionId,
+        underlying,
+        FIXED_INSTANT_SOURCE);
+  }
+
+  @Test
+  void shouldAddTagsAndCleanupWhenClosed() {
+    // given
+    final var partitionId = 1;
+    final var exporterId = "MetricTestExporter";
+    final var underlyingMeterRegistry = new SimpleMeterRegistry();
+    final var context = makeExporterContext(partitionId, exporterId, underlyingMeterRegistry);
+    final var meterRegistry = context.getMeterRegistry();
+    final var allRegistries = List.of(meterRegistry, underlyingMeterRegistry);
+
+    assertThat(meterRegistry.getMeters().size())
+        .isEqualTo(0)
+        .describedAs("Expected no metrics to be measured at start");
+
+    // when
+    final var timer = meterRegistry.timer("test");
+    timer.record(11, TimeUnit.MILLISECONDS);
+
+    final var expectedTags = Tags.of("partition", "1", "exporterId", exporterId);
+
+    // then
+    allRegistries.forEach(
+        mr ->
+            assertThat(mr.timer("test", expectedTags).count())
+                .isEqualTo(1)
+                .describedAs("Expected exactly 1 observed test sample counted"));
+
+    // when
+    context.close();
+
+    // then
+    allRegistries.forEach(
+        mr ->
+            assertThat(mr.timer("test", expectedTags).count())
+                .isEqualTo(0)
+                .describedAs(
+                    "Metrics should be removed from the registry when exporter is closed"));
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -45,7 +45,6 @@ class MetricsExporterTest {
     final var exporter =
         new MetricsExporter(metrics, DEFAULT_KEY_CACHE, DEFAULT_KEY_CACHE, meterRegistry);
     exporter.open(new ExporterTestController());
-
     assertThat(meterRegistry.getMeters().size())
         .isEqualTo(0)
         .describedAs("Expected no metrics to be measured at start");
@@ -82,8 +81,7 @@ class MetricsExporterTest {
             .build());
 
     // then
-    final var jobLifeTime =
-        meterRegistry.timer("zeebe.job.life.time", "partition", String.valueOf(partitionId));
+    final var jobLifeTime = meterRegistry.timer("zeebe.job.life.time");
 
     assertThat(jobLifeTime.count())
         .isEqualTo(1)


### PR DESCRIPTION
## Description

A dedicated CompositeMeterRegistry is created in the ExporterContext, instantiated by ExporterContainer.
When the context is closed, its metrics are cleared and its unregistered from "global" meterRegistry.


<!-- Describe the goal and purpose of this PR. -->

## Checklist
[x] check that metrics are registered/unregistered correctly using a benchmark

Released branch as benchmark: See [grafana](https://grafana.dev.zeebe.io/d/zeebe-dashboard/zeebe?orgId=1&var-DS_PROMETHEUS=prometheus&var-cluster=All&var-namespace=isolated-meter-registery-exporter&var-pod=All&var-partition=All&from=1728478214000&to=1728479125000). At 14:55 a leadership change occurred and metrics from one exporter "stopped" 

## Related issues

closes #22834
