### PR TITLE
Opensearch client for camunda exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -155,6 +155,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.opensearch</groupId>
+      <artifactId>opensearch-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.adapters;
 
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.schema.OpensearchEngineClient;
 import io.camunda.exporter.schema.SchemaManager;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
@@ -22,18 +23,18 @@ import org.opensearch.client.opensearch.core.BulkRequest;
 class OpensearchAdapter implements ClientAdapter {
   private final OpenSearchClient client;
   private final ExporterConfiguration configuration;
+  private final OpensearchEngineClient searchEngineClient;
 
   OpensearchAdapter(final ExporterConfiguration configuration) {
     this.configuration = configuration;
     final var connector = new OpensearchConnector(configuration.getConnect());
     client = connector.createClient();
-    // FIXME add search engine client implementation for opensearch and instantiate it here
+    searchEngineClient = new OpensearchEngineClient(client);
   }
 
   @Override
   public SearchEngineClient getSearchEngineClient() {
-    // TODO return search engine client instance here
-    return null;
+    return searchEngineClient;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/ElasticsearchEngineClient.java
@@ -12,6 +12,7 @@ import static io.camunda.exporter.utils.SearchEngineClientUtils.listIndices;
 import static io.camunda.exporter.utils.SearchEngineClientUtils.mapToSettings;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import co.elastic.clients.elasticsearch.ilm.PutLifecycleRequest;
@@ -59,7 +60,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       client.indices().create(request);
       LOG.debug("Index [{}] was successfully created", indexDescriptor.getIndexName());
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
           String.format("Index [%s] was not created", indexDescriptor.getIndexName());
       LOG.error(errMsg, e);
@@ -78,7 +79,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       client.indices().putIndexTemplate(request);
       LOG.debug("Template [{}] was successfully created", templateDescriptor.getTemplateName());
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
           String.format("Template [%s] was NOT created", templateDescriptor.getTemplateName());
       LOG.error(errMsg, e);
@@ -94,7 +95,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       client.indices().putMapping(request);
       LOG.debug("Mapping in [{}] was successfully updated", indexDescriptor.getIndexName());
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
           String.format("Mapping in [%s] was NOT updated", indexDescriptor.getIndexName());
       LOG.error(errMsg, e);
@@ -121,7 +122,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
                         .metaProperties(metaFromMappings(mappingsBlock))
                         .build();
                   }));
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       throw new ElasticsearchExporterException(
           String.format(
               "Failed retrieving mappings from index/index templates with pattern [%s]",
@@ -137,7 +138,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
 
     try {
       client.indices().putSettings(request);
-    } catch (final IOException e) {
+    } catch (final IOException | ElasticsearchException e) {
       final var errMsg =
           String.format(
               "settings PUT failed for the following indices [%s]", listIndices(indexDescriptors));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -12,27 +12,44 @@ import static java.util.Map.entry;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonParser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
   private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final JsonpMapper JSONP_MAPPER = new JacksonJsonpMapper(MAPPER);
+  private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSONP_MAPPER =
+      new org.opensearch.client.json.jackson.JacksonJsonpMapper(MAPPER);
 
   public Entry<String, Property> toElasticsearchProperty() {
-    try {
-      final var typeDefinitionParser = getTypeDefinitionParser();
-      final var elasticsearchProperty =
-          Property._DESERIALIZER.deserialize(typeDefinitionParser, JSONP_MAPPER);
+    final var typeDefinitionParser = getTypeDefinitionParser();
+    final var elasticsearchProperty =
+        Property._DESERIALIZER.deserialize(typeDefinitionParser, JSONP_MAPPER);
 
-      return entry(name(), elasticsearchProperty);
+    return entry(name(), elasticsearchProperty);
+  }
+
+  public Entry<String, org.opensearch.client.opensearch._types.mapping.Property>
+      toOpensearchProperty() {
+    final var typeDefinitionParser = getTypeDefinitionParser();
+    final var opensearchProperty =
+        org.opensearch.client.opensearch._types.mapping.Property._DESERIALIZER.deserialize(
+            typeDefinitionParser, OPENSEARCH_JSONP_MAPPER);
+
+    return entry(name(), opensearchProperty);
+  }
+
+  private JsonParser getTypeDefinitionParser() {
+    try {
+      final var typeDefinitionJson =
+          IOUtils.toInputStream(
+              MAPPER.writeValueAsString(typeDefinition()), StandardCharsets.UTF_8);
+
+      return JSONP_MAPPER.jsonProvider().createParser(typeDefinitionJson);
     } catch (final IOException e) {
       throw new IllegalStateException(
           String.format(
@@ -40,35 +57,6 @@ public record IndexMappingProperty(String name, Object typeDefinition) {
               this, Property.class.getName()),
           e);
     }
-  }
-
-  private JsonParser getTypeDefinitionParser() throws JsonProcessingException {
-    final var typeDefinitionJson =
-        IOUtils.toInputStream(MAPPER.writeValueAsString(typeDefinition()), StandardCharsets.UTF_8);
-
-    return JSONP_MAPPER.jsonProvider().createParser(typeDefinitionJson);
-  }
-
-  @Override
-  public String toString() {
-    final var typeDefinitionStr =
-        ((HashMap<String, Object>) typeDefinition)
-            .entrySet().stream()
-                .collect(
-                    Collectors.toMap(
-                        Entry::getKey,
-                        (ent) ->
-                            ent.getValue()
-                                + "["
-                                + ent.getValue().getClass().getSimpleName()
-                                + "]"));
-    return "IndexMappingProperty{"
-        + "name='"
-        + name
-        + '\''
-        + ", typeDefinition="
-        + typeDefinitionStr
-        + '}';
   }
 
   public static IndexMappingProperty createIndexMappingProperty(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -16,7 +16,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonParser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
 
 public record IndexMappingProperty(String name, Object typeDefinition) {
@@ -57,6 +59,28 @@ public record IndexMappingProperty(String name, Object typeDefinition) {
               this, Property.class.getName()),
           e);
     }
+  }
+
+  @Override
+  public String toString() {
+    final var typeDefinitionStr =
+        ((HashMap<String, Object>) typeDefinition)
+            .entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Entry::getKey,
+                        (ent) ->
+                            ent.getValue()
+                                + "["
+                                + ent.getValue().getClass().getSimpleName()
+                                + "]"));
+    return "IndexMappingProperty{"
+        + "name='"
+        + name
+        + '\''
+        + ", typeDefinition="
+        + typeDefinitionStr
+        + '}';
   }
 
   public static IndexMappingProperty createIndexMappingProperty(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.schema;
+
+import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
+
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.exceptions.OpensearchExporterException;
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.opensearch.client.json.JsonpDeserializer;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.indices.CreateIndexRequest;
+import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
+import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplateMapping;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpensearchEngineClient implements SearchEngineClient {
+  private static final Logger LOG = LoggerFactory.getLogger(OpensearchEngineClient.class);
+  private final OpenSearchClient client;
+
+  public OpensearchEngineClient(final OpenSearchClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public void createIndex(final IndexDescriptor indexDescriptor, final IndexSettings settings) {
+    final CreateIndexRequest request = createIndexRequest(indexDescriptor, settings);
+
+    try {
+      client.indices().create(request);
+      LOG.debug("Index [{}] was successfully created", indexDescriptor.getIndexName());
+    } catch (final IOException e) {
+      final var errMsg =
+          String.format("Index [%s] was not created", indexDescriptor.getIndexName());
+      LOG.error(errMsg, e);
+      throw new OpensearchExporterException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void createIndexTemplate(
+      final IndexTemplateDescriptor templateDescriptor,
+      final IndexSettings settings,
+      final boolean create) {
+
+    final PutIndexTemplateRequest request = putIndexTemplateRequest(templateDescriptor, settings);
+
+    try {
+      if (create
+          && client
+              .indices()
+              .existsIndexTemplate(req -> req.name(templateDescriptor.getTemplateName()))
+              .value()) {
+        throw new OpensearchExporterException(
+            String.format(
+                "Cannot update template [%s] as create = true",
+                templateDescriptor.getTemplateName()));
+      }
+
+      client.indices().putIndexTemplate(request);
+      LOG.debug("Template [{}] was successfully created", templateDescriptor.getTemplateName());
+    } catch (final IOException e) {
+      final var errMsg =
+          String.format("Template [%s] was NOT created", templateDescriptor.getTemplateName());
+      LOG.error(errMsg, e);
+      throw new OpensearchExporterException(errMsg, e);
+    }
+  }
+
+  @Override
+  public void putMapping(
+      final IndexDescriptor indexDescriptor,
+      final Collection<IndexMappingProperty> newProperties) {}
+
+  @Override
+  public Map<String, IndexMapping> getMappings(
+      final String namePattern, final MappingSource mappingSource) {
+    return Map.of();
+  }
+
+  @Override
+  public void putSettings(
+      final List<IndexDescriptor> indexDescriptors, final Map<String, String> toAppendSettings) {}
+
+  @Override
+  public void putIndexLifeCyclePolicy(final String policyName, final String deletionMinAge) {}
+
+  private PutIndexTemplateRequest putIndexTemplateRequest(
+      final IndexTemplateDescriptor indexTemplateDescriptor, final IndexSettings settings) {
+
+    try (final var templateFile =
+        getClass().getResourceAsStream(indexTemplateDescriptor.getMappingsClasspathFilename())) {
+
+      final var templateFields =
+          deserializeJson(
+              IndexTemplateMapping._DESERIALIZER,
+              appendToFileSchemaSettings(templateFile, settings));
+
+      return new PutIndexTemplateRequest.Builder()
+          .name(indexTemplateDescriptor.getTemplateName())
+          .indexPatterns(indexTemplateDescriptor.getIndexPattern())
+          .template(
+              t ->
+                  t.aliases(indexTemplateDescriptor.getAlias(), a -> a)
+                      .mappings(templateFields.mappings())
+                      .settings(templateFields.settings()))
+          .composedOf(indexTemplateDescriptor.getComposedOf())
+          .build();
+    } catch (final IOException e) {
+      throw new OpensearchExporterException(
+          "Failed to load file "
+              + indexTemplateDescriptor.getMappingsClasspathFilename()
+              + " from classpath.",
+          e);
+    }
+  }
+
+  private CreateIndexRequest createIndexRequest(
+      final IndexDescriptor indexDescriptor, final IndexSettings settings) {
+
+    try (final var templateFile =
+        getClass().getResourceAsStream(indexDescriptor.getMappingsClasspathFilename())) {
+
+      final var templateFields =
+          deserializeJson(
+              IndexTemplateMapping._DESERIALIZER,
+              appendToFileSchemaSettings(templateFile, settings));
+
+      return new CreateIndexRequest.Builder()
+          .index(indexDescriptor.getFullQualifiedName())
+          .aliases(indexDescriptor.getAlias(), a -> a.isWriteIndex(false))
+          .mappings(templateFields.mappings())
+          .settings(templateFields.settings())
+          .build();
+
+    } catch (final IOException e) {
+      throw new OpensearchExporterException(
+          "Failed to load file: "
+              + indexDescriptor.getMappingsClasspathFilename()
+              + " from classpath",
+          e);
+    }
+  }
+
+  private <T> T deserializeJson(final JsonpDeserializer<T> deserializer, final InputStream json) {
+    final JsonbJsonpMapper mapper = new JsonbJsonpMapper();
+
+    try (final var parser = mapper.jsonProvider().createParser(json)) {
+      return deserializer.deserialize(parser, mapper);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.generic.Body;
 import org.opensearch.client.opensearch.generic.Request;
@@ -60,7 +61,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
     try {
       client.indices().create(request);
       LOG.debug("Index [{}] was successfully created", indexDescriptor.getIndexName());
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format("Index [%s] was not created", indexDescriptor.getIndexName());
       LOG.error(errMsg, e);
@@ -90,7 +91,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
       client.indices().putIndexTemplate(request);
       LOG.debug("Template [{}] was successfully created", templateDescriptor.getTemplateName());
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format("Template [%s] was NOT created", templateDescriptor.getTemplateName());
       LOG.error(errMsg, e);
@@ -106,7 +107,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
     try {
       client.indices().putMapping(request);
       LOG.debug("Mapping in [{}] was successfully updated", indexDescriptor.getIndexName());
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format("Mapping in [%s] was NOT updated", indexDescriptor.getIndexName());
       LOG.error(errMsg, e);
@@ -132,7 +133,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
                         .metaProperties(metaFromMappings(mappingsBlock))
                         .build();
                   }));
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new OpensearchExporterException(
           String.format(
               "Failed retrieving mappings from index/index templates with pattern [%s]",
@@ -148,7 +149,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
     try {
       client.indices().putSettings(request);
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format(
               "settings PUT failed for the following indices [%s]", listIndices(indexDescriptors));
@@ -169,7 +170,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
                 policyName, deletionMinAge, response.getBody().get().bodyAsString()));
       }
 
-    } catch (final IOException e) {
+    } catch (final IOException | OpenSearchException e) {
       final var errMsg =
           String.format("Failed to create index state management policy [%s]", policyName);
       LOG.error(errMsg, e);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/OpensearchEngineClient.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.schema;
 import static io.camunda.exporter.utils.SearchEngineClientUtils.appendToFileSchemaSettings;
 
 import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.exceptions.IndexSchemaValidationException;
 import io.camunda.exporter.exceptions.OpensearchExporterException;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
@@ -19,13 +20,16 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.opensearch.client.json.JsonpDeserializer;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.PutIndexTemplateRequest;
 import org.opensearch.client.opensearch.indices.PutMappingRequest;
+import org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem;
 import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplateMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,7 +106,28 @@ public class OpensearchEngineClient implements SearchEngineClient {
   @Override
   public Map<String, IndexMapping> getMappings(
       final String namePattern, final MappingSource mappingSource) {
-    return Map.of();
+    try {
+      final Map<String, TypeMapping> mappings = getCurrentMappings(mappingSource, namePattern);
+      return mappings.entrySet().stream()
+          .collect(
+              Collectors.toMap(
+                  Entry::getKey,
+                  entry -> {
+                    final var mappingsBlock = entry.getValue();
+                    return new IndexMapping.Builder()
+                        .indexName(entry.getKey())
+                        .dynamic(dynamicFromMappings(mappingsBlock))
+                        .properties(propertiesFromMappings(mappingsBlock))
+                        .metaProperties(metaFromMappings(mappingsBlock))
+                        .build();
+                  }));
+    } catch (final IOException e) {
+      throw new OpensearchExporterException(
+          String.format(
+              "Failed retrieving mappings from index/index templates with pattern [%s]",
+              namePattern),
+          e);
+    }
   }
 
   @Override
@@ -111,6 +136,48 @@ public class OpensearchEngineClient implements SearchEngineClient {
 
   @Override
   public void putIndexLifeCyclePolicy(final String policyName, final String deletionMinAge) {}
+
+  private String dynamicFromMappings(final TypeMapping mapping) {
+    final var dynamic = mapping.dynamic();
+    return dynamic == null ? "strict" : dynamic.toString().toLowerCase();
+  }
+
+  private Map<String, Object> metaFromMappings(final TypeMapping mapping) {
+    return mapping.meta().entrySet().stream()
+        .collect(Collectors.toMap(Entry::getKey, ent -> ent.getValue().to(Object.class)));
+  }
+
+  private Set<IndexMappingProperty> propertiesFromMappings(final TypeMapping mapping) {
+    return mapping.properties().entrySet().stream()
+        .map(
+            p ->
+                new IndexMappingProperty.Builder()
+                    .name(p.getKey())
+                    .typeDefinition(Map.of("type", p.getValue()._kind().jsonValue()))
+                    .build())
+        .collect(Collectors.toSet());
+  }
+
+  private Map<String, TypeMapping> getCurrentMappings(
+      final MappingSource mappingSource, final String namePattern) throws IOException {
+    if (mappingSource == MappingSource.INDEX) {
+      return client.indices().getMapping(req -> req.index(namePattern)).result().entrySet().stream()
+          .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().mappings()));
+    } else if (mappingSource == MappingSource.INDEX_TEMPLATE) {
+      return client
+          .indices()
+          .getIndexTemplate(req -> req.name(namePattern))
+          .indexTemplates()
+          .stream()
+          .filter(indexTemplateItem -> indexTemplateItem.indexTemplate().template() != null)
+          .collect(
+              Collectors.toMap(
+                  IndexTemplateItem::name, item -> item.indexTemplate().template().mappings()));
+    } else {
+      throw new IndexSchemaValidationException(
+          "Invalid mapping source provided must be either INDEX or INDEX_TEMPLATE");
+    }
+  }
 
   private PutMappingRequest putMappingRequest(
       final IndexDescriptor indexDescriptor, final Collection<IndexMappingProperty> newProperties) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -10,8 +10,8 @@ package io.camunda.exporter;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import co.elastic.clients.elasticsearch._types.ElasticsearchException;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.exceptions.ElasticsearchExporterException;
 import io.camunda.exporter.utils.TestSupport;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
@@ -77,7 +77,8 @@ public class CamundaExporterAuthenticationIT {
 
     // then
     assertThatThrownBy(() -> exporter.open(controller))
-        .isInstanceOf(ElasticsearchException.class)
+        .isInstanceOf(ElasticsearchExporterException.class)
+        .cause()
         .hasMessageContaining("unable to authenticate user");
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterAuthenticationIT.java
@@ -31,7 +31,7 @@ public class CamundaExporterAuthenticationIT {
 
   @Container
   private static final ElasticsearchContainer CONTAINER =
-      TestSupport.createDefaultContainer()
+      TestSupport.createDefeaultElasticsearchContainer()
           .withPassword(ELASTIC_PASSWORD)
           .withEnv("xpack.security.enabled", "true");
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -74,7 +74,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @TestInstance(Lifecycle.PER_CLASS)
 final class CamundaExporterIT {
   @Container
-  private static final ElasticsearchContainer CONTAINER = TestSupport.createDefaultContainer();
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefeaultElasticsearchContainer();
 
   private final ExporterConfiguration config = new ExporterConfiguration();
   private final ExporterTestController controller = new ExporterTestController();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -33,7 +33,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class ElasticsearchEngineClientIT {
   @Container
-  private static final ElasticsearchContainer CONTAINER = TestSupport.createDefaultContainer();
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefeaultElasticsearchContainer();
 
   private static ElasticsearchClient elsClient;
   private static ElasticsearchEngineClient elsEngineClient;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchSchemaManagerIT.java
@@ -34,7 +34,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers
 public class ElasticsearchSchemaManagerIT {
   @Container
-  private static final ElasticsearchContainer CONTAINER = TestSupport.createDefaultContainer();
+  private static final ElasticsearchContainer CONTAINER =
+      TestSupport.createDefeaultElasticsearchContainer();
 
   private static final ExporterConfiguration CONFIG = new ExporterConfiguration();
   private static ElasticsearchClient elsClient;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
@@ -218,4 +218,24 @@ public class OpensearchEngineClientIT {
                 .typeDefinition(Map.of("type", "keyword"))
                 .build());
   }
+
+  @Test
+  void shouldUpdateSettingsWithPutSettingsRequest() throws IOException {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
+
+    opensearchEngineClient.createIndex(index, new IndexSettings());
+
+    // when
+    final Map<String, String> newSettings = Map.of("index.refresh_interval", "5s");
+    opensearchEngineClient.putSettings(List.of(index), newSettings);
+
+    // then
+    final var indices = openSearchClient.indices().get(req -> req.index("index_name"));
+
+    assertThat(indices.result().size()).isEqualTo(1);
+    assertThat(indices.result().get("index_name").settings().index().refreshInterval().time())
+        .isEqualTo("5s");
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.exceptions.OpensearchExporterException;
+import io.camunda.exporter.utils.TestSupport;
+import io.camunda.search.connect.os.OpensearchConnector;
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public class OpensearchEngineClientIT {
+  @Container
+  private static final OpensearchContainer<?> CONTAINER =
+      TestSupport.createDefaultOpensearchContainer();
+
+  private static OpenSearchClient openSearchClient;
+  private static OpensearchEngineClient opensearchEngineClient;
+
+  @BeforeAll
+  public static void init() {
+    final var config = new ExporterConfiguration();
+    config.getConnect().setUrl(CONTAINER.getHttpHostAddress());
+    openSearchClient = new OpensearchConnector(config.getConnect()).createClient();
+
+    opensearchEngineClient = new OpensearchEngineClient(openSearchClient);
+  }
+
+  @BeforeEach
+  public void refresh() throws IOException {
+    openSearchClient.indices().delete(req -> req.index("*"));
+    openSearchClient.indices().deleteIndexTemplate(req -> req.name("*"));
+  }
+
+  @Test
+  void shouldCreateIndexNormally() throws IOException {
+    // given
+    final var descriptor =
+        SchemaTestUtil.mockIndex("qualified_name", "alias", "index_name", "/mappings.json");
+
+    // when
+    final var indexSettings = new IndexSettings();
+    opensearchEngineClient.createIndex(descriptor, indexSettings);
+
+    // then
+    final var index =
+        openSearchClient.indices().get(req -> req.index("qualified_name")).get("qualified_name");
+
+    SchemaTestUtil.validateMappings(index.mappings(), "/mappings.json");
+
+    assertThat(index.aliases().keySet()).isEqualTo(Set.of("alias"));
+    assertThat(index.settings().index().numberOfReplicas())
+        .isEqualTo(indexSettings.getNumberOfReplicas().toString());
+    assertThat(index.settings().index().numberOfShards())
+        .isEqualTo(indexSettings.getNumberOfShards().toString());
+  }
+
+  @Test
+  void shouldCreateIndexTemplate() throws IOException {
+    // given
+    final var template =
+        SchemaTestUtil.mockIndexTemplate(
+            "index_name",
+            "index_pattern.*",
+            "alias",
+            List.of(),
+            "template_name",
+            "/mappings-and-settings.json");
+
+    // when
+    final var expectedIndexSettings = new IndexSettings();
+    opensearchEngineClient.createIndexTemplate(template, expectedIndexSettings, false);
+
+    // then
+    final var createdTemplate =
+        openSearchClient
+            .indices()
+            .getIndexTemplate(req -> req.name("template_name"))
+            .indexTemplates();
+
+    assertThat(createdTemplate.size()).isEqualTo(1);
+
+    final var indexSettings =
+        createdTemplate
+            .getFirst()
+            .indexTemplate()
+            .template()
+            .settings()
+            .get("index")
+            .toJson()
+            .asJsonObject();
+
+    assertThat(indexSettings.getString("number_of_shards"))
+        .isEqualTo(expectedIndexSettings.getNumberOfShards().toString());
+    assertThat(indexSettings.getString("number_of_replicas"))
+        .isEqualTo(expectedIndexSettings.getNumberOfReplicas().toString());
+    assertThat(indexSettings.getString("refresh_interval")).isEqualTo("2s");
+
+    SchemaTestUtil.validateMappings(
+        createdTemplate.getFirst().indexTemplate().template().mappings(),
+        template.getMappingsClasspathFilename());
+  }
+
+  @Test
+  void shouldFailIndexTemplateUpdateIfCreateTrue() {
+    // given
+    final var template =
+        SchemaTestUtil.mockIndexTemplate(
+            "index_name", "index_pattern.*", "alias", List.of(), "template_name", "/mappings.json");
+    opensearchEngineClient.createIndexTemplate(template, new IndexSettings(), false);
+
+    // when
+    // then
+    assertThatThrownBy(
+            () -> opensearchEngineClient.createIndexTemplate(template, new IndexSettings(), true))
+        .isInstanceOf(OpensearchExporterException.class)
+        .hasMessageContaining("Cannot update template [template_name] as create = true");
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
@@ -164,4 +164,58 @@ public class OpensearchEngineClientIT {
     assertThat(properties.get("email").isKeyword()).isTrue();
     assertThat(properties.get("age").isInteger()).isTrue();
   }
+
+  @Test
+  void shouldRetrieveAllIndexMappingsWithImplementationAgnosticReturnType() {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
+
+    opensearchEngineClient.createIndex(index, new IndexSettings());
+
+    // when
+    final var mappings = opensearchEngineClient.getMappings("*", MappingSource.INDEX);
+
+    // then
+    assertThat(mappings.size()).isEqualTo(1);
+    assertThat(mappings.get("index_qualified_name").dynamic()).isEqualTo("strict");
+
+    assertThat(mappings.get("index_qualified_name").properties())
+        .containsExactlyInAnyOrder(
+            new IndexMappingProperty.Builder()
+                .name("hello")
+                .typeDefinition(Map.of("type", "text"))
+                .build(),
+            new IndexMappingProperty.Builder()
+                .name("world")
+                .typeDefinition(Map.of("type", "keyword"))
+                .build());
+  }
+
+  @Test
+  void shouldRetrieveAllIndexTemplateMappingsWithImplementationAgnosticReturnType() {
+    // given
+    final var template =
+        SchemaTestUtil.mockIndexTemplate(
+            "index_name", "index_pattern.*", "alias", List.of(), "template_name", "/mappings.json");
+
+    opensearchEngineClient.createIndexTemplate(template, new IndexSettings(), true);
+
+    // when
+    final var templateMappings =
+        opensearchEngineClient.getMappings("template_name", MappingSource.INDEX_TEMPLATE);
+
+    // then
+    assertThat(templateMappings.size()).isEqualTo(1);
+    assertThat(templateMappings.get("template_name").properties())
+        .containsExactlyInAnyOrder(
+            new IndexMappingProperty.Builder()
+                .name("hello")
+                .typeDefinition(Map.of("type", "text"))
+                .build(),
+            new IndexMappingProperty.Builder()
+                .name("world")
+                .typeDefinition(Map.of("type", "keyword"))
+                .build());
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
@@ -62,18 +62,37 @@ public final class SchemaTestUtil {
   @SuppressWarnings("unchecked")
   public static void validateMappings(final TypeMapping mapping, final String fileName)
       throws IOException {
+    final var propertiesMap = getFileProperties(fileName);
+
+    assertThat(mapping.properties().size()).isEqualTo(propertiesMap.size());
+    propertiesMap.forEach(
+        (key, value) ->
+            assertThat(mapping.properties().get(key)._kind().jsonValue())
+                .isEqualTo(value.get("type")));
+  }
+
+  public static void validateMappings(
+      final org.opensearch.client.opensearch._types.mapping.TypeMapping mapping,
+      final String fileName)
+      throws IOException {
+
+    final var propertiesMap = getFileProperties(fileName);
+
+    assertThat(mapping.properties().size()).isEqualTo(propertiesMap.size());
+    propertiesMap.forEach(
+        (key, value) ->
+            assertThat(mapping.properties().get(key)._kind().jsonValue())
+                .isEqualTo(value.get("type")));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<String, Map<String, Object>> getFileProperties(final String fileName)
+      throws IOException {
     try (final var expectedMappings = SchemaTestUtil.class.getResourceAsStream(fileName)) {
       final var jsonMap =
           MAPPER.readValue(
               expectedMappings, new TypeReference<Map<String, Map<String, Object>>>() {});
-      final var propertiesMap =
-          (Map<String, Map<String, Object>>) jsonMap.get("mappings").get("properties");
-
-      assertThat(mapping.properties().size()).isEqualTo(propertiesMap.size());
-      propertiesMap.forEach(
-          (key, value) ->
-              assertThat(mapping.properties().get(key)._kind().jsonValue())
-                  .isEqualTo(value.get("type")));
+      return (Map<String, Map<String, Object>>) jsonMap.get("mappings").get("properties");
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
@@ -36,7 +36,7 @@ public final class TestSupport {
   @SuppressWarnings("resource")
   public static OpensearchContainer<?> createDefaultOpensearchContainer() {
     return new OpensearchContainer<>(OPENSEARCH_IMAGE)
-        .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912")
+        .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms512m -Xmx512m -XX:MaxDirectMemorySize=536870912")
         .withEnv("action.auto_create_index", "true");
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/TestSupport.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.utils;
 
 import java.time.Duration;
 import org.elasticsearch.client.RestClient;
+import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -18,7 +19,26 @@ public final class TestSupport {
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
           .withTag(RestClient.class.getPackage().getImplementationVersion());
 
+  private static final DockerImageName OPENSEARCH_IMAGE =
+      DockerImageName.parse("opensearchproject/opensearch").withTag("2.17.1");
+
   private TestSupport() {}
+
+  /**
+   * Returns an OpenSearch container pointing at the same version as the {@link
+   * org.opensearch.client.RestClient}.
+   *
+   * <p>The container is configured to use 512m of heap and 512m of direct memory. This is required
+   * because OpenSearch, by default, will grab all the RAM available otherwise.
+   *
+   * <p>Additionally, security is explicitly disabled to avoid having tons of warning printed out.
+   */
+  @SuppressWarnings("resource")
+  public static OpensearchContainer<?> createDefaultOpensearchContainer() {
+    return new OpensearchContainer<>(OPENSEARCH_IMAGE)
+        .withEnv("OPENSEARCH_JAVA_OPTS", "-Xms256m -Xmx512m -XX:MaxDirectMemorySize=536870912")
+        .withEnv("action.auto_create_index", "true");
+  }
 
   /**
    * Returns an Elasticsearch container pointing at the same version as the {@link RestClient}.
@@ -29,7 +49,7 @@ public final class TestSupport {
    * <p>Additionally, security is explicitly disabled to avoid having tons of warning printed out.
    */
   @SuppressWarnings("resource")
-  public static ElasticsearchContainer createDefaultContainer() {
+  public static ElasticsearchContainer createDefeaultElasticsearchContainer() {
     return new ElasticsearchContainer(ELASTIC_IMAGE)
         // use JVM option files to avoid overwriting default options set by the ES container class
         .withClasspathResourceMapping(


### PR DESCRIPTION
**Description**

The schema manager needs to support Opensearch, and this will involve implementing the `SearchEngineClient` interface which contains all the actions required to create/update schema resources.

**Success Criteria:**
- [x] Can create indices in Opensearch given an index descriptor and settings.
- [x] Can create/update index templates given a descriptor and settings.
- [x] Can update mappings of indices and index templates.
- [x] Can get mapping of indices and templates.
- [x] Can update settings of indices/templates
- [x] Can create index state management resources (Opensearch equivalent of Elasticsearch index lifecycle management).

closes #23163 
