### PR TITLE
[Backport stable/8.6] Revert "ci: revert and use zeebe runners for zeebe-related jobs"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-8-default
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -192,7 +192,7 @@ jobs:
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -203,21 +203,25 @@ jobs:
             maven-modules: "'qa/integration-tests'"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
           - group: modules
             name: "Zeebe Module Integration Tests"
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
+            runs-on: gcp-perf-core-8-default
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-16-default
           - group: qa-update
             name: "Zeebe QA - Update Tests"
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
+            runs-on: gcp-perf-core-8-default
     env:
       ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -29,7 +29,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: gcp-perf-core-8-default
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64
@@ -129,7 +129,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"


### PR DESCRIPTION
# Description
Backport of #23086 to `stable/8.6`.
`cyclonedx-maven-plugin` is not included in pom deps in `stable/8.6` (and will not), it's safe to merge.

relates to camunda/camunda#22999
original author: @clementnero
