### PR TITLE
Revert "deps: Update version.lucene to v8.11.4 (stable/8.6)"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -161,7 +161,7 @@
     <version.postgres-test-container>1.20.2</version.postgres-test-container>
     <version.elasticsearch7>7.17.24</version.elasticsearch7>
     <!-- the lucene version must be coupled with version.elasticsearch7 -->
-    <version.lucene>8.11.4</version.lucene>
+    <version.lucene>8.11.3</version.lucene>
     <version.hdr-histogram>2.2.2</version.hdr-histogram>
     <version.joda-time>2.13.0</version.joda-time>
     <version.commons-collections4>4.4</version.commons-collections4>


### PR DESCRIPTION
Reverts camunda/camunda#23341

The new Lucene version `8.11.4` is incompatible with elasticsearch7 client dependency `7.17.24`. https://github.com/camunda/camunda/actions/runs/11317642495/job/31471326830