### PR TITLE
Refactoring SearchEngineClient to be more generic.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -82,9 +82,8 @@ public class CamundaExporter implements Exporter {
     clientAdapter = ClientAdapter.of(configuration);
     final var searchEngineClient = clientAdapter.getSearchEngineClient();
     final var schemaManager = clientAdapter.createSchemaManager(provider);
-    final var schemaValidator = new IndexSchemaValidator(schemaManager);
 
-    schemaStartup(schemaManager, schemaValidator, searchEngineClient);
+    schemaStartup(schemaManager, searchEngineClient);
     writer = createBatchWriter();
 
     scheduleDelayedFlush();
@@ -134,15 +133,13 @@ public class CamundaExporter implements Exporter {
   }
 
   private void schemaStartup(
-      final SchemaManager schemaManager,
-      final IndexSchemaValidator schemaValidator,
-      final SearchEngineClient searchEngineClient) {
+      final SchemaManager schemaManager, final SearchEngineClient searchEngineClient) {
     if (!configuration.isCreateSchema()) {
       LOG.info(
           "Will not make any changes to indices and index templates as [createSchema] is false");
       return;
     }
-
+    final var schemaValidator = new IndexSchemaValidator();
     final var newIndexProperties = validateIndices(schemaValidator, searchEngineClient);
     final var newIndexTemplateProperties =
         validateIndexTemplates(schemaValidator, searchEngineClient);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -232,11 +232,14 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   private PutMappingRequest putMappingRequest(
       final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {
 
+    final var elsProperties =
+        newProperties.stream()
+            .map(IndexMappingProperty::toElasticsearchProperty)
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
     return new PutMappingRequest.Builder()
         .index(indexDescriptor.getFullQualifiedName())
-        .properties(
-            IndexMappingProperty.toPropertiesMap(
-                newProperties, MAPPER, (inp) -> deserializeJson(Property._DESERIALIZER, inp)))
+        .properties(elsProperties)
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.exporter.schema;
 
+import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
 import static io.camunda.exporter.utils.SearchEngineClientUtils.listIndices;
 import static io.camunda.exporter.utils.SearchEngineClientUtils.mapToSettings;
-import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
@@ -23,18 +23,15 @@ import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplate
 import co.elastic.clients.elasticsearch.indices.put_index_template.IndexTemplateMapping;
 import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.schema;
 
 import static io.camunda.exporter.utils.SearchEngineClientUtils.listIndices;
 import static io.camunda.exporter.utils.SearchEngineClientUtils.mapToSettings;
+import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
@@ -260,7 +261,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              SearchEngineClient.appendToFileSchemaSettings(templateFile, settings, MAPPER));
+              appendToFileSchemaSettings(templateFile, settings));
 
       return new PutIndexTemplateRequest.Builder()
           .name(indexTemplateDescriptor.getTemplateName())
@@ -290,7 +291,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       final var templateFields =
           deserializeJson(
               IndexTemplateMapping._DESERIALIZER,
-              SearchEngineClient.appendToFileSchemaSettings(templateFile, settings, MAPPER));
+              appendToFileSchemaSettings(templateFile, settings));
 
       return new CreateIndexRequest.Builder()
           .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -233,7 +233,9 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
     return new PutMappingRequest.Builder()
         .index(indexDescriptor.getFullQualifiedName())
-        .withJson(IndexMappingProperty.toPropertiesJson(newProperties, MAPPER))
+        .properties(
+            IndexMappingProperty.toPropertiesMap(
+                newProperties, MAPPER, (inp) -> deserializeJson(Property._DESERIALIZER, inp)))
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -11,10 +11,8 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -22,13 +22,13 @@ import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private static final JsonpMapper jsonpMapper = new JacksonJsonpMapper(MAPPER);
+  private static final JsonpMapper JSONP_MAPPER = new JacksonJsonpMapper(MAPPER);
 
   public Entry<String, Property> toElasticsearchProperty() {
     try {
       final var typeDefinitionParser = getTypeDefinitionParser();
       final var elasticsearchProperty =
-          Property._DESERIALIZER.deserialize(typeDefinitionParser, jsonpMapper);
+          Property._DESERIALIZER.deserialize(typeDefinitionParser, JSONP_MAPPER);
 
       return entry(name(), elasticsearchProperty);
     } catch (final IOException e) {
@@ -44,7 +44,7 @@ public record IndexMappingProperty(String name, Object typeDefinition) {
     final var typeDefinitionJson =
         IOUtils.toInputStream(MAPPER.writeValueAsString(typeDefinition()), StandardCharsets.UTF_8);
 
-    return jsonpMapper.jsonProvider().createParser(typeDefinitionJson);
+    return JSONP_MAPPER.jsonProvider().createParser(typeDefinitionJson);
   }
 
   public static IndexMappingProperty createIndexMappingProperty(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -7,32 +7,41 @@
  */
 package io.camunda.exporter.schema;
 
+import static java.util.Map.entry;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
 
-  public static InputStream toPropertiesJson(
-      final Collection<IndexMappingProperty> properties, final ObjectMapper mapper) {
-    final var propertiesAsMap =
-        properties.stream()
-            .collect(
-                Collectors.toMap(IndexMappingProperty::name, IndexMappingProperty::typeDefinition));
-    final var propertiesBlock = new HashMap<>();
-    propertiesBlock.put("properties", propertiesAsMap);
-    try {
-      return IOUtils.toInputStream(
-          mapper.writeValueAsString(propertiesBlock), StandardCharsets.UTF_8);
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException(e);
-    }
+  public static <T> Map<String, T> toPropertiesMap(
+      final Collection<IndexMappingProperty> properties,
+      final ObjectMapper mapper,
+      final Function<InputStream, T> typeDeserializer) {
+
+    return properties.stream()
+        .map(
+            prop -> {
+              try {
+                final var typeJson =
+                    IOUtils.toInputStream(
+                        mapper.writeValueAsString(prop.typeDefinition()), StandardCharsets.UTF_8);
+                final var type = typeDeserializer.apply(typeJson);
+                return entry(prop.name(), type);
+              } catch (final JsonProcessingException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
   }
 
   public static IndexMappingProperty createIndexMappingProperty(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.schema;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.exceptions.IndexSchemaValidationException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -47,12 +48,7 @@ import org.slf4j.LoggerFactory;
  */
 public class IndexSchemaValidator {
   private static final Logger LOGGER = LoggerFactory.getLogger(IndexSchemaValidator.class);
-
-  private final SchemaManager schemaManager;
-
-  public IndexSchemaValidator(final SchemaManager schemaManager) {
-    this.schemaManager = schemaManager;
-  }
+  private static final ObjectMapper MAPPER = new ObjectMapper();
 
   /**
    * Validates existing indices mappings against index/index template mappings defined.
@@ -115,7 +111,7 @@ public class IndexSchemaValidator {
 
   private IndexMappingDifference getIndexMappingDifference(
       final IndexDescriptor indexDescriptor, final Map<String, IndexMapping> indexMappingsGroup) {
-    final IndexMapping indexMappingMustBe = schemaManager.readIndex(indexDescriptor);
+    final IndexMapping indexMappingMustBe = SchemaManager.readIndex(indexDescriptor, MAPPER);
 
     final var differences =
         indexMappingsGroup.values().stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
@@ -111,7 +111,7 @@ public class IndexSchemaValidator {
 
   private IndexMappingDifference getIndexMappingDifference(
       final IndexDescriptor indexDescriptor, final Map<String, IndexMapping> indexMappingsGroup) {
-    final IndexMapping indexMappingMustBe = SchemaManager.readIndex(indexDescriptor, MAPPER);
+    final IndexMapping indexMappingMustBe = IndexMapping.from(indexDescriptor, MAPPER);
 
     final var differences =
         indexMappingsGroup.values().stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -15,6 +15,4 @@ public interface SchemaManager {
   void initialiseResources();
 
   void updateSchema(final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields);
-
-  IndexMapping readIndex(final IndexDescriptor indexDescriptor);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/SearchEngineClientUtils.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.apache.commons.io.IOUtils;
+
+public final class SearchEngineClientUtils {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private SearchEngineClientUtils() {}
+
+  public static InputStream appendToFileSchemaSettings(
+      final InputStream file, final IndexSettings settingsToAppend) throws IOException {
+
+    final var map = MAPPER.readValue(file, new TypeReference<Map<String, Object>>() {});
+
+    final var settingsBlock =
+        (Map<String, Object>) map.computeIfAbsent("settings", k -> new HashMap<>());
+    final var indexBlock =
+        (Map<String, Object>) settingsBlock.computeIfAbsent("index", k -> new HashMap<>());
+
+    indexBlock.put("number_of_shards", settingsToAppend.getNumberOfShards());
+    indexBlock.put("number_of_replicas", settingsToAppend.getNumberOfReplicas());
+
+    return new ByteArrayInputStream(MAPPER.writeValueAsBytes(map));
+  }
+
+  public static String listIndices(final List<IndexDescriptor> indexDescriptors) {
+    return indexDescriptors.stream()
+        .map(IndexDescriptor::getFullQualifiedName)
+        .collect(Collectors.joining(","));
+  }
+
+  public static <T> T mapToSettings(
+      final Map<String, String> settingsMap, final Function<InputStream, T> settingsDeserializer) {
+    try (final var settingsStream =
+        IOUtils.toInputStream(MAPPER.writeValueAsString(settingsMap), StandardCharsets.UTF_8)) {
+
+      return settingsDeserializer.apply(settingsStream);
+    } catch (final IOException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Failed to serialise settings in PutSettingsRequest [%s]", settingsMap.toString()),
+          e);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.utils.TestSupport;
 import io.camunda.search.connect.es.ElasticsearchConnector;
@@ -190,7 +191,7 @@ public class ElasticsearchSchemaManagerIT {
             searchEngineClient, Set.of(), Set.of(), new ExporterConfiguration());
 
     // when
-    final var indexMapping = schemaManager.readIndex(index);
+    final var indexMapping = SchemaManager.readIndex(index, new ObjectMapper());
 
     // then
     assertThat(indexMapping.dynamic()).isEqualTo("strict");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
@@ -191,7 +191,7 @@ public class ElasticsearchSchemaManagerIT {
             searchEngineClient, Set.of(), Set.of(), new ExporterConfiguration());
 
     // when
-    final var indexMapping = SchemaManager.readIndex(index, new ObjectMapper());
+    final var indexMapping = IndexMapping.from(index, new ObjectMapper());
 
     // then
     assertThat(indexMapping.dynamic()).isEqualTo("strict");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexSchemaValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexSchemaValidatorTest.java
@@ -20,15 +20,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 public class IndexSchemaValidatorTest {
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
-  private static final IndexSchemaValidator VALIDATOR =
-      new IndexSchemaValidator(
-          Mockito.mock(ElasticsearchSchemaManager.class, Mockito.CALLS_REAL_METHODS));
+  private static final IndexSchemaValidator VALIDATOR = new IndexSchemaValidator();
 
   @Test
   void shouldDetectIndexWithAddedProperty() throws IOException {


### PR DESCRIPTION
## Description

The opensearch client has some limitations in that you cannot build requests using json, instead you must pass in implementations of `Settings` or `Mappings`. 

In addition there is shared functionality that will also be used by the opensearch client so functions such as `appendToFileSchemaSettings` has been moved to the interface.

**Success Criteria:**
- [x] Common functionality such as `appendToFileSchemaSettings`, `listIndices` are accessible by any `SearchEngineClient` implementation.
- [x] Any requests built using json such as PUT settings and PUT Mapping now instead pass an implementation specific object to the request builders as opensearch does not support request building with json.
- [x] Any builders or functions which create objects required by requests are accessible by any `SearchEngineClient` implementation, in this case `mapToSettings` and `toPropertiesmap`  

## Related issues

Relates to #23163 
