### PR TITLE
Authorization checks on UserTask processors

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -210,7 +210,8 @@ public final class EngineProcessors {
         processingState,
         scheduledTaskStateFactory,
         interPartitionCommandSender);
-    addUserTaskProcessors(typedRecordProcessors, processingState, bpmnBehaviors, writers);
+    addUserTaskProcessors(
+        typedRecordProcessors, processingState, bpmnBehaviors, writers, authCheckBehavior);
 
     UserProcessors.addUserProcessors(
         keyGenerator,
@@ -431,10 +432,15 @@ public final class EngineProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
-      final Writers writers) {
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     final var userTaskProcessor =
         new UserTaskProcessor(
-            processingState, processingState.getKeyGenerator(), bpmnBehaviors, writers);
+            processingState,
+            processingState.getKeyGenerator(),
+            bpmnBehaviors,
+            writers,
+            authCheckBehavior);
 
     UserTaskIntent.commands()
         .forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.usertask;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskAssignProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskClaimProcessor;
@@ -31,7 +32,8 @@ public final class UserTaskCommandProcessors {
       final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final BpmnBehaviors bpmnBehaviors,
-      final Writers writers) {
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     final EventHandle eventHandle =
         new EventHandle(
             keyGenerator,
@@ -45,17 +47,18 @@ public final class UserTaskCommandProcessors {
         new EnumMap<>(
             Map.of(
                 UserTaskIntent.ASSIGN,
-                new UserTaskAssignProcessor(processingState, writers),
+                new UserTaskAssignProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.CLAIM,
-                new UserTaskClaimProcessor(processingState, writers),
+                new UserTaskClaimProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.UPDATE,
-                new UserTaskUpdateProcessor(processingState, writers),
+                new UserTaskUpdateProcessor(processingState, writers, authCheckBehavior),
                 UserTaskIntent.COMPLETE,
-                new UserTaskCompleteProcessor(processingState, eventHandle, writers)));
+                new UserTaskCompleteProcessor(
+                    processingState, eventHandle, writers, authCheckBehavior)));
     validateProcessorsSetup(commandToProcessor);
   }
 
