### PR TITLE
feat: remove enableSync config option from cluster's configManager

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -622,8 +622,6 @@
         # Configure the parameters used for gossiping the dynamic cluster configuration.
         # Note that this is not related to cluster membership gossip.
         # gossip:
-          # Enable the synchronization of the gossip instead of only relying on gossip
-          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
           # enableSync: true
           # Sets the interval between two synchronization requests to other members of the cluster
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -500,9 +500,6 @@
         # Configure the parameters used for gossiping the configuration
         # Note that this is not related to cluster membership gossip.
         # gossip:
-          # Enable the synchronization of the gossip instead of only relying on gossip
-          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
-          # enableSync: true
           # Sets the interval between two synchronization requests to other members of the cluster
           # This setting can also be overridden using the environment variable ZEEBE_BROKER_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY
           # syncDelay: 10s

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -162,9 +162,6 @@
         # Configure the parameters used for gossiping the dynamic cluster configuration.
         # Note that this is not related to cluster membership gossip.
         # gossip:
-          # Enable the synchronization of the gossip instead of only relying on gossip
-          # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_ENABLESYNC
-          # enableSync: true
           # Sets the interval between two synchronization requests to other members of the cluster
           # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_CLUSTER_CONFIGMANAGER_GOSSIP_SYNCDELAY
           # syncDelay: 10s

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -127,19 +127,17 @@ public final class SystemContext {
 
     final var errors = new ArrayList<String>(0);
 
-    if (gossiper.enableSync()) {
-      if (!gossiper.syncDelay().isPositive()) {
-        errors.add(
-            String.format(
-                "syncDelay must be positive: configured value = %d ms",
-                gossiper.syncDelay().toMillis()));
-      }
-      if (!gossiper.syncRequestTimeout().isPositive()) {
-        errors.add(
-            String.format(
-                "syncRequestTimeout must be positive: configured value = %d ms",
-                gossiper.syncRequestTimeout().toMillis()));
-      }
+    if (!gossiper.syncDelay().isPositive()) {
+      errors.add(
+          String.format(
+              "syncDelay must be positive: configured value = %d ms",
+              gossiper.syncDelay().toMillis()));
+    }
+    if (!gossiper.syncRequestTimeout().isPositive()) {
+      errors.add(
+          String.format(
+              "syncRequestTimeout must be positive: configured value = %d ms",
+              gossiper.syncRequestTimeout().toMillis()));
     }
     if (gossiper.gossipFanout() < 2) {
       errors.add(

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/SystemContextTest.java
@@ -373,7 +373,7 @@ final class SystemContextTest {
     final var invalidconfigManagerCfg =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                true, Duration.ofSeconds(10).negated(), Duration.ofSeconds(10).negated(), -1));
+                Duration.ofSeconds(10).negated(), Duration.ofSeconds(10).negated(), -1));
     clusterCfg.setConfigManager(invalidconfigManagerCfg);
 
     // when
@@ -398,7 +398,7 @@ final class SystemContextTest {
     final var invalidConfigManagerCfg =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                true, Duration.ofSeconds(0), Duration.ofSeconds(0), 0));
+                Duration.ofSeconds(0), Duration.ofSeconds(0), 0));
     clusterCfg.setConfigManager(invalidConfigManagerCfg);
 
     // when
@@ -423,7 +423,7 @@ final class SystemContextTest {
     final var invalidDynamicConfig =
         new ConfigManagerCfg(
             new ClusterConfigurationGossiperConfig(
-                true, Duration.ofSeconds(1), Duration.ofSeconds(1), 1));
+                Duration.ofSeconds(1), Duration.ofSeconds(1), 1));
     clusterCfg.setConfigManager(invalidDynamicConfig);
 
     // when
@@ -433,23 +433,5 @@ final class SystemContextTest {
         .hasMessageStartingWith("Invalid ConfigManager configuration:")
         .hasMessageContaining(
             String.format("gossipFanout must be greater than 1: configured value = %d", 1));
-  }
-
-  @Test
-  void shouldAllowInvalidSyncValuesInConfigManagerIfSyncIsNotEnabled() {
-    // given
-    final var brokerCfg = new BrokerCfg();
-    final var clusterCfg = brokerCfg.getCluster();
-
-    final var validConfig =
-        new ConfigManagerCfg(
-            new ClusterConfigurationGossiperConfig(
-                false, Duration.ofSeconds(1).negated(), Duration.ofSeconds(1).negated(), 3));
-    clusterCfg.setConfigManager(validConfig);
-
-    // when
-    assertThatCode(() -> initSystemContext(brokerCfg))
-        // then
-        .doesNotThrowAnyException();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ClusterCfgTest.java
@@ -170,7 +170,7 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    false, Duration.ofSeconds(10), Duration.ofSeconds(30), 10)));
+                    Duration.ofSeconds(10), Duration.ofSeconds(30), 10)));
   }
 
   @Test
