### PR TITLE
Java client PoC: Task Listener job is treated as a regular job

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/ActivatedJob.java
@@ -114,4 +114,9 @@ public interface ActivatedJob {
    */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/13560")
   String getTenantId();
+
+  /**
+   * @return user task data
+   */
+  UserTaskJobData getUserTaskJobData();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskJobData.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UserTaskJobData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+/**
+ * Introducing an interface here to hide implementation details from clients and in order to be
+ * consistent with ActiveJob approach
+ */
+public interface UserTaskJobData {
+
+  String getAssignee();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.response.UserTaskJobData;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,6 +45,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
   private final long deadline;
   private final String variables;
 
+  private final UserTaskJobData userTaskJobData;
+
   private Map<String, Object> variablesAsMap;
 
   public ActivatedJobImpl(final JsonMapper jsonMapper, final GatewayOuterClass.ActivatedJob job) {
@@ -68,6 +71,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = job.getElementId();
     elementInstanceKey = job.getElementInstanceKey();
     tenantId = job.getTenantId();
+    // TODO check for null etc
+    userTaskJobData = new UserTaskJobDataImpl(job.getUserTaskJobData());
   }
 
   public ActivatedJobImpl(
@@ -99,6 +104,8 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = getOrEmpty(job.getElementId());
     elementInstanceKey = getOrEmpty(job.getElementInstanceKey());
     tenantId = getOrEmpty(job.getTenantId());
+    // TODO check for null etc
+    userTaskJobData = new UserTaskJobDataImpl(job.getUserTaskJobData());
   }
 
   @Override
@@ -196,6 +203,11 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public UserTaskJobData getUserTaskJobData() {
+    return userTaskJobData;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskJobDataImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/UserTaskJobDataImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.UserTaskJobData;
+
+public class UserTaskJobDataImpl implements UserTaskJobData {
+
+  private final String assignee;
+
+  /**
+   * @param userTaskJobData from REST response
+   */
+  public UserTaskJobDataImpl(
+      final io.camunda.zeebe.client.protocol.rest.UserTaskJobData userTaskJobData) {
+    assignee = userTaskJobData.getAssignee();
+  }
+
+  /**
+   * @param userTaskJobData from gRPC response
+   */
+  public UserTaskJobDataImpl(
+      final io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UserTaskJobData userTaskJobData) {
+    assignee = userTaskJobData.getAssignee();
+  }
+
+  @Override
+  public String getAssignee() {
+    return assignee;
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -55,6 +55,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskJobData;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
 import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
 import java.util.ArrayList;
@@ -350,6 +351,8 @@ public final class ResponseMapper {
   }
 
   private static ActivatedJob toActivatedJob(final long jobKey, final JobRecord job) {
+    final UserTaskJobData userTaskJobData = job.getUserTaskJobData();
+
     return ActivatedJob.newBuilder()
         .setKey(jobKey)
         .setType(bufferAsString(job.getTypeBuffer()))
@@ -365,6 +368,10 @@ public final class ResponseMapper {
         .setDeadline(job.getDeadline())
         .setVariables(bufferAsJson(job.getVariablesBuffer()))
         .setTenantId(job.getTenantId())
+        .setUserTaskJobData(
+            GatewayOuterClass.UserTaskJobData.newBuilder()
+                .setAssignee(userTaskJobData.getAssignee())
+                .build())
         .build();
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -83,6 +83,27 @@ message ActivatedJob {
   string variables = 13;
   // the id of the tenant that owns the job
   string tenantId = 14;
+  // user task job data if available
+  UserTaskJobData userTaskJobData = 15;
+}
+
+message UserTaskJobData{
+  // the user task key
+  int64 userTaskKey = 1;
+  // the assignee of the user task
+  string assignee = 2;
+  // a list of candidate groups
+  repeated string candidateGroupsList = 3;
+  // a list of candidate users
+  repeated string candidateUsersList = 4;
+  // due date of a task
+  string dueDateProp = 5;
+  // follow up date of a task
+  string followUpDate = 6;
+  // user task form key
+  int64 formKey = 7;
+  // priority of the task
+  int32 priority = 8;
 }
 
 message CancelProcessInstanceRequest {

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -588,7 +588,7 @@ paths:
         Set a precise, static time for the Zeebe engine’s internal clock.
         When the clock is pinned, it remains at the specified time and does not advance.
         To change the time, the clock must be pinned again with a new timestamp.
-        
+
         :::note
         This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
         in future releases.
@@ -624,7 +624,7 @@ paths:
         Resets the Zeebe engine’s internal clock to the current system time, enabling it to tick in real-time.
         This operation is useful for returning the clock to
         normal behavior after it has been pinned to a specific time.
-        
+
         :::note
         This endpoint is an [alpha feature](/reference/alpha-features.md) and may be subject to change
         in future releases.
@@ -2287,10 +2287,10 @@ components:
           type: string
           description: State of this incident with a defined set of values.
           enum:
-          - ACTIVE
-          - MIGRATED
-          - RESOLVED
-          - PENDING
+            - ACTIVE
+            - MIGRATED
+            - RESOLVED
+            - PENDING
         jobKey:
           type: integer
           description: The job key, if exists, associated with this incident.
@@ -2787,6 +2787,41 @@ components:
         tenantId:
           description: The ID of the tenant that owns the job
           type: string
+        userTaskJobData:
+          $ref: "#/components/schemas/UserTaskJobData"
+    UserTaskJobData:
+      type: object
+      properties:
+        userTaskKey:
+          description: user task key
+          type: integer
+          format: int64
+        assignee:
+          description: assignee of the task
+          type: string
+        candidateGroupsList:
+          description: candidate groups
+          type: array
+          items:
+            type: string
+        candidateUsersList:
+          description: candidate users
+          type: array
+          items:
+            type: string
+        dueDate:
+          description: due date of the task
+          type: string
+        followUpDate:
+          description: follow up date of the task
+          type: string
+        formKey:
+          description: form key of the user task
+          type: integer
+          format: int64
+        priority:
+          description: priority of the task
+          type: integer
     JobFailRequest:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserCreateResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskJobData;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
@@ -95,6 +96,8 @@ public final class ResponseMapper {
         .deadline(job.getDeadline())
         .variables(job.getVariables())
         .customHeaders(job.getCustomHeadersObjectMap())
+        // TODO: check for null
+        .userTaskJobData(new UserTaskJobData().assignee(job.getUserTaskJobData().getAssignee()))
         .tenantId(job.getTenantId());
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -17,12 +17,14 @@ import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskJobData;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -81,8 +83,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
 
+  private final ObjectProperty<UserTaskJobData> userTaskJobDataProp =
+      new ObjectProperty<>("userTaskData", new UserTaskJobData());
+
   public JobRecord() {
-    super(21);
+    super(22);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -103,7 +108,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(userTaskJobDataProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -127,6 +133,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    userTaskJobDataProp.getValue().setProperties(record.getUserTaskJobData());
     setChangedAttributes(record.getChangedAttributes());
   }
 
@@ -354,6 +361,15 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  public UserTaskJobData getUserTaskJobData() {
+    return userTaskJobDataProp.getValue();
+  }
+
+  public JobRecord setUserTaskJobData(final UserTaskJobData userTaskJobData) {
+    userTaskJobDataProp.getValue().setProperties(userTaskJobData);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskJobData.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskJobData.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.usertask;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class UserTaskJobData extends UnpackedObject {
+
+  private final LongProperty userTaskKeyProp = new LongProperty("userTaskKey", -1);
+  private final StringProperty assigneeProp = new StringProperty("assignee", "");
+  private final ArrayProperty<StringValue> candidateGroupsListProp =
+      new ArrayProperty<>("candidateGroupsList", StringValue::new);
+  private final ArrayProperty<StringValue> candidateUsersListProp =
+      new ArrayProperty<>("candidateUsersList", StringValue::new);
+  private final StringProperty dueDateProp = new StringProperty("dueDate", "");
+  private final StringProperty followUpDateProp = new StringProperty("followUpDate", "");
+  private final LongProperty formKeyProp = new LongProperty("formKey", -1);
+  private final IntegerProperty priorityProp = new IntegerProperty("priority", 50);
+
+  public UserTaskJobData() {
+    super(9);
+    declareProperty(userTaskKeyProp);
+    declareProperty(assigneeProp);
+    declareProperty(candidateGroupsListProp);
+    declareProperty(candidateUsersListProp);
+    declareProperty(dueDateProp);
+    declareProperty(followUpDateProp);
+    declareProperty(formKeyProp);
+    declareProperty(priorityProp);
+  }
+
+  /** Sets all properties to current instance from provided user task job data */
+  public void setProperties(final UserTaskJobData userTaskJobData) {
+    userTaskKeyProp.setValue(userTaskJobData.getUserTaskKey());
+    assigneeProp.setValue(userTaskJobData.getAssignee());
+    setCandidateGroupsList(userTaskJobData.getCandidateGroupsList());
+    setCandidateUsersList(userTaskJobData.getCandidateUsersList());
+    dueDateProp.setValue(userTaskJobData.getDueDate());
+    followUpDateProp.setValue(userTaskJobData.getFollowUpDate());
+    formKeyProp.setValue(userTaskJobData.getFormKey());
+    priorityProp.setValue(userTaskJobData.getPriority());
+  }
+
+  public String getAssignee() {
+    return bufferAsString(assigneeProp.getValue());
+  }
+
+  public UserTaskJobData setAssignee(final String assignee) {
+    assigneeProp.setValue(assignee);
+    return this;
+  }
+
+  public long getUserTaskKey() {
+    return userTaskKeyProp.getValue();
+  }
+
+  public UserTaskJobData setUserTaskKey(final long userTaskKey) {
+    userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  public List<String> getCandidateGroupsList() {
+    return StreamSupport.stream(candidateGroupsListProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .collect(Collectors.toList());
+  }
+
+  public UserTaskJobData setCandidateGroupsList(final List<String> candidateGroups) {
+    candidateGroupsListProp.reset();
+    candidateGroups.forEach(
+        candidateGroup ->
+            candidateGroupsListProp.add().wrap(BufferUtil.wrapString(candidateGroup)));
+    return this;
+  }
+
+  public List<String> getCandidateUsersList() {
+    return StreamSupport.stream(candidateUsersListProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .collect(Collectors.toList());
+  }
+
+  public UserTaskJobData setCandidateUsersList(final List<String> candidateUsers) {
+    candidateUsersListProp.reset();
+    candidateUsers.forEach(
+        candidateUser -> candidateUsersListProp.add().wrap(BufferUtil.wrapString(candidateUser)));
+    return this;
+  }
+
+  public String getDueDate() {
+    return bufferAsString(dueDateProp.getValue());
+  }
+
+  public UserTaskJobData setDueDate(final String dueDate) {
+    dueDateProp.setValue(dueDate);
+    return this;
+  }
+
+  public String getFollowUpDate() {
+    return bufferAsString(followUpDateProp.getValue());
+  }
+
+  public UserTaskJobData setFollowUpDate(final String followUpDate) {
+    followUpDateProp.setValue(followUpDate);
+    return this;
+  }
+
+  public long getFormKey() {
+    return formKeyProp.getValue();
+  }
+
+  public UserTaskJobData setFormKey(final long formKey) {
+    formKeyProp.setValue(formKey);
+    return this;
+  }
+
+  public int getPriority() {
+    return priorityProp.getValue();
+  }
+
+  public UserTaskJobData setPriority(final int priority) {
+    priorityProp.setValue(priority);
+    return this;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Draft implementation of TLs support in Java Client, currently passing just a single attribute for PoC demo.

A Task Listener job is treated as a regular job.
The activated job has a getUserTaskData() method that provides a typed object UserTaskJobData with the known user task attributes. This will only be populated for Task Listener jobs and will be empty or null for other jobs.
Below is the example of how this approach could look like:

```
zeebeClient
   .newWorker()
   .jobType("listener-1")
   .handler((client, job) -> {
       LOGGER.info("Assignee for the job: {}", job.getUserTaskData().getAssignee());

       client.newCompleteCommand(job.getKey()).send();
       LOGGER.info("Element with id:'{}' processing completed.", job.getElementId());
   })
   .open();
```

Tested with local deployment:

```
        // create and deploy a process
        final BpmnModelInstance process =
                Bpmn.createExecutableProcess("processId_Ana")
                        .startEvent()
                        .userTask(
                                "my_user_task",
                                t -> t.zeebeUserTask().zeebeAssignee("Ana"))
                        .zeebeTaskListener(l -> l.complete().type("listener-1"))
                        .endEvent()
                        .done();

        zeebeClient
                .newDeployResourceCommand()
                .addProcessModel(process, "process.bpmn")
                .send()
                .join();

        // create new process instance
        zeebeClient
                .newCreateInstanceCommand()
                .bpmnProcessId("processId_Ana")
                .latestVersion()
                .send();

        // Option 1 of treating TL job is a regular job
        final JobWorker tlWorker = zeebeClient
                .newWorker()
                .jobType("listener-1")
                .handler((client, job) -> {
                    LOGGER.info("Assignee for the job: {}", job.getUserTaskJobData().getAssignee());

                    client.newCompleteCommand(job.getKey()).send();
                    LOGGER.info("Element with id:'{}' processing completed.", job.getElementId());
                })
                .open();
```

## Related issues

closes #22398
