### PR TITLE
test: disable flaky test to unblock CI

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -33,7 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Disabled("Disabled until https://github.com/camunda/camunda/issues/23706 has been fixed!")
-//@ZeebeIntegration
+// @ZeebeIntegration
 class IncidentQueryTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentQueryTest.class);

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.Process;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.search.response.Incident;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -33,7 +32,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Disabled("Disabled until https://github.com/camunda/camunda/issues/23706 has been fixed!")
-// @ZeebeIntegration
 class IncidentQueryTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentQueryTest.class);

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/IncidentQueryTest.java
@@ -27,11 +27,13 @@ import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@ZeebeIntegration
+@Disabled("Disabled until https://github.com/camunda/camunda/issues/23706 has been fixed!")
+//@ZeebeIntegration
 class IncidentQueryTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentQueryTest.class);


### PR DESCRIPTION
## Description

Disables the flaky `IncidentQueryTest` to unblock CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #23706
