### PR TITLE
feat: allow for disabling cluster health checks

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -126,7 +126,7 @@ public class ElasticsearchConnector {
     // And create the API client
     elasticsearchClient = new ElasticsearchClient(transport);
 
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
       if (!checkHealth(elasticsearchClient)) {
         LOGGER.warn("Elasticsearch cluster is not accessible");
       } else {
@@ -210,7 +210,7 @@ public class ElasticsearchConnector {
         new RestHighLevelClientBuilder(restClientBuilder.build())
             .setApiCompatibilityMode(true)
             .build();
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
       if (!checkHealth(esClient)) {
         LOGGER.warn("Elasticsearch cluster is not accessible");
       } else {

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -127,10 +127,15 @@ public class ElasticsearchConnector {
 
     // And create the API client
     elasticsearchClient = new ElasticsearchClient(transport);
-    if (!checkHealth(elasticsearchClient)) {
-      LOGGER.warn("Elasticsearch cluster is not accessible");
+
+    if (operateProperties.isHealthCheckEnabled()) {
+      if (!checkHealth(elasticsearchClient)) {
+        LOGGER.warn("Elasticsearch cluster is not accessible");
+      } else {
+        LOGGER.debug("Elasticsearch connection was successfully created.");
+      }
     } else {
-      LOGGER.debug("Elasticsearch connection was successfully created.");
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
     }
     return elasticsearchClient;
   }
@@ -207,10 +212,14 @@ public class ElasticsearchConnector {
         new RestHighLevelClientBuilder(restClientBuilder.build())
             .setApiCompatibilityMode(true)
             .build();
-    if (!checkHealth(esClient)) {
-      LOGGER.warn("Elasticsearch cluster is not accessible");
+    if (operateProperties.isHealthCheckEnabled()) {
+      if (!checkHealth(esClient)) {
+        LOGGER.warn("Elasticsearch cluster is not accessible");
+      } else {
+        LOGGER.debug("Elasticsearch connection was successfully created.");
+      }
     } else {
-      LOGGER.debug("Elasticsearch connection was successfully created.");
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
     }
     return esClient;
   }
@@ -222,7 +231,7 @@ public class ElasticsearchConnector {
     setupAuthentication(httpAsyncClientBuilder, elsConfig);
 
     LOGGER.trace("Attempt to load interceptor plugins");
-    for (HttpRequestInterceptor interceptor : interceptors) {
+    for (final HttpRequestInterceptor interceptor : interceptors) {
       httpAsyncClientBuilder.addInterceptorLast(interceptor);
     }
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/ElasticsearchConnector.java
@@ -54,7 +54,6 @@ import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.client.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -67,11 +66,10 @@ public class ElasticsearchConnector {
 
   private PluginRepository esClientRepository = new PluginRepository();
   private PluginRepository zeebeEsClientRepository = new PluginRepository();
-  @Autowired private OperateProperties operateProperties;
+  private final OperateProperties operateProperties;
   private ElasticsearchClient elasticsearchClient;
 
-  @VisibleForTesting
-  public void setOperateProperties(final OperateProperties operateProperties) {
+  public ElasticsearchConnector(final OperateProperties operateProperties) {
     this.operateProperties = operateProperties;
   }
 

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -107,7 +107,7 @@ public class OpensearchConnector {
     osClientRepository.load(operateProperties.getOpensearch().getInterceptorPlugins());
     final OpenSearchClient openSearchClient =
         createOsClient(operateProperties.getOpensearch(), osClientRepository);
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getOpensearch().isHealthCheckEnabled()) {
       try {
         final HealthResponse response = openSearchClient.cluster().health();
         LOGGER.info("OpenSearch cluster health: {}", response.status());
@@ -125,7 +125,7 @@ public class OpensearchConnector {
     osClientRepository.load(operateProperties.getOpensearch().getInterceptorPlugins());
     final OpenSearchAsyncClient openSearchClient =
         createAsyncOsClient(operateProperties.getOpensearch(), osClientRepository);
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getOpensearch().isHealthCheckEnabled()) {
       final CompletableFuture<HealthResponse> healthResponse;
       try {
         healthResponse = openSearchClient.cluster().health();
@@ -184,7 +184,7 @@ public class OpensearchConnector {
     final OpenSearchTransport transport = builder.build();
     final OpenSearchAsyncClient openSearchAsyncClient = new OpenSearchAsyncClient(transport);
 
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getOpensearch().isHealthCheckEnabled()) {
       final CompletableFuture<HealthResponse> healthResponse;
       try {
         healthResponse = openSearchAsyncClient.cluster().health();
@@ -254,7 +254,7 @@ public class OpensearchConnector {
 
     final OpenSearchTransport transport = builder.build();
     final OpenSearchClient openSearchClient = new ExtendedOpenSearchClient(transport);
-    if (operateProperties.isHealthCheckEnabled()) {
+    if (operateProperties.getOpensearch().isHealthCheckEnabled()) {
       try {
         final HealthResponse response = openSearchClient.cluster().health();
         LOGGER.info("OpenSearch cluster health: {}", response.status());

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -107,11 +107,15 @@ public class OpensearchConnector {
     osClientRepository.load(operateProperties.getOpensearch().getInterceptorPlugins());
     final OpenSearchClient openSearchClient =
         createOsClient(operateProperties.getOpensearch(), osClientRepository);
-    try {
-      final HealthResponse response = openSearchClient.cluster().health();
-      LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (final IOException e) {
-      LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
+    if (operateProperties.isHealthCheckEnabled()) {
+      try {
+        final HealthResponse response = openSearchClient.cluster().health();
+        LOGGER.info("OpenSearch cluster health: {}", response.status());
+      } catch (final IOException e) {
+        LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
+      }
+    } else {
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
     }
     return openSearchClient;
   }
@@ -121,19 +125,23 @@ public class OpensearchConnector {
     osClientRepository.load(operateProperties.getOpensearch().getInterceptorPlugins());
     final OpenSearchAsyncClient openSearchClient =
         createAsyncOsClient(operateProperties.getOpensearch(), osClientRepository);
-    final CompletableFuture<HealthResponse> healthResponse;
-    try {
-      healthResponse = openSearchClient.cluster().health();
-      healthResponse.whenComplete(
-          (response, e) -> {
-            if (e != null) {
-              LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
-            } else {
-              LOGGER.info("OpenSearch cluster health: {}", response.status());
-            }
-          });
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
+    if (operateProperties.isHealthCheckEnabled()) {
+      final CompletableFuture<HealthResponse> healthResponse;
+      try {
+        healthResponse = openSearchClient.cluster().health();
+        healthResponse.whenComplete(
+            (response, e) -> {
+              if (e != null) {
+                LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
+              } else {
+                LOGGER.info("OpenSearch cluster health: {}", response.status());
+              }
+            });
+      } catch (final IOException e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
     }
     return openSearchClient;
   }
@@ -176,25 +184,28 @@ public class OpensearchConnector {
     final OpenSearchTransport transport = builder.build();
     final OpenSearchAsyncClient openSearchAsyncClient = new OpenSearchAsyncClient(transport);
 
-    final CompletableFuture<HealthResponse> healthResponse;
-    try {
-      healthResponse = openSearchAsyncClient.cluster().health();
-      healthResponse.whenComplete(
-          (response, e) -> {
-            if (e != null) {
-              LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
-            } else {
-              LOGGER.info("OpenSearch cluster health: {}", response.status());
-            }
-          });
-    } catch (final IOException e) {
-      throw new OperateRuntimeException(e);
-    }
-
-    if (!checkHealth(openSearchAsyncClient)) {
-      LOGGER.warn("OpenSearch cluster is not accessible");
+    if (operateProperties.isHealthCheckEnabled()) {
+      final CompletableFuture<HealthResponse> healthResponse;
+      try {
+        healthResponse = openSearchAsyncClient.cluster().health();
+        healthResponse.whenComplete(
+            (response, e) -> {
+              if (e != null) {
+                LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
+              } else {
+                LOGGER.info("OpenSearch cluster health: {}", response.status());
+              }
+            });
+      } catch (final IOException e) {
+        throw new OperateRuntimeException(e);
+      }
+      if (!checkHealth(openSearchAsyncClient)) {
+        LOGGER.warn("OpenSearch cluster is not accessible");
+      } else {
+        LOGGER.debug("OpenSearch connection was successfully created.");
+      }
     } else {
-      LOGGER.debug("OpenSearch connection was successfully created.");
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
     }
     return openSearchAsyncClient;
   }
@@ -243,17 +254,21 @@ public class OpensearchConnector {
 
     final OpenSearchTransport transport = builder.build();
     final OpenSearchClient openSearchClient = new ExtendedOpenSearchClient(transport);
-    try {
-      final HealthResponse response = openSearchClient.cluster().health();
-      LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (final IOException e) {
-      LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
-    }
+    if (operateProperties.isHealthCheckEnabled()) {
+      try {
+        final HealthResponse response = openSearchClient.cluster().health();
+        LOGGER.info("OpenSearch cluster health: {}", response.status());
+      } catch (final IOException e) {
+        LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
+      }
 
-    if (!checkHealth(openSearchClient)) {
-      LOGGER.warn("OpenSearch cluster is not accessible");
+      if (!checkHealth(openSearchClient)) {
+        LOGGER.warn("OpenSearch cluster is not accessible");
+      } else {
+        LOGGER.debug("OpenSearch connection was successfully created.");
+      }
     } else {
-      LOGGER.debug("OpenSearch connection was successfully created.");
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
     }
     return openSearchClient;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ElasticsearchProperties.java
@@ -39,6 +39,9 @@ public class ElasticsearchProperties {
 
   private boolean createSchema = true;
 
+  /** Indicates whether operate does a proper health check for ES clusters. */
+  private boolean healthCheckEnabled = true;
+
   private String url;
   private String username;
   private String password;
@@ -118,6 +121,14 @@ public class ElasticsearchProperties {
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
   }
 
   public String getPassword() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -39,6 +39,9 @@ public class OpensearchProperties {
 
   private boolean createSchema = true;
 
+  /** Indicates whether operate does a proper health check for ES/OS clusters. */
+  private boolean healthCheckEnabled = true;
+
   private String url;
   private String username;
   private String password;
@@ -120,6 +123,14 @@ public class OpensearchProperties {
 
   public void setCreateSchema(final boolean createSchema) {
     this.createSchema = createSchema;
+  }
+
+  public boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
   }
 
   public String getPassword() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -64,7 +64,7 @@ public class OperateProperties {
   private String version = UNKNOWN_VERSION;
 
   @NestedConfigurationProperty
-  private final OperateElasticsearchProperties elasticsearch = new OperateElasticsearchProperties();
+  private OperateElasticsearchProperties elasticsearch = new OperateElasticsearchProperties();
 
   @NestedConfigurationProperty
   private OperateOpensearchProperties opensearch = new OperateOpensearchProperties();
@@ -157,6 +157,10 @@ public class OperateProperties {
 
   public OperateElasticsearchProperties getElasticsearch() {
     return elasticsearch;
+  }
+
+  public void setElasticsearch(final OperateElasticsearchProperties elasticsearch) {
+    this.elasticsearch = elasticsearch;
   }
 
   public OperateOpensearchProperties getOpensearch() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -41,9 +41,6 @@ public class OperateProperties {
   /** Indicates, whether CSRF prevention is enabled. */
   private boolean csrfPreventionEnabled = true;
 
-  /** Indicates whether operate does a proper health check for ES/OS clusters. */
-  private boolean healthCheckEnabled = true;
-
   /** Standard user data */
   private String userId = "demo";
 
@@ -145,14 +142,6 @@ public class OperateProperties {
 
   public void setCsrfPreventionEnabled(final boolean csrfPreventionEnabled) {
     this.csrfPreventionEnabled = csrfPreventionEnabled;
-  }
-
-  public boolean isHealthCheckEnabled() {
-    return healthCheckEnabled;
-  }
-
-  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
-    this.healthCheckEnabled = healthCheckEnabled;
   }
 
   public OperateElasticsearchProperties getElasticsearch() {

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateProperties.java
@@ -41,6 +41,9 @@ public class OperateProperties {
   /** Indicates, whether CSRF prevention is enabled. */
   private boolean csrfPreventionEnabled = true;
 
+  /** Indicates whether operate does a proper health check for ES/OS clusters. */
+  private boolean healthCheckEnabled = true;
+
   /** Standard user data */
   private String userId = "demo";
 
@@ -142,6 +145,14 @@ public class OperateProperties {
 
   public void setCsrfPreventionEnabled(final boolean csrfPreventionEnabled) {
     this.csrfPreventionEnabled = csrfPreventionEnabled;
+  }
+
+  public boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
   }
 
   public OperateElasticsearchProperties getElasticsearch() {

--- a/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
@@ -43,7 +43,7 @@ class ElasticsearchConnectorTest {
   public void shouldNotDoClusterHealthCheckWhenDisabled() {
     final OperateProperties operateProperties = new OperateProperties();
     final OperateElasticsearchProperties esProperties = new OperateElasticsearchProperties();
-    operateProperties.setHealthCheckEnabled(false);
+    esProperties.setHealthCheckEnabled(false);
     operateProperties.setElasticsearch(esProperties);
     final ElasticsearchConnector connector = spy(new ElasticsearchConnector(operateProperties));
 

--- a/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
@@ -8,10 +8,18 @@
 package io.camunda.operate.connect;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.operate.property.ElasticsearchProperties;
+import io.camunda.operate.property.OperateElasticsearchProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.plugin.search.header.CustomHeader;
 import io.camunda.plugin.search.header.DatabaseCustomHeaderSupplier;
@@ -28,9 +36,34 @@ import org.apache.http.protocol.BasicHttpContext;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 class ElasticsearchConnectorTest {
+
+  @Test
+  public void shouldNotDoClusterHealthCheckWhenDisabled() {
+    final OperateProperties operateProperties = new OperateProperties();
+    final OperateElasticsearchProperties esProperties = new OperateElasticsearchProperties();
+    operateProperties.setHealthCheckEnabled(false);
+    operateProperties.setElasticsearch(esProperties);
+    final ElasticsearchConnector connector = spy(new ElasticsearchConnector(operateProperties));
+
+    connector.createEsClient(esProperties, mock());
+
+    verify(connector, never()).checkHealth(any(RestHighLevelClient.class));
+  }
+
+  @Test
+  public void shouldDoClusterHealthCheckWhenDefaultPropertyValuesUsed() {
+    final OperateProperties operateProperties = new OperateProperties();
+    final OperateElasticsearchProperties esProperties = new OperateElasticsearchProperties();
+    operateProperties.setElasticsearch(esProperties);
+    final ElasticsearchConnector connector = spy(new ElasticsearchConnector(operateProperties));
+    doReturn(true).when(connector).checkHealth(any(RestHighLevelClient.class));
+
+    connector.createEsClient(esProperties, mock());
+
+    verify(connector, times(1)).checkHealth(any(RestHighLevelClient.class));
+  }
 
   @Test
   void shouldApplyRequestInterceptorsInOrderForNativeRestClient() {

--- a/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/ElasticsearchConnectorTest.java
@@ -39,10 +39,9 @@ class ElasticsearchConnectorTest {
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(
         List.of(new PluginConfiguration("plg1", TestPlugin.class.getName(), null)));
-    final var connector = Mockito.spy(new ElasticsearchConnector());
-    Mockito.doReturn(true).when(connector).checkHealth(Mockito.any(ElasticsearchClient.class));
+    final var connector = spy(new ElasticsearchConnector(operateProperties));
+    doReturn(true).when(connector).checkHealth(any(ElasticsearchClient.class));
     connector.setEsClientRepository(pluginRepository);
-    connector.setOperateProperties(operateProperties);
     final var client = connector.elasticsearchClient();
 
     // when
@@ -66,9 +65,8 @@ class ElasticsearchConnectorTest {
     final PluginRepository pluginRepository = new PluginRepository();
     pluginRepository.load(
         List.of(new PluginConfiguration("plg1", TestPlugin.class.getName(), null)));
-    final var connector = Mockito.spy(new ElasticsearchConnector());
-    Mockito.doReturn(true).when(connector).checkHealth(Mockito.any(RestHighLevelClient.class));
-    connector.setOperateProperties(operateProperties);
+    final var connector = spy(new ElasticsearchConnector(operateProperties));
+    doReturn(true).when(connector).checkHealth(any(RestHighLevelClient.class));
     final var client = connector.createEsClient(esProperties, pluginRepository);
 
     // when

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -10,7 +10,11 @@ package io.camunda.operate.connect;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -25,6 +29,7 @@ import java.util.List;
 import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
 import org.apache.hc.core5.concurrent.FutureCallback;
 import org.apache.hc.core5.http.message.BasicHttpRequest;
 import org.apache.hc.core5.http.protocol.BasicHttpContext;
@@ -99,6 +104,43 @@ public class OpensearchConnectorTest {
         spyConnector.createAsyncOsClient(opensearchProperties, new PluginRepository());
 
     assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void shouldNotDoClusterHealthCheckWhenDisabled() {
+    final OperateProperties operateProperties = new OperateProperties();
+    operateProperties.setHealthCheckEnabled(false);
+    final OperateOpensearchProperties osProperties = new OperateOpensearchProperties();
+    operateProperties.setOpensearch(osProperties);
+    final OpensearchConnector connector = spy(new OpensearchConnector(operateProperties, mock()));
+    doReturn(mock(HttpAsyncClientBuilder.class))
+        .when(connector)
+        .configureHttpClient(any(), any(), any());
+
+    connector.createAsyncOsClient(osProperties, mock());
+    verify(connector, never()).checkHealth(any(OpenSearchAsyncClient.class));
+
+    connector.createOsClient(osProperties, mock());
+    verify(connector, never()).checkHealth(any(OpenSearchClient.class));
+  }
+
+  @Test
+  public void shouldDoClusterHealthCheckWhenDefaultPropertyValuesUsed() {
+    final OperateProperties operateProperties = new OperateProperties();
+    final OperateOpensearchProperties osProperties = new OperateOpensearchProperties();
+    operateProperties.setOpensearch(osProperties);
+    final OpensearchConnector connector = spy(new OpensearchConnector(operateProperties, mock()));
+    doReturn(true).when(connector).checkHealth(any(OpenSearchClient.class));
+    doReturn(true).when(connector).checkHealth(any(OpenSearchAsyncClient.class));
+    doReturn(mock(HttpAsyncClientBuilder.class))
+        .when(connector)
+        .configureHttpClient(any(), any(), any());
+
+    connector.createAsyncOsClient(osProperties, mock());
+    verify(connector, times(1)).checkHealth(any(OpenSearchAsyncClient.class));
+
+    connector.createOsClient(osProperties, mock());
+    verify(connector, times(1)).checkHealth(any(OpenSearchClient.class));
   }
 
   @Test

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -109,8 +109,8 @@ public class OpensearchConnectorTest {
   @Test
   public void shouldNotDoClusterHealthCheckWhenDisabled() {
     final OperateProperties operateProperties = new OperateProperties();
-    operateProperties.setHealthCheckEnabled(false);
     final OperateOpensearchProperties osProperties = new OperateOpensearchProperties();
+    osProperties.setHealthCheckEnabled(false);
     operateProperties.setOpensearch(osProperties);
     final OpensearchConnector connector = spy(new OpensearchConnector(operateProperties, mock()));
     doReturn(mock(HttpAsyncClientBuilder.class))

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/TestElasticsearchConnector.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/util/elasticsearch/TestElasticsearchConnector.java
@@ -10,6 +10,7 @@ package io.camunda.operate.schema.util.elasticsearch;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.property.ElasticsearchProperties;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.util.ObservableConnector;
 import io.camunda.operate.schema.util.ObservableConnector.OperateTestHttpRequest;
 import java.io.IOException;
@@ -29,6 +30,10 @@ public class TestElasticsearchConnector extends ElasticsearchConnector
     implements ObservableConnector {
 
   private final List<Consumer<OperateTestHttpRequest>> requestListeners = new ArrayList<>();
+
+  public TestElasticsearchConnector(final OperateProperties operateProperties) {
+    super(operateProperties);
+  }
 
   /**
    * Adds a request interceptor that a test case can plug in, so that we can assert requests made to

--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
@@ -36,18 +36,10 @@ public class IndicesHealthIndicator implements HealthIndicator {
   @Override
   public Health health() {
     LOGGER.debug("Indices check is called");
-    if (isClusterHealthy() && indicesCheck.indicesArePresent()) {
+    if (indicesCheck.isHealthy() && indicesCheck.indicesArePresent()) {
       return Health.up().build();
     } else {
       return Health.down().build();
     }
-  }
-
-  private boolean isClusterHealthy() {
-    if (!properties.isHealthCheckEnabled()) {
-      LOGGER.warn("Cluster health check is disabled.");
-      return true;
-    }
-    return indicesCheck.isHealthy();
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.management;
 
+import io.camunda.operate.property.OperateProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +21,7 @@ public class IndicesHealthIndicator implements HealthIndicator {
   private static final Logger LOGGER = LoggerFactory.getLogger(IndicesHealthIndicator.class);
 
   @Autowired private IndicesCheck indicesCheck;
+  @Autowired private OperateProperties properties;
 
   @Override
   public Health getHealth(final boolean includeDetails) {
@@ -29,10 +31,18 @@ public class IndicesHealthIndicator implements HealthIndicator {
   @Override
   public Health health() {
     LOGGER.debug("Indices check is called");
-    if (indicesCheck.isHealthy() && indicesCheck.indicesArePresent()) {
+    if (isClusterHealthy() && indicesCheck.indicesArePresent()) {
       return Health.up().build();
     } else {
       return Health.down().build();
     }
+  }
+
+  private boolean isClusterHealthy() {
+    if (!properties.isHealthCheckEnabled()) {
+      LOGGER.warn("Cluster health check is disabled.");
+      return true;
+    }
+    return indicesCheck.isHealthy();
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/management/IndicesHealthIndicator.java
@@ -10,7 +10,6 @@ package io.camunda.operate.management;
 import io.camunda.operate.property.OperateProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
@@ -20,8 +19,14 @@ public class IndicesHealthIndicator implements HealthIndicator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IndicesHealthIndicator.class);
 
-  @Autowired private IndicesCheck indicesCheck;
-  @Autowired private OperateProperties properties;
+  private final IndicesCheck indicesCheck;
+  private final OperateProperties properties;
+
+  public IndicesHealthIndicator(
+      final IndicesCheck indicesCheck, final OperateProperties operateProperties) {
+    this.indicesCheck = indicesCheck;
+    properties = operateProperties;
+  }
 
   @Override
   public Health getHealth(final boolean includeDetails) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -160,7 +160,12 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Override
   public boolean isHealthy() {
-    return retryElasticsearchClient.isHealthy();
+    if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
+      return retryElasticsearchClient.isHealthy();
+    } else {
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
+      return true;
+    }
   }
 
   @Override

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -193,7 +193,12 @@ public class OpensearchSchemaManager implements SchemaManager {
 
   @Override
   public boolean isHealthy() {
-    return richOpenSearchClient.cluster().isHealthy();
+    if (operateProperties.getOpensearch().isHealthCheckEnabled()) {
+      return richOpenSearchClient.cluster().isHealthy();
+    } else {
+      LOGGER.warn("OpenSearch cluster health check is disabled.");
+      return true;
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Introduced a property `camunda.operate.elasticsearch.healthCheck.enabled` and `camunda.operate.opensearch.healthCheck.enabled` (default: `true`) with which health checks can be disabled. Operate then assumes that the cluster is healthy. This is to allow for running operate with an elasticsearch/opensearch user that does not have `monitor` privileges.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/22918
