### PR TITLE
[Backport stable/optimize-8.6] ci: use infra github-managed runners for `ci.yml/java-unit-tests` workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,14 +139,10 @@ jobs:
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
-    runs-on: [ self-hosted, linux, amd64, "16" ]
+    runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Install and allow strace tests
-        run: |
-          sudo apt-get -qq update && sudo apt-get install -y strace
-          sudo sysctl -w kernel.yama.ptrace_scope=0
       - uses: ./.github/actions/setup-zeebe
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -186,6 +186,57 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+  strace-tests:
+    # Zeebe tests requiring strace
+    name: Strace Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install and allow strace tests
+        run: |
+          sudo apt-get -qq update && sudo apt-get install -y strace
+          sudo sysctl -w kernel.yama.ptrace_scope=0
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Maven Test Build
+        run: >
+          ./mvnw -T1C -B --no-snapshot-updates
+          -P include-strace-tests
+          -D junitThreadCount=2
+          -D skipChecks
+          -f zeebe
+          test
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+          # workaround to avoid https://github.com/camunda/camunda/issues/16604
+          skipSummary: true
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: Strace Tests
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
     runs-on: ubuntu-latest
@@ -260,6 +311,7 @@ jobs:
       - property-tests
       - performance-tests
       - docker-checks
+      - strace-tests
     steps:
       - uses: actions/checkout@v4
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2342,8 +2342,8 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${plugin.version.surefire}</version>
           <configuration>
-            <!-- by default, exclude performance tests -->
-            <groups>!performance</groups>
+            <!-- by default, exclude performance and strace tests -->
+            <excludedGroups>performance, strace</excludedGroups>
             <failIfNoTests>false</failIfNoTests>
             <trimStackTrace>false</trimStackTrace>
             <redirectTestOutputToFile>true</redirectTestOutputToFile>
@@ -2876,6 +2876,24 @@
     </profile>
 
     <profile>
+      <!-- Dedicated profile to run ONLY tests requiring strace. -->
+      <id>include-strace-tests</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <groups>strace</groups>
+              <!-- Reset <excludedGroups> as it take precedence over <groups> -->
+              <excludedGroups combine.self="override"></excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
       <!-- Dedicated profile to run ONLY performance tests. The include config overwrites the default pattern-->
       <id>include-performance-tests</id>
       <build>
@@ -2885,6 +2903,8 @@
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
               <groups>performance</groups>
+              <!-- Reset <excludedGroups> as it take precedence over <groups> -->
+              <excludedGroups combine.self="override"></excludedGroups>
             </configuration>
           </plugin>
         </plugins>

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.test.util.STracer;
 import io.camunda.zeebe.test.util.STracer.Syscall;
 import io.camunda.zeebe.test.util.asserts.strace.FSyncTraceAssert;
 import io.camunda.zeebe.test.util.asserts.strace.STracerAssert;
+import io.camunda.zeebe.test.util.junit.StraceTest;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -26,7 +27,6 @@ import org.agrona.IoUtil;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.api.io.TempDir;
 
 public final class SnapshotChecksumTest {
@@ -129,8 +129,7 @@ public final class SnapshotChecksumTest {
    * This test is only enabled on CI as it relies on strace. You can run it manually directly if
    * your system supports strace. See {@link io.camunda.zeebe.test.util.STracer} for more.
    */
-  @EnabledIfEnvironmentVariable(named = "CI", matches = "true")
-  @Test
+  @StraceTest
   void shouldFlushOnPersist() throws Exception {
     // given
     final var traceFile = temporaryFolder.resolve("traceFile");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/STracer.java
@@ -128,7 +128,7 @@ public final class STracer implements AutoCloseable {
   public Stream<FSyncTrace> fSyncTraces() {
     try {
       return Files.readAllLines(outputFile).stream()
-          .filter(s -> s.contains("fsync"))
+          .filter(s -> s.contains("fsync") && !s.contains("resumed"))
           .map(FSyncTrace::of);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/StraceTest.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/StraceTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+/**
+ * Marker annotation indicating the following test requires strace to be installed on the machine.
+ * By default, such tests are run only in CI where we can guarantee strace is installed. Of course
+ * the test will also run when running it explicitly via your IDE or command line.
+ *
+ * @see io.camunda.zeebe.test.util.STracer
+ */
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Tag("strace")
+@EnabledIfEnvironmentVariable(named = "CI", matches = "true")
+@Test
+public @interface StraceTest {}


### PR DESCRIPTION
# Description
Backport of #22609 to `stable/optimize-8.6`.

relates to 
original author: @clementnero