### PR TITLE
feat: store commitIndex in raft MetaStore

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/PriorityElectionTimer.java
@@ -77,6 +77,7 @@ public class PriorityElectionTimer implements ElectionTimer {
                 log.debug("Failed to poll a majority of the cluster in {}", pollTimeout);
                 reset();
               });
+      log.trace("Node triggering an election");
       triggerElection.run();
     } else {
       log.debug(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -243,20 +243,18 @@ public final class FollowerRole extends ActiveRole {
       return;
     }
 
-    if (raft.getFirstCommitIndex() == 0 || raft.getState() == RaftContext.State.READY) {
-      final var timeSinceLastHeartbeatMs = System.currentTimeMillis() - raft.getLastHeartbeat();
-      final var leader =
-          Optional.ofNullable(raft.getLeader())
-              .map(DefaultRaftMember::memberId)
-              .map(MemberId::id)
-              .orElse("a known leader");
+    final var timeSinceLastHeartbeatMs = System.currentTimeMillis() - raft.getLastHeartbeat();
+    final var leader =
+        Optional.ofNullable(raft.getLeader())
+            .map(DefaultRaftMember::memberId)
+            .map(MemberId::id)
+            .orElse("a known leader");
 
-      log.info("No heartbeat from {} since {}ms", leader, timeSinceLastHeartbeatMs);
-      raft.getRaftRoleMetrics().countHeartbeatMiss();
+    log.info("No heartbeat from {} since {}ms", leader, timeSinceLastHeartbeatMs);
+    raft.getRaftRoleMetrics().countHeartbeatMiss();
 
-      raft.setLeader(null);
-      sendPollRequests();
-    }
+    raft.setLeader(null);
+    sendPollRequests();
   }
 
   private void handlePollResponse(

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -710,8 +710,7 @@ public class PassiveRole extends InactiveRole {
     final long lastEntryIndex = request.prevLogIndex() + request.entries().size();
 
     // Ensure the commitIndex is not increased beyond the index of the last entry in the request.
-    final long commitIndex =
-        Math.max(raft.getCommitIndex(), Math.min(request.commitIndex(), lastEntryIndex));
+    final long commitIndex = Math.min(request.commitIndex(), lastEntryIndex);
 
     // Track the last log index while entries are appended.
     long lastLogIndex = request.prevLogIndex();

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStoreRecord.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/system/MetaStoreRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.storage.system;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Represents information stored in the MetaStore with "Meta" SBE message (see
+ * raft-entry-schema.xml)
+ */
+public record MetaStoreRecord(long term, long lastFlushedIndex, long commitIndex, String votedFor) {
+
+  public MetaStoreRecord {
+    checkArgument(term >= 0, "term must be >= 0, but was: %d", term);
+    checkArgument(
+        lastFlushedIndex >= -1,
+        "lastFlushedIndex term must be >= -1, but was: %d",
+        lastFlushedIndex);
+    checkArgument(commitIndex >= -1, "commitIndex must be >= -1 , but was: ", commitIndex);
+  }
+}

--- a/zeebe/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/zeebe/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.atomix.raft.storage.serializer" id="8" version="3"
+  package="io.atomix.raft.storage.serializer" id="8" version="4"
   semanticVersion="0.1.0" description="Raft Entry" byteOrder="littleEndian"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://fixprotocol.io/2016/sbe http://fixprotocol.io/2016/sbe/sbe.xsd">
@@ -81,6 +81,7 @@
   <sbe:message name="Meta" id="6">
     <field name="term" id="0" type="uint64"/>
     <field name="lastFlushedIndex" id="1" type="uint64"/>
+    <field name="commitIndex" id="3" type="uint64" sinceVersion="4"/>
     <data name="votedFor" id="2" type="varDataEncoding"/>
   </sbe:message>
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftCorruptedDataTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftServer.Role;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+public class RaftCorruptedDataTest {
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  @DisplayName(
+      "When nodes with corrupted data forms a quorum, the remaining one should not delete its files")
+  public void upToDateFollowerShouldNotLoseDataWhenQuorumExperienceCorruption() throws Exception {
+    // given
+    // nodes 0, 1 experience corruption: all data is lost
+    final var servers = raftRule.getServers().toArray(RaftServer[]::new);
+    // name == memberId since the name is not specified
+    final var node0 = MemberId.from(servers[0].name());
+    final var node1 = MemberId.from(servers[1].name());
+    final var node2 = MemberId.from(servers[2].name());
+
+    raftRule.appendEntries(100);
+    raftRule.appendEntries(1);
+    Awaitility.await("commitIndex is > 0 on all nodes")
+        .until(() -> Arrays.stream(servers).allMatch(s -> s.getContext().getCommitIndex() >= 100));
+
+    final var commitIndex = servers[2].getContext().getCommitIndex();
+
+    for (final RaftServer server : servers) {
+      raftRule.shutdownServer(server);
+    }
+
+    raftRule.triggerDataLossOnNode(node0.id());
+    raftRule.triggerDataLossOnNode(node1.id());
+
+    // after shutdown the servers must be created from scratch with the same server name.
+    final var server1 = raftRule.createServer(node0);
+    final var server2 = raftRule.createServer(node1);
+
+    // bootstrap the nodes with data loss
+    CompletableFuture.allOf(
+            server1.bootstrap(node0, node1, node2), server2.bootstrap(node0, node1, node2))
+        .join();
+
+    // wait for the two corrupted nodes to form quorum
+    Awaitility.await("corrupted nodes form a quorum")
+        .until(() -> server1.isLeader() || server2.isLeader());
+    // when
+    // the node with up-to-date log joins the cluster
+    final var server3 = raftRule.createServer(node2);
+
+    // then
+    // node3 fails to boostrap, because it detects the commitIndex mismatch
+    assertThatThrownBy(() -> server3.bootstrap(node0, node1, node2).get(2, TimeUnit.SECONDS))
+        .isExactlyInstanceOf(TimeoutException.class);
+
+    // node does not become follower
+    Awaitility.await("node becomes INACTIVE").until(() -> server3.getRole().equals(Role.INACTIVE));
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSingleNodeTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSingleNodeTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import io.atomix.raft.impl.RaftContext.State;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RaftSingleNodeTest {
+  @Rule public final RaftRule rule = RaftRule.withBootstrappedNodes(1);
+
+  @Test
+  public void singleNodeClusterShouldBecomeReadyOnRestart() throws Exception {
+    final var server = rule.getServers().iterator().next();
+    final var name = server.name();
+    Awaitility.await("Node should become ready")
+        .until(() -> server.getContext().getState() == State.READY);
+    rule.shutdownLeader();
+    rule.joinCluster(name);
+
+    Awaitility.await("Node should become ready")
+        .until(() -> server.getContext().getState() == State.READY);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -185,11 +185,13 @@ class MetaStoreTest {
       // when
       metaStore.storeTerm(1L);
       metaStore.storeLastFlushedIndex(2L);
+      metaStore.storeCommitIndex(12);
       metaStore.storeVote(MemberId.from("a"));
 
       // then
       assertThat(metaStore.loadTerm()).isEqualTo(1L);
       assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(2L);
+      assertThat(metaStore.commitIndex()).isEqualTo(12);
       assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
     }
   }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -121,12 +121,15 @@ class MetaStoreTest {
     }
 
     @Test
-    void shouldLoadLatestTermAndVoteAfterRestart() throws IOException {
+    void shouldLoadLatestValuesAfterRestart() throws IOException {
       //  given
       metaStore.storeTerm(2L);
-      metaStore.storeVote(MemberId.from("0"));
-      metaStore.storeTerm(3L);
+      metaStore.storeCommitIndex(1L);
       metaStore.storeVote(MemberId.from("1"));
+      metaStore.storeTerm(3L);
+      metaStore.storeCommitIndex(2L);
+      // different length than previous value
+      metaStore.storeVote(MemberId.from("11029830219830192831"));
 
       // when
       metaStore.close();
@@ -134,7 +137,8 @@ class MetaStoreTest {
 
       // then
       assertThat(metaStore.loadTerm()).isEqualTo(3L);
-      assertThat(metaStore.loadVote().id()).isEqualTo("1");
+      assertThat(metaStore.commitIndex()).isEqualTo(2L);
+      assertThat(metaStore.loadVote().id()).isEqualTo("11029830219830192831");
     }
 
     @Test
@@ -186,13 +190,13 @@ class MetaStoreTest {
       metaStore.storeTerm(1L);
       metaStore.storeLastFlushedIndex(2L);
       metaStore.storeCommitIndex(12);
-      metaStore.storeVote(MemberId.from("a"));
+      metaStore.storeVote(MemberId.from("a1029381092831"));
 
       // then
       assertThat(metaStore.loadTerm()).isEqualTo(1L);
       assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(2L);
       assertThat(metaStore.commitIndex()).isEqualTo(12);
-      assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
+      assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a1029381092831"));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/RebalancingEndpointIT.java
@@ -23,10 +23,14 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ZeebeIntegration
 @AutoCloseResources
 final class RebalancingEndpointIT {
+  private static final Logger LOG = LoggerFactory.getLogger(RebalancingEndpointIT.class);
+
   @TestZeebe
   private final TestCluster cluster =
       TestCluster.builder()
@@ -70,7 +74,9 @@ final class RebalancingEndpointIT {
     if (hasGoodLeaderDistribution()) {
       final var brokerId = MemberId.from("1");
       final var stoppedBroker = cluster.brokers().get(brokerId).stop();
+      LOG.debug("Broker stopped");
       waitForBadLeaderDistribution();
+      LOG.debug("Bad distribution of partition: waiting for the broker to be ready");
       stoppedBroker.start().await(TestHealthProbe.READY);
 
       // wait until the node has rejoined the cluster before triggering rebalancing, otherwise it


### PR DESCRIPTION
## Description
The raft commitIndex is saved in the MetaStore, when lastFlushedIndex is written to disk.

A new version of the SBE schema in raft-entry-schema.xml has been created to accomodate a new field.
On startup the MetaStore reads the file and rewrites it using the current version of the message to be able to update it in place.

## Related issues
closes #13790