### PR TITLE
fix: avoid npe when logging bulkresponse errors

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -919,6 +919,7 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
                   itemName,
                   getHintForErrorMsg(bulkResponse),
                   bulkResponse.items().stream()
+                      .filter(i -> Objects.nonNull(i.error()))
                       .map(
                           i ->
                               i.operationType() + " " + i.error().type() + " " + i.error().reason())


### PR DESCRIPTION
related to #23523

## Description
Avoid NPEs when logging bulkresponse errors. This also needs backported to 8.6

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #23523
