### PR TITLE
build: remove unused dependencies

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -262,11 +262,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>identity-sdk</artifactId>
     </dependency>

--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -45,11 +45,6 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.postgresql</groupId>
-      <artifactId>postgresql</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/identity/pom.xml
+++ b/identity/pom.xml
@@ -46,11 +46,6 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1571,12 +1571,6 @@
       </dependency>
 
       <dependency>
-        <groupId>com.h2database</groupId>
-        <artifactId>h2</artifactId>
-        <version>${version.h2}</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.netflix.concurrency-limits</groupId>
         <artifactId>concurrency-limits-core</artifactId>
         <version>${version.netflix.concurrency}</version>
@@ -2675,7 +2669,6 @@
                   <dep>org.junit.vintage:junit-vintage-engine</dep>
                   <dep>com.tngtech.archunit:archunit-junit5-engine</dep>
                   <dep>org.openjdk.jmh:jmh-generator-annprocess</dep>
-                  <dep>com.h2database:h2</dep>
                   <dep>org.postgresql:postgresql</dep>
                   <dep>io.camunda:camunda-authentication</dep>
                   <dep>org.skyscreamer:jsonassert</dep>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
It was noticed that the H2 dependency in use introduces a CVE, after looking further, this dependency was in Identity from a time that predates the new architectural approach of using Zeebe.

As we don't use H2 actively I believe its safe to remove (we also don't use Postgres in Identity for the same reason so I have also removed that dependency too)
