### PR TITLE
Reject pull request updates using merge commits

### DIFF
--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -22,11 +22,14 @@ jobs:
 
       - name: Check for invalid merge commits
         run: |
+          base="origin/${{ github.event.pull_request.base.ref }}"
+          head=${{ github.event.pull_request.head.sha }}
+
           # Find the common ancestor between the base and the head
-          common_ancestor=$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})
+          common_ancestor=$(git merge-base $base $head)
 
           # Get the list of merge commits in the pull request
-          merge_commits=$(git rev-list --merges $common_ancestor..${{ github.event.pull_request.head.sha }})
+          merge_commits=$(git rev-list --merges $common_ancestor..$head)
 
           # Check each merge commit
           for merge_commit in $merge_commits; do
@@ -35,7 +38,7 @@ jobs:
 
             # Check if any parent commit exists in the base branch
             for parent in $parents; do
-              if git merge-base --is-ancestor $parent origin/${{ github.event.pull_request.base.ref }}; then
+              if git merge-base --is-ancestor $parent $base; then
                 echo "Updating your pull request using a merge commit is allowed. Please update your pull request by rebasing your branch on the base branch."
                 exit 1
               fi

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -1,0 +1,44 @@
+# This workflow ensures that pull requests aren't updated using merge commits.
+# To update a pull request with the latest changes you should rebase your branch on the base branch.
+# See our contributing guide's section on 'Creating a pull request' for more information:
+# https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#creating-a-pull-request
+#
+# It is allowed to have merge commits in a pull request.
+# An example is a pull request that builds upon the work of another pull request.
+
+name: Reject Merge Commits
+on: [pull_request]
+
+jobs:
+  check-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ github.event.pull_request.commits }}
+
+      - name: Check for invalid merge commits
+        run: |
+          # Find the common ancestor between the base and the head
+          common_ancestor=$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})
+
+          # Get the list of merge commits in the pull request
+          merge_commits=$(git rev-list --merges $common_ancestor..${{ github.event.pull_request.head.sha }})
+
+          # Check each merge commit
+          for merge_commit in $merge_commits; do
+            # Get the parent commits of the merge commit
+            parents=$(git rev-list --parents -n 1 $merge_commit | cut -d' ' -f2-)
+
+            # Check if any parent commit exists in the base branch
+            for parent in $parents; do
+              if git merge-base --is-ancestor $parent origin/${{ github.event.pull_request.base.ref }}; then
+                echo "Updating your pull request using a merge commit is allowed. Please update your pull request by rebasing your branch on the base branch."
+                exit 1
+              fi
+            done
+          done
+
+          echo "No invalid merge commits found."

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ github.event.pull_request.commits }}
-          # todo: make this blobless
+          filter: blob:none
 
       - name: Fetch commits up to the merge-base
         run: |

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -17,26 +17,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ github.event.pull_request.commits }}
-          filter: blob:none
-
-      - name: Fetch commits up to the merge-base
-        run: |
-          depth=100
-          while [ -z "$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})" ]; do
-            echo "Current number of commits on log:"
-            git log origin/${{ github.event.pull_request.base.ref }} --oneline | wc -l
-
-            echo "Fetching $depth commits"
-            git fetch --depth=${depth} --filter=blob:none origin ${{ github.event.pull_request.base.ref }}
-            if [ $depth -gt 2000000 ]; then
-              echo "Too many commits between PR and base branch. Ignoring this check."
-              exit 0
-            fi
-            depth=$((depth * 4))
-
-            echo "Checking git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }} again: $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})"
-          done
+          fetch-depth: 0
+          filter: tree:0
 
       - name: Check for invalid merge commits
         run: |

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -40,12 +40,18 @@ jobs:
             for parent in $parents; do
               if git merge-base --is-ancestor $parent $base; then
                 echo "Updating your pull request using a merge commit is not allowed."
