### PR TITLE
Template descriptor creates indices

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -51,9 +51,13 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     indexTemplateDescriptors.stream()
         .filter(descriptor -> !existingTemplateNames.contains(descriptor.getTemplateName()))
         .forEach(
-            descriptor ->
-                elasticsearchClient.createIndexTemplate(
-                    descriptor, getIndexSettings(descriptor.getIndexName()), true));
+            descriptor -> {
+              elasticsearchClient.createIndexTemplate(
+                  descriptor, getIndexSettings(descriptor.getIndexName()), true);
+
+              elasticsearchClient.createIndex(
+                  descriptor, getIndexSettings(descriptor.getIndexName()));
+            });
 
     indexDescriptors.stream()
         .filter(descriptor -> !existingIndexNames.contains(descriptor.getFullQualifiedName()))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -108,7 +108,7 @@ final class CamundaExporterIT {
 
     indexTemplate =
         SchemaTestUtil.mockIndexTemplate(
-            "template_name",
+            "index_name",
             "test*",
             "template_alias",
             Collections.emptyList(),
@@ -121,6 +121,9 @@ final class CamundaExporterIT {
             "alias",
             "index_name",
             "/mappings.json");
+
+    when(indexTemplate.getFullQualifiedName())
+        .thenReturn(config.getIndex().getPrefix() + "template_index_qualified_name");
   }
 
   @Test
@@ -341,6 +344,9 @@ final class CamundaExporterIT {
               "new_template_name",
               "/mappings-added-property.json");
 
+      when(newIndexTemplate.getFullQualifiedName())
+          .thenReturn(config.getIndex().getPrefix() + "new_template_index_qualified_name");
+
       when(resourceProvider.getIndexDescriptors()).thenReturn(Set.of(index, newIndex));
       when(resourceProvider.getIndexTemplateDescriptors())
           .thenReturn(Set.of(indexTemplate, newIndexTemplate));
@@ -404,6 +410,17 @@ final class CamundaExporterIT {
       final var policies = testClient.ilm().getLifecycle();
 
       assertThat(policies.get("not_created_policy")).isNull();
+    }
+
+    @Test
+    void shouldCreateIndexInAdditionToTemplateFromTemplateDescriptor() throws IOException {
+      config.setCreateSchema(true);
+
+      startExporter();
+
+      final var indices =
+          testClient.indices().get(req -> req.index(indexTemplate.getFullQualifiedName()));
+      assertThat(indices.result().size()).isEqualTo(1);
     }
   }
 


### PR DESCRIPTION
## Description

Template descriptors should create the index template then create the matching index so that it is visible during startup to operate.

**Success Criteria:**
- [x] Template descriptors create template and then matching index.

