### PR TITLE
fix: Add Backoff Mechanism to Handle ElasticSearch Unavailability in Tasklist Importer

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/util/BackoffIdleStrategy.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/util/BackoffIdleStrategy.java
@@ -25,10 +25,10 @@ public class BackoffIdleStrategy {
     this.baseIdleTime = baseIdleTime;
     this.idleIncreaseFactor = idleIncreaseFactor;
     this.maxIdleTime = maxIdleTime;
-    this.maxIdles = ((int) log(idleIncreaseFactor, maxIdleTime / baseIdleTime)) + 1;
+    maxIdles = calculateMaxIdles();
   }
 
-  private double log(double base, double value) {
+  private double log(final double base, final double value) {
     return Math.log10(value) / Math.log10(base);
   }
 
@@ -65,5 +65,12 @@ public class BackoffIdleStrategy {
     }
 
     return idleTime;
+  }
+
+  private int calculateMaxIdles() {
+    if (baseIdleTime <= 0) {
+      return 1;
+    }
+    return ((int) log(idleIncreaseFactor, maxIdleTime / baseIdleTime)) + 1;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/tasklist/issues/4526
inspired from https://github.com/camunda/camunda/pull/17134
