### PR TITLE
ci: enable connection pool for wagon transport

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -9,6 +9,10 @@ inputs:
     description: A modifier key used for the maven cache, can be used to create isolated caches for certain jobs.
     default: "shared"
     required: false
+  maven-wagon-http-pool:
+    description: Whether to use a connection pool for HTTP connections.
+    default: "true"
+    required: false
 
 runs:
   using: composite
@@ -34,7 +38,7 @@ runs:
         --batch-mode
         --update-snapshots
         -D maven.wagon.httpconnectionManager.ttlSeconds=120
-        -D maven.wagon.http.pool=false
+        -D maven.wagon.http.pool=${{ inputs.maven-wagon-http-pool }}
         -D maven.resolver.transport=wagon
         -D maven.wagon.http.retryHandler.class=standard
         -D maven.wagon.http.retryHandler.requestSentEnabled=true


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674 and this [comment](https://github.com/camunda/team-infrastructure/issues/674).

Connection pool for wagon transport can improve performance significantly, but it is currently set to “false” in the `setup-maven-cache` composite action. Retries should normally be triggered if a connection fails (see `maven.wagon.http.retryHandler.*`).

This PR enables connection pool by default and introduces a new corresponding input.

Tests: https://github.com/camunda/team-infrastructure/issues/674#issuecomment-2407432385 and https://github.com/camunda/camunda/actions/runs/11294603579/job/31415448837?pr=23395

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
