### PR TITLE
ci: set maven cache for all workflows and switch to mvnw wrapper

### DIFF
--- a/.github/actions/build-operate-setup/action.yml
+++ b/.github/actions/build-operate-setup/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     type: number
     default: 21
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "operate"
+    required: false
   nexusUsername:
     required: true
     type: string
@@ -25,12 +29,12 @@ runs:
       with:
         distribution: "adopt"
         java-version: ${{ inputs.javaVersion }}
-        cache: "maven"
 
     - name: Setup Maven
-      uses: stCarolas/setup-maven@v5
+      uses: ./.github/actions/setup-maven-dist
       with:
         maven-version: 3.8.6
+        set-mvnw: true
 
     # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven settings.xml
@@ -44,3 +48,8 @@ runs:
             "password": "${{ inputs.nexusPassword }}"
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+
+    - name: Configure Maven
+      uses: ./.github/actions/setup-maven-cache
+      with:
+        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/build-tasklist-setup/action.yml
+++ b/.github/actions/build-tasklist-setup/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     type: number
     default: 21
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "tasklist"
+    required: false
   nexusUsername:
     required: true
     type: string
@@ -25,12 +29,12 @@ runs:
       with:
         distribution: "adopt"
         java-version: ${{ inputs.javaVersion }}
-        cache: "maven"
 
     - name: Setup Maven
-      uses: stCarolas/setup-maven@v4.5
+      uses: ./.github/actions/setup-maven-dist
       with:
         maven-version: 3.8.6
+        set-mvnw: true
 
     # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
     - name: Create Maven settings.xml
@@ -44,3 +48,8 @@ runs:
             "password": "${{ inputs.nexusPassword }}"
           }]
         mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+
+    - name: Configure Maven
+      uses: ./.github/actions/setup-maven-cache
+      with:
+        maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}

--- a/.github/actions/run-maven/maven.sh
+++ b/.github/actions/run-maven/maven.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn $PARAMETERS -T $THREADS -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+./mvnw $PARAMETERS -T $THREADS -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -56,6 +56,7 @@ runs:
         # it matters for caching as absolute paths on self-hosted and GitHub runners differ
         # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
         KEY_PREFIX: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+      shell: sh
       run: |
         maven_version=$(./mvnw --version | head -n 1 | sed "s/Apache Maven \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/g")
         # Only cache release artifacts for Maven version 3.9+
@@ -73,7 +74,6 @@ runs:
           echo "MAVEN_CACHE_KEY=${KEY_PREFIX}-full-${HASH_FILES}" >> $GITHUB_ENV
           echo "MAVEN_CACHE_KEY_PREFIX=${KEY_PREFIX}-full" >> $GITHUB_ENV
         fi
-      shell: sh
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
       if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}

--- a/.github/actions/setup-maven/action.yml
+++ b/.github/actions/setup-maven/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: Java distribution to be used
     required: false
     default: 'temurin'
+  maven-cache-key-modifier:
+    description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
+    default: "optimize"
+    required: false
   maven-version:
     description: Maven version to be used
     required: false
@@ -36,11 +40,11 @@ runs:
     with:
       java-version: ${{ inputs.java-version }}
       distribution: ${{ inputs.distribution }}
-      cache: "maven"
   - name: Setup Maven
-    uses: stCarolas/setup-maven@v5
+    uses: ./.github/actions/setup-maven-dist
     with:
       maven-version: ${{ inputs.maven-version }}
+      set-mvnw: true
   - name: 'Create settings.xml'
     uses: s4u/maven-settings-action@7802f6aec16c9098b4798ad1f1d8ac75198194bd # v3.0.0
     with:
@@ -52,6 +56,10 @@ runs:
           "password": "${{ steps.secrets.outputs.NEXUS_PASSWORD }}"
         }]
       mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+  - name: Configure Maven
+    uses: ./.github/actions/setup-maven-cache
+    with:
+      maven-cache-key-modifier: ${{ inputs.maven-cache-key-modifier }}
   # workaround, maven has troubles creating a subdirectory of a non existing directory
   - shell: bash
     run: mkdir -p ${{ github.workspace }}/optimize/backend/target/classes/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Test
         uses: ./.github/actions/run-maven

