### PR TITLE
[Backport stable/8.6] fix: permit requests to swagger endpoint `/v3/api-docs/**`

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/OpenApiConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/OpenApiConfig.java
@@ -31,7 +31,7 @@ public class OpenApiConfig {
 
   private GroupedOpenApi apiDefinitionFor(final String version) {
     return GroupedOpenApi.builder()
-        .group(version)
+        .group(String.format("Operate-%s", version))
         .addOpenApiCustomizer(
             openApi ->
                 openApi

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
@@ -26,6 +26,7 @@ public final class OperateURIs {
     "/swagger-resources",
     "/swagger-resources/**",
     "/swagger-ui.html",
+    "/v3/api-docs/**",
     "/documentation",
     "/actuator/**",
     LOGIN_RESOURCE,

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/config/OpenApiConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/config/OpenApiConfig.java
@@ -115,7 +115,7 @@ public class OpenApiConfig {
 
   private GroupedOpenApi versionedPublicApi(final String version) {
     return GroupedOpenApi.builder()
-        .group(version)
+        .group(String.format("Tasklist-%s", version))
         .addOpenApiCustomizer(
             openApi -> {
               openApi
@@ -153,7 +153,7 @@ public class OpenApiConfig {
    */
   @Bean("springdocObjectMapperProvider")
   public ObjectMapperProvider objectMapperProvider(
-      SpringDocConfigProperties springDocConfigProperties) {
+      final SpringDocConfigProperties springDocConfigProperties) {
     return new ObjectMapperProvider(springDocConfigProperties);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
@@ -55,7 +55,8 @@ public final class TasklistURIs {
       AntPathRequestMatcher.antMatcher(LOGIN_RESOURCE),
       AntPathRequestMatcher.antMatcher(LOGOUT_RESOURCE),
       AntPathRequestMatcher.antMatcher(REST_V1_EXTERNAL_API),
-      new MvcRequestMatcher(introspector, NEW_FORM)
+      new MvcRequestMatcher(introspector, NEW_FORM),
+      AntPathRequestMatcher.antMatcher("/v3/api-docs/**")
     };
     return requestMatchers;
   }


### PR DESCRIPTION
# Description
Backport of #23350 to `stable/8.6`.

relates to #23300
original author: @romansmirnov