### PR TITLE
fix: set isTruncated as a Boolean instead of primitive 

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/VariableFilterTransformer.java
@@ -83,7 +83,10 @@ public class VariableFilterTransformer implements FilterTransformer<VariableFilt
     return stringTerms("tenantId", tenant);
   }
 
-  private SearchQuery getIsTruncatedQuery(final boolean isTruncated) {
+  private SearchQuery getIsTruncatedQuery(final Boolean isTruncated) {
+    if (isTruncated == null) {
+      return null;
+    }
     return term("isPreview", isTruncated);
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/VariableFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/VariableFilter.java
@@ -22,7 +22,7 @@ public final record VariableFilter(
     List<Long> processInstanceKeys,
     List<Long> variableKeys,
     List<String> tenantIds,
-    boolean isTruncated)
+    Boolean isTruncated)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<VariableFilter> {
@@ -31,7 +31,7 @@ public final record VariableFilter(
     private List<Long> processInstanceKeys;
     private List<Long> variableKeys;
     private List<String> tenantIds;
-    private boolean isTruncated;
+    private Boolean isTruncated;
 
     public Builder variable(final List<VariableValueFilter> values) {
       variableFilters = addValuesToList(variableFilters, values);
@@ -83,7 +83,7 @@ public final record VariableFilter(
       return this;
     }
 
-    public Builder isTruncated(final boolean value) {
+    public Builder isTruncated(final Boolean value) {
       isTruncated = value;
       return this;
     }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/VariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/VariableEntity.java
@@ -63,7 +63,7 @@ public class VariableEntity extends OperateZeebeEntity<VariableEntity> {
     return isPreview;
   }
 
-  public VariableEntity setIsPreview(final Boolean preview) {
+  public VariableEntity setIsPreview(final boolean preview) {
     isPreview = preview;
     return this;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/VariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/VariableEntity.java
@@ -63,7 +63,7 @@ public class VariableEntity extends OperateZeebeEntity<VariableEntity> {
     return isPreview;
   }
 
-  public VariableEntity setIsPreview(final boolean preview) {
+  public VariableEntity setIsPreview(final Boolean preview) {
     isPreview = preview;
     return this;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableQueryController.java
@@ -54,14 +54,14 @@ public class VariableQueryController {
           RestErrorMapper.createProblemDetail(
               HttpStatus.BAD_REQUEST,
               e.getMessage(),
-              "Validation failed for UserTask Search Query");
+              "Validation failed for Variable Search Query");
       return RestErrorMapper.mapProblemToResponse(problemDetail);
     } catch (final Exception e) {
       final var problemDetail =
           RestErrorMapper.createProblemDetail(
               HttpStatus.INTERNAL_SERVER_ERROR,
               e.getMessage(),
-              "Failed to execute UserTask Search Query");
+              "Failed to execute Variable Search Query");
       return RestErrorMapper.mapProblemToResponse(problemDetail);
     }
   }


### PR DESCRIPTION
## Description

- VariableFilter `isTruncated` should set as object and not primitive on FilterRequests