### PR TITLE
Check permissions in `MessageCorrelationCorrelateProcessor`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/Rejection.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/Rejection.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing;
+
+import io.camunda.zeebe.protocol.record.RejectionType;
+
+public record Rejection(RejectionType type, String reason) {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -169,19 +169,14 @@ public final class MessageCorrelationCorrelateProcessor
     final var isAuthorized =
         correlatingSubscriptions.visitSubscriptions(
             subscription -> {
-              if (subscription.isStartEventSubscription()) {
-                request.set(
-                    new AuthorizationRequest(
-                        command,
-                        AuthorizationResourceType.PROCESS_DEFINITION,
-                        PermissionType.CREATE));
-              } else {
-                request.set(
-                    new AuthorizationRequest(
-                        command,
-                        AuthorizationResourceType.PROCESS_DEFINITION,
-                        PermissionType.UPDATE));
-              }
+              final PermissionType permissionType =
+                  subscription.isStartEventSubscription()
+                      ? PermissionType.CREATE
+                      : PermissionType.UPDATE;
+
+              request.set(
+                  new AuthorizationRequest(
+                      command, AuthorizationResourceType.PROCESS_DEFINITION, permissionType));
 
               request.get().addResourceId(bufferAsString(subscription.getBpmnProcessId()));
               return authCheckBehavior.isAuthorized(request.get());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -133,7 +133,8 @@ public final class MessageEventProcessors {
                 startEventSubscriptionState,
                 messageState,
                 subscriptionState,
-                subscriptionCommandSender))
+                subscriptionCommandSender,
+                authCheckBehavior))
         .withListener(
             new MessageObserver(
                 scheduledTaskStateFactory,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -141,5 +141,9 @@ public final class Subscriptions {
     public long getElementInstanceKey() {
       return elementInstanceKey;
     }
+
+    public boolean isStartEventSubscription() {
+      return isStartEventSubscription;
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventSubscriptionException;
@@ -116,7 +117,7 @@ public final class ProcessInstanceCreationCreateProcessor
         .flatMap(process -> validateCommand(command.getValue(), process))
         .ifRightOrLeft(
             process -> createProcessInstance(controller, record, process),
-            rejection -> controller.reject(rejection.type, rejection.reason));
+            rejection -> controller.reject(rejection.type(), rejection.reason()));
 
     return true;
   }
@@ -428,8 +429,6 @@ public final class ProcessInstanceCreationCreateProcessor
           elementActivationBehavior.activateElement(processInstance, element);
         });
   }
-
-  private record Rejection(RejectionType type, String reason) {}
 
   private record ElementIdAndType(String elementId, BpmnElementType elementType) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBeha
 import static java.util.function.Predicate.not;
 
 import io.camunda.zeebe.auth.impl.TenantAuthorizationCheckerImpl;
+import io.camunda.zeebe.engine.processing.Rejection;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
@@ -796,8 +797,6 @@ public final class ProcessInstanceModificationModifyProcessor
         // no activate instruction requires this element instance
         && !requiredKeysForActivation.contains(elementInstance.getKey());
   }
