### PR TITLE
docs: add c8run bug type when creating github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/c8run_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/c8run_bug_report.md
@@ -1,0 +1,40 @@
+---
+
+name: C8Run Issue
+about: Issue relating to camunda 8 run distribution
+title: ''
+labels: ['component/c8run']
+
+---
+
+**Describe the issue:**
+
+<!-- A clear and concise description of what the issue is. -->
+
+**Actual behavior:**
+
+<!-- A clear and concise description of what actually happens. -->
+
+**Expected behavior:**
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+**How to reproduce:**
+
+<!--
+Steps to reproduce the issue.
+
+If possible add a minimal reproducer code sample in a new repo/branch.
+-->
+
+**Logs:**
+
+<!-- If possible add the full logs related to the issue. -->
+
+**Environment:**
+
+**Please note: Without the following info, it's hard to resolve the issue and probably it will be closed.**
+
+- Platform: <!-- [e.g. Mac, Windows, Linux etc] -->
+- Architecture: <!-- [e.g. x86, ARM] -->
+- Version: <!-- [e.g. 8.x.x] -->

--- a/.github/ISSUE_TEMPLATE/c8run_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/c8run_bug_report.md
@@ -38,3 +38,4 @@ If possible add a minimal reproducer code sample in a new repo/branch.
 - Platform: <!-- [e.g. Mac, Windows, Linux etc] -->
 - Architecture: <!-- [e.g. x86, ARM] -->
 - Version: <!-- [e.g. 8.x.x] -->
+


### PR DESCRIPTION
## Description

This PR will create a GitHub Issue type for c8run.  This should make it easier to create github issues relating to the project, and help provide structure if any community members want to report bugs.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
