### PR TITLE
Move PostImportIncident Exporter handler to main

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -9,6 +9,7 @@ package io.camunda.exporter;
 
 import static io.camunda.zeebe.protocol.record.ValueType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
+import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
@@ -174,7 +175,7 @@ public class CamundaExporter implements Exporter {
   private record CamundaExporterRecordFilter() implements RecordFilter {
     // TODO include other value types to export
     private static final Set<ValueType> VALUE_TYPES_2_EXPORT =
-        Set.of(USER, AUTHORIZATION, DECISION, PROCESS_INSTANCE, VARIABLE);
+        Set.of(USER, AUTHORIZATION, DECISION, PROCESS_INSTANCE, VARIABLE, INCIDENT);
 
     @Override
     public boolean acceptType(final RecordType recordType) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -87,8 +87,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 templateDescriptorsMap.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new DecisionRequirementsHandler(
-                indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName(),
-                configuration.getIndex().getVariableSizeThreshold()),
+                indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
             new PostImporterQueueFromIncidentHandler(
                 templateDescriptorsMap
                     .get(PostImporterQueueTemplate.class)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.handlers.DecisionHandler;
 import io.camunda.exporter.handlers.DecisionRequirementsHandler;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.exporter.handlers.ListViewProcessInstanceFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.UserRecordValueExportHandler;
 import io.camunda.exporter.handlers.VariableHandler;
 import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
@@ -24,6 +25,7 @@ import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsI
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import java.util.Collection;
@@ -56,7 +58,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             ListViewTemplate.class,
             new ListViewTemplate(operateIndexPrefix, isElasticsearch),
             VariableTemplate.class,
-            new VariableTemplate(operateIndexPrefix, isElasticsearch));
+            new VariableTemplate(operateIndexPrefix, isElasticsearch),
+            PostImporterQueueTemplate.class,
+            new PostImporterQueueTemplate(operateIndexPrefix, isElasticsearch));
 
     indexDescriptorsMap =
         Map.of(
@@ -83,7 +87,12 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 templateDescriptorsMap.get(VariableTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new DecisionRequirementsHandler(
-                indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName()));
+                indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName(),
+                configuration.getIndex().getVariableSizeThreshold()),
+            new PostImporterQueueFromIncidentHandler(
+                templateDescriptorsMap
+                    .get(PostImporterQueueTemplate.class)
+                    .getFullQualifiedName()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterQueueEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public class PostImporterQueueFromIncidentHandler
+    implements ExportHandler<PostImporterQueueEntity, IncidentRecordValue> {
+
+  private final String indexName;
+
+  public PostImporterQueueFromIncidentHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.INCIDENT;
+  }
+
+  @Override
+  public Class<PostImporterQueueEntity> getEntityType() {
+    return PostImporterQueueEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<IncidentRecordValue> record) {
+    return true;
+  }
+
+  @Override
+  public List<String> generateIds(final Record<IncidentRecordValue> record) {
+    String intent = record.getIntent().name();
+    if (intent.equals(IncidentIntent.MIGRATED.toString())) {
+      intent = IncidentIntent.CREATED.toString();
+    }
+    return List.of(String.format("%d-%s", record.getKey(), intent));
+  }
+
+  @Override
+  public PostImporterQueueEntity createNewEntity(final String id) {
+    return new PostImporterQueueEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<IncidentRecordValue> record, final PostImporterQueueEntity entity) {
+    final IncidentRecordValue recordValue = record.getValue();
+    String intent = record.getIntent().name();
+    if (intent.equals(IncidentIntent.MIGRATED.toString())) {
+      intent = IncidentIntent.CREATED.toString();
+    }
+    entity
+        .setId(String.format("%d-%s", record.getKey(), intent))
+        .setActionType(PostImporterActionType.INCIDENT)
+        .setIntent(intent)
+        .setKey(record.getKey())
+        .setPosition(record.getPosition())
+        .setCreationTime(OffsetDateTime.now())
+        .setPartitionId(record.getPartitionId())
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey());
+  }
+
+  @Override
+  public void flush(final PostImporterQueueEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(indexName, entity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandler.java
@@ -44,8 +44,8 @@ public class PostImporterQueueFromIncidentHandler
   @Override
   public List<String> generateIds(final Record<IncidentRecordValue> record) {
     String intent = record.getIntent().name();
-    if (intent.equals(IncidentIntent.MIGRATED.toString())) {
-      intent = IncidentIntent.CREATED.toString();
+    if (intent.equals(IncidentIntent.MIGRATED.name())) {
+      intent = IncidentIntent.CREATED.name();
     }
     return List.of(String.format("%d-%s", record.getKey(), intent));
   }
@@ -60,8 +60,8 @@ public class PostImporterQueueFromIncidentHandler
       final Record<IncidentRecordValue> record, final PostImporterQueueEntity entity) {
     final IncidentRecordValue recordValue = record.getValue();
     String intent = record.getIntent().name();
-    if (intent.equals(IncidentIntent.MIGRATED.toString())) {
-      intent = IncidentIntent.CREATED.toString();
+    if (intent.equals(IncidentIntent.MIGRATED.name())) {
+      intent = IncidentIntent.CREATED.name();
     }
     entity
         .setId(String.format("%d-%s", record.getKey(), intent))

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -132,7 +132,7 @@ public class PostImporterQueueFromIncidentHandlerTest {
 
     final Record<IncidentRecordValue> incidentRecord =
         factory.generateRecord(
-            ValueType.DECISION,
+            ValueType.INCIDENT,
             r ->
                 r.withIntent(IncidentIntent.CREATED)
                     .withValue(incidentRecordValue)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/PostImporterQueueFromIncidentHandlerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterQueueEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableIncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class PostImporterQueueFromIncidentHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-post-import-queue";
+  private final PostImporterQueueFromIncidentHandler underTest =
+      new PostImporterQueueFromIncidentHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.INCIDENT);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(PostImporterQueueEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.CREATED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(incidentRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIdsForCreated() {
+    // given
+    final long expectedId = 123;
+    final IncidentRecordValue decisionRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> decisionRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withIntent(IncidentIntent.CREATED)
+                    .withValue(decisionRecordValue)
+                    .withKey(expectedId));
+
+    // when
+    final var idList = underTest.generateIds(decisionRecord);
+
+    // then
+    assertThat(idList).containsExactly(expectedId + "-" + IncidentIntent.CREATED);
+  }
+
+  @Test
+  void shouldGenerateIdsForMigrated() {
+    // given
+    final long expectedId = 123;
+    final IncidentRecordValue decisionRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> decisionRecord =
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r ->
+                r.withIntent(IncidentIntent.MIGRATED)
+                    .withValue(decisionRecordValue)
+                    .withKey(expectedId));
+
+    // when
+    final var idList = underTest.generateIds(decisionRecord);
+
+    // then
+    assertThat(idList).containsExactly(expectedId + "-" + IncidentIntent.CREATED);
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final PostImporterQueueEntity inputEntity = new PostImporterQueueEntity().setId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long recordKey = 123L;
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r ->
+                r.withIntent(IncidentIntent.CREATED)
+                    .withValue(incidentRecordValue)
+                    .withKey(recordKey));
+
+    // when
+    final PostImporterQueueEntity postImporterQueueEntity = new PostImporterQueueEntity();
+    underTest.updateEntity(incidentRecord, postImporterQueueEntity);
+
+    // then
+    assertThat(postImporterQueueEntity.getId()).isEqualTo(recordKey + "-" + IncidentIntent.CREATED);
+    assertThat(postImporterQueueEntity.getKey()).isEqualTo(123L);
+    assertThat(postImporterQueueEntity.getIntent()).isEqualTo(IncidentIntent.CREATED.name());
+    assertThat(postImporterQueueEntity.getActionType()).isEqualTo(PostImporterActionType.INCIDENT);
+    assertThat(postImporterQueueEntity.getCreationTime()).isNotNull();
+    assertThat(postImporterQueueEntity.getPartitionId()).isEqualTo(incidentRecord.getPartitionId());
+    assertThat(postImporterQueueEntity.getPosition()).isEqualTo(incidentRecord.getPosition());
+    assertThat(postImporterQueueEntity.getProcessInstanceKey())
+        .isEqualTo(incidentRecordValue.getProcessInstanceKey());
+  }
+
+  @Test
+  void shouldUpdateMigratedIntentAsCreatedFromRecord() {
+    // given
+    final long recordKey = 123L;
+    final IncidentRecordValue incidentRecordValue =
+        ImmutableIncidentRecordValue.builder()
+            .from(factory.generateObject(IncidentRecordValue.class))
+            .build();
+
+    final Record<IncidentRecordValue> incidentRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r ->
+                r.withIntent(IncidentIntent.MIGRATED)
+                    .withValue(incidentRecordValue)
+                    .withKey(recordKey));
+
+    // when
+    final PostImporterQueueEntity postImporterQueueEntity = new PostImporterQueueEntity();
+    underTest.updateEntity(incidentRecord, postImporterQueueEntity);
+
+    // then
+    assertThat(postImporterQueueEntity.getId()).isEqualTo(recordKey + "-" + IncidentIntent.CREATED);
+    assertThat(postImporterQueueEntity.getKey()).isEqualTo(incidentRecord.getKey());
+    assertThat(postImporterQueueEntity.getIntent()).isEqualTo(IncidentIntent.CREATED.name());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Introduce the PostImporterQueueFromIncident export handler in the new exporter.

p.s: @sdorokhova took a look on some of Operate's ITs but they seem to be using multiple record readers and Operate specific services to run the scenarios.
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
