### PR TITLE
fix: complete future with error when leadership change is cancelled

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStep.java
@@ -40,7 +40,6 @@ final class CommandApiServiceStep extends AbstractBrokerStartupStep {
 
     final var commandApiServiceActor = brokerShutdownContext.getCommandApiService();
 
-    brokerShutdownContext.removePartitionListener(commandApiServiceActor);
     brokerShutdownContext
         .getDiskSpaceUsageMonitor()
         .removeDiskUsageListener(commandApiServiceActor);
@@ -73,7 +72,6 @@ final class CommandApiServiceStep extends AbstractBrokerStartupStep {
         proceed(
             () -> {
               brokerStartupContext.setCommandApiService(commandApiService);
-              brokerStartupContext.addPartitionListener(commandApiService);
               brokerStartupContext
                   .getDiskSpaceUsageMonitor()
                   .addDiskUsageListener(commandApiService);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.broker.system.partitions.impl.steps.SnapshotDirectorPart
 import io.camunda.zeebe.broker.system.partitions.impl.steps.StreamProcessorTransitionStep;
 import io.camunda.zeebe.broker.system.partitions.impl.steps.ZeebeDbPartitionTransitionStep;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.broker.transport.commandapi.CommandApiServiceTransitionStep;
 import io.camunda.zeebe.db.AccessMetricsConfiguration;
 import io.camunda.zeebe.db.impl.rocksdb.ZeebeRocksDbFactory;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -84,6 +85,7 @@ public final class ZeebePartitionFactory {
           new BackupServiceTransitionStep(),
           new InterPartitionCommandServiceStep(),
           new StreamProcessorTransitionStep(),
+          new CommandApiServiceTransitionStep(),
           new SnapshotDirectorPartitionTransitionStep(),
           new ExporterDirectorPartitionTransitionStep(),
           new BackupApiRequestHandlerStep(),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiService.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.broker.transport.commandapi;
 
+import io.camunda.zeebe.engine.state.QueryService;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 
 public interface CommandApiService {
@@ -18,4 +21,9 @@ public interface CommandApiService {
   void onPaused(final int partitionId);
 
   void onResumed(final int partitionId);
+
+  ActorFuture<Void> registerHandlers(
+      final int partitionId, final LogStream logStream, final QueryService queryService);
+
+  ActorFuture<Void> unregisterHandlers(final int partitionId);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceTransitionStep.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
+public class CommandApiServiceTransitionStep implements PartitionTransitionStep {
+  @Override
+  public void onNewRaftRole(final PartitionTransitionContext context, final Role newRole) {}
+
+  @Override
+  public ActorFuture<Void> prepareTransition(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    return switch (targetRole) {
+      case LEADER -> context.getConcurrencyControl().createCompletedFuture();
+      default -> context.getCommandApiService().unregisterHandlers(context.getPartitionId());
+    };
+  }
+
+  @Override
+  public ActorFuture<Void> transitionTo(
+      final PartitionTransitionContext context, final long term, final Role targetRole) {
+    return switch (targetRole) {
+      case LEADER ->
+          context
+              .getCommandApiService()
+              .registerHandlers(
+                  context.getPartitionId(), context.getLogStream(), context.getQueryService());
+      default -> context.getConcurrencyControl().createCompletedFuture();
+    };
+  }
+
+  @Override
+  public String getName() {
+    return "CommandApiService";
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -124,19 +124,6 @@ class CommandApiServiceStepTest {
     }
 
     @Test
-    void shouldAddCommandApiServiceAsPartitionListener() {
-      // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
-      await().until(startupFuture::isDone);
-
-      // then
-      final var commandApiService = testBrokerStartupContext.getCommandApiService();
-
-      assertThat(commandApiService).isNotNull();
-      assertThat(testBrokerStartupContext.getPartitionListeners()).contains(commandApiService);
-    }
-
-    @Test
     void shouldAddCommandApiServiceAsDiskSpaceUsageListener() {
       // given
       final var mockDiskSpaceUsageMonitor = mock(DiskSpaceUsageMonitorActor.class);
@@ -174,7 +161,6 @@ class CommandApiServiceStepTest {
 
       testBrokerStartupContext.setGatewayBrokerTransport(mockAtomixServerTransport);
       testBrokerStartupContext.setCommandApiService(mockCommandApiService);
-      testBrokerStartupContext.addPartitionListener(mockCommandApiService);
       testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
       testBrokerStartupContext
           .getDiskSpaceUsageMonitor()
@@ -195,17 +181,6 @@ class CommandApiServiceStepTest {
 
       // then
       verify(mockDiskSpaceUsageMonitor).removeDiskUsageListener(mockCommandApiService);
-    }
-
-    @Test
-    void shouldRemoveCommandApiFromPartitionListenerList() {
-      // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
-      await().until(shutdownFuture::isDone);
-
-      // then
-      assertThat(testBrokerStartupContext.getPartitionListeners())
-          .doesNotContain(mockCommandApiService);
     }
 
     @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiServiceImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.transport.commandapi;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.RaftServer.Role;
+import io.camunda.zeebe.broker.system.configuration.QueryApiCfg;
+import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
+import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
+import io.camunda.zeebe.transport.RequestType;
+import io.camunda.zeebe.transport.ServerTransport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CommandApiServiceImplTest {
+
+  @Mock private ServerTransport serverTransport;
+  @Mock private QueryApiCfg queryApi;
+  private CommandApiServiceImpl commandApiService;
+  @Mock private PartitionTransitionContext transitionContext;
+  @Mock private LogStream logStream;
+
+  @RegisterExtension
+  private ControlledActorSchedulerExtension scheduler = new ControlledActorSchedulerExtension();
+
+  @BeforeEach
+  public void setup() {
+    final ConcurrencyControl cc = mock();
+    when(cc.createCompletedFuture()).thenReturn(CompletableActorFuture.completed(null));
+    commandApiService =
+        new CommandApiServiceImpl(serverTransport, scheduler.getActorScheduler(), queryApi);
+    when(transitionContext.getCommandApiService()).thenReturn(commandApiService);
+    when(transitionContext.getConcurrencyControl()).thenReturn(cc);
+    scheduler.submitActor(commandApiService);
+    scheduler.workUntilDone();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = Role.class,
+      names = {"FOLLOWER", "CANDIDATE", "INACTIVE"})
+  public void subscribesWhenBecomingLeader(final Role nonLeaderRole) {
+    // given
+    when(transitionContext.getPartitionId()).thenReturn(1);
+    when(logStream.newLogStreamWriter()).thenReturn(mock());
+    when(transitionContext.getLogStream()).thenReturn(logStream);
+    when(transitionContext.getQueryService()).thenReturn(mock());
+    final var transitionStep = new CommandApiServiceTransitionStep();
+    final var prepareFuture = transitionStep.prepareTransition(transitionContext, 1L, Role.LEADER);
+    scheduler.workUntilDone();
+    prepareFuture.join();
+
+    // when - becomes LEADER for the partition
+    final var transitionFuture = transitionStep.transitionTo(transitionContext, 1, Role.LEADER);
+    scheduler.workUntilDone();
+    transitionFuture.join();
+    // then
+    verify(logStream, times(1)).newLogStreamWriter();
+    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.QUERY), any());
+    verify(serverTransport, times(1)).subscribe(eq(1), eq(RequestType.COMMAND), any());
+
+    // when - become not a leader, subscriptions are cleaned up
+    final var prepareFollowerFuture =
+        transitionStep.prepareTransition(transitionContext, 2, nonLeaderRole);
+    scheduler.workUntilDone();
+    prepareFollowerFuture.join();
+    // then
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.QUERY));
+    verify(serverTransport, times(1)).unsubscribe(eq(1), eq(RequestType.COMMAND));
+
+    // it does not unsubscribe twice
+    clearInvocations(serverTransport);
+    final var transitionFollowerFuture =
+        transitionStep.transitionTo(transitionContext, 2, nonLeaderRole);
+    transitionFollowerFuture.join();
+    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.QUERY));
+    verify(serverTransport, never()).unsubscribe(eq(1), eq(RequestType.COMMAND));
+  }
+}

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -91,6 +91,10 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
     return clock;
   }
 
+  public ActorScheduler getActorScheduler() {
+    return actorScheduler;
+  }
+
   static final class ControlledActorThreadFactory implements ActorThreadFactory {
     private ControlledActorThread controlledThread;
 


### PR DESCRIPTION
## Description
While there a transition to a leader is cancelled, the logStream will be closed, throwing an exception when creating a Writer.

To avoid concurrency issues, the `CommandServiceApiImpl` is not a `PartitionListener` anymore, but it's a `PartitionTransitionStep`: this should avoid it as they would be executed serially.

## Related issues
closes #10141