### PR TITLE
[Backport stable/optimize-8.6] ci: use infra self-hosted runners for zeebe-ci.yml/smoke-tests

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -29,7 +29,7 @@ jobs:
           - os: windows
             runner: windows-latest
           - os: linux
-            runner: [ self-hosted, linux, amd64 ]
+            runner: gcp-perf-core-8-default
           - os: linux
             runner: "aws-arm-core-4-default"
             arch: arm64


### PR DESCRIPTION
# Description
Backport of #22807 to `stable/optimize-8.6`.

relates to 
original author: @clementnero