### PR TITLE
ci: split and cache release artifacts only for Maven 3.9+

### DIFF
--- a/.github/actions/setup-maven-cache/action.yaml
+++ b/.github/actions/setup-maven-cache/action.yaml
@@ -46,27 +46,46 @@ runs:
         -D aether.syncContext.named.time=180
         -D maven.artifact.threads=32
         EOF
+    - name: Get cache path and keys
+      env:
+        HASH_FILES: ${{ hashFiles('**/pom.xml') }}
+        # it matters for caching as absolute paths on self-hosted and GitHub runners differ
+        # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+        KEY_PREFIX: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+      run: |
+        maven_version=$(./mvnw --version | head -n 1 | sed "s/Apache Maven \([[:digit:]]\.[[:digit:]]\.[[:digit:]]\).*/\1/g")
+        # Only cache release artifacts for Maven version 3.9+
+        # GitHub env variables are used instead of outputs, as outputs are not available in post steps
+        # https://github.com/actions/runner/issues/2009
+        if echo "3.9.0\n$maven_version" | sort --version-sort --check=quiet; then
+          # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
+          # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
+          # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
+          echo "MAVEN_CACHE_PATH=~/.m2/repository/cached/releases/" >> $GITHUB_ENV
+          echo "MAVEN_CACHE_KEY=${KEY_PREFIX}-${HASH_FILES}" >> $GITHUB_ENV
+          echo "MAVEN_CACHE_KEY_PREFIX=${KEY_PREFIX}" >> $GITHUB_ENV
+        else
+          echo "MAVEN_CACHE_PATH=~/.m2/repository/" >> $GITHUB_ENV
+          echo "MAVEN_CACHE_KEY=${KEY_PREFIX}-full-${HASH_FILES}" >> $GITHUB_ENV
+          echo "MAVEN_CACHE_KEY_PREFIX=${KEY_PREFIX}-full" >> $GITHUB_ENV
+        fi
+      shell: sh
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
       if: ${{ startsWith(github.ref_name, 'stable/') || github.ref_name == 'main' }}
       uses: actions/cache@v4
       with:
-        # This is the path used by the `enhancedLocalRepository` set up in the 'Configure Maven' step.
-        # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
-        # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
-        path: ~/.m2/repository/cached/releases/
-        # it matters for caching as absolute paths on self-hosted and GitHub runners differ
-        # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        path: ${{ env.MAVEN_CACHE_PATH }}
+        key: ${{ env.MAVEN_CACHE_KEY }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ env.MAVEN_CACHE_KEY_PREFIX }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
       if: ${{ !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main') }}
       uses: actions/cache/restore@v4
       with:
         # This has to match the 'Cache local Maven repository' step above
-        path: ~/.m2/repository/cached/releases/
-        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        path: ${{ env.MAVEN_CACHE_PATH }}
+        key: ${{ env.MAVEN_CACHE_KEY }}
         restore-keys: |
-          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ env.MAVEN_CACHE_KEY_PREFIX }}


### PR DESCRIPTION
## Description

Related to https://github.com/camunda/team-infrastructure/issues/674.

Splitting cached artifacts using the `aether.enhancedLocalRepository.split*` properties only works for Maven 3.9+ (ignored otherwise). As we still have workflows using older versions, the `setup-maven-cache` composite should enable caching of the entire `.m2/repository` folder for these cases.

Regarding Maven version detection, it is assumed that the `setup-maven-cache` action is always used in conjunction with the `mvnw` wrapper (i.e. `./mvnw --version` is used to get Maven version).

Same cache keys are used for Maven 3.9+ (release artifacts) and a new cache key modifier `-full-` is introduced for <3.9 (all artifacts). 

Tests:
- save cache
    - release artifacts: https://github.com/camunda/camunda/actions/runs/11330389443/job/31517266675
    - all artifacts: https://github.com/camunda/camunda/actions/runs/11330389411/job/31517315975
- restore cache
    - release artifacts: https://github.com/camunda/camunda/actions/runs/11330389443/job/31516525402
    - all artifacts: https://github.com/camunda/camunda/actions/runs/11330389411/job/31508148065

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
