### PR TITLE
ci: populate preview envs with data

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -333,6 +333,9 @@ camunda-platform:
       fullURL: "https://test.camunda.camunda.cloud/identity"
 
     operate:
+      env:
+        - name: SPRING_PROFILES_ACTIVE
+          value: dev-data
       image:
         registry: registry.camunda.cloud
         repository: team-camunda/operate


### PR DESCRIPTION
## Description

This pr is meant to add test data to the monorepo preview environemnts as evidently there is currently none. Following what we have been doing in the past for other preview envs ([ref](https://camunda.slack.com/archives/CHY2S7KDJ/p1729166619770409?thread_ts=1729166445.506369&cid=CHY2S7KDJ)), the solution can involve simply setting the dev-data env variable in Operate's side.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues
https://camunda.slack.com/archives/C5AHF1D8T/p1729165670509199

## Test

Operate and Optimize both show a number of test data
https://preview-env-dat.camunda.camunda.cloud/optimize/#/
https://preview-env-dat.camunda.camunda.cloud/operate/operate