--- a/.github/workflows/operate-check-project-versions.yml
+++ b/.github/workflows/operate-check-project-versions.yml
@@ -24,16 +24,17 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: 3.8.6
+          set-mvnw: true
 
       - name: Check versions
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
           BRANCH_NAME: ${{ inputs.branch }}
         run: |
-          IDENTITY_VERSION=$(mvn -f operate help:evaluate -Dexpression=version.identity -q -DforceStdout)
+          IDENTITY_VERSION=$(./mvnw -f operate help:evaluate -Dexpression=version.identity -q -DforceStdout)
 
           if [[ $IDENTITY_VERSION != $RELEASE_VERSION ]]; then
             echo "Please update Identity versions!"

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -98,7 +98,7 @@ jobs:
       # Build: maven artifacts and Docker images
       - name: Build Maven
         run: |
-          mvn clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging
@@ -149,7 +149,7 @@ jobs:
       - name: Deploy - Nexus SNAPSHOT
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
-          mvn -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -84,13 +84,14 @@ jobs:
       - uses: ./.github/actions/build-operate-setup
         name: Build setup
         with:
+          maven-cache-key-modifier: operate-tests
           nexusUsername: ${{ steps.secrets.outputs.NEXUS_USR }}
           nexusPassword: ${{ steps.secrets.outputs.NEXUS_PSW }}
 
       # Build: all Maven artifacts
       - name: Build Maven
         run: |
-          mvn clean install -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw clean install -B -T1C -P -docker,skipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       # Run integration tests in parallel
       - name: Backend - ${{ inputs.test-type }}

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -51,7 +51,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -pl operate -am verify -T1C -B -P spotbugs,skipFrontendBuild -DskipTests -DskipDockerProfile -DskipQaBuild
+      command: ./mvnw -pl operate -am verify -T1C -B -P spotbugs,skipFrontendBuild -DskipTests -DskipDockerProfile -DskipQaBuild
       runner-type: gcp-core-4-default
 
   run-unit-tests:
@@ -60,7 +60,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
+      command: ./mvnw -f operate verify -T1C -B -P skipFrontendBuild -DskipITs -DskipDockerProfile -DskipChecks
       test-type: Unit Tests
       runner-type: gcp-core-4-default
 
@@ -70,7 +70,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate/qa/integration-tests verify -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItStage1 -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Integration Tests
       runner-type: gcp-core-32-default
 
@@ -80,6 +80,6 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-      command: mvn -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Opensearch ITs
       runner-type: gcp-core-32-default

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -70,9 +70,10 @@ jobs:
           distribution: "adopt"
           java-version: "21"
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: "3.9.6"
+          set-mvnw: true
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.0.0
@@ -86,7 +87,7 @@ jobs:
             }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Build backend
-        run: mvn clean install -B -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+        run: ./mvnw clean install -B -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -102,7 +103,7 @@ jobs:
           tags: ${{ env.OPERATE_TEST_DOCKER_IMAGE }}
           file: operate.Dockerfile
       - name: Run Docker tests
-        run: mvn -pl operate/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+        run: ./mvnw -pl operate/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-operate-test-artifacts

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -89,9 +89,10 @@ jobs:
           distribution: "adopt"
           java-version: "21"
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: "3.9.6"
+          set-mvnw: true
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"
         uses: s4u/maven-settings-action@v3.0.0
@@ -107,9 +108,9 @@ jobs:
       - name: Build backend
         # Currently, the e2e environment of operate conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this operate's workflow.
-        run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+        run: ./mvnw clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Operate
-        run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true -Dspring-boot.run.main-class=io.camunda.application.StandaloneOperate
+        run: ./mvnw -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true -Dspring-boot.run.main-class=io.camunda.application.StandaloneOperate
         env:
           CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED: false
       - name: Run tests

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -115,12 +115,17 @@ jobs:
         with:
           distribution: "adopt"
           java-version: ${{ env.JAVA_VERSION }}
-          cache: "maven"
 
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: 3.9.6
+          set-mvnw: true
+
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: operate
 
       # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: Create Maven settings.xml
@@ -146,7 +151,7 @@ jobs:
         env:
           NEXT_DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
         run: |
-          mvn -f operate release:prepare -P -docker,skipFrontendBuild \
+          ./mvnw -f operate release:prepare -P -docker,skipFrontendBuild \
           -DpushChanges=false \
           -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
