### PR TITLE
fix: correct broken test steps and create new version of process to enable valid migration

### DIFF
--- a/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
+++ b/operate/client/e2e-playwright/docs-screenshots/process-instance-migration.spec.ts
@@ -52,7 +52,7 @@ test.describe('process instance migration', () => {
             completed: 0,
           },
         ],
-        processXml: open('orderProcess.bpmn'),
+        processXml: open('orderProcess_v3.bpmn'),
       }),
     );
 
@@ -193,7 +193,7 @@ test.describe('process instance migration', () => {
 
     await migrationView.nextButton.click();
 
-    await commonPage.addUpArrow(page.getByTestId('state-overlay'));
+    await commonPage.addUpArrow(page.getByTestId('state-overlay-active'));
     await commonPage.addUpArrow(page.getByTestId('modifications-overlay'));
 
     await page.screenshot({
@@ -232,9 +232,13 @@ test.describe('process instance migration', () => {
 
     await migrationView.confirmButton.click();
 
+    await migrationView.confirmMigration();
+
     await processesPage.diagram.moveCanvasHorizontally(-200);
 
-    await expect(page.getByTestId('state-overlay')).toBeVisible();
+    await expect(
+      page.getByTestId('state-overlay-checkPayment-active'),
+    ).toBeVisible();
     await expect(page.getByText(mockMigrationOperation.id)).toHaveCount(1);
 
     await page.screenshot({

--- a/operate/client/e2e-playwright/pages/DecisionInstance.ts
+++ b/operate/client/e2e-playwright/pages/DecisionInstance.ts
@@ -47,6 +47,6 @@ export class DecisionInstance {
   }: {
     decisionInstanceKey: string;
   }) {
-    await this.page.goto('.' + Paths.decisionInstance(decisionInstanceKey));
+    await this.page.goto(Paths.decisionInstance(decisionInstanceKey));
   }
 }

--- a/operate/client/e2e-playwright/pages/Decisions.ts
+++ b/operate/client/e2e-playwright/pages/Decisions.ts
@@ -81,12 +81,12 @@ export class Decisions {
     options?: Parameters<Page['goto']>[1];
   }) {
     if (searchParams === undefined) {
-      await this.page.goto('.' + Paths.decisions());
+      await this.page.goto(Paths.decisions());
       return;
     }
 
     await this.page.goto(
-      `.${Paths.decisions()}?${convertToQueryString(searchParams)}`,
+      `${Paths.decisions()}?${convertToQueryString(searchParams)}`,
       options,
     );
   }

--- a/operate/client/e2e-playwright/pages/Login.ts
+++ b/operate/client/e2e-playwright/pages/Login.ts
@@ -45,6 +45,6 @@ export class Login {
   }
 
   async navigateToLogin() {
-    await this.page.goto('.' + Paths.login());
+    await this.page.goto(Paths.login());
   }
 }

--- a/operate/client/e2e-playwright/pages/ProcessInstance.ts
+++ b/operate/client/e2e-playwright/pages/ProcessInstance.ts
@@ -94,7 +94,7 @@ export class ProcessInstance {
     id: string;
     options?: Parameters<Page['goto']>[1];
   }) {
-    await this.page.goto('.' + Paths.processInstance(id), options);
+    await this.page.goto(Paths.processInstance(id), options);
   }
 
   async getNthTreeNodeTestId(n: number) {

--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -63,12 +63,12 @@ export class Processes {
     options?: Parameters<Page['goto']>[1];
   }) {
     if (searchParams === undefined) {
-      await this.page.goto('.' + Paths.processes());
+      await this.page.goto(Paths.processes());
       return;
     }
 
     await this.page.goto(
-      `.${Paths.processes()}?${convertToQueryString(searchParams)}`,
+      `${Paths.processes()}?${convertToQueryString(searchParams)}`,
       options,
     );
   }

--- a/operate/client/e2e-playwright/tests/login.spec.ts
+++ b/operate/client/e2e-playwright/tests/login.spec.ts
@@ -28,7 +28,7 @@ test.describe('login page', () => {
     await expect(
       page.getByRole('alert').getByText('Username and password do not match'),
     ).toBeVisible();
-    await expect(page).toHaveURL(Paths.login());
+    await expect(page).toHaveURL(`.${Paths.login()}`);
   });
 
   test('Log in with valid user account', async ({loginPage, page}) => {
@@ -48,13 +48,13 @@ test.describe('login page', () => {
 
     await expect(page).toHaveURL('../operate'); // dashboard url, we need to do this because baseURL contains a slash at the end as expected by playwright
     await commonPage.logout();
-    await expect(page).toHaveURL(Paths.login());
+    await expect(page).toHaveURL(`.${Paths.login()}`);
   });
 
   test('Redirect to initial page after login', async ({loginPage, page}) => {
-    await expect(page).toHaveURL(Paths.login());
-    await page.goto(`${Paths.processes()}?active=true&incidents=true`);
-    await expect(page).toHaveURL(Paths.login());
+    await expect(page).toHaveURL(`.${Paths.login()}`);
+    await page.goto(`.${Paths.processes()}?active=true&incidents=true`);
+    await expect(page).toHaveURL(`.${Paths.login()}`);
 
     await loginPage.login({
       username: 'demo',
@@ -62,7 +62,7 @@ test.describe('login page', () => {
     });
 
     await expect(page).toHaveURL(
-      `${Paths.processes()}?active=true&incidents=true`,
+      `.${Paths.processes()}?active=true&incidents=true`,
     );
   });
 });

--- a/operate/client/e2e-playwright/tests/login.spec.ts
+++ b/operate/client/e2e-playwright/tests/login.spec.ts
@@ -28,7 +28,7 @@ test.describe('login page', () => {
     await expect(
       page.getByRole('alert').getByText('Username and password do not match'),
     ).toBeVisible();
-    await expect(page).toHaveURL('.' + Paths.login());
+    await expect(page).toHaveURL(Paths.login());
   });
 
   test('Log in with valid user account', async ({loginPage, page}) => {
@@ -48,13 +48,13 @@ test.describe('login page', () => {
 
     await expect(page).toHaveURL('../operate'); // dashboard url, we need to do this because baseURL contains a slash at the end as expected by playwright
     await commonPage.logout();
-    await expect(page).toHaveURL('.' + Paths.login());
+    await expect(page).toHaveURL(Paths.login());
   });
 
   test('Redirect to initial page after login', async ({loginPage, page}) => {
-    await expect(page).toHaveURL('.' + Paths.login());
-    await page.goto(`.${Paths.processes()}?active=true&incidents=true`);
-    await expect(page).toHaveURL('.' + Paths.login());
+    await expect(page).toHaveURL(Paths.login());
+    await page.goto(`${Paths.processes()}?active=true&incidents=true`);
+    await expect(page).toHaveURL(Paths.login());
 
     await loginPage.login({
       username: 'demo',
@@ -62,7 +62,7 @@ test.describe('login page', () => {
     });
 
     await expect(page).toHaveURL(
-      `.${Paths.processes()}?active=true&incidents=true`,
+      `${Paths.processes()}?active=true&incidents=true`,
     );
   });
 });

--- a/operate/client/e2e-playwright/tests/processes.spec.ts
+++ b/operate/client/e2e-playwright/tests/processes.spec.ts
@@ -173,7 +173,7 @@ test.describe('Processes', () => {
     ).toBeVisible();
 
     await expect(page).toHaveURL(
-      `.${Paths.processes()}?${convertToQueryString({
+      `${Paths.processes()}?${convertToQueryString({
         active: 'true',
         incidents: 'true',
         ids: instance.processInstanceKey,
@@ -197,7 +197,7 @@ test.describe('Processes', () => {
     await expect(page.getByRole('table').getByRole('row')).toHaveCount(2);
 
     await expect(page).toHaveURL(
-      `.${Paths.processes()}?${convertToQueryString({
+      `${Paths.processes()}?${convertToQueryString({
         active: 'true',
         incidents: 'true',
         ids: instance.processInstanceKey,

--- a/operate/client/e2e-playwright/tests/processes.spec.ts
+++ b/operate/client/e2e-playwright/tests/processes.spec.ts
@@ -173,7 +173,7 @@ test.describe('Processes', () => {
     ).toBeVisible();
 
     await expect(page).toHaveURL(
-      `${Paths.processes()}?${convertToQueryString({
+      `.${Paths.processes()}?${convertToQueryString({
         active: 'true',
         incidents: 'true',
         ids: instance.processInstanceKey,
@@ -197,7 +197,7 @@ test.describe('Processes', () => {
     await expect(page.getByRole('table').getByRole('row')).toHaveCount(2);
 
     await expect(page).toHaveURL(
-      `${Paths.processes()}?${convertToQueryString({
+      `.${Paths.processes()}?${convertToQueryString({
         active: 'true',
         incidents: 'true',
         ids: instance.processInstanceKey,

--- a/operate/client/playwright.config.ts
+++ b/operate/client/playwright.config.ts
@@ -26,11 +26,7 @@ const getPort = () => {
 };
 
 const getBasePath = () => {
-  if (IS_CI) {
-    return IS_E2E ? '/operate/' : '';
-  }
-
-  return '/operate/';
+  return IS_CI && !IS_E2E ? '' : '/operate/';
 };
 
 /**

--- a/operate/client/playwright.config.ts
+++ b/operate/client/playwright.config.ts
@@ -26,7 +26,11 @@ const getPort = () => {
 };
 
 const getBasePath = () => {
-  return IS_E2E ? '/operate/' : '';
+  if (IS_CI) {
+    return IS_E2E ? '/operate/' : '';
+  }
+
+  return '/operate/';
 };
 
 /**

--- a/operate/client/src/modules/mocks/diagrams/orderProcess_v3.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/orderProcess_v3.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0-nightly.20240821">
+  <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:serviceTask id="checkPayment" name="Check payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="checkPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="EndEvent_042s0oc" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
+      <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:serviceTask id="requestForPayment" name="Request for payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="requestPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="shipArticles" name="Ship Articles">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="shipArticles" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="156" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="300" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="792" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="469" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="460" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="444" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05tsons_di" bpmnElement="shipArticles">
+        <dc:Bounds x="633" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="138" />
+        <di:waypoint x="300" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
+        <di:waypoint x="733" y="138" />
+        <di:waypoint x="792" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
+        <di:waypoint x="400" y="138" />
+        <di:waypoint x="469" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54.5" y="227" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
+        <di:waypoint x="494" y="163" />
+        <di:waypoint x="494" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="188" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="444" y="300" />
+        <di:waypoint x="350" y="300" />
+        <di:waypoint x="350" y="178" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
+        <di:waypoint x="519" y="138" />
+        <di:waypoint x="633" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="566" y="117" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

- Fixes domain path problems which had roots related to #18604 
- Fixes overlay test ids that were changed in a different PR for E2E tests but not updated for the update docs screenshots workflow
- Creates a new version of the `orderProcess` process in order to have a valid mapping for the instance migration screenshots

## Related issues

relates to #21387 (closes part of the ticket)
