### PR TITLE
deps: using zeebe 8.6.3 version for docker-compose and e2e tests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -50,7 +50,7 @@ jobs:
           - 9200:9200
           - 9300:9300
       zeebe:
-        image: camunda/zeebe:SNAPSHOT
+        image: camunda/zeebe:8.6.3
         env:
           JAVA_TOOL_OPTIONS: "-Xms512m -Xmx512m"
           ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   zeebe:
     container_name: zeebe
-    image: camunda/zeebe:SNAPSHOT
+    image: camunda/zeebe:8.6.3
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -46,7 +46,7 @@ services:
 
   zeebe-e2e:
     container_name: zeebe-e2e
-    image: camunda/zeebe:SNAPSHOT
+    image: camunda/zeebe:8.6.3
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -104,7 +104,7 @@ services:
       - ./os-snapshots:/usr/local/os-snapshots
   zeebe-opensearch:
     container_name: zeebe-opensearch
-    image: camunda/zeebe:SNAPSHOT
+    image: camunda/zeebe:8.6.3
     environment:
       - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
       - ZEEBE_HOST=${ZEEBE_HOST:-}
@@ -119,7 +119,7 @@ services:
       - 8000:8000
     restart: always
   operate-opensearch:
-    image: camunda/operate:8.5.7
+    image: camunda/operate:SNAPSHOT
     container_name: operate-opensearch
     environment:
       - SERVER_PORT=8080


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Tests may fail for operate version 8.6 if the zeebe version for e2e tests is the 8.7 SNAPSHOT due to the disparity between minor versions.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
