### PR TITLE
Move Incident Exporter handler to main

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
@@ -10,9 +10,9 @@ package io.camunda.it.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.UUID;

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
@@ -10,9 +10,9 @@ package io.camunda.it.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.it.utils.CamundaExporterITInvocationProvider;
-import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import java.util.UUID;

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.webapps.schema.entities.operate.ErrorType;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.function.Consumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CamundaExporterITInvocationProvider.class)
+public class IncidentExporterIT {
+
+  @TestTemplate
+  void shouldExportIncident(final TestStandaloneBroker testBroker) {
+    final var client = testBroker.newClientBuilder().build();
+
+    final var resource =
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("process/error-end-event.bpmn")
+            .send()
+            .join();
+
+    final var processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(resource.getProcesses().getFirst().getBpmnProcessId())
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    waitForIncident(client, f -> f.processInstanceKey(processInstanceKey));
+
+    final var incidents =
+        client
+            .newIncidentQuery()
+            .filter(f -> f.processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(incidents).isNotEmpty();
+    assertThat(incidents.size()).isEqualTo(1);
+    assertThat(incidents.getFirst().getErrorType())
+        .isEqualTo(ErrorType.UNHANDLED_ERROR_EVENT.name());
+    assertThat(incidents.getFirst().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @TestTemplate
+  void shouldExportUnhandledErrorIncident(final TestStandaloneBroker testBroker) {
+    final var client = testBroker.newClientBuilder().build();
+
+    final var resource =
+        client
+            .newDeployResourceCommand()
+            .addResourceFromClasspath("process/errorProcess.bpmn")
+            .send()
+            .join();
+
+    final var processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(resource.getProcesses().getFirst().getBpmnProcessId())
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    throwIncident(client, "errorTask", "this-errorcode-does-not-exists", "Process error");
+
+    waitForIncident(client, f -> f.processInstanceKey(processInstanceKey));
+
+    final var incidents =
+        client
+            .newIncidentQuery()
+            .filter(f -> f.processInstanceKey(processInstanceKey))
+            .send()
+            .join()
+            .items();
+
+    // then
+    assertThat(incidents).isNotEmpty();
+    assertThat(incidents.size()).isEqualTo(1);
+    assertThat(incidents.getFirst().getErrorType())
+        .isEqualTo(ErrorType.UNHANDLED_ERROR_EVENT.name());
+    assertThat(incidents.getFirst().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  private void waitForIncident(final ZeebeClient client, final Consumer<IncidentFilter> filterFn) {
+    Awaitility.await()
+        .ignoreExceptions()
+        .timeout(Duration.ofSeconds(30))
+        .until(() -> !client.newIncidentQuery().filter(filterFn).send().join().items().isEmpty());
+  }
+
+  private void throwIncident(
+      final ZeebeClient client,
+      final String jobType,
+      final String errorCode,
+      final String errorMessage) {
+    client
+        .newActivateJobsCommand()
+        .jobType(jobType)
+        .maxJobsToActivate(1)
+        .workerName(UUID.randomUUID().toString())
+        .send()
+        .join()
+        .getJobs()
+        .forEach(
+            j -> {
+              final var inc =
+                  client
+                      .newThrowErrorCommand(j.getKey())
+                      .errorCode(errorCode)
+                      .errorMessage(errorMessage)
+                      .send()
+                      .join();
+            });
+  }
+}

--- a/qa/integration-tests/src/test/resources/process/error-end-event.bpmn
+++ b/qa/integration-tests/src/test/resources/process/error-end-event.bpmn
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0j0fp4a" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="error-end-process" isExecutable="true">
+    <bpmn:startEvent id="start">
+      <bpmn:outgoing>SequenceFlow_05ep9w5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>SequenceFlow_05ep9w5</bpmn:incoming>
+      <bpmn:errorEventDefinition errorRef="Error_1" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_05ep9w5" sourceRef="start" targetRef="end" />
+  </bpmn:process>
+  <bpmn:error id="Error_1" name="errorEnd" errorCode="end" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="error-end-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_13vjvo9_di" bpmnElement="end">
+        <dc:Bounds x="252" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_05ep9w5_di" bpmnElement="SequenceFlow_05ep9w5">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="252" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/qa/integration-tests/src/test/resources/process/errorProcess.bpmn
+++ b/qa/integration-tests/src/test/resources/process/errorProcess.bpmn
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_02hgizz" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.8.0">
+  <bpmn:process id="errorProcess" name="Error Process" isExecutable="true">
+    <bpmn:startEvent id="startEvent" name="Start">
+      <bpmn:outgoing>SequenceFlow_1i0srtx</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1i0srtx" sourceRef="startEvent" targetRef="serviceTask" />
+    <bpmn:endEvent id="endEvent" name="End">
+      <bpmn:incoming>SequenceFlow_1jg1gnc</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1jg1gnc" sourceRef="serviceTask" targetRef="endEvent" />
+    <bpmn:serviceTask id="serviceTask" name="Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="errorTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1i0srtx</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1jg1gnc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="errorBoundaryEvent" name="Error Boundary" attachedToRef="serviceTask">
+      <bpmn:outgoing>SequenceFlow_1sch794</bpmn:outgoing>
+      <bpmn:errorEventDefinition errorRef="Error_12y8yzc" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="boundaryEndEvent" name="Boundary End">
+      <bpmn:incoming>SequenceFlow_1sch794</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sch794" sourceRef="errorBoundaryEvent" targetRef="boundaryEndEvent" />
+    <bpmn:subProcess id="errorSubProcess" name="Error Sub Process" triggeredByEvent="true">
+      <bpmn:startEvent id="subProcessStartEvent" name="Sub Process Start">
+        <bpmn:outgoing>SequenceFlow_1jhttdc</bpmn:outgoing>
+        <bpmn:errorEventDefinition errorRef="Error_1ibaxgv" />
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="SequenceFlow_1jhttdc" sourceRef="subProcessStartEvent" targetRef="subProcessEndEvent" />
+      <bpmn:endEvent id="subProcessEndEvent" name="Sub Process End">
+        <bpmn:incoming>SequenceFlow_1jhttdc</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmn:error id="Error_12y8yzc" name="boundaryError" errorCode="boundary" />
+  <bpmn:error id="Error_1ibaxgv" name="subProcessError" errorCode="subProcess" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="errorProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="142" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i0srtx_di" bpmnElement="SequenceFlow_1i0srtx">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_1niethi_di" bpmnElement="endEvent">
+        <dc:Bounds x="412" y="99" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="420" y="142" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jg1gnc_di" bpmnElement="SequenceFlow_1jg1gnc">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="412" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0fvkxt5_di" bpmnElement="serviceTask">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_148d2nx_di" bpmnElement="errorBoundaryEvent">
+        <dc:Bounds x="282" y="139" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="312" y="182" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0e1q20q_di" bpmnElement="boundaryEndEvent">
+        <dc:Bounds x="372" y="222" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="355" y="265" width="70" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sch794_di" bpmnElement="SequenceFlow_1sch794">
+        <di:waypoint x="300" y="175" />
+        <di:waypoint x="300" y="240" />
+        <di:waypoint x="372" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="SubProcess_0xvpj1r_di" bpmnElement="errorSubProcess" isExpanded="true">
+        <dc:Bounds x="170" y="330" width="330" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_17b52dz_di" bpmnElement="subProcessStartEvent">
+        <dc:Bounds x="242" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="215" y="455" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jhttdc_di" bpmnElement="SequenceFlow_1jhttdc">
+        <di:waypoint x="278" y="430" />
+        <di:waypoint x="402" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0qjdr1l_di" bpmnElement="subProcessEndEvent">
+        <dc:Bounds x="402" y="412" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="378" y="455" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
-import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.handlers.AuthorizationRecordValueExportHandler;
 import io.camunda.exporter.handlers.DecisionHandler;
 import io.camunda.exporter.handlers.DecisionRequirementsHandler;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.IncidentHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.UserRecordValueExportHandler;
@@ -24,6 +25,7 @@ import io.camunda.webapps.schema.descriptors.operate.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
@@ -60,7 +62,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             VariableTemplate.class,
             new VariableTemplate(operateIndexPrefix, isElasticsearch),
             PostImporterQueueTemplate.class,
-            new PostImporterQueueTemplate(operateIndexPrefix, isElasticsearch));
+            new PostImporterQueueTemplate(operateIndexPrefix, isElasticsearch),
+            IncidentTemplate.class,
+            new IncidentTemplate(operateIndexPrefix, isElasticsearch));
 
     indexDescriptorsMap =
         Map.of(
@@ -91,7 +95,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new PostImporterQueueFromIncidentHandler(
                 templateDescriptorsMap
                     .get(PostImporterQueueTemplate.class)
-                    .getFullQualifiedName()));
+                    .getFullQualifiedName()),
+            new IncidentHandler(
+                templateDescriptorsMap.get(IncidentTemplate.class).getFullQualifiedName(), false));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -93,9 +93,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new DecisionRequirementsHandler(
                 indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
             new PostImporterQueueFromIncidentHandler(
-                templateDescriptorsMap
-                    .get(PostImporterQueueTemplate.class)
-                    .getFullQualifiedName()),
+                templateDescriptorsMap.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
             new IncidentHandler(
                 templateDescriptorsMap.get(IncidentTemplate.class).getFullQualifiedName(), false));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/IncidentHandler.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate.*;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.operate.ErrorType;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class IncidentHandler implements ExportHandler<IncidentEntity, IncidentRecordValue> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(IncidentHandler.class);
+  private final Map<String, Record<IncidentRecordValue>> recordsMap = new HashMap<>();
+  private final String indexName;
+  private final boolean concurrencyMode;
+
+  public IncidentHandler(final String indexName, final boolean concurrencyMode) {
+    this.indexName = indexName;
+    this.concurrencyMode = concurrencyMode;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.INCIDENT;
+  }
+
+  @Override
+  public Class<IncidentEntity> getEntityType() {
+    return IncidentEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<IncidentRecordValue> record) {
+    final String intentStr = record.getIntent().name();
+    return !intentStr.equals(IncidentIntent.RESOLVED.toString());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<IncidentRecordValue> record) {
+    return List.of(ExporterUtil.toStringOrNull(record.getKey()));
+  }
+
+  @Override
+  public IncidentEntity createNewEntity(final String id) {
+    return new IncidentEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<IncidentRecordValue> record, final IncidentEntity entity) {
+    final IncidentRecordValue recordValue = record.getValue();
+    final long incidentKey = record.getKey();
+    entity
+        .setId(ExporterUtil.toStringOrNull(incidentKey))
+        .setKey(incidentKey)
+        .setPartitionId(record.getPartitionId())
+        .setPosition(record.getPosition());
+    if (recordValue.getJobKey() > 0) {
+      entity.setJobKey(recordValue.getJobKey());
+    }
+    if (recordValue.getProcessInstanceKey() > 0) {
+      entity.setProcessInstanceKey(recordValue.getProcessInstanceKey());
+    }
+    if (recordValue.getProcessDefinitionKey() > 0) {
+      entity.setProcessDefinitionKey(recordValue.getProcessDefinitionKey());
+    }
+    entity.setBpmnProcessId(recordValue.getBpmnProcessId());
+    final String errorMessage = ExporterUtil.trimWhitespace(recordValue.getErrorMessage());
+    entity
+        .setErrorMessage(errorMessage)
+        .setErrorType(
+            ErrorType.fromZeebeErrorType(
+                recordValue.getErrorType() == null ? null : recordValue.getErrorType().name()))
+        .setFlowNodeId(recordValue.getElementId());
+    if (recordValue.getElementInstanceKey() > 0) {
+      entity.setFlowNodeInstanceKey(recordValue.getElementInstanceKey());
+    }
+    entity
+        .setState(IncidentState.PENDING)
+        .setCreationTime(
+            OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC))
+        .setTenantId(ExporterUtil.tenantOrDefault(recordValue.getTenantId()));
+
+    recordsMap.put(entity.getId(), record);
+  }
+
+  @Override
+  public void flush(final IncidentEntity entity, final BatchRequest batchRequest) {
+    final String id = entity.getId();
+    final Record<IncidentRecordValue> record = recordsMap.get(id);
+    final String intentStr = (record == null) ? null : record.getIntent().name();
+    if (intentStr == null) {
+      LOGGER.warn("Intent is null for incident: id {}", id);
+    }
+    final Map<String, Object> updateFields = getUpdateFieldsMapByIntent(intentStr, entity);
+    updateFields.put(POSITION, entity.getPosition());
+    if (concurrencyMode) {
+      batchRequest.upsertWithScript(
+          indexName, String.valueOf(entity.getKey()), entity, getScript(), updateFields);
+    } else {
+      batchRequest.upsert(indexName, String.valueOf(entity.getKey()), entity, updateFields);
+    }
+  }
+
+  private static Map<String, Object> getUpdateFieldsMapByIntent(
+      final String intent, final IncidentEntity incidentEntity) {
+    final Map<String, Object> updateFields = new HashMap<>();
+    if (Objects.equals(intent, IncidentIntent.MIGRATED.name())) {
+      updateFields.put(BPMN_PROCESS_ID, incidentEntity.getBpmnProcessId());
+      updateFields.put(PROCESS_DEFINITION_KEY, incidentEntity.getProcessDefinitionKey());
+      updateFields.put(FLOW_NODE_ID, incidentEntity.getFlowNodeId());
+    }
+    return updateFields;
+  }
+
+  private static String getScript() {
+    return String.format(
+        "if (ctx._source.%s == null || ctx._source.%s < params.%s) { "
+            + "ctx._source.%s = params.%s; " // position
+            + "if (params.%s != null) {"
+            + "   ctx._source.%s = params.%s; " // PROCESS_DEFINITION_KEY
+            + "   ctx._source.%s = params.%s; " // BPMN_PROCESS_ID
+            + "   ctx._source.%s = params.%s; " // FLOW_NODE_ID
+            + "}"
+            + "}",
+        POSITION,
+        POSITION,
+        POSITION,
+        POSITION,
+        POSITION,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_DEFINITION_KEY,
+        BPMN_PROCESS_ID,
+        BPMN_PROCESS_ID,
+        FLOW_NODE_ID,
+        FLOW_NODE_ID);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/ExporterUtil.java
@@ -21,4 +21,16 @@ public final class ExporterUtil {
     }
     return tenantId;
   }