@@ -165,7 +170,7 @@ jobs:
 
       - name: Perform Maven release
         run: |
-          mvn -f operate release:perform -P -docker \
+          ./mvnw -f operate release:perform -P -docker \
           -DlocalCheckout=true \
           -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -31,7 +31,15 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "21"
-          cache: "maven"
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
+        with:
+          maven-version: 3.8.8
+          set-mvnw: true
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: operate-tests
       - name: "Create settings.xml"
         uses: s4u/maven-settings-action@v3.0.0
         with:
@@ -44,7 +52,7 @@ jobs:
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Build Operate
-        run: mvn -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
+        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
       - name: Run Tests
         run: ${{ inputs.command }}
       - name: Send Slack notification on failure

--- a/.github/workflows/operate-test-backup-restore.yml
+++ b/.github/workflows/operate-test-backup-restore.yml
@@ -7,5 +7,5 @@ jobs:
   run-backup-restore-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify
+      command: ./mvnw -B -pl operate/qa/backup-restore-tests -DskipChecks -P -docker,-skipTests verify
     secrets: inherit

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -7,5 +7,5 @@ jobs:
   run-importer-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -f operate verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+      command: ./mvnw -f operate verify -T1C -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit

--- a/.github/workflows/operate-test-migrate-elasticsearch-data.yml
+++ b/.github/workflows/operate-test-migrate-elasticsearch-data.yml
@@ -7,5 +7,5 @@ jobs:
   run-migration-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -B -pl operate/qa/migration-tests/migration-test -DskipChecks -DskipTests=false verify
+      command: ./mvnw -B -pl operate/qa/migration-tests/migration-test -DskipChecks -DskipTests=false verify
     secrets: inherit

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -67,6 +67,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
@@ -130,6 +131,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
@@ -209,6 +211,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry
@@ -290,6 +293,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry
@@ -373,6 +377,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Login to Harbor registry

--- a/.github/workflows/optimize-dependency-check.yml
+++ b/.github/workflows/optimize-dependency-check.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "21"
-          cache: "maven"
       - name: Import Secrets
         id: secrets
         uses: hashicorp/vault-action@d1720f055e0635fd932a1d2a48f87a666a57906c # v3.0.0
@@ -35,6 +34,15 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
+        with:
+          maven-version: 3.8.8
+          set-mvnw: true
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: optimize
       - name: "Create settings.xml"
         uses: s4u/maven-settings-action@7802f6aec16c9098b4798ad1f1d8ac75198194bd # v3.0.0
         with:
@@ -47,4 +55,4 @@ jobs:
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Run dependency analysis
-        run: mvn -f optimize/pom.xml dependency:analyze -DskipTests -DskipDocker -DdependencyAnalyzeFailOnWarning
+        run: ./mvnw -f optimize/pom.xml dependency:analyze -DskipTests -DskipDocker -DdependencyAnalyzeFailOnWarning

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
           java-version: 21
           distribution: zulu
@@ -75,7 +76,7 @@ jobs:
       working-directory: ./optimize/client
       run: yarn install
     - name: 'build backend & frontend'
-      run: mvn clean install -DskipTests -Dskip.docker -pl optimize/backend -am
+      run: ./mvnw clean install -DskipTests -Dskip.docker -pl optimize/backend -am
     - name: 'start backend'
       working-directory: ./optimize/client
       run: |

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -59,6 +59,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
 
       - name: Install firefox deps
@@ -108,7 +109,7 @@ jobs:
           additional_flags: "--profile self-managed"
 
       - name: Build backend
-        run: mvn clean install -T1C -DskipTests -Dskip.docker -pl optimize/backend -am -P skipFrontendBuild
+        run: ./mvnw clean install -T1C -DskipTests -Dskip.docker -pl optimize/backend -am -P skipFrontendBuild
 
       - name: Create backend logs file
         run: mkdir -p ./optimize/client/build && touch ./optimize/client/build/backendLogs.log

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Prepare release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DpushChanges=false \
             -DskipTests=true \
             -DignoreSnapshots=true \
@@ -201,7 +201,7 @@ jobs:
 
       - name: Perform release
         run: |
