### PR TITLE
feat: Add PARTITION_UNAVAILABLE error code when partition pauses processing

### DIFF
--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointTest.java
@@ -68,6 +68,9 @@ final class BackupEndpointTest {
               new BrokerErrorException(new BrokerError(ErrorCode.RESOURCE_EXHAUSTED, "failure")),
               503),
           Arguments.of(
+              new BrokerErrorException(new BrokerError(ErrorCode.PARTITION_UNAVAILABLE, "failure")),
+              500),
+          Arguments.of(
               new BrokerErrorException(new BrokerError(ErrorCode.INTERNAL_ERROR, "failure")), 500),
           Arguments.of(
               new BrokerErrorException(new BrokerError(ErrorCode.UNSUPPORTED_MESSAGE, "failure")),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -41,6 +41,7 @@ public final class ErrorResponseWriter implements BufferWriter {
   private static final String PROCESS_NOT_FOUND_FORMAT =
       "Expected to get process with %s, but no such process found";
   private static final String RESOURCE_EXHAUSTED = "Reached maximum capacity of requests handled";
+  private static final String PARTITION_UNAVAILABLE = "Cannot accept requests for partition %d.";
   private static final String OUT_OF_DISK_SPACE =
       "Cannot accept requests for partition %d. Broker is out of disk space";
 
@@ -86,6 +87,15 @@ public final class ErrorResponseWriter implements BufferWriter {
 
   public ErrorResponseWriter resourceExhausted(final String message) {
     return errorCode(ErrorCode.RESOURCE_EXHAUSTED).errorMessage(message);
+  }
+
+  public ErrorResponseWriter partitionUnavailable(final int partitionId) {
+    return errorCode(ErrorCode.PARTITION_UNAVAILABLE)
+        .errorMessage(String.format(PARTITION_UNAVAILABLE, partitionId));
+  }
+
+  public ErrorResponseWriter partitionUnavailable(final String message) {
+    return errorCode(ErrorCode.PARTITION_UNAVAILABLE).errorMessage(message);
   }
 
   public ErrorResponseWriter outOfDiskSpace(final int partitionId) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -85,7 +85,8 @@ final class CommandApiRequestHandler
 
     if (processingPaused.getOrDefault(partitionId, false)) {
       return Either.left(
-          errorWriter.internalError("Processing paused for partition '%s'", partitionId));
+          errorWriter.partitionUnavailable(
+              String.format("Processing paused for partition '%s'", partitionId)));
     }
 
     final var command = reader.getMessageDecoder();

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -176,6 +176,10 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.UNAVAILABLE_VALUE);
       }
       case MALFORMED_REQUEST -> builder.setCode(Code.INVALID_ARGUMENT_VALUE);
+      case PARTITION_UNAVAILABLE -> {
+        logger.debug("Partition is currently unavailable: {}", error, rootError);
+        builder.setCode(Code.UNAVAILABLE_VALUE);
+      }
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not expected
         // to solve anything

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -180,4 +180,22 @@ final class GrpcErrorMapperTest {
     // then
     assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ABORTED);
   }
+
+  @Test
+  void shouldLogPartitionUnavailableErrorOnDebug() {
+    // given
+    final var brokerError =
+        new BrokerError(ErrorCode.PARTITION_UNAVAILABLE, "Partition unavailable");
+    final BrokerErrorException exception = new BrokerErrorException(brokerError);
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(exception, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.UNAVAILABLE);
+    assertThat(recorder.getAppendedEvents()).hasSize(1);
+    final LogEvent event = recorder.getAppendedEvents().getFirst();
+    assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
+  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -193,6 +193,11 @@ public class RestErrorMapper {
             "Target broker was not the leader of the partition: {}", error, rootError);
         yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, message, title);
       }
+      case PARTITION_UNAVAILABLE -> {
+        REST_GATEWAY_LOGGER.debug(
+            "Partition in target broker is currently unavailable: {}", error, rootError);
+        yield createProblemDetail(HttpStatus.SERVICE_UNAVAILABLE, message, title);
+      }
       default -> {
         // all the following are for cases where retrying (with the same gateway) is not
         // expected

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -18,6 +18,7 @@
       <validValue name="INVALID_DEPLOYMENT_PARTITION">6</validValue>
       <validValue name="PROCESS_NOT_FOUND">7</validValue>
       <validValue name="RESOURCE_EXHAUSTED">8</validValue>
+      <validValue name="PARTITION_UNAVAILABLE">9</validValue>
     </enum>
 
     <enum name="ValueType" encodingType="uint8" description="The type of a record value">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -27,12 +27,16 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+import io.grpc.StatusRuntimeException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import org.agrona.DirectBuffer;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,6 +92,13 @@ public class BrokerAdminServiceTest {
     final var status = partitions.resumeProcessing();
 
     // then
+    try (final var client = zeebe.newClientBuilder().build()) {
+      final Future<?> response =
+          client.newPublishMessageCommand().messageName("test2").correlationKey("test-key").send();
+
+      assertThat(response).isNotNull().succeedsWithin(Duration.ofSeconds(5));
+    }
+
     assertThat(status.get(1).streamProcessorPhase()).isEqualTo(Phase.PROCESSING.toString());
   }
 
@@ -107,7 +118,11 @@ public class BrokerAdminServiceTest {
           .failsWithin(Duration.ofSeconds(5))
           .withThrowableThat()
           .havingCause()
-          .withMessageContaining("Processing paused for partition");
+          .withMessageContaining("UNAVAILABLE: Processing paused for partition")
+          .asInstanceOf(InstanceOfAssertFactories.throwable(StatusRuntimeException.class))
+          .extracting(StatusRuntimeException::getStatus)
+          .extracting(Status::getCode)
+          .isEqualTo(Code.UNAVAILABLE);
     }
   }
 


### PR DESCRIPTION
## Description
Create a new `PARTITION_UNAVAILABLE` error code corresponding to when a partition pauses processing requests.

## Checklist

- [x]  Add a new `PARTITION_UNAVAILABLE` error code (as in, to the SBE generated `ErrorCode` enum), which is documented as meaning that the command cannot be processed because the processor is temporarily unavailable.
- [x]  Update the `CommandApiRequestHandler` to return this error, instead of the current `INTERNAL_ERROR`.
- [x]  Map `PARTITION_UNAVAILABLE` error code in `GrpcErrorMapper` such that the error is logged as debug, and the mapped gRPC error is `UNAVAILABLE`.
- [x]  Map `PARTITION_UNAVAILABLE` error code in `RestErrorMapper` such that the error is logged as debug, and the mapped HTTP code is 503 (`SERVICE_UNAVAILABLE`).
- [x]  Write test for `GrpcErrorMapper`
- [x]  Write test for `RestErrorMapper`  in `ErrorMapperTest`
- [x]  Updated integration/QA regression tests

## Related issues

closes #22928
