### PR TITLE
ci: toggle long classpath flag on generate-sbe

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2501,6 +2501,7 @@
                 -->
                 <executable>java</executable>
                 <includePluginDependencies>true</includePluginDependencies>
+                <longClasspath>true</longClasspath>
                 <arguments combine.children="append">
                   <argument>-Dsbe.output.dir=${project.build.directory}/generated-sources/sbe</argument>
                   <argument>-Dsbe.java.generate.interfaces=true</argument>


### PR DESCRIPTION
## Description

Otherwise we run at risk that the generate-sbe command fails on windows smoke tests due to a command length limit.
```
2024-10-09T16:22:54.9366695Z java.io.IOException: Cannot run program "C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\21.0.4-7.0\x64\bin\java.exe" (in directory "D:\a\camunda\camunda\zeebe\broker\target\generated-sources"): CreateProcess error=206, The filename or extension is too long
```

For some reason it only happened on `stable/8.6` so far (slightly different dependency versions than `main`?).

I checked via maven debug and actually we slightly exceeded the windows command length limit by 10 characters, see this screenshot
![image](https://github.com/user-attachments/assets/95dab4cc-3dec-4f47-b6e7-dcd963b63836)
and
>once the command line length exceeds 32767 , a Win32 The filename or extension is too long exception is thrown

See job https://github.com/camunda/camunda/actions/runs/11258967243/job/31306933138?pr=23211

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

