### PR TITLE
spike: archiver with in exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import io.camunda.exporter.archiver.Archiver;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -36,4 +37,6 @@ public interface ExporterResourceProvider {
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
   Set<ExportHandler> getExportHandlers();
+
+  Archiver getArchiver(int partitionId);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -22,10 +22,13 @@ class ElasticsearchAdapter implements ClientAdapter {
   private final ElasticsearchClient client;
   private final ElasticsearchEngineClient searchEngineClient;
 
+  // TODO: private final ElasticsearchAsyncClient asyncClient;
+
   ElasticsearchAdapter(final ExporterConfiguration configuration) {
     final var connector = new ElasticsearchConnector(configuration.getConnect());
     client = connector.createClient();
     searchEngineClient = new ElasticsearchEngineClient(client);
+    // TODO: asyncClient = connector.createAsyncClient(); // for Archiver
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -15,17 +15,20 @@ import io.camunda.exporter.store.OpensearchBatchRequest;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.search.connect.os.OpensearchConnector;
 import java.io.IOException;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch.core.BulkRequest;
 
 class OpensearchAdapter implements ClientAdapter {
   private final OpenSearchClient client;
   private final OpensearchEngineClient searchEngineClient;
+  private final OpenSearchAsyncClient asyncClient;
 
   OpensearchAdapter(final ExporterConfiguration configuration) {
     final var connector = new OpensearchConnector(configuration.getConnect());
     client = connector.createClient();
     searchEngineClient = new OpensearchEngineClient(client);
+    asyncClient = connector.createAsyncClient();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/AbstractArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/AbstractArchiverJob.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class AbstractArchiverJob implements ArchiverJob {
+
+  public static final String DATES_AGG = "datesAgg";
+  public static final String INSTANCES_AGG = "instancesAgg";
+  private static final Logger LOGGER = LoggerFactory.getLogger(AbstractArchiverJob.class);
+
+  protected final ScheduledExecutorService archiverExecutor;
+
+  private final BackoffIdleStrategy idleStrategy;
+  private final BackoffIdleStrategy errorStrategy;
+  private boolean shutdown = false;
+  private final double rolloverBatchSize;
+  private final long delayBetweenRuns;
+
+  public AbstractArchiverJob(final ScheduledExecutorService archiverExecutor) {
+    this.archiverExecutor = archiverExecutor;
+    idleStrategy = new BackoffIdleStrategy(2_000, 1.2f, 60_000);
+    errorStrategy = new BackoffIdleStrategy(100, 1.2f, 10_000);
+
+    rolloverBatchSize = 100; // TODO operateProperties.getArchiver().getRolloverBatchSize();
+    delayBetweenRuns =
+        Duration.ofMinutes(1)
+            .toMillis(); // TODO: operateProperties.getArchiver().getDelayBetweenRuns();
+  }
+
+  @Override
+  public void run() {
+    archiveNextBatch()
+        .thenApply(
+            (count) -> {
+              errorStrategy.reset();
+
+              if (count >= rolloverBatchSize) {
+                idleStrategy.reset();
+              } else {
+                idleStrategy.idle();
+              }
+
+              final var delay = Math.max(delayBetweenRuns, idleStrategy.idleTime());
+
+              return delay;
+            })
+        .exceptionally(
+            (t) -> {
+              LOGGER.error("Error occurred while archiving data. Will be retried.", t);
+              errorStrategy.idle();
+              final var delay = Math.max(delayBetweenRuns, errorStrategy.idleTime());
+              return delay;
+            })
+        .thenAccept(
+            (delay) -> {
+              if (!shutdown) {
+                archiverExecutor.schedule(this, delay, TimeUnit.MILLISECONDS);
+              }
+            });
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveNextBatch() {
+    return getNextBatch().thenCompose(this::archiveBatch);
+  }
+
+  @Override
+  public void shutdown() {
+    shutdown = true;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiveBatch.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+
+public class ArchiveBatch {
+
+  private String finishDate;
+  private List<Object> ids;
+
+  public ArchiveBatch(final String finishDate, final List<Object> ids) {
+    this.finishDate = finishDate;
+    this.ids = ids;
+  }
+
+  public String getFinishDate() {
+    return finishDate;
+  }
+
+  public void setFinishDate(final String finishDate) {
+    this.finishDate = finishDate;
+  }
+
+  public List<Object> getIds() {
+    return ids;
+  }
+
+  public void setIds(final List<Object> ids) {
+    this.ids = ids;
+  }
+
+  @Override
+  public String toString() {
+    return "ArchiveBatch{" + "finishDate='" + finishDate + '\'' + ", ids=" + ids + '}';
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Archiver {
+  protected static final String INDEX_NAME_PATTERN = "%s%s";
+  private static final Logger LOGGER = LoggerFactory.getLogger(Archiver.class);
+  private final ArchiverRepository archiverRepository;
+
+  private final ScheduledExecutorService archiverExecutor;
+  private final int partitionId;
+
+  private final List<ArchiverJob> archiverJobs;
+
+  public Archiver(
+      final ArchiverRepository archiverRepository,
+      final ScheduledExecutorService archiverExecutor,
+      final int partitionId,
+      final List<ArchiverJob> archiverJobs) {
+    this.archiverRepository = archiverRepository;
+    this.archiverExecutor = archiverExecutor;
+    this.partitionId = partitionId;
+    this.archiverJobs = archiverJobs;
+  }
+
+  public void startArchiving() {
+    //  TODO: if (operateProperties.getArchiver().isRolloverEnabled()) {
+    LOGGER.info("INIT: Start archiving data...");
+
+    LOGGER.info("Starting archiver for partition: {}", partitionId);
+
+    for (final var archiverJob : archiverJobs) {
+      archiverExecutor.execute(archiverJob);
+    }
+
+    // }
+  }
+
+  public void stopArchiving() {
+    // TODO: check if we need to do more during closing
+    archiverJobs.forEach(a -> a.shutdown());
+    archiverExecutor.shutdownNow();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverJob.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ArchiverJob extends Runnable {
+
+  CompletableFuture<Integer> archiveBatch(ArchiveBatch archiveBatch);
+
+  CompletableFuture<ArchiveBatch> getNextBatch();
+
+  CompletableFuture<Integer> archiveNextBatch();
+
+  void shutdown();
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public interface ArchiverRepository {
+  CompletableFuture<ArchiveBatch> getBatchOperationNextBatch();
+
+  CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(List<Integer> partitionIds);
+
+  void setIndexLifeCycle(final String destinationIndexName);
+
+  CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys);
+
+  CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys);
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverUtil.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static io.camunda.exporter.archiver.Archiver.INDEX_NAME_PATTERN;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+public class ArchiverUtil {
+
+  private final ArchiverRepository archiverRepository;
+
+  public ArchiverUtil(final ArchiverRepository archiverRepository) {
+    this.archiverRepository = archiverRepository;
+  }
+
+  public CompletableFuture<Void> moveDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final String finishDate,
+      final List<Object> ids) {
+    final var destinationIndexName = getDestinationIndexName(sourceIndexName, finishDate);
+    return archiverRepository
+        .reindexDocuments(sourceIndexName, destinationIndexName, idFieldName, ids)
+        .thenCompose(
+            (ignore) -> {
+              archiverRepository.setIndexLifeCycle(destinationIndexName);
+              return archiverRepository.deleteDocuments(sourceIndexName, idFieldName, ids);
+            });
+  }
+
+  public String getDestinationIndexName(final String sourceIndexName, final String finishDate) {
+    return String.format(INDEX_NAME_PATTERN, sourceIndexName, finishDate);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BackoffIdleStrategy.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BackoffIdleStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+public class BackoffIdleStrategy {
+
+  private static final int NOT_IDLE = 0;
+  private static final int IDLE = 1;
+
+  private final long baseIdleTime;
+  private final float idleIncreaseFactor;
+  private final long maxIdleTime;
+  private final int maxIdles;
+
+  private int state = NOT_IDLE;
+  private int idles;
+
+  public BackoffIdleStrategy(
+      final long baseIdleTime, final float idleIncreaseFactor, final long maxIdleTime) {
+    this.baseIdleTime = baseIdleTime;
+    this.idleIncreaseFactor = idleIncreaseFactor;
+    this.maxIdleTime = maxIdleTime;
+    maxIdles = calculateMaxIdles();
+  }
+
+  private double log(final double base, final double value) {
+    return Math.log10(value) / Math.log10(base);
+  }
+
+  public void idle() {
+    switch (state) {
+      case NOT_IDLE:
+        state = IDLE;
+        idles = 1;
+        break;
+
+      default:
+        idles++;
+        idles = Math.min(idles, maxIdles);
+    }
+  }
+
+  public void reset() {
+    idles = 0;
+    state = NOT_IDLE;
+  }
+
+  public long idleTime() {
+    final long idleTime;
+
+    switch (state) {
+      case NOT_IDLE:
+        idleTime = 0;
+        break;
+
+      default:
+        final var t = (long) (baseIdleTime * Math.pow(idleIncreaseFactor, idles - 1));
+        idleTime = Math.min(maxIdleTime, t);
+    }
+
+    return idleTime;
+  }
+
+  private int calculateMaxIdles() {
+    if (baseIdleTime <= 0) {
+      return 1;
+    }
+    return ((int) log(idleIncreaseFactor, maxIdleTime / baseIdleTime)) + 1;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class BatchOperationArchiverJob extends AbstractArchiverJob {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJob.class);
+
+  private final ArchiverUtil archiver;
+
+  // TODO: private BatchOperationTemplate batchOperationTemplate;
+  // Temp: because BatchOperationTemplate is not available in the common webapps-schema.
+  private final String batchOperationIndexName = "batch-operation";
+  private final String batchOperationIndexId = "id";
+
+  private final ArchiverRepository archiverRepository;
+
+  public BatchOperationArchiverJob(
+      final ArchiverUtil archiver,
+      final ArchiverRepository archiverRepository,
+      final ScheduledExecutorService executor) {
+    super(executor);
+    this.archiver = archiver;
+    this.archiverRepository = archiverRepository;
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+    final CompletableFuture<Integer> archiveBatchFuture;
+
+    if (archiveBatch != null) {
+      LOGGER.debug("Following batch operations are found for archiving: {}", archiveBatch);
+
+      archiveBatchFuture = new CompletableFuture<>();
+      archiver
+          .moveDocuments(
+              //  batchOperationTemplate.getFullQualifiedName(),
+              // BatchOperationTemplate.ID,
+              batchOperationIndexName, // temp
+              batchOperationIndexId, // temp
+              archiveBatch.getFinishDate(),
+              archiveBatch.getIds())
+          .whenComplete(
+              (v, e) -> {
+                if (e != null) {
+                  archiveBatchFuture.completeExceptionally(e);
+                  return;
+                }
+                archiveBatchFuture.complete(archiveBatch.getIds().size());
+              });
+    } else {
+      LOGGER.debug("Nothing to archive");
+      archiveBatchFuture = CompletableFuture.completedFuture(0);
+    }
+
+    return archiveBatchFuture;
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getNextBatch() {
+    return archiverRepository.getBatchOperationNextBatch();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchArchiverRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+// TODO: Implement. The existing implementation use a different ES client that what is used in the
+// exporter
+public class ElasticsearchArchiverRepository implements ArchiverRepository {
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getBatchOperationNextBatch() {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(
+      final List<Integer> partitionIds) {
+    return null;
+  }
+
+  @Override
+  public void setIndexLifeCycle(final String destinationIndexName) {}
+
+  @Override
+  public CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys) {
+    return null;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/OpensearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/OpensearchArchiverRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+// TODO: Implement. The existing implementation use a different ES client that what is used in the
+// exporter
+public class OpensearchArchiverRepository implements ArchiverRepository {
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getBatchOperationNextBatch() {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch(
+      final List<Integer> partitionIds) {
+    return null;
+  }
+
+  @Override
+  public void setIndexLifeCycle(final String destinationIndexName) {}
+
+  @Override
+  public CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys) {
+    return null;
+  }
+
+  @Override
+  public CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<Object> processInstanceKeys) {
+    return null;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessInstancesArchiverJob extends AbstractArchiverJob {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstancesArchiverJob.class);
+
+  private final List<Integer> partitionIds;
+
+  private final ArchiverUtil archiver;
+
+  private final ListViewTemplate processInstanceTemplate;
+
+  private final List<ProcessInstanceDependant> processInstanceDependantTemplates;
+
+  //  private Metrics metrics;
+
+  private ArchiverRepository archiverRepository;
+
+  public ProcessInstancesArchiverJob(
+      final ArchiverUtil archiver,
+      final List<Integer> partitionIds,
+      final ListViewTemplate processInstanceTemplate,
+      final List<ProcessInstanceDependant> processInstanceDependantTemplates,
+      final ScheduledExecutorService executor) {
+    super(executor);
+    this.partitionIds = partitionIds;
+    this.archiver = archiver;
+    this.processInstanceTemplate = processInstanceTemplate;
+    this.processInstanceDependantTemplates = processInstanceDependantTemplates;
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+    final CompletableFuture<Integer> archiveBatchFuture;
+
+    if (archiveBatch != null) {
+      LOGGER.debug("Following process instances are found for archiving: {}", archiveBatch);
+
+      archiveBatchFuture = new CompletableFuture<Integer>();
+      final var finishDate = archiveBatch.getFinishDate();
+      final var processInstanceKeys = archiveBatch.getIds();
+
+      moveDependableDocuments(finishDate, processInstanceKeys)
+          .thenCompose(
+              (v) -> {
+                return moveProcessInstanceDocuments(finishDate, processInstanceKeys);
+              })
+          .thenAccept(
+              (i) -> {
+                // metrics.recordCounts(Metrics.COUNTER_NAME_ARCHIVED, i);
+                archiveBatchFuture.complete(i);
+              })
+          .exceptionally(
+              (t) -> {
+                archiveBatchFuture.completeExceptionally(t);
+                return null;
+              });
+
+    } else {
+      LOGGER.debug("Nothing to archive");
+      archiveBatchFuture = CompletableFuture.completedFuture(0);
+    }
+
+    return archiveBatchFuture;
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getNextBatch() {
+    return archiverRepository.getProcessInstancesNextBatch(partitionIds);
+  }
+
+  private CompletableFuture<Void> moveDependableDocuments(
+      final String finishDate, final List<Object> processInstanceKeys) {
+    final var dependableFutures = new ArrayList<CompletableFuture<Void>>();
+
+    for (final ProcessInstanceDependant template : processInstanceDependantTemplates) {
+      final var moveDocumentsFuture =
+          archiver.moveDocuments(
+              template.getFullQualifiedName(),
+              ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+              finishDate,
+              processInstanceKeys);
+      dependableFutures.add(moveDocumentsFuture);
+    }
+
+    return CompletableFuture.allOf(
+        dependableFutures.toArray(new CompletableFuture[dependableFutures.size()]));
+  }
+
+  private CompletableFuture<Integer> moveProcessInstanceDocuments(
+      final String finishDate, final List<Object> processInstanceKeys) {
+    final var future = new CompletableFuture<Integer>();
+
+    archiver
+        .moveDocuments(
+            processInstanceTemplate.getFullQualifiedName(),
+            ListViewTemplate.PROCESS_INSTANCE_KEY,
+            finishDate,
+            processInstanceKeys)
+        .thenAccept((ignore) -> future.complete(processInstanceKeys.size()))
+        .exceptionally(
+            (t) -> {
+              future.completeExceptionally(t);
+              return null;
+            });
+
+    return future;
+  }
+}


### PR DESCRIPTION
## Description

A skeleton of how archiver will be integrated with the exporter

Main things to make it work with the exporter:
1. Implementation for Opensearch and Elasticsearch interface. The existing implementation uses different clients than what is available in the exporter. However, I assume this is not a blocker - just some busy work to adapt the apis. 
2. Injecting dependencies needs to be done manually instead of using spring magic. 
3. `BatchOperationTemplate` should be added to common `webapps-schema`. It was not added before because it is not needed by the exporter, but only the webapps. But the archiver needs some info of it (only index name and id). 

Note: This PR won't run because Opensearch/Elasticsearch implementation does not exist. 