+
+  public static String toStringOrNull(final Object object) {
+    return toStringOrDefault(object, null);
+  }
+
+  public static String toStringOrDefault(final Object object, final String defaultString) {
+    return object == null ? defaultString : object.toString();
+  }
+
+  public static String trimWhitespace(final String str) {
+    return (str == null) ? null : str.strip();
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/IncidentHandlerTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor.POSITION;
+import static io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate.BPMN_PROCESS_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate.PROCESS_DEFINITION_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class IncidentHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-incident";
+  private final IncidentHandler underTest = new IncidentHandler(indexName, false);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.INCIDENT);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(IncidentEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(ProcessIntent.CREATED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecord() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final long expectedId = 123;
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withIntent(ProcessIntent.CREATED)
+                    .withValue(incidentRecordValue)
+                    .withKey(expectedId));
+
+    // when
+    final var idList = underTest.generateIds(incidentRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(expectedId));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final IncidentEntity inputEntity = new IncidentEntity();
+    inputEntity.setPosition(1L);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).upsert(indexName, "0", inputEntity, Map.of("position", 1L));
+  }
+
+  @Test
+  void shouldAddEntityOnFlushWithScript() {
+    // given
+    final IncidentEntity inputEntity = new IncidentEntity();
+    final var underTest = new IncidentHandler(indexName, true);
+    inputEntity.setPosition(1L);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsertWithScript(
+            indexName, "0", inputEntity, concurrencyScriptMock(), Map.of("position", 1L));
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long recordKey = 123L;
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withIntent(ProcessIntent.CREATED)
+                    .withValue(incidentRecordValue)
+                    .withKey(recordKey)
+                    .withPartitionId(2)
+                    .withPosition(100)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final IncidentEntity incidentEntity = new IncidentEntity();
+    underTest.updateEntity(incidentRecord, incidentEntity);
+
+    // then
+    assertThat(incidentEntity.getId()).isEqualTo(String.valueOf(recordKey));
+    assertThat(incidentEntity.getKey()).isEqualTo(123L);
+    assertThat(incidentEntity.getPartitionId()).isEqualTo(incidentRecord.getPartitionId());
+    assertThat(incidentEntity.getPosition()).isEqualTo(incidentRecord.getPosition());
+    assertThat(incidentEntity.getFlowNodeId()).isEqualTo(incidentRecordValue.getElementId());
+    assertThat(incidentEntity.getErrorMessage())
+        .isEqualTo(ExporterUtil.trimWhitespace(incidentRecordValue.getErrorMessage()));
+    assertThat(incidentEntity.getErrorType().name())
+        .isEqualTo(incidentRecordValue.getErrorType().name());
+    assertThat(incidentEntity.getBpmnProcessId()).isEqualTo(incidentRecordValue.getBpmnProcessId());
+    assertThat(incidentEntity.getProcessDefinitionKey())
+        .isEqualTo(incidentRecordValue.getProcessDefinitionKey());
+    assertThat(incidentEntity.getJobKey()).isEqualTo(incidentRecordValue.getJobKey());
+    assertThat(incidentEntity.getCreationTime())
+        .isEqualTo(
+            OffsetDateTime.ofInstant(
+                Instant.ofEpochMilli(incidentRecord.getTimestamp()), ZoneOffset.UTC));
+    assertThat(incidentEntity.getErrorMessage())
+        .isEqualTo(ExporterUtil.trimWhitespace(incidentRecordValue.getErrorMessage()));
+    assertThat(incidentEntity.getFlowNodeInstanceKey())
+        .isEqualTo(incidentRecordValue.getElementInstanceKey());
+    assertThat(incidentEntity.getErrorMessageHash())
+        .isEqualTo(incidentRecordValue.getErrorMessage().hashCode());
+  }
+
+  private String concurrencyScriptMock() {
+    return String.format(
+        "if (ctx._source.%s == null || ctx._source.%s < params.%s) { "
+            + "ctx._source.%s = params.%s; " // position
+            + "if (params.%s != null) {"
+            + "   ctx._source.%s = params.%s; " // PROCESS_DEFINITION_KEY
+            + "   ctx._source.%s = params.%s; " // BPMN_PROCESS_ID
+            + "   ctx._source.%s = params.%s; " // FLOW_NODE_ID
+            + "}"
+            + "}",
+        POSITION,
+        POSITION,
+        POSITION,
+        POSITION,
+        POSITION,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_DEFINITION_KEY,
+        PROCESS_DEFINITION_KEY,
+        BPMN_PROCESS_ID,
+        BPMN_PROCESS_ID,
+        FLOW_NODE_ID,
+        FLOW_NODE_ID);
+  }
+}


### PR DESCRIPTION
## Description
Include the `operate-incident` index template handler in the new CamundaExporter.

p.s: looking for more IT tests from operate to include them, the base functionality is there

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
