### PR TITLE
[Backport stable/8.6] fix: add backward compatability to preferRestOverGrpc property

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -326,7 +326,11 @@ public class ZeebeClientConfigurationImpl implements ZeebeClientConfiguration {
 
   @Override
   public boolean preferRestOverGrpc() {
-    return camundaClientProperties.getZeebe().isPreferRestOverGrpc();
+    return getOrDefault(
+        "preferRestOverGrpc",
+        () -> camundaClientProperties.getZeebe().isPreferRestOverGrpc(),
+        DEFAULT.preferRestOverGrpc(),
+        configCache);
   }
 
   private CredentialsProvider credentialsProvider() {

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -75,5 +75,6 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
     assertThat(client.getConfiguration().getOverrideAuthority()).isNull();
     assertThat(client.getConfiguration().getRestAddress())
         .isEqualTo(new URI("https://0.0.0.0:8080"));
+    assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
@@ -195,4 +195,10 @@ public class ZeebeClientConfigurationImplSaasTest {
     assertThat(output).contains("clientId='***'");
     assertThat(output).contains("clientSecret='***'");
   }
+
+  @Test
+  void shouldHaveDefaultPreferRestOverGrpc() {
+    assertThat(zeebeClientConfiguration.preferRestOverGrpc())
+        .isEqualTo(DEFAULT.preferRestOverGrpc());
+  }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
@@ -183,4 +183,10 @@ public class ZeebeClientConfigurationImplSelfManagedTest {
     assertThat(zeebeClientConfiguration.useDefaultRetryPolicy())
         .isEqualTo(DEFAULT.useDefaultRetryPolicy());
   }
+
+  @Test
+  void shouldHaveDefaultPreferRestOverGrpc() {
+    assertThat(zeebeClientConfiguration.preferRestOverGrpc())
+        .isEqualTo(DEFAULT.preferRestOverGrpc());
+  }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -117,6 +117,7 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(client.getConfiguration().getDefaultJobPollInterval())
         .isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
   }
 
   @EnableConfigurationProperties(CamundaClientProperties.class)

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
@@ -110,6 +110,7 @@ public class ZeebeClientStarterAutoConfigurationTest {
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(client.getConfiguration().getDefaultJobPollInterval())
         .isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().preferRestOverGrpc()).isFalse();
   }
 
   @EnableConfigurationProperties(CamundaClientProperties.class)


### PR DESCRIPTION
# Description
Backport of #23186 to `stable/8.6`.

relates to #23183
original author: @nicpuppa