### PR TITLE
Refactor exporter config

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -164,7 +164,7 @@ public class CamundaExporter implements Exporter {
       final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
     final var currentIndices =
         searchEngineClient.getMappings(
-            configuration.getConnect().getIndexPrefix() + "*", MappingSource.INDEX);
+            configuration.getIndex().getPrefix() + "*", MappingSource.INDEX);
 
     return schemaValidator.validateIndexMappings(currentIndices, provider.getIndexDescriptors());
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -22,7 +22,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
 
   @Override
   public void init(final ExporterConfiguration configuration) {
-    operateIndexPrefix = configuration.getConnect().getIndexPrefix();
+    operateIndexPrefix = configuration.getIndex().getPrefix();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -14,7 +14,7 @@ import java.util.Map;
 public class ExporterConfiguration {
 
   private ConnectConfiguration connect = new ConnectConfiguration();
-  private IndexSettings defaultSettings = new IndexSettings();
+  private IndexSettings index = new IndexSettings();
   private BulkConfiguration bulk = new BulkConfiguration();
   private RetentionConfiguration retention = new RetentionConfiguration();
   private Map<String, Integer> replicasByIndexName = new HashMap<>();
@@ -29,12 +29,12 @@ public class ExporterConfiguration {
     this.connect = connect;
   }
 
-  public IndexSettings getDefaultSettings() {
-    return defaultSettings;
+  public IndexSettings getIndex() {
+    return index;
   }
 
-  public void setDefaultSettings(final IndexSettings defaultSettings) {
-    this.defaultSettings = defaultSettings;
+  public void setIndex(final IndexSettings index) {
+    this.index = index;
   }
 
   public BulkConfiguration getBulk() {
@@ -82,8 +82,8 @@ public class ExporterConfiguration {
     return "ExporterConfiguration{"
         + "connect="
         + connect
-        + ", defaultSettings="
-        + defaultSettings
+        + ", index="
+        + index
         + ", bulk="
         + bulk
         + ", retention="
@@ -98,8 +98,17 @@ public class ExporterConfiguration {
   }
 
   public static final class IndexSettings {
+    private String prefix = "camunda-record";
     private Integer numberOfShards = 1;
     private Integer numberOfReplicas = 0;
+
+    public String getPrefix() {
+      return prefix;
+    }
+
+    public void setPrefix(final String prefix) {
+      this.prefix = prefix;
+    }
 
     public Integer getNumberOfShards() {
       return numberOfShards;
@@ -120,7 +129,10 @@ public class ExporterConfiguration {
     @Override
     public String toString() {
       return "IndexSettings{"
-          + "numberOfShards="
+          + "prefix='"
+          + prefix
+          + '\''
+          + ", numberOfShards="
           + numberOfShards
           + ", numberOfReplicas="
           + numberOfReplicas

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -46,7 +46,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
         elasticsearchClient.getMappings("*", MappingSource.INDEX_TEMPLATE).keySet();
     final var existingIndexNames =
         elasticsearchClient
-            .getMappings(config.getConnect().getIndexPrefix() + "*", MappingSource.INDEX)
+            .getMappings(config.getIndex().getPrefix() + "*", MappingSource.INDEX)
             .keySet();
     indexTemplateDescriptors.stream()
         .filter(descriptor -> !existingTemplateNames.contains(descriptor.getTemplateName()))
@@ -115,11 +115,11 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     final var templateReplicas =
         config
             .getReplicasByIndexName()
-            .getOrDefault(indexName, config.getDefaultSettings().getNumberOfReplicas());
+            .getOrDefault(indexName, config.getIndex().getNumberOfReplicas());
     final var templateShards =
         config
             .getShardsByIndexName()
-            .getOrDefault(indexName, config.getDefaultSettings().getNumberOfShards());
+            .getOrDefault(indexName, config.getIndex().getNumberOfShards());
 
     final var settings = new IndexSettings();
     settings.setNumberOfShards(templateShards);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -87,7 +87,7 @@ final class CamundaExporterIT {
   @BeforeAll
   public void beforeAll() {
     config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-    config.getConnect().setIndexPrefix("camunda-record");
+    config.getIndex().setPrefix("camunda-record");
 
     testClient = new ElasticsearchConnector(config.getConnect()).createClient();
   }
@@ -117,7 +117,7 @@ final class CamundaExporterIT {
 
     index =
         SchemaTestUtil.mockIndex(
-            config.getConnect().getIndexPrefix() + "qualified_name",
+            config.getIndex().getPrefix() + "qualified_name",
             "alias",
             "index_name",
             "/mappings.json");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
@@ -55,8 +55,8 @@ public class ElasticsearchSchemaManagerIT {
   @Test
   void shouldInheritDefaultSettingsIfNoIndexSpecificSettings() throws IOException {
     final var properties = new ExporterConfiguration();
-    properties.getDefaultSettings().setNumberOfReplicas(10);
-    properties.getDefaultSettings().setNumberOfShards(10);
+    properties.getIndex().setNumberOfReplicas(10);
+    properties.getIndex().setNumberOfShards(10);
 
     final var indexTemplate =
         SchemaTestUtil.mockIndexTemplate(
@@ -86,8 +86,8 @@ public class ElasticsearchSchemaManagerIT {
   @Test
   void shouldUseIndexSpecificSettingsIfSpecified() throws IOException {
     final var properties = new ExporterConfiguration();
-    properties.getDefaultSettings().setNumberOfReplicas(10);
-    properties.getDefaultSettings().setNumberOfShards(10);
+    properties.getIndex().setNumberOfReplicas(10);
+    properties.getIndex().setNumberOfShards(10);
     properties.setReplicasByIndexName(Map.of("index_name", 5));
     properties.setShardsByIndexName(Map.of("index_name", 5));
 


### PR DESCRIPTION
## Description

Refactor exporter configs to match zeebe configs as possible

The goal is to avoid confusion when configuring the new exporter and make it more fluent
- rename IndexSettings var to index
- move indexPrefix to be part of IndexSettings
- adjust usages

In addition, also made appendToFileSchemaSettings more concise

## Related issues

relates to #22866
