### PR TITLE
Add RoleEntityRemovedApplier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -458,6 +458,9 @@ public final class EventAppliers implements EventApplier {
     register(
         RoleIntent.ENTITY_ADDED,
         new RoleEntityAddedApplier(state.getRoleState(), state.getUserState()));
+    register(
+        RoleIntent.ENTITY_REMOVED,
+        new RoleEntityRemovedApplier(state.getRoleState(), state.getUserState()));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+
+public class RoleEntityRemovedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
+
+  private final MutableRoleState roleState;
+  private final MutableUserState userState;
+
+  public RoleEntityRemovedApplier(
+      final MutableRoleState roleState, final MutableUserState userState) {
+    this.roleState = roleState;
+    this.userState = userState;
+  }
+
+  @Override
+  public void applyState(final long key, final RoleRecord value) {
+    roleState.removeEntity(value.getRoleKey(), value.getEntityKey());
+    if (value.getEntityType() == EntityType.USER) {
+      userState.removeRole(value.getEntityKey(), value.getRoleKey());
+    }
+    // todo remove entity to mapping state when implemented
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbRoleState.java
@@ -100,6 +100,13 @@ public class DbRoleState implements MutableRoleState {
   }
 
   @Override
+  public void removeEntity(final long roleKey, final long entityKey) {
+    this.roleKey.wrapLong(roleKey);
+    this.entityKey.wrapLong(entityKey);
+    entityTypeByRoleColumnFamily.deleteExisting(fkRoleKeyAndEntityKey);
+  }
+
+  @Override
   public Optional<PersistedRole> getRole(final long roleKey) {
     this.roleKey.wrapLong(roleKey);
     final var persistedRole = roleColumnFamily.get(this.roleKey);
@@ -117,7 +124,7 @@ public class DbRoleState implements MutableRoleState {
   public Optional<EntityType> getEntityType(final long roleKey, final long entityKey) {
     this.roleKey.wrapLong(roleKey);
     this.entityKey.wrapLong(entityKey);
-    return Optional.ofNullable(
-        entityTypeByRoleColumnFamily.get(fkRoleKeyAndEntityKey).getEntityType());
+    final var result = entityTypeByRoleColumnFamily.get(fkRoleKeyAndEntityKey);
+    return Optional.ofNullable(result).map(EntityTypeValue::getEntityType);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoleState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableRoleState.java
@@ -12,9 +12,11 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 
 public interface MutableRoleState extends RoleState {
 
-  void create(RoleRecord roleRecord);
+  void create(final RoleRecord roleRecord);
 
-  void update(RoleRecord roleRecord);
+  void update(final RoleRecord roleRecord);
 
   void addEntity(final RoleRecord roleRecord);
+
+  void removeEntity(final long roleKey, final long entityKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -15,4 +15,6 @@ public interface MutableUserState extends UserState {
   void create(final UserRecord user);
 
   void addRole(final long userKey, final long roleKey);
+
+  void removeRole(final long userKey, final long roleKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -61,6 +62,16 @@ public class DbUserState implements UserState, MutableUserState {
     this.userKey.wrapLong(userKey);
     final var persistedUser = userByUserKeyColumnFamily.get(this.userKey);
     persistedUser.getUser().addRoleKey(roleKey);
+    userByUserKeyColumnFamily.update(this.userKey, persistedUser);
+  }
+
+  @Override
+  public void removeRole(final long userKey, final long roleKey) {
+    this.userKey.wrapLong(userKey);
+    final var persistedUser = userByUserKeyColumnFamily.get(this.userKey);
+    final List<Long> roleKeys = persistedUser.getUser().getRoleKeysList();
+    roleKeys.remove(roleKey);
+    persistedUser.getUser().setRoleKeysList(roleKeys);
     userByUserKeyColumnFamily.update(this.userKey, persistedUser);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/RoleStateTest.java
@@ -103,4 +103,26 @@ public class RoleStateTest {
     final var entityType = roleState.getEntityType(roleKey, 1L).get();
     assertThat(entityType).isEqualTo(EntityType.USER);
   }
+
+  @Test
+  void shouldRemoveEntity() {
+    // given
+    final long roleKey = 1L;
+    final String roleName = "foo";
+    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    roleState.create(roleRecord);
+    roleRecord.setEntityKey(1L).setEntityType(EntityType.USER);
+    roleState.addEntity(roleRecord);
+    roleState.addEntity(
+        new RoleRecord().setRoleKey(roleKey).setEntityKey(2L).setEntityType(EntityType.USER));
+
+    // when
+    roleState.removeEntity(roleKey, 1L);
+
+    // then
+    final var deletedEntity = roleState.getEntityType(roleKey, 1L);
+    assertThat(deletedEntity).isEmpty();
+    final var entityType = roleState.getEntityType(roleKey, 2L).get();
+    assertThat(entityType).isEqualTo(EntityType.USER);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/user/UserStateTest.java
@@ -221,4 +221,30 @@ public class UserStateTest {
     final var persistedUser = userState.getUser(userKey).get();
     assertThat(persistedUser.getRoleKeysList()).contains(roleKey);
   }
+
+  @Test
+  void shouldRemoveRole() {
+    // given
+    final long userKey = 1L;
+    final var username = "username";
+    final var name = "Foo";
+    final var email = "foo@bar.com";
+    final var password = "password";
+    userState.create(
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(name)
+            .setEmail(email)
+            .setPassword(password));
+    final long roleKey = 1L;
+    userState.addRole(userKey, roleKey);
+
+    // when
+    userState.removeRole(userKey, roleKey);
+
+    // then
+    final var persistedUser = userState.getUser(userKey).get();
+    assertThat(persistedUser.getRoleKeysList()).isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR:

- Adds a method to to the MutableRoleState interface to remove an entity from a role
- Adds a method to the MutableUserState interface to remove a role from a user
- Adds RoleEntityRemovedApplier

## Related issues

closes #22926 