-          mvn -f optimize \
+          ./mvnw -f optimize \
             -DlocalCheckout=true \
             -DskipTests=true \
             -B \

--- a/.github/workflows/optimize-run-java-checks.yml
+++ b/.github/workflows/optimize-run-java-checks.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "21"
-          cache: "maven"
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
+        with:
+          maven-version: 3.8.8
+          set-mvnw: true
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: optimize
       - name: "Create settings.xml"
         uses: s4u/maven-settings-action@7802f6aec16c9098b4798ad1f1d8ac75198194bd # v3.0.0
         with:
@@ -46,4 +54,4 @@ jobs:
              }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Run checks
-        run: mvn -f optimize/pom.xml -T1C -B -D skipTests -P !autoFormat,checkFormat verify
+        run: ./mvnw -f optimize/pom.xml -T1C -B -D skipTests -P !autoFormat,checkFormat verify

--- a/.github/workflows/optimize-zeebe-compatibility.yml
+++ b/.github/workflows/optimize-zeebe-compatibility.yml
@@ -28,6 +28,7 @@ jobs:
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
+          maven-cache-key-modifier: optimize-tests
           secrets: ${{ toJSON(secrets) }}
           java-version: ${{ steps.pom-info.outputs.java_version }}
       - name: Login to Harbor registry

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -66,16 +66,21 @@ jobs:
           distribution: "temurin"
           java-version: "21"
 
-      - name: Cache Maven packages
-        uses: actions/cache@v4
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
         with:
-          path: ~/.m2
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          maven-version: 3.8.8
+          set-mvnw: true
+
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: sbom
+
       - name: Generate SBOM (CycloneDX)
         run: |
-          mvn org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom
+          ./mvnw org.cyclonedx:cyclonedx-maven-plugin:makeAggregateBom
+
       - name: Upload SBOM as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -44,12 +44,17 @@ jobs:
         with:
           distribution: "adopt"
           java-version: ${{ env.JAVA_VERSION }}
-          cache: "maven"
 
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: 3.8.6
+          set-mvnw: true
+
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: tasklist-tests
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: Create Maven settings.xml
@@ -67,12 +72,12 @@ jobs:
       # Build: maven artifacts
       - name: Build backend
         run: |
-          mvn clean install -B -T1C -DskipChecks -P skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw clean install -B -T1C -DskipChecks -P skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       # Tests: run backup and restore tests
       - name: Run backup and restore tests
         run: |
-          mvn -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -P -skipTests verify
+          ./mvnw -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -P -skipTests verify
 
       # Notify: send Slack notification on tests failure
       - name: Send Slack notification on failure

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -96,7 +96,7 @@ jobs:
       # Build backend
       - name: Build backend
         run: |
-          mvn -T1C clean deploy -B -PskipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -T1C clean deploy -B -PskipFrontendBuild -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging
@@ -147,7 +147,7 @@ jobs:
       - name: Deploy - Nexus SNAPSHOT
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
-          mvn -f tasklist org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -PskipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          ./mvnw -f tasklist org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -PskipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -78,16 +78,17 @@ jobs:
       - uses: ./.github/actions/build-tasklist-setup
         name: Build setup
         with:
+          maven-cache-key-modifier: tasklist-tests
           nexusUsername: ${{ steps.secrets.outputs.NEXUS_USR }}
           nexusPassword: ${{ steps.secrets.outputs.NEXUS_PSW }}
 
       - name: Build backend
-        run: mvn -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
+        run: ./mvnw -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
 
       # Run integration tests in parallel
       - name: Run Integration Tests
         run: |
-          mvn -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
+          ./mvnw -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
 
       # Sanitize the branch name to replace non alphanumeric characters with `-`
       - id: sanitize

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -69,9 +69,10 @@ jobs:
           distribution: "adopt"
           java-version: "21"
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: "3.9.6"
+          set-mvnw: true
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.0.0
@@ -85,7 +86,7 @@ jobs:
             }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Build backend
-        run: mvn clean install -B -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+        run: ./mvnw clean install -B -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -101,7 +102,7 @@ jobs:
           tags: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
           file: tasklist.Dockerfile
       - name: Run Docker tests
