### PR TITLE
test: fix qa generation naming for 8.6

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -71,7 +71,7 @@ jobs:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
-            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-version) }}
+            generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.second-last-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.second-last-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.third-last-version) }}


### PR DESCRIPTION
The naming schema changed from "Camunda 8.6.0" to "Camunda 8.6-gen1". This fix is not very smart, we'll have to redo it until all supported minor versions use the new naming scheme.

See https://camunda.slack.com/archives/CKZK2E7RP/p1728898155269379?thread_ts=1728897908.564069&cid=CKZK2E7RP