@@ -192,7 +192,7 @@ public final class ClusterCfgTest {
         .isEqualTo(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    true, Duration.ofSeconds(5), Duration.ofSeconds(6), 6)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(6), 6)));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiper.java
@@ -118,9 +118,7 @@ public final class ClusterConfigurationGossiper
   }
 
   private void scheduleSync() {
-    if (config.enableSync()) {
-      executor.schedule(config.syncDelay(), this::sync);
-    }
+    executor.schedule(config.syncDelay(), this::sync);
   }
 
   private void sync() {
@@ -288,12 +286,7 @@ public final class ClusterConfigurationGossiper
           // When a new member is added to the cluster, immediately sync with it so that the new
           // member
           // receives the latest topology as fast as possible.
-          executor.run(
-              () -> {
-                if (config.enableSync()) {
-                  sync(event.subject().id());
-                }
-              });
+          executor.run(() -> sync(event.subject().id()));
       case MEMBER_REMOVED ->
           // When a member is removed, remove it from the list of members to sync so that we don't
           // try

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/gossip/ClusterConfigurationGossiperConfig.java
@@ -11,23 +11,18 @@ import java.time.Duration;
 import java.util.Optional;
 
 public record ClusterConfigurationGossiperConfig(
-    Boolean enableSync, Duration syncDelay, Duration syncRequestTimeout, Integer gossipFanout) {
+    Duration syncDelay, Duration syncRequestTimeout, Integer gossipFanout) {
 
-  public static final boolean ENABLE_SYNC = true;
   public static final Duration DEFAULT_SYNC_DELAY = Duration.ofSeconds(10);
   public static final Duration DEFAULT_SYNC_REQUEST_TIMEOUT = Duration.ofSeconds(2);
   public static final int DEFAULT_GOSSIP_FANOUT = 2;
 
   public static final ClusterConfigurationGossiperConfig DEFAULT =
       new ClusterConfigurationGossiperConfig(
-          ENABLE_SYNC, DEFAULT_SYNC_DELAY, DEFAULT_SYNC_REQUEST_TIMEOUT, DEFAULT_GOSSIP_FANOUT);
+          DEFAULT_SYNC_DELAY, DEFAULT_SYNC_REQUEST_TIMEOUT, DEFAULT_GOSSIP_FANOUT);
 
   public ClusterConfigurationGossiperConfig(
-      final Boolean enableSync,
-      final Duration syncDelay,
-      final Duration syncRequestTimeout,
-      final Integer gossipFanout) {
-    this.enableSync = enableSync;
+      final Duration syncDelay, final Duration syncRequestTimeout, final Integer gossipFanout) {
     this.syncDelay = Optional.ofNullable(syncDelay).orElse(DEFAULT_SYNC_DELAY);
     this.syncRequestTimeout =
         Optional.ofNullable(syncRequestTimeout).orElse(DEFAULT_SYNC_REQUEST_TIMEOUT);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -249,7 +249,7 @@ class ClusterConfigurationManagementIntegrationTest {
             cluster.getCommunicationService(),
             cluster.getMembershipService(),
             new ClusterConfigurationGossiperConfig(
-                true, Duration.ofSeconds(1), Duration.ofMillis(100), 2),
+                Duration.ofSeconds(1), Duration.ofMillis(100), 2),
             true);
     return new TestNode(cluster, service);
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -47,7 +47,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    false, Duration.ofSeconds(5), Duration.ofSeconds(30), 6)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(30), 6)));
     CUSTOM_CFG
         .getSecurity()
         .setEnabled(true)
@@ -130,7 +130,6 @@ public final class GatewayCfgTest {
 
     // then
     final var gossiperConfig = gatewayCfg.getCluster().getConfigManager().gossip();
-    assertThat(gossiperConfig.enableSync()).isEqualTo(false);
     assertThat(gossiperConfig.syncDelay()).isEqualTo(Duration.ofSeconds(5));
     assertThat(gossiperConfig.syncRequestTimeout()).isEqualTo(Duration.ofSeconds(30));
     assertThat(gossiperConfig.gossipFanout()).isEqualTo(6);
@@ -195,7 +194,7 @@ public final class GatewayCfgTest {
         .setConfigManager(
             new ConfigManagerCfg(
                 new ClusterConfigurationGossiperConfig(
-                    false, Duration.ofSeconds(5), Duration.ofSeconds(5), 4)));
+                    Duration.ofSeconds(5), Duration.ofSeconds(5), 4)));
     expected.getThreads().setManagementThreads(32);
     expected
         .getSecurity()


### PR DESCRIPTION
## Description
Removes the possibility to disable enableSync from configuration 
## Related issues

closes #23441 
