### PR TITLE
[Backport stable/optimize-8.6] fix: avoid npe when logging bulkresponse errors

### DIFF
--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/es/OptimizeElasticsearchClient.java
@@ -917,6 +917,7 @@ public class OptimizeElasticsearchClient extends DatabaseClient {
                   itemName,
                   getHintForErrorMsg(bulkResponse),
                   bulkResponse.items().stream()
+                      .filter(i -> Objects.nonNull(i.error()))
                       .map(
                           i ->
                               i.operationType() + " " + i.error().type() + " " + i.error().reason())


### PR DESCRIPTION
# Description
Backport of #23637 to `stable/optimize-8.6`.

relates to #23523 #23523
original author: @PHWaechtler