### PR TITLE
fix: return jobKey in REST for activated job

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -74,7 +74,7 @@ public final class ActivatedJobImpl implements ActivatedJob {
       final JsonMapper jsonMapper, final io.camunda.zeebe.client.protocol.rest.ActivatedJob job) {
     this.jsonMapper = jsonMapper;
 
-    key = getOrEmpty(job.getKey());
+    key = getOrEmpty(job.getJobKey());
     type = getOrEmpty(job.getType());
     customHeaders =
         job.getCustomHeaders() == null

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/rest/ActivateJobsRestTest.java
@@ -46,7 +46,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     // given
     final ActivatedJob activatedJob1 =
         new ActivatedJob()
-            .key(12L)
+            .jobKey(12L)
             .type("foo")
             .processInstanceKey(123L)
             .processDefinitionId("test1")
@@ -63,7 +63,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
 
     final ActivatedJob activatedJob2 =
         new ActivatedJob()
-            .key(42L)
+            .jobKey(42L)
             .type("foo")
             .processInstanceKey(333L)
             .processDefinitionId("test3")
@@ -97,7 +97,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(response.getJobs()).hasSize(2);
 
     io.camunda.zeebe.client.api.response.ActivatedJob job = response.getJobs().get(0);
-    assertThat(job.getKey()).isEqualTo(activatedJob1.getKey());
+    assertThat(job.getKey()).isEqualTo(activatedJob1.getJobKey());
     assertThat(job.getType()).isEqualTo(activatedJob1.getType());
     assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob1.getProcessDefinitionId());
     assertThat(job.getElementId()).isEqualTo(activatedJob1.getElementId());
@@ -114,7 +114,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
     assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
 
     job = response.getJobs().get(1);
-    assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
+    assertThat(job.getKey()).isEqualTo(activatedJob2.getJobKey());
     assertThat(job.getType()).isEqualTo(activatedJob2.getType());
     assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob2.getProcessDefinitionId());
     assertThat(job.getElementId()).isEqualTo(activatedJob2.getElementId());

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2697,7 +2697,7 @@ components:
     ActivatedJob:
       type: object
       properties:
-        key:
+        jobKey:
           description: the key, a unique identifier for the job
           type: integer
           format: int64

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -82,7 +82,7 @@ public final class ResponseMapper {
 
   private static ActivatedJob toActivatedJob(final long jobKey, final JobRecord job) {
     return new ActivatedJob()
-        .key(jobKey)
+        .jobKey(jobKey)
         .type(job.getType())
         .processDefinitionId(job.getBpmnProcessId())
         .elementId(job.getElementId())
@@ -376,7 +376,7 @@ public final class ResponseMapper {
     @Override
     public List<ActivatedJob> getJobs() {
       return response.getJobs().stream()
-          .map(j -> new ActivatedJob(j.getKey(), j.getRetries()))
+          .map(j -> new ActivatedJob(j.getJobKey(), j.getRetries()))
           .toList();
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsRestTest.java
@@ -999,7 +999,7 @@ public class LongPollingActivateJobsRestTest {
     final var brokerRequestValue = failRequest.getRequestWriter();
     final var activatedJob = activatedJobRef.get();
 
-    assertThat(failRequest.getKey()).isEqualTo(activatedJob.getKey());
+    assertThat(failRequest.getKey()).isEqualTo(activatedJob.getJobKey());
     assertThat(brokerRequestValue.getRetries()).isEqualTo(activatedJob.getRetries());
     assertThat(brokerRequestValue.getRetryBackoff()).isEqualTo(0);
     assertThat(brokerRequestValue.getErrorMessageBuffer()).isNotNull();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -81,7 +81,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         {
           "jobs": [
             {
-              "key": 2251799813685248,
+              "jobKey": 2251799813685248,
               "type": "TEST",
               "processInstanceKey": 123,
               "processDefinitionKey": 4532,
@@ -97,7 +97,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               "worker": "bar"
             },
             {
-              "key": 2251799813685249,
+              "jobKey": 2251799813685249,
               "type": "TEST",
               "processInstanceKey": 123,
               "processDefinitionKey": 4532,
@@ -213,7 +213,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
             .returnResult()
             .getResponseBody();
 
-    final int basePartition = Protocol.decodePartitionId(JsonPath.read(result, "$.jobs[0].key"));
+    final int basePartition = Protocol.decodePartitionId(JsonPath.read(result, "$.jobs[0].jobKey"));
     final int partitionsCount =
         stubbedBrokerClient.getTopologyManager().getTopology().getPartitionsCount();
 
@@ -237,9 +237,9 @@ public class JobControllerLongPollingTest extends RestControllerTest {
           .expectHeader()
           .contentType(MediaType.APPLICATION_JSON)
           .expectBody()
-          .jsonPath("$.jobs[0].key")
+          .jsonPath("$.jobs[0].jobKey")
           .isEqualTo(Protocol.encodePartitionId(expectedPartitionId, 0))
-          .jsonPath("$.jobs[1].key")
+          .jsonPath("$.jobs[1].jobKey")
           .isEqualTo(Protocol.encodePartitionId(expectedPartitionId, 1));
     }
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -90,7 +90,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         {
           "jobs": [
             {
-              "key": %d,
+              "jobKey": %d,
               "type": "TEST",
               "processInstanceKey": 123,
               "processDefinitionKey": 4532,
@@ -106,7 +106,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
               "worker": "bar"
             },
             {
-              "key": %d,
+              "jobKey": %d,
               "type": "TEST",
               "processInstanceKey": 123,
               "processDefinitionKey": 4532,
@@ -228,9 +228,9 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
           .expectHeader()
           .contentType(MediaType.APPLICATION_JSON)
           .expectBody()
-          .jsonPath("$.jobs[0].key")
+          .jsonPath("$.jobs[0].jobKey")
           .isEqualTo(Protocol.encodePartitionId(expectedPartitionId, 0))
-          .jsonPath("$.jobs[1].key")
+          .jsonPath("$.jobs[1].jobKey")
           .isEqualTo(Protocol.encodePartitionId(expectedPartitionId, 1));
     }
   }
@@ -320,7 +320,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
     // reset the results in the test class' observer (created anew per request in production setup)
     responseObserver.reset();
     // return the current partition
-    return Protocol.decodePartitionId(JsonPath.read(result, "$.jobs[0].key"));
+    return Protocol.decodePartitionId(JsonPath.read(result, "$.jobs[0].jobKey"));
   }
 
   private static int getExpectedPartitionId(


### PR DESCRIPTION
## Description

Instead of returning a `key` attribute in an activated job response, return a `jobKey` for consistent naming in the API.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23101 