-  public UserTaskCommandProcessor getCommandProcessor(UserTaskIntent userTaskIntent) {
+  public UserTaskCommandProcessor getCommandProcessor(final UserTaskIntent userTaskIntent) {
     if (userTaskIntent.isEvent()) {
       throw new IllegalArgumentException(
           "Expected a command, but received an event: '%s'. Valid UserTask commands are: %s"
@@ -70,7 +73,7 @@ public final class UserTaskCommandProcessors {
   }
 
   private static void validateProcessorsSetup(
-      Map<UserTaskIntent, UserTaskCommandProcessor> commandToProcessor) {
+      final Map<UserTaskIntent, UserTaskCommandProcessor> commandToProcessor) {
     final var missingProcessors =
         UserTaskIntent.commands().stream()
             .filter(intent -> !commandToProcessor.containsKey(intent))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.usertask;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -25,17 +26,21 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
+  private final AuthorizationCheckBehavior authCheckBehavior;
 
   public UserTaskProcessor(
       final ProcessingState state,
       final KeyGenerator keyGenerator,
       final BpmnBehaviors bpmnBehaviors,
-      final Writers writers) {
-    this.commandProcessors =
-        new UserTaskCommandProcessors(state, keyGenerator, bpmnBehaviors, writers);
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
+    this.authCheckBehavior = authCheckBehavior;
+    commandProcessors =
+        new UserTaskCommandProcessors(
+            state, keyGenerator, bpmnBehaviors, writers, authCheckBehavior);
 
-    this.rejectionWriter = writers.rejection();
-    this.responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -28,12 +29,15 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
-  public UserTaskAssignProcessor(final ProcessingState state, final Writers writers) {
+  public UserTaskAssignProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
         new UserTaskCommandPreconditionChecker(
-            List.of(LifecycleState.CREATED), "assign", state.getUserTaskState());
+            List.of(LifecycleState.CREATED), "assign", state.getUserTaskState(), authCheckBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -33,7 +34,10 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
-  public UserTaskClaimProcessor(final ProcessingState state, final Writers writers) {
+  public UserTaskClaimProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
@@ -41,7 +45,8 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
             List.of(LifecycleState.CREATED),
             "claim",
             UserTaskClaimProcessor::checkClaim,
-            state.getUserTaskState());
+            state.getUserTaskState(),
+            authCheckBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
@@ -37,7 +38,10 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
   public UserTaskCompleteProcessor(
-      final ProcessingState state, final EventHandle eventHandle, final Writers writers) {
+      final ProcessingState state,
+      final EventHandle eventHandle,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     elementInstanceState = state.getElementInstanceState();
     this.eventHandle = eventHandle;
     stateWriter = writers.state();
@@ -45,7 +49,10 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
     responseWriter = writers.response();
     preconditionChecker =
         new UserTaskCommandPreconditionChecker(
-            List.of(LifecycleState.CREATED), "complete", state.getUserTaskState());
+            List.of(LifecycleState.CREATED),
+            "complete",
+            state.getUserTaskState(),
+            authCheckBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskUpdateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.usertask.processors;
 
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -29,12 +30,15 @@ public final class UserTaskUpdateProcessor implements UserTaskCommandProcessor {
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
 
-  public UserTaskUpdateProcessor(final ProcessingState state, final Writers writers) {
+  public UserTaskUpdateProcessor(
+      final ProcessingState state,
+      final Writers writers,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
         new UserTaskCommandPreconditionChecker(
-            List.of(LifecycleState.CREATED), "update", state.getUserTaskState());
+            List.of(LifecycleState.CREATED), "update", state.getUserTaskState(), authCheckBehavior);
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class UserTaskAssignAuthorizationIT {
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHENTICATED_USERNAME = "foo";
+  public static final String UNAUTHENTICATED_USERNAME = "bar";
+  public static final String USER_TASK_ID = "userTask";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask(USER_TASK_ID)
+                .zeebeUserTask()
+                .endEvent()
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHENTICATED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            UNAUTHENTICATED_USERNAME,
+            "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToAssignUserTaskWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        defaultUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(DEFAULT_USERNAME)
+            .allowOverride(true)
+            .send()
+            .join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToAssignUserTaskWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        authorizedUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(AUTHENTICATED_USERNAME)
+            .allowOverride(true)
+            .send()
+            .join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToAssignUserTaskIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when we use the unauthorized client
+    final var response =
+        unauthorizedUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(UNAUTHENTICATED_USERNAME)
+            .allowOverride(true)
+            .send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  private long createProcessInstance() {
+    return defaultUserClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private static long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .limit(1)
+        .findFirst()
+        .orElseThrow()
+        .getKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class UserTaskClaimAuthorizationIT {
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHENTICATED_USERNAME = "foo";
+  public static final String UNAUTHENTICATED_USERNAME = "bar";
+  public static final String USER_TASK_ID = "userTask";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask(USER_TASK_ID)
+                .zeebeUserTask()
+                .endEvent()
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHENTICATED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            UNAUTHENTICATED_USERNAME,
+            "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToClaimUserTaskWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        defaultUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(DEFAULT_USERNAME)
+            .send()
+            .join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToClaimUserTaskWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        authorizedUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(AUTHENTICATED_USERNAME)
+            .send()
+            .join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToClaimUserTaskIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when we use the unauthorized client
+    final var response =
+        unauthorizedUserClient
+            .newUserTaskAssignCommand(userTaskKey)
+            .assignee(UNAUTHENTICATED_USERNAME)
+            .send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  private long createProcessInstance() {
+    return defaultUserClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private static long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .limit(1)
+        .findFirst()
+        .orElseThrow()
+        .getKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class UserTaskCompleteAuthorizationIT {
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHENTICATED_USERNAME = "foo";
+  public static final String UNAUTHENTICATED_USERNAME = "bar";
+  public static final String USER_TASK_ID = "userTask";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask(USER_TASK_ID)
+                .zeebeUserTask()
+                .endEvent()
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHENTICATED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            UNAUTHENTICATED_USERNAME,
+            "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToCompleteUserTaskWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response = defaultUserClient.newUserTaskCompleteCommand(userTaskKey).send().join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToCompleteUserTaskWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response = authorizedUserClient.newUserTaskCompleteCommand(userTaskKey).send().join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToCompleteUserTaskIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when we use the unauthorized client
+    final var response = unauthorizedUserClient.newUserTaskCompleteCommand(userTaskKey).send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  private long createProcessInstance() {
+    return defaultUserClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private static long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .limit(1)
+        .findFirst()
+        .orElseThrow()
+        .getKey();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class UserTaskUpdateAuthorizationIT {
+  public static final String DEFAULT_USERNAME = "demo";
+  public static final String AUTHENTICATED_USERNAME = "foo";
+  public static final String UNAUTHENTICATED_USERNAME = "bar";
+  public static final String USER_TASK_ID = "userTask";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, DEFAULT_USERNAME, "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), DEFAULT_USERNAME);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask(USER_TASK_ID)
+                .zeebeUserTask()
+                .endEvent()
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            AUTHENTICATED_USERNAME,
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            UNAUTHENTICATED_USERNAME,
+            "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToUpdateUserTaskWithDefaultUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        defaultUserClient.newUserTaskUpdateCommand(userTaskKey).priority(100).send().join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToUpdateUserTaskWithUser() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when then
+    final var response =
+        authorizedUserClient.newUserTaskUpdateCommand(userTaskKey).priority(100).send().join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToUpdateUserTaskIfNoPermissions() {
+    // given
+    final var processInstanceKey = createProcessInstance();
+    final var userTaskKey = getUserTaskKey(processInstanceKey);
+
+    // when we use the unauthorized client
+    final var response =
+        unauthorizedUserClient.newUserTaskUpdateCommand(userTaskKey).priority(100).send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  private long createProcessInstance() {
+    return defaultUserClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private static long getUserTaskKey(final long processInstanceKey) {
+    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId(USER_TASK_ID)
+        .limit(1)
+        .findFirst()
+        .orElseThrow()
+        .getKey();
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserTaskRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserTaskRecordStream.java
@@ -26,4 +26,8 @@ public class UserTaskRecordStream
   public UserTaskRecordStream withProcessInstanceKey(final long processInstanceKey) {
     return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
   }
+
+  public UserTaskRecordStream withElementId(final String elementId) {
+    return valueFilter(v -> v.getElementId().equals(elementId));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds authorization checks to the UserTask processors. These have all been as part of a single PR as they are intertwined with one another. This makes it easier to do the check in a single location instead of all separately.
The PR seems quite large, but it's mostly the test cases.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22601 
closes #22602 
closes #22603 
closes #22604 
