### PR TITLE
fix: reverting password encryption change to fix migration of users

### DIFF
--- a/operate/client/e2e-playwright/tests/login.spec.ts
+++ b/operate/client/e2e-playwright/tests/login.spec.ts
@@ -26,7 +26,7 @@ test.describe('login page', () => {
     });
 
     await expect(
-      page.getByRole('alert').getByText('Username and password do not match'),
+      page.getByRole('alert').getByText('Credentials could not be verified'),
     ).toBeVisible();
     await expect(page).toHaveURL(`.${Paths.login()}`);
   });

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -24,7 +24,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -55,7 +55,7 @@ public class OperateUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    return new BCryptPasswordEncoder();
   }
 
   public void initializeUsers() {

--- a/tasklist/client/e2e/tests/login.spec.ts
+++ b/tasklist/client/e2e/tests/login.spec.ts
@@ -46,7 +46,7 @@ test.describe.parallel('login page', () => {
 
     await expect(page).toHaveURL('/tasklist/login');
     await expect(loginPage.errorMessage).toContainText(
-      'Username and password do not match',
+      'Credentials could not be verified',
     );
 
     const results = await makeAxeBuilder().analyze();

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    return new BCryptPasswordEncoder();
   }
 
   public void initializeUsers() {


### PR DESCRIPTION
This fixes the migration of users from previous versions to 8.6

## Description

Reverting change around Encryptor as it's causing problems on the migrations - it's not backward compatible so when coming from 8.5, password cannot be checked.

Related to: https://github.com/camunda/camunda/pull/23220

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/23213