-                echo "We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow automated porting of the pull request."
-                echo "Please update your pull request by rebasing your branch on the base branch."
+                echo "Please remove merge commit '$merge_commit' from your pull request,"
+                echo "and update your pull request by rebasing your branch onto '$base'."
+                echo "For more information, please refer to our contributing guide's section on 'Updating a pull request':"
+                echo "https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#updating-a-pull-request"
+
                 echo "> [!IMPORTANT]" >> $GITHUB_STEP_SUMMARY
                 echo "> Updating your pull request using a merge commit is not allowed." >> $GITHUB_STEP_SUMMARY
-                echo "> We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow automated porting of the pull request." >> $GITHUB_STEP_SUMMARY
-                echo "> Please update your pull request by rebasing your branch on the base branch." >> $GITHUB_STEP_SUMMARY
+                echo "> Please remove merge commit '$merge_commit' from your pull request," >> $GITHUB_STEP_SUMMARY
+                echo "> and update your pull request by rebasing your branch onto '$base'." >> $GITHUB_STEP_SUMMARY
+                echo "> For more information, please refer to our contributing guide's section on 'Updating a pull request':" >> $GITHUB_STEP_SUMMARY
+                echo "> https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#updating-a-pull-request" >> $GITHUB_STEP_SUMMARY
+
                 exit 1
               fi
             done

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -18,6 +18,25 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: ${{ github.event.pull_request.commits }}
+          # todo: make this blobless
+
+      - name: Fetch commits up to the merge-base
+        run: |
+          depth=100
+          while [ -z "$(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})" ]; do
+            echo "Current number of commits on log:"
+            git log origin/${{ github.event.pull_request.base.ref }} --oneline | wc -l
+
+            echo "Fetching $depth commits"
+            git fetch --depth=${depth} --filter=blob:none origin ${{ github.event.pull_request.base.ref }}
+            if [ $depth -gt 2000000 ]; then
+              echo "Too many commits between PR and base branch. Ignoring this check."
+              exit 0
+            fi
+            depth=$((depth * 4))
+
+            echo "Checking git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }} again: $(git merge-base origin/${{ github.event.pull_request.base.ref }} ${{ github.event.pull_request.head.sha }})"
+          done
 
       - name: Check for invalid merge commits
         run: |

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -9,6 +9,8 @@
 name: Reject Merge Commits
 on: [pull_request]
 
+permissions: {}
+
 jobs:
   check-merge-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -39,7 +39,11 @@ jobs:
             # Check if any parent commit exists in the base branch
             for parent in $parents; do
               if git merge-base --is-ancestor $parent $base; then
-                echo "Updating your pull request using a merge commit is allowed. Please update your pull request by rebasing your branch on the base branch."
+                echo "Updating your pull request using a merge commit is allowed."
+                echo "Please update your pull request by rebasing your branch on the base branch."
+                echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
+                echo "> Updating your pull request using a merge commit is allowed." >> $GITHUB_STEP_SUMMARY
+                echo "> Please update your pull request by rebasing your branch on the base branch." >> $GITHUB_STEP_SUMMARY
                 exit 1
               fi
             done

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -1,7 +1,7 @@
 # This workflow ensures that pull requests aren't updated using merge commits.
 # To update a pull request with the latest changes you should rebase your branch on the base branch.
-# See our contributing guide's section on 'Creating a pull request' for more information:
-# https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#creating-a-pull-request
+# For more information, please refer to our contributing guide's section on 'Updating a pull request':
+# https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md#updating-a-pull-request
 #
 # It is allowed to have merge commits in a pull request.
 # An example is a pull request that builds upon the work of another pull request.

--- a/.github/workflows/reject-updates-using-merge-commit.yml
+++ b/.github/workflows/reject-updates-using-merge-commit.yml
@@ -39,10 +39,12 @@ jobs:
             # Check if any parent commit exists in the base branch
             for parent in $parents; do
               if git merge-base --is-ancestor $parent $base; then
