### PR TITLE
fix: migration issue for passwords on ES/OS

### DIFF
--- a/operate/client/e2e-playwright/tests/login.spec.ts
+++ b/operate/client/e2e-playwright/tests/login.spec.ts
@@ -26,7 +26,7 @@ test.describe('login page', () => {
     });
 
     await expect(
-      page.getByRole('alert').getByText('Username and password do not match'),
+      page.getByRole('alert').getByText('Credentials could not be verified'),
     ).toBeVisible();
     await expect(page).toHaveURL('.' + Paths.login());
   });

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -56,7 +56,7 @@ public class OperateUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    return new BCryptPasswordEncoder();
   }
 
   public void initializeUsers() {

--- a/tasklist/client/e2e/tests/login.spec.ts
+++ b/tasklist/client/e2e/tests/login.spec.ts
@@ -46,7 +46,7 @@ test.describe.parallel('login page', () => {
 
     await expect(page).toHaveURL('/tasklist/login');
     await expect(loginPage.errorMessage).toContainText(
-      'Username and password do not match',
+      'Credentials could not be verified',
     );
 
     const results = await makeAxeBuilder().analyze();

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    return new BCryptPasswordEncoder();
   }
 
   public void initializeUsers() {
@@ -86,10 +86,10 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
     }
   }
 
-  private boolean userExists(final String userId) {
+  private boolean userExists(String userId) {
     try {
       return userStore.getByUserId(userId) != null;
-    } catch (final Exception t) {
+    } catch (Exception t) {
       return false;
     }
   }
@@ -113,7 +113,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   }
 
   @Override
-  public User loadUserByUsername(final String username) throws UsernameNotFoundException {
+  public User loadUserByUsername(String username) throws UsernameNotFoundException {
     try {
       final UserEntity userEntity = userStore.getByUserId(username);
       return new User(
@@ -122,7 +122,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
               map(userEntity.getRoles(), Role::fromString))
           .setDisplayName(userEntity.getDisplayName())
           .setRoles(map(userEntity.getRoles(), Role::fromString));
-    } catch (final NotFoundApiException e) {
+    } catch (NotFoundApiException e) {
       throw new UsernameNotFoundException(
           String.format("User with user id '%s' not found.", username), e);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Reverting change around Encryptor as it's causing problems on the migrations - it's not backward compatible so when coming from 8.5, password cannot be checked.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23213
