### PR TITLE
ci: use maven cache for ci.yml/deploy-snapshots job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,10 @@ jobs:
               "password": "${{ steps.secrets.outputs.ARTIFACTS_PSW }}"
             }]
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+      - name: Configure Maven
+        uses: ./.github/actions/setup-maven-cache
+        with:
+          maven-cache-key-modifier: snapshots    
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator


### PR DESCRIPTION
## Description

Related https://github.com/camunda/team-infrastructure/issues/674 (and last desired outcome).

This PR introduces  Maven cache for the `deploy-snapshots` job in `ci.yml` workflow.

Test: (with `-Dmaven.deploy.skip=true`) https://github.com/camunda/camunda/actions/runs/11330477050/job/31508625379

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
