### PR TITLE
fix: c8run enable v2 apis and add test for APIs

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -70,6 +70,10 @@ jobs:
         run: npx playwright test
         working-directory: ./c8run/e2e_tests
 
+      - name: Run v2 API endpoint test
+        run: ./api_tests.sh
+        working-directory: ./c8run/e2e_tests
+
       - uses: actions/upload-artifact@v4
         with:
           name: playwright-report-${{ matrix.os }}

--- a/c8run/connectors-application.properties
+++ b/c8run/connectors-application.properties
@@ -1,6 +1,6 @@
 zeebe.client.broker.gateway-address=127.0.0.1:26500
 zeebe.client.security.plaintext=true
-camunda.operate.client.url=http://localhost:8080/operate
+camunda.operate.client.url=http://localhost:8080
 camunda.operate.client.username=demo
 camunda.operate.client.password=demo
 server.port=8085

--- a/c8run/e2e_tests/api_tests.sh
+++ b/c8run/e2e_tests/api_tests.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+printf "\nTest: Authenticate\n"
+curl -f --request POST 'http://localhost:8080/api/login?username=demo&password=demo' \
+   --cookie-jar cookie.txt
+
+returnCode=$?
+
+if [[ "$returnCode" != 0 ]]; then
+   echo "test failed"
+   exit 1
+fi
+
+
+printf "\nTest: Operate process instance api\n"
+
+curl -f -L -X POST 'http://localhost:8080/v2/process-instances/search' --cookie cookie.txt \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+--data-raw '{
+  "filter": {
+    "running": true,
+    "active": true
+  }
+}'
+
+returnCode=$?
+
+if [[ "$returnCode" != 0 ]]; then
+   echo "test failed"
+   exit 1
+fi
+
+
+printf "\nTest: Tasklist user task\n"
+curl -f -L -X POST 'http://localhost:8080/v2/user-tasks/search' --cookie cookie.txt \
+-H 'Content-Type: application/json' \
+-H 'Accept: application/json' \
+--data-raw '{}'
+
+returnCode=$?
+
+if [[ "$returnCode" != 0 ]]; then
+   echo "test failed"
+   exit 1
+fi
+
+
+printf "\nTest: Zeebe topology endpoint\n"
+curl -f --cookie  cookie.txt  localhost:8080/v2/topology
+
+returnCode=$?
+if [[ "$returnCode" != 0 ]]; then
+   echo "test failed"
+   exit 1
+fi
+
+

--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -27,6 +27,9 @@ OPTIONS_HELP="Options:
 export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME="io.camunda.zeebe.exporter.ElasticsearchExporter"
 export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL="http://localhost:9200"
 export ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX="zeebe-record"
+export CAMUNDA_REST_QUERY_ENABLED=true
+export CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=false
+export CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED=false
 
 architectureRaw="$(uname -m)"
 case "${architectureRaw}" in

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -148,6 +148,10 @@ func main() {
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL", "http://localhost:9200")
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_INDEX_PREFIX", "zeebe-record")
 
+	os.Setenv("CAMUNDA_REST_QUERY_ENABLED", "true")
+	os.Setenv("CAMUNDA_OPERATE_CSRFPREVENTIONENABLED", "false")
+	os.Setenv("CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED", "false")
+
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 
 	baseCommand := ""


### PR DESCRIPTION
## Description

As part of our discussion in the c8run-sdk-auth-issue slack channel, we learned that some of the v2 api's are locked behind a feature flag. This PR proposes enabling those by default inside c8run, as well as disabling CSRF prevention which causes issues when interacting with the v1 API's in c8run.

Here are the 3 flags changed:

```diff
+export CAMUNDA_REST_QUERY_ENABLED=true
+export CAMUNDA_OPERATE_CSRFPREVENTIONENABLED=false
+export CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED=false

```

And this PR also introduces a bash script unit test for validating that these API's are operational. One thing I'd like to note is that the windows version does not execute this bash API integration test because windows doesn't use bash.  This was simply the quickest / easiest thing I could hack together. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
