### PR TITLE
Support delete operations in the batch request

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -53,6 +53,8 @@ public interface BatchRequest {
   BatchRequest updateWithScript(
       String index, String id, String script, Map<String, Object> parameters);
 
+  BatchRequest delete(String index, String id);
+
   /**
    * Applies all updates in this batch.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -206,6 +206,13 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
+  public BatchRequest delete(final String index, final String id) {
+    LOGGER.debug("Add delete request for index {} and id {}", index, id);
+    bulkRequestBuilder.operations(op -> op.delete(del -> del.index(index).id(id)));
+    return this;
+  }
+
+  @Override
   public void execute() throws PersistenceException {
     execute(false);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -200,6 +200,13 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
+  public BatchRequest delete(final String index, final String id) {
+    LOGGER.debug("Add delete request for index {} and id {}", index, id);
+    bulkRequestBuilder.operations(op -> op.delete(del -> del.index(index).id(id)));
+    return this;
+  }
+
+  @Override
   public void execute() throws PersistenceException {
     execute(false);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ElasticsearchBatchRequestTest.java
@@ -319,6 +319,28 @@ class ElasticsearchBatchRequestTest {
   }
 
   @Test
+  void shouldDeleteEntity() throws IOException, PersistenceException {
+    // When
+    batchRequest.delete(INDEX, ID);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(elasticsearchClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isDelete()).isTrue();
+
+    final var delete = bulkOperation.delete();
+    assertThat(delete.index()).isEqualTo(INDEX);
+    assertThat(delete.id()).isEqualTo(ID);
+  }
+
+  @Test
   void shouldExecuteWithMultipleOperationsInBatch() throws PersistenceException, IOException {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -308,6 +308,31 @@ class OpensearchBatchRequestTest {
   }
 
   @Test
+  void shouldDeleteEntity() throws IOException, PersistenceException {
+    // Given
+    final TestExporterEntity entity = new TestExporterEntity().setId(ID);
+
+    // When
+    batchRequest.delete(INDEX, ID);
+    batchRequest.execute();
+
+    // Then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isDelete()).isTrue();
+
+    final var delete = bulkOperation.delete();
+    assertThat(delete.index()).isEqualTo(INDEX);
+    assertThat(delete.id()).isEqualTo(ID);
+  }
+
+  @Test
   void shouldExecuteWithMultipleOperationsInBatch() throws PersistenceException, IOException {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Identity has a requirement that we perform deletes by doc ID, this PR introduces the base `delete` method in the BatchRequest class such that it can be used later in the handlers to process deletes.