-        run: mvn -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
+        run: ./mvnw -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test
       - name: Upload Test Report
         if: failure()
         uses: ./.github/actions/collect-tasklist-test-artifacts

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -98,9 +98,10 @@ jobs:
           distribution: "adopt"
           java-version: "21"
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: "3.9.6"
+          set-mvnw: true
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: "Create settings.xml"
         uses: s4u/maven-settings-action@v3.0.0
@@ -116,9 +117,9 @@ jobs:
       - name: Build backend
         # Currently, the e2e environment of tasklist conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this tasklist's workflow.
-        run: mvn clean install -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+        run: ./mvnw clean install -T1C -DskipChecks -PskipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Tasklist
-        run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.main-class=io.camunda.application.StandaloneTasklist -Dspring-boot.run.fork=true -Dspring-boot.run.profiles=e2e-test -Dspring-boot.run.arguments="--camunda.tasklist.cloud.clusterId=449ac2ad-d3c6-4c73-9c68-7752e39ae616 --camunda.tasklist.csrfPreventionEnabled=false"
+        run: ./mvnw -q -B spring-boot:start -pl dist -Dspring-boot.run.main-class=io.camunda.application.StandaloneTasklist -Dspring-boot.run.fork=true -Dspring-boot.run.profiles=e2e-test -Dspring-boot.run.arguments="--camunda.tasklist.cloud.clusterId=449ac2ad-d3c6-4c73-9c68-7752e39ae616 --camunda.tasklist.csrfPreventionEnabled=false"
       - name: Python setup
         if: always()
         uses: actions/setup-python@v5

--- a/.github/workflows/tasklist-migrate-elasticsearch-data.yml
+++ b/.github/workflows/tasklist-migrate-elasticsearch-data.yml
@@ -41,12 +41,17 @@ jobs:
         with:
           distribution: "adopt"
           java-version: ${{ env.JAVA_VERSION }}
-          cache: "maven"
 
       - name: Setup Maven
-        uses: stCarolas/setup-maven@v4.5
+        uses: ./.github/actions/setup-maven-dist
         with:
           maven-version: 3.8.6
+          set-mvnw: true
+
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: tasklist-tests
 
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: Create Maven settings.xml
@@ -64,12 +69,12 @@ jobs:
       # Build: maven artifacts
       - name: Build backend
         run: |
-          mvn -B -DskipTests -DskipChecks -T1C -P skipFrontendBuild clean install
+          ./mvnw -B -DskipTests -DskipChecks -T1C -P skipFrontendBuild clean install
 
       # Tests: run migration tests
       - name: Run migration tests
         run: |
-          mvn -B -f tasklist/qa/migration-tests -DskipTests=false -DskipChecks verify
+          ./mvnw -B -f tasklist/qa/migration-tests -DskipTests=false -DskipChecks verify
 
       # Notify: send Slack notification on tests failure
       - name: Send Slack notification on failure

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -193,7 +193,15 @@ jobs:
         with:
           distribution: "adopt"
           java-version: "21"
-          cache: "maven"
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven-dist
+        with:
+          maven-version: 3.8.8
+          set-mvnw: true
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: operate
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
       - name: 'Create settings.xml'
         uses: s4u/maven-settings-action@v3.0.0
@@ -207,7 +215,7 @@ jobs:
             }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
       - name: Build backend
-        run: mvn clean install -DskipChecks -P -docker -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+        run: ./mvnw clean install -DskipChecks -P -docker -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build and push to Zeebe gcr.io registry


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674.

This PR introduces the use of the `setup-maven-cache` composite action for workflows which already use cache, in order to adhere to the caching strategy. It also introduces the use of the `mvnw` wrapper for all workflows.

`stCarolas/setup-maven` is (temporarily) replaced by [setup-maven-dist](https://github.com/camunda/camunda/pull/23117), which allows a specific Maven version to be configured for the `mvnw` wrapper, until the same Maven version is used for all projects in the monorepo.

For cases where the `mvn` binary pre-installed in GitHub-managed runners is used (currently `3.8.8`), the `setup-maven-dist` action is introduced configuring the wrapper to use the same  (`3.8.8`) version.

For team projects, I have introduced cache key modifiers to separate test-related caches (e.g. `optimize` and `optimize-tests`) because of specific dependencies being fetched. This is a first step towards cache optimization, which can be refined subsequently.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
