### PR TITLE
[Backport stable/8.5] fix: include stack trace on failed GRPC token verification

### DIFF
--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -79,9 +79,10 @@ public final class IdentityInterceptor implements ServerInterceptor {
       identity.authentication().verifyToken(token);
     } catch (final TokenVerificationException e) {
       LOGGER.debug(
-          "Denying call {} as the token could not be fully verified. Error message: {}",
+          "Denying call {} as the token could not be verified successfully. Error message: {}",
           methodDescriptor.getFullMethodName(),
-          e.getMessage());
+          e.getMessage(),
+          e);
 
       return deny(
           call,


### PR DESCRIPTION
# Description
Backport of #23600 to `stable/8.5`.

relates to 
original author: @megglos