### PR TITLE
fix: bypass sequence flow check after resolving incident on parallel gateway

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -210,6 +210,11 @@ public final class ProcessInstanceStateTransitionGuard {
       return Either.right(null);
     }
 
+    // Accept after incident resolved
+    if (hasElementInstanceWithState(context, ProcessInstanceIntent.ELEMENT_ACTIVATING).isRight()) {
+      return Either.right(null);
+    }
+
     final var element = (ExecutableFlowNode) executableFlowElement;
     final int numberOfIncomingSequenceFlows = element.getIncoming().size();
     final int numberOfTakenSequenceFlows =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -208,19 +208,19 @@ public final class ProcessInstanceStateTransitionGuard {
       final BpmnElementContext context, final ExecutableFlowElement executableFlowElement) {
     if (context.getBpmnElementType() != BpmnElementType.PARALLEL_GATEWAY) {
       return Either.right(null);
-    } else {
-      final var element = (ExecutableFlowNode) executableFlowElement;
-      final int numberOfIncomingSequenceFlows = element.getIncoming().size();
-      final int numberOfTakenSequenceFlows =
-          stateBehavior.getNumberOfTakenSequenceFlows(context.getFlowScopeKey(), element.getId());
-      return numberOfTakenSequenceFlows >= numberOfIncomingSequenceFlows
-          ? Either.right(null)
-          : Either.left(
-              String.format(
-                  "Expected to be able to activate parallel gateway '%s',"
-                      + " but not all sequence flows have been taken.",
-                  BufferUtil.bufferAsString(element.getId())));
     }
+
+    final var element = (ExecutableFlowNode) executableFlowElement;
+    final int numberOfIncomingSequenceFlows = element.getIncoming().size();
+    final int numberOfTakenSequenceFlows =
+        stateBehavior.getNumberOfTakenSequenceFlows(context.getFlowScopeKey(), element.getId());
+    return numberOfTakenSequenceFlows >= numberOfIncomingSequenceFlows
+        ? Either.right(null)
+        : Either.left(
+            String.format(
+                "Expected to be able to activate parallel gateway '%s',"
+                    + " but not all sequence flows have been taken.",
+                BufferUtil.bufferAsString(element.getId())));
   }
 
   private Either<String, ?> canActivateInclusiveGateway(


### PR DESCRIPTION
## Description
This PR resolves an issue where a process instance gets stuck after resolving an incident on a parallel gateway due to an expression evaluation failure in the start execution listener job property.

### Root cause:
The process instance doesn't continue after resolving the incident because the failed command `ACTIVATE_ELEMENT` is rejected with the message: `Expected to be able to activate parallel gateway '<element_id>', but not all sequence flows have been taken.`

This happens because the sequence flows are cleaned up when the `ELEMENT_ACTIVATING` event for the parallel gateway is applied (by `ProcessInstanceElementActivatingApplier#cleanupSequenceFlowsTaken` method), before attempt to evaluate properties for start execution listener, so when the incident is resolved and the gateway is reactivated, engine checks for the number of sequence flows taken and fails.

### Changes:
- Added a process element state check to bypass the sequence flow count check if the element is already in the `ELEMENT_ACTIVATING` state. This ensures that after the incident is resolved, the process can proceed as expected.
- Added a test to verify that processes with a parallel gateway don't get stuck after resolving incidents caused by expression evaluation failure in start execution listener property.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22140 