-
-  private record Rejection(RejectionType type, String reason) {}
 
   /**
    * Exception that can be thrown when child instance is being modified. If all active element

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.awaitUserExistsInElasticsearch;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClientWithAuthorization;
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createUserWithPermissions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ResourceTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequestPermissionsInner.PermissionTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+public class MessageCorrelationCorrelateAuthorizationIT {
+
+  public static final String INTERMEDIATE_MSG_NAME = "intermediateMsg";
+  public static final String START_MSG_NAME = "startMsg";
+  public static final String CORRELATION_KEY_VARIABLE = "correlationKey";
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  private static final String PROCESS_ID = "processId";
+  @TestZeebe private TestStandaloneBroker zeebe;
+  private ZeebeClient defaultUserClient;
+  private ZeebeClient authorizedUserClient;
+  private ZeebeClient unauthorizedUserClient;
+
+  @BeforeAll
+  void beforeAll() throws Exception {
+    zeebe =
+        new TestStandaloneBroker()
+            .withRecordingExporter(true)
+            .withBrokerConfig(
+                b ->
+                    b.getExperimental()
+                        .getEngine()
+                        .getAuthorizations()
+                        .setEnableAuthorization(true))
+            .withCamundaExporter("http://" + CONTAINER.getHttpHostAddress())
+            .withAdditionalProfile(Profile.AUTH_BASIC);
+    zeebe.start();
+    defaultUserClient = createClientWithAuthorization(zeebe, "demo", "demo");
+    awaitUserExistsInElasticsearch(CONTAINER.getHttpHostAddress(), "demo");
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .intermediateCatchEvent()
+                .message(
+                    m ->
+                        m.name(INTERMEDIATE_MSG_NAME)
+                            .zeebeCorrelationKeyExpression(CORRELATION_KEY_VARIABLE))
+                .endEvent()
+                .moveToProcess(PROCESS_ID)
+                .startEvent()
+                .message(m -> m.name(START_MSG_NAME))
+                .done(),
+            "process.xml")
+        .send()
+        .join();
+
+    authorizedUserClient =
+        createUserWithPermissions(
+            zeebe,
+            defaultUserClient,
+            CONTAINER.getHttpHostAddress(),
+            "foo",
+            "password",
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.UPDATE,
+                List.of(PROCESS_ID)),
+            new Permissions(
+                ResourceTypeEnum.PROCESS_DEFINITION,
+                PermissionTypeEnum.CREATE,
+                List.of(PROCESS_ID)));
+    unauthorizedUserClient =
+        createUserWithPermissions(
+            zeebe, defaultUserClient, CONTAINER.getHttpHostAddress(), "bar", "password");
+  }
+
+  @Test
+  void shouldBeAuthorizedToCorrelateMessageToIntermediateEventWithDefaultUser() {
+    // given
+    final var correlationKey = UUID.randomUUID().toString();
+    final var processInstance = createProcessInstance(correlationKey);
+
+    // when
+    final var response =
+        defaultUserClient
+            .newCorrelateMessageCommand()
+            .messageName(INTERMEDIATE_MSG_NAME)
+            .correlationKey(correlationKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isEqualTo(processInstance.getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldBeAuthorizedToCorrelateMessageToIntermediateEventWithUser() {
+    // given
+    final var correlationKey = UUID.randomUUID().toString();
+    final var processInstance = createProcessInstance(correlationKey);
+
+    // when
+    final var response =
+        authorizedUserClient
+            .newCorrelateMessageCommand()
+            .messageName(INTERMEDIATE_MSG_NAME)
+            .correlationKey(correlationKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isEqualTo(processInstance.getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldBeUnauthorizedToCorrelateMessageToIntermediateEventIfNoPermissions() {
+    // given
+    final var correlationKey = UUID.randomUUID().toString();
+    createProcessInstance(correlationKey);
+
+    // when
+    final var response =
+        unauthorizedUserClient
+            .newCorrelateMessageCommand()
+            .messageName(INTERMEDIATE_MSG_NAME)
+            .correlationKey(correlationKey)
+            .send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @Test
+  void shouldBeAuthorizedToCorrelateMessageToStartEventWithDefaultUser() {
+    // when
+    final var response =
+        defaultUserClient
+            .newCorrelateMessageCommand()
+            .messageName(START_MSG_NAME)
+            .withoutCorrelationKey()
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isPositive();
+  }
+
+  @Test
+  void shouldBeAuthorizedToCorrelateMessageToStartEventWithUser() {
+    // when
+    final var response =
+        authorizedUserClient
+            .newCorrelateMessageCommand()
+            .messageName(START_MSG_NAME)
+            .withoutCorrelationKey()
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getProcessInstanceKey()).isPositive();
+  }
+
+  @Test
+  void shouldBeUnauthorizedToCorrelateMessageToStartEventIfNoPermissions() {
+    // when
+    final var response =
+        unauthorizedUserClient
+            .newCorrelateMessageCommand()
+            .messageName(START_MSG_NAME)
+            .withoutCorrelationKey()
+            .send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @Test
+  void shouldNotCorrelateAnyMessageIfUnauthorizedForOne() {
+    // given a process with a processId the user is not authorized for
+    final var unauthorizedProcessId = "unauthorizedProcessId";
+    final var resourceName = "unauthorizedProcess.xml";
+    final var deploymentKey =
+        defaultUserClient
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess(unauthorizedProcessId)
+                    .startEvent()
+                    .message(m -> m.name(START_MSG_NAME))
+                    .endEvent()
+                    .done(),
+                resourceName)
+            .send()
+            .join()
+            .getKey();
+
+    // when
+    final var response =
+        authorizedUserClient
+            .newCorrelateMessageCommand()
+            .messageName(START_MSG_NAME)
+            .withoutCorrelationKey()
+            .send();
+
+    // then
+    assertThatThrownBy(response::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: UNAUTHORIZED")
+        .hasMessageContaining("status: 401")
+        .hasMessageContaining(
+            "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION'");
+
+    final var deploymentPosition =
+        RecordingExporter.deploymentRecords(DeploymentIntent.CREATED)
+            .withRecordKey(deploymentKey)
+            .getFirst()
+            .getPosition();
+    assertThat(
+            RecordingExporter.records()
+                .after(deploymentPosition)
+                .limit(r -> r.getRejectionType() == RejectionType.UNAUTHORIZED)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+                .withBpmnProcessId(unauthorizedProcessId)
+                .exists())
+        .isFalse();
+  }
+
+  private ProcessInstanceEvent createProcessInstance(final String correlationKey) {
+    return defaultUserClient
+        .newCreateInstanceCommand()
+        .bpmnProcessId(PROCESS_ID)
+        .latestVersion()
+        .variables(Map.of(CORRELATION_KEY_VARIABLE, correlationKey))
+        .send()
+        .join();
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -39,6 +39,10 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return supply(dropWhile(Predicate.not(lowerBound))).limit(upperBound::test);
   }
 
+  public RecordStream after(final long lowerBoundPosition) {
+    return supply(dropWhile(r -> r.getPosition() <= lowerBoundPosition));
+  }
+
   public RecordStream limitToProcessInstance(final long processInstanceKey) {
     return limit(
         r ->


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It's a bit of an odd one since there's different permissions to check here. The current solution is likely not the most performant, but it is the easiest way to implement it at this time. If it becomes a problem we can improve upon this later.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22885 
