### PR TITLE
refactor: remove stable branches from Optimize health view

### DIFF
--- a/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
+++ b/.github/optimize/scripts/healthStatusReport/createHealthStatusConfig.ts
@@ -19,13 +19,11 @@ const CONFIG_FILE_NAME = 'config.json';
 async function createHealthStatusConfig() {
   const githubService = new GitHubService(GITHUB_TOKEN, GITHUB_ORG, GITHUB_REPO);
   const releaseBranches = await githubService.getBranchesWithPrefix('release/optimize-');
-  const stableBranches = await githubService.getBranchesWithPrefix('stable/');
   const optimizeStableBranches = await githubService.getBranchesWithPrefix('stable/optimize-');
   const ciBranches = [
     MAIN_BRANCH,
     ...releaseBranches,
     ...optimizeStableBranches,
-    ...stableBranches,
   ].sort(githubService.sortBranches);
 
   const config: Partial<Config> = {


### PR DESCRIPTION
## Description

We only need to report about the branches `stable/optimize-{suffix}`, therefore we can remove `stable/{suffix}` from the health status reports.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
