### PR TITLE
Identity/process user delete command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class UserDeleteProcessor implements DistributedTypedRecordProcessor<UserRecord> {
+  private final UserState userState;
+  private final AuthorizationState authorizationState;
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final CommandDistributionBehavior distributionBehavior;
+
+  public UserDeleteProcessor(
+      final KeyGenerator keyGenerator,
+      final ProcessingState state,
+      final Writers writers,
+      final CommandDistributionBehavior distributionBehavior) {
+    this.keyGenerator = keyGenerator;
+    userState = state.getUserState();
+    authorizationState = state.getAuthorizationState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    this.distributionBehavior = distributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<UserRecord> command) {
+    final long userKey = command.getValue().getUserKey();
+    final var persistedUser = userState.getUser(userKey);
+
+    if (persistedUser.isEmpty()) {
+      final var rejectionMessage =
+          "Expected to delete user with key %s, but a user with this key does not exist"
+              .formatted(command.getValue().getUserKey());
+
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, rejectionMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, rejectionMessage);
+      return;
+    }
+
+    stateWriter.appendFollowUpEvent(userKey, UserIntent.DELETED, command.getValue());
+    responseWriter.writeEventOnCommand(userKey, UserIntent.DELETED, command.getValue(), command);
+
+    final long distributionKey = keyGenerator.nextKey();
+    distributionBehavior
+        .withKey(distributionKey)
+        .inQueue(DistributionQueue.IDENTITY.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<UserRecord> command) {
+    stateWriter.appendFollowUpEvent(
+        command.getValue().getUserKey(), UserIntent.DELETED, command.getValue());
+
+    distributionBehavior.acknowledgeCommand(command);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -33,6 +33,10 @@ public class UserProcessors {
             ValueType.USER,
             UserIntent.UPDATE,
             new UserUpdateProcessor(keyGenerator, processingState, writers, distributionBehavior))
+        .onCommand(
+            ValueType.USER,
+            UserIntent.DELETE,
+            new UserDeleteProcessor(keyGenerator, processingState, writers, distributionBehavior))
         .withListener(new DefaultUserCreator(processingState, config));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -15,13 +16,17 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 
 public class UserDeletedApplier implements TypedEventApplier<UserIntent, UserRecord> {
   private final MutableUserState userState;
+  private final MutableAuthorizationState authorizationState;
 
   public UserDeletedApplier(final MutableProcessingState processingState) {
     userState = processingState.getUserState();
+    authorizationState = processingState.getAuthorizationState();
   }
 
   @Override
   public void applyState(final long key, final UserRecord value) {
+    authorizationState.deleteAuthorizationsByOwnerKeyPrefix(value.getUserKey());
+    authorizationState.deleteOwnerTypeByKey(value.getUserKey());
     userState.deleteUser(value.getUserKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -122,6 +122,16 @@ public class DbAuthorizationState implements AuthorizationState, MutableAuthoriz
   }
 
   @Override
+  public void deleteAuthorizationsByOwnerKeyPrefix(final long ownerKey) {
+    this.ownerKey.wrapLong(ownerKey);
+    resourceIdsByOwnerKeyResourceTypeAndPermissionColumnFamily.whileEqualPrefix(
+        this.ownerKey,
+        (compositeKey, resourceIdentifiers) -> {
+          resourceIdsByOwnerKeyResourceTypeAndPermissionColumnFamily.deleteExisting(compositeKey);
+        });
+  }
+
+  @Override
   public Set<String> getResourceIdentifiers(
       final Long ownerKey,
       final AuthorizationResourceType resourceType,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbAuthorizationState.java
@@ -132,6 +132,12 @@ public class DbAuthorizationState implements AuthorizationState, MutableAuthoriz
   }
 
   @Override
+  public void deleteOwnerTypeByKey(final long ownerKey) {
+    this.ownerKey.wrapLong(ownerKey);
+    ownerTypeByOwnerKeyColumnFamily.deleteExisting(this.ownerKey);
+  }
+
+  @Override
   public Set<String> getResourceIdentifiers(
       final Long ownerKey,
       final AuthorizationResourceType resourceType,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
@@ -40,4 +40,6 @@ public interface MutableAuthorizationState extends AuthorizationState {
    * @param ownerType the type of the owner
    */
   void insertOwnerTypeByKey(final long ownerKey, final AuthorizationOwnerType ownerType);
+
+  void deleteAuthorizationsByOwnerKeyPrefix(final long ownerKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableAuthorizationState.java
@@ -41,5 +41,17 @@ public interface MutableAuthorizationState extends AuthorizationState {
    */
   void insertOwnerTypeByKey(final long ownerKey, final AuthorizationOwnerType ownerType);
 
+  /**
+   * Removes all permissions for the provided ownerKey.
+   *
+   * @param ownerKey the key of the owner of the authorizations
+   */
   void deleteAuthorizationsByOwnerKeyPrefix(final long ownerKey);
+
+  /**
+   * Removes the owner type for the provided ownerKey.
+   *
+   * @param ownerKey the key of the owner
+   */
+  void deleteOwnerTypeByKey(final long ownerKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class DeleteUserMultiPartitionTest {
+  private static final int PARTITION_COUNT = 3;
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDistributeUserDeleteCommand() {
+    final var username = UUID.randomUUID().toString();
+
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    ENGINE
+        .user()
+        .deleteUser(userRecord.getKey())
+        .withUsername(username)
+        .withName("Bar Foo")
+        .withEmail("bar@foo.com")
+        .withPassword("password")
+        .delete();
+
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+        .withDistributionIntent(UserIntent.CREATE)
+        .await();
+
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the creation was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(UserIntent.DELETE, RecordType.COMMAND, 1),
+            tuple(UserIntent.DELETED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(UserIntent.DELETED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(UserIntent.DELETE, UserIntent.DELETED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    final var username = UUID.randomUUID().toString();
+    // when
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    ENGINE
+        .user()
+        .deleteUser(userRecord.getKey())
+        .withUsername(username)
+        .withName("Bar Foo")
+        .withEmail("bar@foo.com")
+        .withPassword("password")
+        .delete();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -16,7 +16,6 @@ import java.util.UUID;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.DisplayName;
 
 public class DeleteUserTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
@@ -25,7 +24,6 @@ public class DeleteUserTest {
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  @DisplayName("should delete a user if the user exists")
   @Test
   public void shouldDeleteAUser() {
     final var username = UUID.randomUUID().toString();
@@ -57,24 +55,13 @@ public class DeleteUserTest {
         .hasFieldOrPropertyWithValue("password", "Foo Bar");
   }
 
-  @DisplayName("should reject the command if user does not exist")
   @Test
   public void shouldRejectTheCommandIfUserDoesNotExist() {
-    final var username = UUID.randomUUID().toString();
-    final var userRecord =
-        ENGINE
-            .user()
-            .newUser(username)
-            .withName("Foo Bar")
-            .withEmail("foo@bar.com")
-            .withPassword("password")
-            .create();
-
     final var userNotFoundRejection =
         ENGINE
             .user()
-            .deleteUser(-1L)
-            .withUsername(userRecord.getValue().getUsername())
+            .deleteUser(1234L)
+            .withUsername("foobar")
             .withName("Bar Foo")
             .withEmail("foo@bar.blah")
             .withPassword("Foo Bar")
@@ -84,6 +71,6 @@ public class DeleteUserTest {
     assertThat(userNotFoundRejection)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to delete user with key -1, but a user with this key does not exist");
+            "Expected to delete user with key 1234, but a user with this key does not exist");
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.user;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.UUID;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+
+public class DeleteUserTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @DisplayName("should delete a user if the user exists")
+  @Test
+  public void shouldDeleteAUser() {
+    final var username = UUID.randomUUID().toString();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    final var deletedUser =
+        ENGINE
+            .user()
+            .deleteUser(userRecord.getKey())
+            .withUsername(userRecord.getValue().getUsername())
+            .withName("Bar Foo")
+            .withEmail("foo@bar.blah")
+            .withPassword("Foo Bar")
+            .delete()
+            .getValue();
+
+    assertThat(deletedUser)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("username", username)
+        .hasFieldOrPropertyWithValue("name", "Bar Foo")
+        .hasFieldOrPropertyWithValue("email", "foo@bar.blah")
+        .hasFieldOrPropertyWithValue("password", "Foo Bar");
+  }
+
+  @DisplayName("should reject the command if user does not exist")
+  @Test
+  public void shouldRejectTheCommandIfUserDoesNotExist() {
+    final var username = UUID.randomUUID().toString();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+
+    final var userNotFoundRejection =
+        ENGINE
+            .user()
+            .deleteUser(-1L)
+            .withUsername(userRecord.getValue().getUsername())
+            .withName("Bar Foo")
+            .withEmail("foo@bar.blah")
+            .withPassword("Foo Bar")
+            .expectRejection()
+            .delete();
+
+    assertThat(userNotFoundRejection)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to delete user with key -1, but a user with this key does not exist");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserDeletedApplierTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.CREATE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.DELETE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserDeletedApplierTest {
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableUserState userState;
+  private MutableAuthorizationState authorizationState;
+  private UserDeletedApplier userDeletedApplier;
+
+  @BeforeEach
+  public void setup() {
+    userState = processingState.getUserState();
+    authorizationState = processingState.getAuthorizationState();
+    userDeletedApplier = new UserDeletedApplier(processingState);
+  }
+
+  @Test
+  void shouldDeleteAuthorizationsForAUser() {
+    // given
+    final var userRecord =
+        new UserRecord()
+            .setUserKey(1L)
+            .setName("foo")
+            .setUsername("foobar")
+            .setEmail("foo@bar")
+            .setPassword("password");
+    userState.create(userRecord);
+
+    authorizationState.insertOwnerTypeByKey(userRecord.getUserKey(), AuthorizationOwnerType.USER);
+
+    authorizationState.createOrAddPermission(
+        userRecord.getUserKey(), PROCESS_DEFINITION, CREATE, List.of("process1", "process2"));
+
+    authorizationState.createOrAddPermission(
+        userRecord.getUserKey(), DECISION_DEFINITION, DELETE, List.of("definition1"));
+
+    final var ownerType = authorizationState.getOwnerType(userRecord.getUserKey());
+
+    assertThat(ownerType).isPresent();
+    assertThat(ownerType.get()).isEqualTo(AuthorizationOwnerType.USER);
+
+    assertThat(
+            authorizationState.getResourceIdentifiers(
+                userRecord.getUserKey(), PROCESS_DEFINITION, CREATE))
+        .hasSize(2)
+        .containsExactlyInAnyOrder("process1", "process2");
+
+    assertThat(
+            authorizationState.getResourceIdentifiers(
+                userRecord.getUserKey(), DECISION_DEFINITION, DELETE))
+        .hasSize(1)
+        .containsExactlyInAnyOrder("definition1");
+
+    // when
+    userDeletedApplier.applyState(userRecord.getUserKey(), userRecord);
+
+    // then
+    assertThat(authorizationState.getOwnerType(userRecord.getUserKey())).isEmpty();
+    assertThat(
+            authorizationState.getResourceIdentifiers(
+                userRecord.getUserKey(), PROCESS_DEFINITION, CREATE))
+        .hasSize(0);
+    assertThat(
+            authorizationState.getResourceIdentifiers(
+                userRecord.getUserKey(), DECISION_DEFINITION, DELETE))
+        .hasSize(0);
+    assertThat(userState.getUser(userRecord.getUserKey())).isEmpty();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserIntent.java
@@ -20,7 +20,8 @@ public enum UserIntent implements Intent {
   CREATED(1),
   UPDATE(2),
   UPDATED(3),
-  DELETED(4);
+  DELETE(4),
+  DELETED(5);
 
   private final short value;
 
@@ -56,6 +57,8 @@ public enum UserIntent implements Intent {
       case 3:
         return UPDATED;
       case 4:
+        return DELETE;
+      case 5:
         return DELETED;
       default:
         return UNKNOWN;


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR adds in the support for the user delete processor, I would like to highlight:

1. In this PR we don't emit an event for each authorization belonging to the user, instead we handle the changes to the authorization state within the user delete applier. This approach was suggested by @remcowesterhoud 
2. We also remove the owner type from the authorization state when the user is deleted to ensure the ownerType -> ownerKey mapping is clean.

## Related issues

closes #21679
