### PR TITLE
Always send add permissions command to deployment partition

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -23,6 +24,7 @@ public class BrokerAuthorizationPatchRequest extends BrokerExecuteCommand<Author
 
   public BrokerAuthorizationPatchRequest() {
     super(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
   public BrokerAuthorizationPatchRequest setOwnerKey(final Long ownerKey) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The deployment partition (partition 1) should receive all the commands that need to be distributed. This way we can guarantee the latest state is available on this partition and the order of command processing is guaranteed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23554 
