### PR TITLE
ci: fix preview env build reference to feature branch

### DIFF
--- a/.github/workflows/preview-env-build-and-deploy.yml
+++ b/.github/workflows/preview-env-build-and-deploy.yml
@@ -211,7 +211,7 @@ jobs:
     if: always() && needs.deploy-preview.result != 'skipped' && needs.deploy-preview.result != 'cancelled'
     name: Clean Preview Environment
     needs: [deploy-preview]
-    uses: camunda/camunda/.github/workflows/preview-env-clean.yml@preview-env-build-helmchart
+    uses: camunda/camunda/.github/workflows/preview-env-clean.yml@main
     secrets: inherit
     with:
       pull-request: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-env-teardown.yml
+++ b/.github/workflows/preview-env-teardown.yml
@@ -53,7 +53,7 @@ jobs:
 
   clean:
     if: always() && needs.teardown-preview.result != 'skipped'
-    uses: camunda/camunda/.github/workflows/preview-env-clean.yml@preview-env-build-helmchart
+    uses: camunda/camunda/.github/workflows/preview-env-clean.yml@main
     needs: [teardown-preview]
     secrets: inherit
     with:


### PR DESCRIPTION
## Description

This pr aims to correct two typos relating to the preview env build and teardown workflows. More specifically, the workflows should be referencing the branch `main` instead of the feature branch `preview env build`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/team-infrastructure/issues/655
