### PR TITLE
Use new record to transmit acknowledgement

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -55,8 +55,6 @@ public final class CommandDistributionBehavior {
       new CommandDistributionRecord();
   private final CommandDistributionRecord commandDistributionEnqueued =
       new CommandDistributionRecord();
-  private final CommandDistributionRecord commandDistributionAcknowledge =
-      new CommandDistributionRecord();
   private final CommandDistributionRecord commandDistributionContinuation =
       new CommandDistributionRecord();
 
@@ -247,10 +245,9 @@ public final class CommandDistributionBehavior {
   public <T extends UnifiedRecordValue> void acknowledgeCommand(final TypedRecord<T> command) {
     final long distributionKey = command.getKey();
 
-    commandDistributionAcknowledge.reset();
-
-    final var distributionRecord =
-        commandDistributionAcknowledge
+    // ACKNOWLEDGE must be a new record as it is transmitted as a side effect
+    final var acknowledgeRecord =
+        new CommandDistributionRecord()
             .setPartitionId(currentPartitionId)
             .setValueType(command.getValueType())
             .setIntent(command.getIntent());
@@ -263,7 +260,7 @@ public final class CommandDistributionBehavior {
               ValueType.COMMAND_DISTRIBUTION,
               CommandDistributionIntent.ACKNOWLEDGE,
               distributionKey,
-              distributionRecord);
+              acknowledgeRecord);
           return true;
         });
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Fixes a race condition for the command distribution `ACKNOWLEDGE` command that may lead to incorrect acknowledgements.

This requires a backport to 8.6 [only](https://github.com/camunda/camunda/issues/23361#issuecomment-2407027465).

## Related issues

closes #23361 