### PR TITLE
getMappings now retrieves all property fields.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Map;
@@ -25,7 +24,8 @@ public final class SchemaResourceSerializer {
 
   public static Map<String, Object> serialize(
       final Function<JsonGenerator, jakarta.json.stream.JsonGenerator> jacksonGenerator,
-      final Consumer<jakarta.json.stream.JsonGenerator> serialize) {
+      final Consumer<jakarta.json.stream.JsonGenerator> serialize)
+      throws IOException {
     try (final var out = new StringWriter();
         final var jsonGenerator = new JsonFactory().createGenerator(out);
         final jakarta.json.stream.JsonGenerator jacksonJsonpGenerator =
@@ -34,9 +34,6 @@ public final class SchemaResourceSerializer {
       jacksonJsonpGenerator.flush();
 
       return MAPPER.readValue(out.toString(), new TypeReference<>() {});
-
-    } catch (final IOException e) {
-      throw new ElasticsearchExporterException("Serialisation failed", e);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/SchemaResourceSerializer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.exceptions.ElasticsearchExporterException;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public final class SchemaResourceSerializer {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private SchemaResourceSerializer() {}
+
+  public static Map<String, Object> serialize(
+      final Function<JsonGenerator, jakarta.json.stream.JsonGenerator> jacksonGenerator,
+      final Consumer<jakarta.json.stream.JsonGenerator> serialize) {
+    try (final var out = new StringWriter();
+        final var jsonGenerator = new JsonFactory().createGenerator(out);
+        final jakarta.json.stream.JsonGenerator jacksonJsonpGenerator =
+            jacksonGenerator.apply(jsonGenerator)) {
+      serialize.accept(jacksonJsonpGenerator);
+      jacksonJsonpGenerator.flush();
+
+      return MAPPER.readValue(out.toString(), new TypeReference<>() {});
+
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException("Serialisation failed", e);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -26,7 +26,6 @@ import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpDeserializer;
 import co.elastic.clients.json.jackson.JacksonJsonpGenerator;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -222,10 +222,15 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   }
 
   private Map<String, Object> propertyToMap(final Property property) {
-    return SchemaResourceSerializer.serialize(
-        (JacksonJsonpGenerator::new),
-        (jacksonJsonpGenerator) ->
-            property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(MAPPER)));
+    try {
+      return SchemaResourceSerializer.serialize(
+          (JacksonJsonpGenerator::new),
+          (jacksonJsonpGenerator) ->
+              property.serialize(jacksonJsonpGenerator, new JacksonJsonpMapper(MAPPER)));
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException(
+          String.format("Failed to serialize property [%s]", property.toString()), e);
+    }
   }
 
   private String dynamicFromMappings(final TypeMapping mapping) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -17,7 +17,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonParser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
@@ -45,6 +47,28 @@ public record IndexMappingProperty(String name, Object typeDefinition) {
         IOUtils.toInputStream(MAPPER.writeValueAsString(typeDefinition()), StandardCharsets.UTF_8);
 
     return JSONP_MAPPER.jsonProvider().createParser(typeDefinitionJson);
+  }
+
+  @Override
+  public String toString() {
+    final var typeDefinitionStr =
+        ((HashMap<String, Object>) typeDefinition)
+            .entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Entry::getKey,
+                        (ent) ->
+                            ent.getValue()
+                                + "["
+                                + ent.getValue().getClass().getSimpleName()
+                                + "]"));
+    return "IndexMappingProperty{"
+        + "name='"
+        + name
+        + '\''
+        + ", typeDefinition="
+        + typeDefinitionStr
+        + '}';
   }
 
   public static IndexMappingProperty createIndexMappingProperty(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -240,4 +240,23 @@ public class ElasticsearchEngineClientIT {
         .isEqualTo("20d");
     assertThat(policy.result().get("policy_name").policy().phases().delete().actions()).isNotNull();
   }
+
+  @Test
+  void shouldAccountForAllPropertyFieldsWhenGetMappings() {
+    final var index =
+        SchemaTestUtil.mockIndex(
+            "index_qualified_name", "alias", "index_name", "/mappings-complex-property.json");
+
+    elsEngineClient.createIndex(index, new IndexSettings());
+
+    final var mappings = elsEngineClient.getMappings("*", MappingSource.INDEX);
+    assertThat(mappings.size()).isEqualTo(1);
+
+    final var createdIndexMappings = mappings.get(index.getFullQualifiedName());
+    final Map<String, Object> complexProperty =
+        (Map<String, Object>) createdIndexMappings.toMap().get("hello");
+    assertThat(complexProperty.get("type")).isEqualTo("text");
+    assertThat(complexProperty.get("index")).isEqualTo(false);
+    assertThat(complexProperty.get("eager_global_ordinals")).isEqualTo(true);
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/resources/mappings-complex-property.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/mappings-complex-property.json
@@ -4,8 +4,8 @@
     "properties": {
       "hello": {
         "type": "text",
-        "index": "false",
-        "eager_global_ordinals": "true"
+        "index": false,
+        "eager_global_ordinals": true
       },
       "world": {
         "type": "keyword"

--- a/zeebe/exporters/camunda-exporter/src/test/resources/mappings-complex-property.json
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/mappings-complex-property.json
@@ -1,0 +1,15 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "hello": {
+        "type": "text",
+        "index": "false",
+        "eager_global_ordinals": "true"
+      },
+      "world": {
+        "type": "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Previously when serialising mappings from Elasticsearch(ELS) only the `type` field would be captured.

This cause an issue where:
- If there is a schema file with complex property fields e.g. type, index, format etc... This resource would be correctly created in ELS with all the property fields. 
- When retrieving mappings and converting to an implementation agnostic object we would only serialize the `type` field missing the other fields this would cause an error during schema validation as it thinks the fields are different. 
  - As an example `[name=creationTime, leftValue=IndexMappingProperty[name=creationTime, typeDefinition={format=date_time || epoch_millis, type=date}], rightValue=IndexMappingProperty[name=creationTime, typeDefinition={type=date}]],` here we see creation time has 2 fields in its properties but for the `rightValue` only the `type` value was serialised.

In addition there is an error case where elasticsearch recognises a setting say `"index": "false"` as a boolean false and in the index sets the value to false. Then when comparing the schema to the state in the database we get a difference and validation fails as `"index": "false"`(in json file) != `"index": false`(in els database). This error should not occur as long as fields are given their correct type but if it does the error should be recognised, the default tostring method hides this mismatch so a more detailed one is to be implemented.

**Success Criteria:**
- [x] For a property field with multiple fields `getMappings` will capture all fields.
- [x] More descriptor IndexMappingProperty toString 

## Related issues

relates to  #23040 
