### PR TITLE
Add exporter handler for Decision records with integration tests

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -145,6 +145,22 @@
       <artifactId>camunda-search-domain</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CamundaExporterITInvocationProvider.class)
+final class DecisionExporterIT {
+
+  @TestTemplate
+  void shouldExportDecision(final TestStandaloneBroker testBroker) {
+    // given
+    final var client = testBroker.newClientBuilder().build();
+
+    final var resource =
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("decisions/decision_model.dmn")
+            .send()
+            .join();
+    final var expectedDecisionName = resource.getDecisions().get(0).getDmnDecisionName();
+
+    // when
+    // broker has exported
+    Awaitility.await()
+        .ignoreExceptions()
+        .timeout(Duration.ofSeconds(30))
+        .until(() -> !client.newDecisionDefinitionQuery().send().join().items().isEmpty());
+
+    // then
+    final var result = client.newDecisionDefinitionQuery().send().join();
+    assertThat(result.items().get(0).getDmnDecisionName()).isEqualTo(expectedDecisionName);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaExporterITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaExporterITInvocationProvider.java
@@ -96,6 +96,7 @@ public class CamundaExporterITInvocationProvider
                   testBrokers.put(entry.getKey(), testBroker);
                   testBroker.awaitCompleteTopology();
                 }
+                default -> throw new RuntimeException("Unknown exporter type");
               }
               LOGGER.info("Start up of '{}' finished.", entry.getKey());
             });

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaExporterITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/CamundaExporterITInvocationProvider.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.utils;
+
+import static java.util.Arrays.asList;
+
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Invocation context provider that provides TestStandaloneBroker instances configured with each
+ * exporter type. The lifecyle of the TestStandaloneBroker and the exporter backend is per class.
+ * The tests must take this into account, as the state in Zeebe and the exporter backend is not
+ * reset between test cases.
+ */
+public class CamundaExporterITInvocationProvider
+    implements TestTemplateInvocationContextProvider, AfterAllCallback, BeforeAllCallback {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(CamundaExporterITInvocationProvider.class);
+
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  private final Map<String, ExporterType> exporterTypes;
+  private final Map<String, TestStandaloneBroker> testBrokers = new HashMap<>();
+
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  public CamundaExporterITInvocationProvider() {
+    exporterTypes = new HashMap<>();
+    exporterTypes.put(
+        "with-camunda-exporter-elasticsearch", ExporterType.CAMUNDA_EXPORTER_ELASTIC_SEARCH);
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    LOGGER.info("Starting up '{}' camunda instances", exporterTypes.size());
+    exporterTypes.entrySet().parallelStream()
+        .forEach(
+            entry -> {
+              LOGGER.info("Start up '{}'", entry.getKey());
+
+              switch (entry.getValue()) {
+                case CAMUNDA_EXPORTER_ELASTIC_SEARCH -> {
+                  final ElasticsearchContainer elasticsearchContainer =
+                      new ElasticsearchContainer(ELASTIC_IMAGE)
+                          // use JVM option files to avoid overwriting default options set by the ES
+                          // container class
+                          .withClasspathResourceMapping(
+                              "elasticsearch-fast-startup.options",
+                              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+                              BindMode.READ_ONLY)
+                          // can be slow in CI
+                          .withStartupTimeout(Duration.ofMinutes(5))
+                          .withEnv("action.auto_create_index", "true")
+                          .withEnv("xpack.security.enabled", "false")
+                          .withEnv("xpack.watcher.enabled", "false")
+                          .withEnv("xpack.ml.enabled", "false");
+                  elasticsearchContainer.start();
+                  closeables.add(elasticsearchContainer);
+
+                  final var testBroker =
+                      new TestStandaloneBroker()
+                          .withCamundaExporter(
+                              "http://" + elasticsearchContainer.getHttpHostAddress())
+                          .withProperty("zeebe.broker.gateway.enable", true)
+                          .withProperty("camunda.rest.query.enabled", true)
+                          .start();
+                  closeables.add(testBroker);
+                  testBrokers.put(entry.getKey(), testBroker);
+                  testBroker.awaitCompleteTopology();
+                }
+              }
+              LOGGER.info("Start up of '{}' finished.", entry.getKey());
+            });
+  }
+
+  @Override
+  public boolean supportsTestTemplate(final ExtensionContext extensionContext) {
+    return true;
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      final ExtensionContext extensionContext) {
+    return testBrokers.keySet().stream().map(this::invocationContext);
+  }
+
+  private TestTemplateInvocationContext invocationContext(final String standaloneCamundaKey) {
+    return new TestTemplateInvocationContext() {
+
+      @Override
+      public String getDisplayName(final int invocationIndex) {
+        return standaloneCamundaKey;
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return asList(
+            new ParameterResolver() {
+
+              @Override
+              public boolean supportsParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return parameterCtx.getParameter().getType().equals(TestStandaloneBroker.class);
+              }
+
+              @Override
+              public Object resolveParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return testBrokers.get(standaloneCamundaKey);
+              }
+            });
+      }
+    };
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    closeables.parallelStream()
+        .forEach(
+            c -> {
+              try {
+                c.close();
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+
+  public enum ExporterType {
+    CAMUNDA_EXPORTER_ELASTIC_SEARCH
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/AbstractExporterEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/AbstractExporterEntity.java
@@ -17,7 +17,8 @@ import java.util.Objects;
 public abstract class AbstractExporterEntity<T extends AbstractExporterEntity<T>>
     implements ExporterEntity<T> {
 
-  public static final String DEFAULT_TENANT_ID = "<default>";
+  /** Deprecated: Use TenantOwned.DEFAULT_TENANT_IDENTIFIER instead. */
+  @Deprecated public static final String DEFAULT_TENANT_ID = "<default>";
 
   private String id;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
+import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 
 import co.elastic.clients.util.VisibleForTesting;
@@ -223,7 +224,8 @@ public class CamundaExporter implements Exporter {
 
   private record ElasticsearchRecordFilter() implements RecordFilter {
     // TODO include other value types to export
-    private static final Set<ValueType> VALUE_TYPES_2_EXPORT = Set.of(USER, AUTHORIZATION);
+    private static final Set<ValueType> VALUE_TYPES_2_EXPORT =
+        Set.of(USER, AUTHORIZATION, DECISION);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -15,8 +15,6 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
-import io.camunda.exporter.handlers.AuthorizationRecordValueExportHandler;
-import io.camunda.exporter.handlers.UserRecordValueExportHandler;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.schema.IndexMappingProperty;
 import io.camunda.exporter.schema.IndexSchemaValidator;
@@ -186,11 +184,9 @@ public class CamundaExporter implements Exporter {
   }
 
   private ExporterBatchWriter createBatchWriter() {
-    // TODO register all handlers here
-    return ExporterBatchWriter.Builder.begin()
-        .withHandler(new UserRecordValueExportHandler())
-        .withHandler(new AuthorizationRecordValueExportHandler())
-        .build();
+    final var builder = ExporterBatchWriter.Builder.begin();
+    provider.getExportHandlers().stream().forEach(builder::withHandler);
+    return builder.build();
   }
 
   private void scheduleDelayedFlush() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -159,7 +160,7 @@ public class CamundaExporter implements Exporter {
     }
   }
 
-  private Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndices(
+  private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndices(
       final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
     final var currentIndices =
         searchEngineClient.getMappings(
@@ -168,7 +169,7 @@ public class CamundaExporter implements Exporter {
     return schemaValidator.validateIndexMappings(currentIndices, provider.getIndexDescriptors());
   }
 
-  private Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexTemplates(
+  private Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndexTemplates(
       final IndexSchemaValidator schemaValidator, final SearchEngineClient searchEngineClient) {
     final var currentTemplates = searchEngineClient.getMappings("*", MappingSource.INDEX_TEMPLATE);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -8,6 +8,9 @@
 package io.camunda.exporter;
 
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.handlers.AuthorizationRecordValueExportHandler;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.UserRecordValueExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.Set;
@@ -52,5 +55,11 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     //        new SequenceFlowTemplate(operateIndexPrefix, true),
     //        new UserTaskTemplate(operateIndexPrefix, true),
     //        new VariableTemplate(operateIndexPrefix, true));
+  }
+
+  @Override
+  public Set<ExportHandler> getExportHandlers() {
+    // Register all handlers here
+    return Set.of(new UserRecordValueExportHandler(), new AuthorizationRecordValueExportHandler());
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.util.Collection;
 import java.util.Set;
 
 public interface ExporterResourceProvider {
@@ -22,7 +23,7 @@ public interface ExporterResourceProvider {
    *
    * @return A {@link Set} of {@link IndexDescriptor}
    */
-  Set<IndexDescriptor> getIndexDescriptors();
+  Collection<IndexDescriptor> getIndexDescriptors();
 
   /**
    * This should return descriptors describing the desired state of all index templates provided.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter;
 
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.Set;
@@ -29,4 +30,9 @@ public interface ExporterResourceProvider {
    * @return A {@link Set} of {@link IndexTemplateDescriptor}
    */
   Set<IndexTemplateDescriptor> getIndexTemplateDescriptors();
+
+  /**
+   * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
+   */
+  Set<ExportHandler> getExportHandlers();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -19,7 +19,7 @@ public class ExporterConfiguration {
   private RetentionConfiguration retention = new RetentionConfiguration();
   private Map<String, Integer> replicasByIndexName = new HashMap<>();
   private Map<String, Integer> shardsByIndexName = new HashMap<>();
-  private boolean createSchema;
+  private boolean createSchema = true;
 
   public ConnectConfiguration getConnect() {
     return connect;
@@ -98,7 +98,7 @@ public class ExporterConfiguration {
   }
 
   public static final class IndexSettings {
-    private String prefix = "camunda-record";
+    private String prefix = "operate";
     private Integer numberOfShards = 1;
     private Integer numberOfReplicas = 0;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/DecisionHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import java.util.List;
+import java.util.Set;
+
+public class DecisionHandler
+    implements ExportHandler<DecisionDefinitionEntity, DecisionRecordValue> {
+
+  private static final Set<String> STATES = Set.of(ProcessIntent.CREATED.name());
+  private final String indexName;
+
+  public DecisionHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.DECISION;
+  }
+
+  @Override
+  public Class<DecisionDefinitionEntity> getEntityType() {
+    return DecisionDefinitionEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<DecisionRecordValue> record) {
+    final String intentStr = record.getIntent().name();
+    return STATES.contains(intentStr);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<DecisionRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getDecisionKey()));
+  }
+
+  @Override
+  public DecisionDefinitionEntity createNewEntity(final String id) {
+    return new DecisionDefinitionEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<DecisionRecordValue> record, final DecisionDefinitionEntity entity) {
+    final DecisionRecordValue decision = record.getValue();
+    entity
+        .setId(String.valueOf(decision.getDecisionKey()))
+        .setKey(decision.getDecisionKey())
+        .setName(decision.getDecisionName())
+        .setVersion(decision.getVersion())
+        .setDecisionId(decision.getDecisionId())
+        .setDecisionRequirementsId(decision.getDecisionRequirementsId())
+        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+        .setTenantId(tenantOrDefault(decision.getTenantId()));
+  }
+
+  @Override
+  public void flush(final DecisionDefinitionEntity entity, final BatchRequest batchRequest) {
+    batchRequest.addWithId(indexName, String.valueOf(entity.getKey()), entity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -30,6 +30,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,7 +85,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
   @Override
   public void putMapping(
-      final IndexDescriptor indexDescriptor, final Set<IndexMappingProperty> newProperties) {
+      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {
     final PutMappingRequest request = putMappingRequest(indexDescriptor, newProperties);
 
     try {
@@ -238,7 +239,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   }
 
   private PutMappingRequest putMappingRequest(
-      final IndexDescriptor indexDescriptor, final Set<IndexMappingProperty> newProperties) {
+      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {
 
     return new PutMappingRequest.Builder()
         .index(indexDescriptor.getFullQualifiedName())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchSchemaManager.java
@@ -15,8 +15,8 @@ import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,14 +25,14 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchSchemaManager.class);
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private final SearchEngineClient elasticsearchClient;
-  private final Set<IndexDescriptor> indexDescriptors;
-  private final Set<IndexTemplateDescriptor> indexTemplateDescriptors;
+  private final Collection<IndexDescriptor> indexDescriptors;
+  private final Collection<IndexTemplateDescriptor> indexTemplateDescriptors;
   private final ExporterConfiguration config;
 
   public ElasticsearchSchemaManager(
       final SearchEngineClient elasticsearchClient,
-      final Set<IndexDescriptor> indexDescriptors,
-      final Set<IndexTemplateDescriptor> indexTemplateDescriptors,
+      final Collection<IndexDescriptor> indexDescriptors,
+      final Collection<IndexTemplateDescriptor> indexTemplateDescriptors,
       final ExporterConfiguration config) {
     this.elasticsearchClient = elasticsearchClient;
     this.indexDescriptors = indexDescriptors;
@@ -68,7 +68,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   }
 
   @Override
-  public void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
+  public void updateSchema(final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields) {
     for (final var newFieldEntry : newFields.entrySet()) {
       final var descriptor = newFieldEntry.getKey();
       final var newProperties = newFieldEntry.getValue();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -11,16 +11,16 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
 
   public static InputStream toPropertiesJson(
-      final Set<IndexMappingProperty> properties, final ObjectMapper mapper) {
+      final Collection<IndexMappingProperty> properties, final ObjectMapper mapper) {
     final var propertiesAsMap =
         properties.stream()
             .collect(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexSchemaValidator.java
@@ -63,10 +63,10 @@ public class IndexSchemaValidator {
    * @throws IndexSchemaValidationException if the existing indices cannot be updated with the given
    *     mappings.
    */
-  public Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexMappings(
-      final Map<String, IndexMapping> mappings, final Set<IndexDescriptor> indexDescriptors)
+  public Map<IndexDescriptor, Collection<IndexMappingProperty>> validateIndexMappings(
+      final Map<String, IndexMapping> mappings, final Collection<IndexDescriptor> indexDescriptors)
       throws IndexSchemaValidationException {
-    final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields = new HashMap<>();
+    final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields = new HashMap<>();
     for (final IndexDescriptor indexDescriptor : indexDescriptors) {
       final Map<String, IndexMapping> indexMappingsGroup =
           filterIndexMappings(mappings, indexDescriptor);
@@ -83,7 +83,7 @@ public class IndexSchemaValidator {
   private void validateDifferenceAndCollectNewFields(
       final IndexDescriptor indexDescriptor,
       final IndexMappingDifference difference,
-      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
+      final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields) {
     if (difference != null && !difference.equal()) {
       LOGGER.debug(
           "Index fields differ from expected. Index name: {}. Difference: {}.",

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -8,13 +8,13 @@
 package io.camunda.exporter.schema;
 
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import java.util.Collection;
 import java.util.Map;
-import java.util.Set;
 
 public interface SchemaManager {
   void initialiseResources();
 
-  void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
+  void updateSchema(final Map<IndexDescriptor, Collection<IndexMappingProperty>> newFields);
 
   IndexMapping readIndex(final IndexDescriptor indexDescriptor);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SearchEngineClient.java
@@ -10,9 +10,9 @@ package io.camunda.exporter.schema;
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public interface SearchEngineClient {
   void createIndex(final IndexDescriptor indexDescriptor, final IndexSettings settings);
@@ -27,7 +27,7 @@ public interface SearchEngineClient {
    * @param newProperties New properties to be appended to the index
    */
   void putMapping(
-      final IndexDescriptor indexDescriptor, final Set<IndexMappingProperty> newProperties);
+      final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties);
 
   Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
+
+import org.springframework.util.StringUtils;
+
+public final class ExporterUtil {
+
+  private ExporterUtil() {
+    // utility class
+  }
+
+  public static String tenantOrDefault(final String tenantId) {
+    if (!StringUtils.hasLength(tenantId)) {
+      return DEFAULT_TENANT_ID;
+    }
+    return tenantId;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -8,7 +8,6 @@
 package io.camunda.exporter.utils;
 
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import org.springframework.util.StringUtils;
 
 public final class ExporterUtil {
 
@@ -17,7 +16,7 @@ public final class ExporterUtil {
   }
 
   public static String tenantOrDefault(final String tenantId) {
-    if (!StringUtils.hasLength(tenantId)) {
+    if (tenantId == null || tenantId.isEmpty()) {
       return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     }
     return tenantId;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.exporter.utils;
 
-import static io.camunda.webapps.schema.entities.AbstractExporterEntity.DEFAULT_TENANT_ID;
-
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.springframework.util.StringUtils;
 
 public final class ExporterUtil {
@@ -19,7 +18,7 @@ public final class ExporterUtil {
 
   public static String tenantOrDefault(final String tenantId) {
     if (!StringUtils.hasLength(tenantId)) {
-      return DEFAULT_TENANT_ID;
+      return TenantOwned.DEFAULT_TENANT_IDENTIFIER;
     }
     return tenantId;
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.schema.SchemaTestUtil.validateMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -192,7 +193,8 @@ final class CamundaExporterIT {
   private ExporterResourceProvider mockResourceProvider(
       final Set<IndexDescriptor> indexDescriptors,
       final Set<IndexTemplateDescriptor> templateDescriptors) {
-    final var provider = mock(DefaultExporterResourceProvider.class);
+    final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
+    provider.init(config);
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -11,7 +11,6 @@ import static io.camunda.exporter.schema.SchemaTestUtil.validateMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -193,7 +192,7 @@ final class CamundaExporterIT {
   private ExporterResourceProvider mockResourceProvider(
       final Set<IndexDescriptor> indexDescriptors,
       final Set<IndexTemplateDescriptor> templateDescriptors) {
-    final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
+    final var provider = mock(DefaultExporterResourceProvider.class);
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -120,6 +120,7 @@ final class DecisionHandlerTest {
     assertThat(decisionDefinitionEntity.getId()).isEqualTo("123");
     assertThat(decisionDefinitionEntity.getKey()).isEqualTo(123L);
     assertThat(decisionDefinitionEntity.getName()).isEqualTo("decisionName");
+    assertThat(decisionDefinitionEntity.getDecisionId()).isEqualTo("decisionId");
     assertThat(decisionDefinitionEntity.getVersion()).isEqualTo(2);
     assertThat(decisionDefinitionEntity.getDecisionRequirementsId())
         .isEqualTo("decisionRequirementsId");

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.*;
 
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -53,7 +52,7 @@ final class DecisionHandlerTest {
     final long expectedId = 123;
     final DecisionRecordValue decisionRecordValue =
         ImmutableDecisionRecordValue.builder()
-            .from(factory.generateObject(DecisionRecord.class))
+            .from(factory.generateObject(DecisionRecordValue.class))
             .withDecisionKey(expectedId)
             .build();
 
@@ -97,7 +96,7 @@ final class DecisionHandlerTest {
     // given
     final DecisionRecordValue decisionRecordValue =
         ImmutableDecisionRecordValue.builder()
-            .from(factory.generateObject(DecisionRecord.class))
+            .from(factory.generateObject(DecisionRecordValue.class))
             .withDecisionKey(123)
             .withDecisionName("decisionName")
             .withVersion(2)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/DecisionHandlerTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+final class DecisionHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-decision";
+  private final DecisionHandler underTest = new DecisionHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.DECISION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(DecisionDefinitionEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<DecisionRecordValue> decisionRecord =
+        factory.generateRecord(ValueType.DECISION, r -> r.withIntent(ProcessIntent.CREATED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(decisionRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final long expectedId = 123;
+    final DecisionRecordValue decisionRecordValue =
+        ImmutableDecisionRecordValue.builder()
+            .from(factory.generateObject(DecisionRecord.class))
+            .withDecisionKey(expectedId)
+            .build();
+
+    final Record<DecisionRecordValue> decisionRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r -> r.withIntent(ProcessIntent.CREATED).withValue(decisionRecordValue));
+
+    // when
+    final var idList = underTest.generateIds(decisionRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(expectedId));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final DecisionDefinitionEntity inputEntity = new DecisionDefinitionEntity();
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).addWithId(indexName, "0", inputEntity);
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final DecisionRecordValue decisionRecordValue =
+        ImmutableDecisionRecordValue.builder()
+            .from(factory.generateObject(DecisionRecord.class))
+            .withDecisionKey(123)
+            .withDecisionName("decisionName")
+            .withVersion(2)
+            .withDecisionId("decisionId")
+            .withDecisionRequirementsId("decisionRequirementsId")
+            .withDecisionRequirementsKey(222)
+            .withTenantId("tenantId")
+            .build();
+
+    final Record<DecisionRecordValue> decisionRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r -> r.withIntent(ProcessIntent.CREATED).withValue(decisionRecordValue));
+
+    // when
+    final DecisionDefinitionEntity decisionDefinitionEntity = new DecisionDefinitionEntity();
+    underTest.updateEntity(decisionRecord, decisionDefinitionEntity);
+
+    // then
+    assertThat(decisionDefinitionEntity.getId()).isEqualTo("123");
+    assertThat(decisionDefinitionEntity.getKey()).isEqualTo(123L);
+    assertThat(decisionDefinitionEntity.getName()).isEqualTo("decisionName");
+    assertThat(decisionDefinitionEntity.getVersion()).isEqualTo(2);
+    assertThat(decisionDefinitionEntity.getDecisionRequirementsId())
+        .isEqualTo("decisionRequirementsId");
+    assertThat(decisionDefinitionEntity.getDecisionRequirementsKey()).isEqualTo(222L);
+    assertThat(decisionDefinitionEntity.getTenantId()).isEqualTo("tenantId");
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
@@ -18,6 +18,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
@@ -132,7 +133,7 @@ public class ElasticsearchSchemaManagerIT {
     // when
     when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
 
-    final Map<IndexDescriptor, Set<IndexMappingProperty>> schemasToChange =
+    final Map<IndexDescriptor, Collection<IndexMappingProperty>> schemasToChange =
         Map.of(indexTemplate, Set.of());
     schemaManager.updateSchema(schemasToChange);
 
@@ -162,7 +163,7 @@ public class ElasticsearchSchemaManagerIT {
     newProperties.add(new IndexMappingProperty("foo", Map.of("type", "text")));
     newProperties.add(new IndexMappingProperty("bar", Map.of("type", "keyword")));
 
-    final Map<IndexDescriptor, Set<IndexMappingProperty>> schemasToChange =
+    final Map<IndexDescriptor, Collection<IndexMappingProperty>> schemasToChange =
         Map.of(index, newProperties);
 
     schemaManager.updateSchema(schemasToChange);


### PR DESCRIPTION
## Description

* Move `DecisionHandler` from branch `feat-operate-exporter` to `camunda-exporter` in `main`.
* Refactored added unit test for the handler. Mostly removed the mocks and instead used the protocol factory to generate the records. 
* Added an integration test for Decision records in `qa/integration-tests`. The test can be easily extended to run for Opensearch when it is fully supported. This test serve as a reference for other integration tests. 

ps:- the index prefix has been changed to "operate" because this is hard-corded in the rest api. This should be updated based on the decision from [ongoing discussion](https://camunda.slack.com/archives/C06F0GLJNFM/p1728568094544759)


## Related issues
 
related to  https://github.com/camunda/camunda/issues/22642