-                echo "Updating your pull request using a merge commit is allowed."
+                echo "Updating your pull request using a merge commit is not allowed."
+                echo "We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow automated porting of the pull request."
                 echo "Please update your pull request by rebasing your branch on the base branch."
-                echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
-                echo "> Updating your pull request using a merge commit is allowed." >> $GITHUB_STEP_SUMMARY
+                echo "> [!IMPORTANT]" >> $GITHUB_STEP_SUMMARY
+                echo "> Updating your pull request using a merge commit is not allowed." >> $GITHUB_STEP_SUMMARY
+                echo "> We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow automated porting of the pull request." >> $GITHUB_STEP_SUMMARY
                 echo "> Please update your pull request by rebasing your branch on the base branch." >> $GITHUB_STEP_SUMMARY
                 exit 1
               fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,11 +184,43 @@ Before opening your first pull request, please have a look at this [guide](https
 3. The reviewer will look at the pull request in the following days and give you either feedback or accept the changes. Your reviewer might use [emoji code](#review-emoji-code) during the reviewing process.
    1. If there are changes requested, address them in a new commit. Notify the reviewer in a comment if the pull request is ready for review again. If the changes are accepted squash them again in the related commit and force push. Then initiate a merge by adding your PR to the merge queue via the `Merge when ready` button.
    2. If no changes are requested, the reviewer will initiate a merge themselves.
-4. If there are merge conflicts, the author of the pull request has to manually rebase their branch onto the target branch (often `main`) and force push. We try to avoid using merge commits in pull requests to keep the history easy to follow, and allow [automated porting of the pull request](#backporting-changes).
+4. If there are merge conflicts, the author of the pull request has to [update their pull request by manually rebasing](#updating-a-pull-request).
 5. When a merge is initiated, a bot will merge your branch with the latest
    `main` and run the CI on it.
    1. If everything goes well, the branch is merged and deleted and the issue and pull request are closed.
    2. If there are CI errors, the author of the pull request has to check if they are caused by its changes and address them. If they are flaky tests, please have a look at this [guide](docs/ci.md#determine-flakiness) on how to handle them. Once the CI errors are resolved, a merge can be retried by simply enqueueing the PR again.
+
+## Updating a pull request
+
+If there are merge conflicts on a pull request, the author of the pull request has to update it with the latest changes and resolve the conflicts manually.
+You can do this by rebasing your branch onto the target branch (often `main`) and force push.
+
+First fetch the latest changes, and start rebasing on the target branch:
+
+```sh
+# Example: target is origin/main
+git fetch origin
+git rebase origin/main
+```
+
+After resolving the conflicts, you can continue the rebase:
+
+```sh
+git rebase --continue
+```
+
+After the rebase is completed, you can force push your branch:
+
+```sh
+git push --force-with-lease
+```
+
+We require rebasing instead of using merge commits to update a pull request to:
+- keep the history easy to follow,
+- allow [automated porting of the pull request](#backporting-changes),
+- and avoid automatically requesting reviews from unrelated users due to [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+
+We encourage contributors to regularly rebase their pull requests to minimize the accumulation of merge conflicts.
 
 ## Reviewing a pull request
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Our contributing guide is clear about updating pull requests using rebase. However, there's no way to limit GitHub's 'Update this Pull Request' buttons to only allow rebases. It's always possible to use merge commits to update the pull request. However, this doesn't align with our guidelines.

This PR adds a workflow that ensures pull requests are not updated using merge commits. Some merge commits are still allowed, as long as they don't bring in commits from the base branch directly, for example if another pull request is merged into this pull request.

The PR also expands the contributing guide with a section dedicated to updating a pull request. This section is linked from the workflow's output. The workflow's output also provides instructions how to recover from having updated the pull request using a merge commit.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

This should not be part of the common CI, as it only needs to be run on pull requests.

## Related issues

NA