### PR TITLE
[Backport stable/8.6] Use overrides from @JsonProperty when it's provided

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -119,11 +119,11 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
     parameters.forEach(
         pi ->
             ReflectionUtils.doWithFields(
-                pi.getParameterInfo().getType(), f -> result.add(extractParameterName(f))));
+                pi.getParameterInfo().getType(), f -> result.add(extractFieldName(f))));
     return result;
   }
 
-  private String extractParameterName(final Field field) {
+  private String extractFieldName(final Field field) {
     if (field.isAnnotationPresent(JsonProperty.class)) {
       return field.getAnnotation(JsonProperty.class).value();
     }

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfiguration
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.lang3.StringUtils.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.spring.client.annotation.Variable;
 import io.camunda.zeebe.spring.client.annotation.VariablesAsType;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.spring.client.bean.CopyNotNullBeanUtilsBean;
 import io.camunda.zeebe.spring.client.bean.MethodInfo;
 import io.camunda.zeebe.spring.client.bean.ParameterInfo;
 import io.camunda.zeebe.spring.client.properties.common.ZeebeClientProperties;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -117,8 +119,15 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
     parameters.forEach(
         pi ->
             ReflectionUtils.doWithFields(
-                pi.getParameterInfo().getType(), f -> result.add(f.getName())));
+                pi.getParameterInfo().getType(), f -> result.add(extractParameterName(f))));
     return result;
+  }
+
+  private String extractParameterName(final Field field) {
+    if (field.isAnnotationPresent(JsonProperty.class)) {
+      return field.getAnnotation(JsonProperty.class).value();
+    }
+    return field.getName();
   }
 
   private void applyOverrides(final ZeebeWorkerValue zeebeWorker) {

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizer.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.ReflectionUtils;
@@ -125,7 +126,10 @@ public class PropertyBasedZeebeWorkerValueCustomizer implements ZeebeWorkerValue
 
   private String extractFieldName(final Field field) {
     if (field.isAnnotationPresent(JsonProperty.class)) {
-      return field.getAnnotation(JsonProperty.class).value();
+      final String value = field.getAnnotation(JsonProperty.class).value();
+      if (StringUtils.isNotBlank(value)) {
+        return value;
+      }
     }
     return field.getName();
   }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.spring.client.properties;
 
 import static org.assertj.core.api.Assertions.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.spring.client.annotation.JobWorker;
 import io.camunda.zeebe.spring.client.annotation.Variable;
@@ -67,6 +68,9 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
 
   @JobWorker
   void activatedJobWorker(@Variable final String var1, final ActivatedJob activatedJob) {}
+
+  @JobWorker
+  void sampleWorkerWithJsonProperty(@VariablesAsType final PropertyAnnotatedClass annotatedClass) {}
 
   @Test
   void shouldNotAdjustVariableFilterVariablesAsActivatedJobIsInjectedLegacy() {
@@ -387,6 +391,21 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     assertThat(zeebeWorkerValue.getEnabled()).isFalse();
   }
 
+  @Test
+  void shouldApplyPropertyAnnotationOnVariableFiltering() {
+    // given
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties());
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(methodInfo(this, "testBean", "sampleWorkerWithJsonProperty"));
+
+    // when
+    customizer.customize(zeebeWorkerValue);
+
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("some_name");
+  }
+
   private static final class ComplexProcessVariable {
     private String var3;
     private String var4;
@@ -406,5 +425,10 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     public void setVar4(final String var4) {
       this.var4 = var4;
     }
+  }
+
+  private static class PropertyAnnotatedClass {
+    @JsonProperty("some_name")
+    private String value;
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -72,6 +72,10 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   @JobWorker
   void sampleWorkerWithJsonProperty(@VariablesAsType final PropertyAnnotatedClass annotatedClass) {}
 
+  @JobWorker
+  void sampleWorkerWithEmptyJsonProperty(
+      @VariablesAsType final PropertyAnnotatedClassEmptyValue annotatedClass) {}
+
   @Test
   void shouldNotAdjustVariableFilterVariablesAsActivatedJobIsInjectedLegacy() {
     // given
@@ -406,6 +410,22 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("some_name");
   }
 
+  @Test
+  void shouldNotApplyPropertyAnnotationOnEmptyValue() {
+    // given
+    final PropertyBasedZeebeWorkerValueCustomizer customizer =
+        new PropertyBasedZeebeWorkerValueCustomizer(legacyProperties(), properties());
+    final ZeebeWorkerValue zeebeWorkerValue = new ZeebeWorkerValue();
+    zeebeWorkerValue.setMethodInfo(
+        methodInfo(this, "testBean", "sampleWorkerWithEmptyJsonProperty"));
+
+    // when
+    customizer.customize(zeebeWorkerValue);
+
+    // then
+    assertThat(zeebeWorkerValue.getFetchVariables()).containsExactly("value");
+  }
+
   private static final class ComplexProcessVariable {
     private String var3;
     private String var4;
@@ -430,5 +450,9 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   private static final class PropertyAnnotatedClass {
     @JsonProperty("some_name")
     private String value;
+  }
+
+  private static final class PropertyAnnotatedClassEmptyValue {
+    @JsonProperty() private String value;
   }
 }

--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -427,7 +427,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
     }
   }
 
-  private static class PropertyAnnotatedClass {
+  private static final class PropertyAnnotatedClass {
     @JsonProperty("some_name")
     private String value;
   }


### PR DESCRIPTION
# Description
Backport of #23219 to `stable/8.6`.

relates to camunda-community-hub/spring-zeebe#903 #21962
original author: @ana-vinogradova-camunda