### PR TITLE
Configuration parameter to enable resource permissions checks

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -102,10 +102,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
     <dependency>

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -14,7 +14,6 @@ import io.camunda.authentication.handler.AuthFailureHandler;
 import io.camunda.authentication.handler.CustomMethodSecurityExpressionHandler;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -42,7 +41,7 @@ public class WebSecurityConfig {
   @Bean
   @ConditionalOnMissingBean(MethodSecurityExpressionHandler.class)
   public MethodSecurityExpressionHandler methodSecurityExpressionHandler(
-      final AuthorizationServices<AuthorizationRecord> authorizationServices) {
+      final AuthorizationServices authorizationServices) {
     return new CustomMethodSecurityExpressionHandler(authorizationServices);
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionHandler.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionHandler.java
@@ -8,7 +8,6 @@
 package io.camunda.authentication.handler;
 
 import io.camunda.service.AuthorizationServices;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
@@ -18,10 +17,9 @@ import org.springframework.security.core.Authentication;
 
 public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurityExpressionHandler {
   private final AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-  private final AuthorizationServices<AuthorizationRecord> authorizationServices;
+  private final AuthorizationServices authorizationServices;
 
-  public CustomMethodSecurityExpressionHandler(
-      final AuthorizationServices<AuthorizationRecord> authorizationServices) {
+  public CustomMethodSecurityExpressionHandler(final AuthorizationServices authorizationServices) {
     this.authorizationServices = authorizationServices;
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionRoot.java
+++ b/authentication/src/main/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionRoot.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.handler;
 
 import io.camunda.authentication.entity.CamundaUser;
 import io.camunda.service.AuthorizationServices;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Optional;
@@ -27,13 +26,12 @@ public class CustomMethodSecurityExpressionRoot extends SecurityExpressionRoot
       Set.of(
           PermissionType.UPDATE.name(), PermissionType.CREATE.name(), PermissionType.DELETE.name());
 
-  private final AuthorizationServices<AuthorizationRecord> authorizationServices;
+  private final AuthorizationServices authorizationServices;
   private Object filterObject;
   private Object returnObject;
 
   public CustomMethodSecurityExpressionRoot(
-      final Authentication authentication,
-      final AuthorizationServices<AuthorizationRecord> authorizationServices) {
+      final Authentication authentication, final AuthorizationServices authorizationServices) {
     super(authentication);
     this.authorizationServices = authorizationServices;
   }

--- a/authentication/src/test/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionRootTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/handler/CustomMethodSecurityExpressionRootTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.zeebe.auth.impl.Authorization;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.time.Instant;
@@ -38,7 +37,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @ExtendWith(SpringExtension.class)
 public class CustomMethodSecurityExpressionRootTest {
   @MockBean private JwtAuthenticationToken authentication;
-  @MockBean private AuthorizationServices<AuthorizationRecord> authorizationServices;
+  @MockBean private AuthorizationServices authorizationServices;
 
   @BeforeEach
   void setup() {

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.service;
 
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.clients.DecisionInstanceSearchClient;
@@ -84,8 +85,10 @@ public class CamundaServicesConfiguration {
   @Bean
   public ProcessInstanceServices processInstanceServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final ProcessInstanceSearchClient processInstanceSearchClient) {
-    return new ProcessInstanceServices(brokerClient, processInstanceSearchClient, null);
+    return new ProcessInstanceServices(
+        brokerClient, securityConfiguration, processInstanceSearchClient, null);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -55,31 +55,41 @@ public class CamundaServicesConfiguration {
   @Bean
   public JobServices<JobActivationResponse> jobServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
-    return new JobServices<>(brokerClient, activateJobsHandler, null);
+    return new JobServices<>(brokerClient, securityConfiguration, activateJobsHandler, null);
   }
 
   @Bean
   public DecisionDefinitionServices decisionDefinitionServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementSearchClient decisionRequirementSearchClient) {
     return new DecisionDefinitionServices(
-        brokerClient, decisionDefinitionSearchClient, decisionRequirementSearchClient, null);
+        brokerClient,
+        securityConfiguration,
+        decisionDefinitionSearchClient,
+        decisionRequirementSearchClient,
+        null);
   }
 
   @Bean
   public DecisionInstanceServices decisionInstanceServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final DecisionInstanceSearchClient decisionInstanceSearchClient) {
-    return new DecisionInstanceServices(brokerClient, decisionInstanceSearchClient, null);
+    return new DecisionInstanceServices(
+        brokerClient, securityConfiguration, decisionInstanceSearchClient, null);
   }
 
   @Bean
   public ProcessDefinitionServices processDefinitionServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final ProcessDefinitionSearchClient processDefinitionSearchClient) {
-    return new ProcessDefinitionServices(brokerClient, processDefinitionSearchClient, null);
+    return new ProcessDefinitionServices(
+        brokerClient, securityConfiguration, processDefinitionSearchClient, null);
   }
 
   @Bean
@@ -94,81 +104,104 @@ public class CamundaServicesConfiguration {
   @Bean
   public DecisionRequirementsServices decisionRequirementsServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final DecisionRequirementSearchClient decisionRequirementSearchClient) {
-    return new DecisionRequirementsServices(brokerClient, decisionRequirementSearchClient, null);
+    return new DecisionRequirementsServices(
+        brokerClient, securityConfiguration, decisionRequirementSearchClient, null);
   }
 
   @Bean
   public FlowNodeInstanceServices flownodeInstanceServices(
       final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient) {
-    return new FlowNodeInstanceServices(brokerClient, flowNodeInstanceSearchClient, null);
+    return new FlowNodeInstanceServices(
+        brokerClient, securityConfiguration, flowNodeInstanceSearchClient, null);
   }
 
   @Bean
   public IncidentServices incidentServices(
-      final BrokerClient brokerClient, final IncidentSearchClient incidentSearchClient) {
-    return new IncidentServices(brokerClient, incidentSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final IncidentSearchClient incidentSearchClient) {
+    return new IncidentServices(brokerClient, securityConfiguration, incidentSearchClient, null);
   }
 
   @Bean
   public UserServices userServices(
-      final BrokerClient brokerClient, final UserSearchClient userSearchClient) {
-    return new UserServices(brokerClient, userSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final UserSearchClient userSearchClient) {
+    return new UserServices(brokerClient, securityConfiguration, userSearchClient, null);
   }
 
   @Bean
   public UserTaskServices userTaskServices(
-      final BrokerClient brokerClient, final UserTaskSearchClient userTaskSearchClient) {
-    return new UserTaskServices(brokerClient, userTaskSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final UserTaskSearchClient userTaskSearchClient) {
+    return new UserTaskServices(brokerClient, securityConfiguration, userTaskSearchClient, null);
   }
 
   @Bean
   public VariableServices variableServices(
-      final BrokerClient brokerClient, final VariableSearchClient variableSearchClient) {
-    return new VariableServices(brokerClient, variableSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final VariableSearchClient variableSearchClient) {
+    return new VariableServices(brokerClient, securityConfiguration, variableSearchClient, null);
   }
 
   @Bean
-  public MessageServices messageServices(final BrokerClient brokerClient) {
-    return new MessageServices(brokerClient, null);
+  public MessageServices messageServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new MessageServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
-  public DocumentServices documentServices(final BrokerClient brokerClient) {
-    return new DocumentServices(brokerClient, null);
+  public DocumentServices documentServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new DocumentServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
   public AuthorizationServices authorizationServices(
-      final BrokerClient brokerClient, final AuthorizationSearchClient authorizationSearchClient) {
-    return new AuthorizationServices(brokerClient, authorizationSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final AuthorizationSearchClient authorizationSearchClient) {
+    return new AuthorizationServices(
+        brokerClient, securityConfiguration, authorizationSearchClient, null);
   }
 
   @Bean
-  public ClockServices clockServices(final BrokerClient brokerClient) {
-    return new ClockServices(brokerClient, null);
+  public ClockServices clockServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new ClockServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
-  public ResourceServices resourceServices(final BrokerClient brokerClient) {
-    return new ResourceServices(brokerClient, null);
+  public ResourceServices resourceServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new ResourceServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
-  public ElementInstanceServices elementServices(final BrokerClient brokerClient) {
-    return new ElementInstanceServices(brokerClient, null);
+  public ElementInstanceServices elementServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new ElementInstanceServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
-  public SignalServices signalServices(final BrokerClient brokerClient) {
-    return new SignalServices(brokerClient, null);
+  public SignalServices signalServices(
+      final BrokerClient brokerClient, final ServiceSecurityProperties securityConfiguration) {
+    return new SignalServices(brokerClient, securityConfiguration, null);
   }
 
   @Bean
   public FormServices formServices(
-      final BrokerClient brokerClient, final FormSearchClient formSearchClient) {
-    return new FormServices(brokerClient, formSearchClient, null);
+      final BrokerClient brokerClient,
+      final ServiceSecurityProperties securityConfiguration,
+      final FormSearchClient formSearchClient) {
+    return new FormServices(brokerClient, securityConfiguration, formSearchClient, null);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/service/ServiceSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/ServiceSecurityConfiguration.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.service;
+
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnRestGatewayEnabled
+@EnableConfigurationProperties(ServiceSecurityProperties.class)
+public class ServiceSecurityConfiguration {
+
+  @ConfigurationProperties("camunda.security")
+  public static final class ServiceSecurityProperties extends SecurityConfiguration {}
+}

--- a/identity/migration/pom.xml
+++ b/identity/migration/pom.xml
@@ -29,10 +29,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-protocol-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
     <dependency>

--- a/identity/migration/src/main/java/io/camunda/identity/migration/AuthorizationMigrationHandler.java
+++ b/identity/migration/src/main/java/io/camunda/identity/migration/AuthorizationMigrationHandler.java
@@ -10,7 +10,6 @@ package io.camunda.identity.migration;
 import io.camunda.identity.migration.dto.UserResourceAuthorization;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.AuthorizationServices.PatchAuthorizationRequest;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -25,11 +24,11 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuthorizationMigrationHandler {
 
-  private final AuthorizationServices<AuthorizationRecord> authorizationService;
+  private final AuthorizationServices authorizationService;
   private final ManagementIdentityProxy managementIdentityProxy;
 
   public AuthorizationMigrationHandler(
-      final AuthorizationServices<AuthorizationRecord> authorizationService,
+      final AuthorizationServices authorizationService,
       final ManagementIdentityProxy managementIdentityProxy) {
     this.authorizationService = authorizationService;
     this.managementIdentityProxy = managementIdentityProxy;

--- a/identity/migration/src/main/java/io/camunda/identity/migration/MigrationRunner.java
+++ b/identity/migration/src/main/java/io/camunda/identity/migration/MigrationRunner.java
@@ -11,7 +11,6 @@ import static java.util.Arrays.asList;
 
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
@@ -23,13 +22,13 @@ public class MigrationRunner implements ApplicationRunner {
 
   final UserServices userService;
 
-  final AuthorizationServices<AuthorizationRecord> authorizationServices;
+  final AuthorizationServices authorizationServices;
 
   final AuthorizationMigrationHandler authorizationMigrationHandler;
 
   public MigrationRunner(
       final UserServices userService,
-      final AuthorizationServices<AuthorizationRecord> authorizationServices,
+      final AuthorizationServices authorizationServices,
       final AuthorizationMigrationHandler authorizationMigrationHandler) {
     this.userService = userService;
     this.authorizationServices = authorizationServices;

--- a/identity/migration/src/test/java/io/camunda/identity/migration/AuthorizationMigrationHandlerTest.java
+++ b/identity/migration/src/test/java/io/camunda/identity/migration/AuthorizationMigrationHandlerTest.java
@@ -16,7 +16,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.identity.migration.dto.UserResourceAuthorization;
 import io.camunda.service.AuthorizationServices;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import java.util.Collection;
 import java.util.List;
 import org.hamcrest.Matchers;
@@ -29,7 +28,7 @@ import org.mockito.MockitoAnnotations;
 
 class AuthorizationMigrationHandlerTest {
 
-  @Mock AuthorizationServices<AuthorizationRecord> authorizationServices;
+  @Mock AuthorizationServices authorizationServices;
   @Mock ManagementIdentityProxy managementIdentityProxy;
   AuthorizationMigrationHandler migrationHandler;
 

--- a/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/SecurityContext.java
@@ -51,6 +51,20 @@ public record SecurityContext(Authentication authentication, Authorization autho
       return withAuthorization(Authorization.of(builderFunction));
     }
 
+    public Builder withAuthorizationIfEnabled(
+        final boolean enabled,
+        final Function<Authorization.Builder, Authorization.Builder> builderFunction) {
+      if (enabled) {
+        return withAuthorization(builderFunction);
+      }
+      return withoutAuthorization();
+    }
+
+    public Builder withoutAuthorization() {
+      authentication = null;
+      return this;
+    }
+
     public SecurityContext build() {
       return new SecurityContext(authentication, authorization);
     }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizationsConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/AuthorizationsConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class AuthorizationsConfiguration {
+
+  private boolean enabled = SecurityConfiguration.DEFAULT_AUTHORIZATIONS_ENABLED;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(final boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class SecurityConfiguration {
+
+  static final boolean DEFAULT_AUTHORIZATIONS_ENABLED = false;
+
+  private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
+
+  public AuthorizationsConfiguration getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final AuthorizationsConfiguration authorizations) {
+    this.authorizations = authorizations;
+  }
+}

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.exception.CamundaBrokerException;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
@@ -23,10 +24,15 @@ import org.agrona.concurrent.UnsafeBuffer;
 public abstract class ApiServices<T extends ApiServices<T>> {
 
   protected final BrokerClient brokerClient;
+  protected final SecurityConfiguration securityConfiguration;
   protected final Authentication authentication;
 
-  protected ApiServices(final BrokerClient brokerClient, final Authentication authentication) {
+  protected ApiServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
     this.brokerClient = brokerClient;
+    this.securityConfiguration = securityConfiguration;
     this.authentication = authentication;
   }
 

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -14,6 +14,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerAuthorizationPatchRequest;
@@ -27,22 +28,24 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-public class AuthorizationServices<T>
-    extends SearchQueryService<AuthorizationServices<T>, AuthorizationQuery, AuthorizationEntity> {
+public class AuthorizationServices
+    extends SearchQueryService<AuthorizationServices, AuthorizationQuery, AuthorizationEntity> {
 
   private final AuthorizationSearchClient authorizationSearchClient;
 
   public AuthorizationServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final AuthorizationSearchClient authorizationSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.authorizationSearchClient = authorizationSearchClient;
   }
 
   @Override
-  public AuthorizationServices<T> withAuthentication(final Authentication authentication) {
-    return new AuthorizationServices<>(brokerClient, authorizationSearchClient, authentication);
+  public AuthorizationServices withAuthentication(final Authentication authentication) {
+    return new AuthorizationServices(
+        brokerClient, securityConfiguration, authorizationSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/ClockServices.java
+++ b/service/src/main/java/io/camunda/service/ClockServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockPinRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerClockResetRequest;
@@ -16,13 +17,16 @@ import java.util.concurrent.CompletableFuture;
 
 public final class ClockServices extends ApiServices<ClockServices> {
 
-  public ClockServices(final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+  public ClockServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public ClockServices withAuthentication(final Authentication authentication) {
-    return new ClockServices(brokerClient, authentication);
+    return new ClockServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<ClockRecord> pinClock(final long pinnedEpoch) {

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -39,10 +40,11 @@ public final class DecisionDefinitionServices
 
   public DecisionDefinitionServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final DecisionDefinitionSearchClient decisionDefinitionSearchClient,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.decisionDefinitionSearchClient = decisionDefinitionSearchClient;
     this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
@@ -51,6 +53,7 @@ public final class DecisionDefinitionServices
   public DecisionDefinitionServices withAuthentication(final Authentication authentication) {
     return new DecisionDefinitionServices(
         brokerClient,
+        securityConfiguration,
         decisionDefinitionSearchClient,
         decisionRequirementSearchClient,
         authentication);

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -19,6 +19,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -32,16 +33,18 @@ public final class DecisionInstanceServices
 
   public DecisionInstanceServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final DecisionInstanceSearchClient decisionInstanceSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
 
     this.decisionInstanceSearchClient = decisionInstanceSearchClient;
   }
 
   @Override
   public DecisionInstanceServices withAuthentication(final Authentication authentication) {
-    return new DecisionInstanceServices(brokerClient, decisionInstanceSearchClient, authentication);
+    return new DecisionInstanceServices(
+        brokerClient, securityConfiguration, decisionInstanceSearchClient, authentication);
   }
 
   /**

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -30,16 +31,17 @@ public final class DecisionRequirementsServices
 
   public DecisionRequirementsServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final DecisionRequirementSearchClient decisionRequirementSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.decisionRequirementSearchClient = decisionRequirementSearchClient;
   }
 
   @Override
   public DecisionRequirementsServices withAuthentication(final Authentication authentication) {
     return new DecisionRequirementsServices(
-        brokerClient, decisionRequirementSearchClient, authentication);
+        brokerClient, securityConfiguration, decisionRequirementSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -14,6 +14,7 @@ import io.camunda.document.api.DocumentMetadataModel;
 import io.camunda.document.api.DocumentStoreRecord;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.io.InputStream;
 import java.time.ZonedDateTime;
@@ -23,17 +24,16 @@ public class DocumentServices extends ApiServices<DocumentServices> {
 
   private final SimpleDocumentStoreRegistry registry = new SimpleDocumentStoreRegistry();
 
-  public DocumentServices(final BrokerClient brokerClient) {
-    this(brokerClient, null);
-  }
-
-  public DocumentServices(final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+  public DocumentServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public DocumentServices withAuthentication(final Authentication authentication) {
-    return new DocumentServices(brokerClient, authentication);
+    return new DocumentServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<DocumentReferenceResponse> createDocument(

--- a/service/src/main/java/io/camunda/service/ElementInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ElementInstanceServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableDocumentRecord;
@@ -17,13 +18,15 @@ import java.util.concurrent.CompletableFuture;
 public class ElementInstanceServices extends ApiServices<ElementInstanceServices> {
 
   public ElementInstanceServices(
-      final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public ElementInstanceServices withAuthentication(final Authentication authentication) {
-    return new ElementInstanceServices(brokerClient, authentication);
+    return new ElementInstanceServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<VariableDocumentRecord> setVariables(final SetVariablesRequest request) {

--- a/service/src/main/java/io/camunda/service/FlowNodeInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/FlowNodeInstanceServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -29,15 +30,17 @@ public final class FlowNodeInstanceServices
 
   public FlowNodeInstanceServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final FlowNodeInstanceSearchClient flowNodeInstanceSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.flowNodeInstanceSearchClient = flowNodeInstanceSearchClient;
   }
 
   @Override
   public FlowNodeInstanceServices withAuthentication(final Authentication authentication) {
-    return new FlowNodeInstanceServices(brokerClient, flowNodeInstanceSearchClient, authentication);
+    return new FlowNodeInstanceServices(
+        brokerClient, securityConfiguration, flowNodeInstanceSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/FormServices.java
+++ b/service/src/main/java/io/camunda/service/FormServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 
@@ -25,15 +26,16 @@ public final class FormServices extends SearchQueryService<FormServices, FormQue
 
   public FormServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final FormSearchClient formSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.formSearchClient = formSearchClient;
   }
 
   @Override
   public FormServices withAuthentication(final Authentication authentication) {
-    return new FormServices(brokerClient, formSearchClient, authentication);
+    return new FormServices(brokerClient, securityConfiguration, formSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/IncidentServices.java
+++ b/service/src/main/java/io/camunda/service/IncidentServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -31,9 +32,10 @@ public class IncidentServices
 
   public IncidentServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final IncidentSearchClient incidentSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.incidentSearchClient = incidentSearchClient;
   }
 
@@ -50,7 +52,8 @@ public class IncidentServices
 
   @Override
   public IncidentServices withAuthentication(final Authentication authentication) {
-    return new IncidentServices(brokerClient, incidentSearchClient, authentication);
+    return new IncidentServices(
+        brokerClient, securityConfiguration, incidentSearchClient, authentication);
   }
 
   public IncidentEntity getByKey(final Long key) {

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
@@ -28,15 +29,17 @@ public final class JobServices<T> extends ApiServices<JobServices<T>> {
 
   public JobServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final ActivateJobsHandler<T> activateJobsHandler,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.activateJobsHandler = activateJobsHandler;
   }
 
   @Override
   public JobServices<T> withAuthentication(final Authentication authentication) {
-    return new JobServices<>(brokerClient, activateJobsHandler, authentication);
+    return new JobServices<>(
+        brokerClient, securityConfiguration, activateJobsHandler, authentication);
   }
 
   public void activateJobs(

--- a/service/src/main/java/io/camunda/service/MessageServices.java
+++ b/service/src/main/java/io/camunda/service/MessageServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCorrelateMessageRequest;
@@ -19,13 +20,16 @@ import java.util.concurrent.CompletableFuture;
 
 public final class MessageServices extends ApiServices<MessageServices> {
 
-  public MessageServices(final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+  public MessageServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public MessageServices withAuthentication(final Authentication authentication) {
-    return new MessageServices(brokerClient, authentication);
+    return new MessageServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<MessageCorrelationRecord> correlateMessage(

--- a/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessDefinitionServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.Optional;
@@ -28,9 +29,10 @@ public class ProcessDefinitionServices
 
   public ProcessDefinitionServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final ProcessDefinitionSearchClient processDefinitionSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.processDefinitionSearchClient = processDefinitionSearchClient;
   }
 
@@ -43,7 +45,7 @@ public class ProcessDefinitionServices
   @Override
   public ProcessDefinitionServices withAuthentication(final Authentication authentication) {
     return new ProcessDefinitionServices(
-        brokerClient, processDefinitionSearchClient, authentication);
+        brokerClient, securityConfiguration, processDefinitionSearchClient, authentication);
   }
 
   public ProcessDefinitionEntity getByKey(final Long processDefinitionKey) {

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -16,6 +16,7 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -48,15 +49,17 @@ public final class ProcessInstanceServices
 
   public ProcessInstanceServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final ProcessInstanceSearchClient processInstanceSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.processInstanceSearchClient = processInstanceSearchClient;
   }
 
   @Override
   public ProcessInstanceServices withAuthentication(final Authentication authentication) {
-    return new ProcessInstanceServices(brokerClient, processInstanceSearchClient, authentication);
+    return new ProcessInstanceServices(
+        brokerClient, securityConfiguration, processInstanceSearchClient, authentication);
   }
 
   @Override
@@ -66,7 +69,8 @@ public final class ProcessInstanceServices
         SecurityContext.of(
             s ->
                 s.withAuthentication(authentication)
-                    .withAuthorization(
+                    .withAuthorizationIfEnabled(
+                        securityConfiguration.getAuthorizations().isEnabled(),
                         a ->
                             a.resourceType(AuthorizationResourceType.PROCESS_DEFINITION)
                                 .permissionType(PermissionType.READ_INSTANCE))));

--- a/service/src/main/java/io/camunda/service/ResourceServices.java
+++ b/service/src/main/java/io/camunda/service/ResourceServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeleteResourceRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerDeployResourceRequest;
@@ -18,13 +19,16 @@ import java.util.concurrent.CompletableFuture;
 
 public final class ResourceServices extends ApiServices<ResourceServices> {
 
-  public ResourceServices(final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+  public ResourceServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public ResourceServices withAuthentication(final Authentication authentication) {
-    return new ResourceServices(brokerClient, authentication);
+    return new ResourceServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<DeploymentRecord> deployResources(

--- a/service/src/main/java/io/camunda/service/SignalServices.java
+++ b/service/src/main/java/io/camunda/service/SignalServices.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerBroadcastSignalRequest;
@@ -17,13 +18,16 @@ import java.util.concurrent.CompletableFuture;
 
 public class SignalServices extends ApiServices<SignalServices> {
 
-  public SignalServices(final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+  public SignalServices(
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   @Override
   public SignalServices withAuthentication(final Authentication authentication) {
-    return new SignalServices(brokerClient, authentication);
+    return new SignalServices(brokerClient, securityConfiguration, authentication);
   }
 
   public CompletableFuture<BrokerResponse<SignalRecord>> broadcastSignal(

--- a/service/src/main/java/io/camunda/service/UserServices.java
+++ b/service/src/main/java/io/camunda/service/UserServices.java
@@ -13,6 +13,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UserQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserCreateRequest;
@@ -26,9 +27,10 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
 
   public UserServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final UserSearchClient userSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.userSearchClient = userSearchClient;
   }
 
@@ -40,7 +42,7 @@ public class UserServices extends SearchQueryService<UserServices, UserQuery, Us
 
   @Override
   public UserServices withAuthentication(final Authentication authentication) {
-    return new UserServices(brokerClient, userSearchClient, authentication);
+    return new UserServices(brokerClient, securityConfiguration, userSearchClient, authentication);
   }
 
   public CompletableFuture<UserRecord> createUser(final UserDTO request) {

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.UserTaskQuery.Builder;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -36,15 +37,17 @@ public final class UserTaskServices
 
   public UserTaskServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final UserTaskSearchClient userTaskSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.userTaskSearchClient = userTaskSearchClient;
   }
 
   @Override
   public UserTaskServices withAuthentication(final Authentication authentication) {
-    return new UserTaskServices(brokerClient, userTaskSearchClient, authentication);
+    return new UserTaskServices(
+        brokerClient, securityConfiguration, userTaskSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -17,6 +17,7 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.search.query.VariableQuery.Builder;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -29,15 +30,17 @@ public final class VariableServices
 
   public VariableServices(
       final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
       final VariableSearchClient variableSearchClient,
       final Authentication authentication) {
-    super(brokerClient, authentication);
+    super(brokerClient, securityConfiguration, authentication);
     this.variableSearchClient = variableSearchClient;
   }
 
   @Override
   public VariableServices withAuthentication(final Authentication authentication) {
-    return new VariableServices(brokerClient, variableSearchClient, authentication);
+    return new VariableServices(
+        brokerClient, securityConfiguration, variableSearchClient, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -10,6 +10,7 @@ package io.camunda.service.search.core;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.ApiServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 
@@ -17,8 +18,10 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
     extends ApiServices<T> {
 
   protected SearchQueryService(
-      final BrokerClient brokerClient, final Authentication authentication) {
-    super(brokerClient, authentication);
+      final BrokerClient brokerClient,
+      final SecurityConfiguration securityConfiguration,
+      final Authentication authentication) {
+    super(brokerClient, securityConfiguration, authentication);
   }
 
   public abstract SearchQueryResult<D> search(final Q query);

--- a/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
+++ b/service/src/test/java/io/camunda/service/AuthorizationServiceTest.java
@@ -16,20 +16,22 @@ import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class AuthorizationServiceTest {
 
-  private AuthorizationServices<AuthorizationRecord> services;
+  private AuthorizationServices services;
   private AuthorizationSearchClient client;
 
   @BeforeEach
   public void before() {
     client = mock(AuthorizationSearchClient.class);
-    services = new AuthorizationServices<>(mock(BrokerClient.class), client, null);
+    services =
+        new AuthorizationServices(
+            mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -24,6 +24,7 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,7 +42,11 @@ public final class DecisionDefinitionServiceTest {
     decisionRequirementSearchClient = mock(DecisionRequirementSearchClient.class);
     services =
         new DecisionDefinitionServices(
-            mock(BrokerClient.class), client, decisionRequirementSearchClient, null);
+            mock(BrokerClient.class),
+            new SecurityConfiguration(),
+            client,
+            decisionRequirementSearchClient,
+            null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -19,6 +19,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,7 +33,9 @@ class DecisionInstanceServiceTest {
   @BeforeEach
   public void before() {
     client = mock(DecisionInstanceSearchClient.class);
-    services = new DecisionInstanceServices(mock(BrokerClient.class), client, null);
+    services =
+        new DecisionInstanceServices(
+            mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -17,6 +17,7 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +31,9 @@ public final class DecisionRequirementsServiceTest {
   @BeforeEach
   public void before() {
     client = mock(DecisionRequirementSearchClient.class);
-    services = new DecisionRequirementsServices(mock(BrokerClient.class), client, null);
+    services =
+        new DecisionRequirementsServices(
+            mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,9 @@ public final class FlowNodeInstanceServiceTest {
   @BeforeEach
   public void before() {
     client = mock(FlowNodeInstanceSearchClient.class);
-    services = new FlowNodeInstanceServices(mock(BrokerClient.class), client, null);
+    services =
+        new FlowNodeInstanceServices(
+            mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/FormServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FormServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.FormSearchClient;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,8 @@ public final class FormServiceTest {
   @BeforeEach
   public void before() {
     client = mock(FormSearchClient.class);
-    services = new FormServices(mock(BrokerClient.class), client, null);
+    services =
+        new FormServices(mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,8 @@ public final class IncidentServiceTest {
   @BeforeEach
   public void before() {
     client = mock(IncidentSearchClient.class);
-    services = new IncidentServices(mock(BrokerClient.class), client, null);
+    services =
+        new IncidentServices(mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UserServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserServiceTest.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,8 @@ public class UserServiceTest {
   @BeforeEach
   public void before() {
     client = mock(UserSearchClient.class);
-    services = new UserServices(mock(BrokerClient.class), client, null);
+    services =
+        new UserServices(mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -18,6 +18,7 @@ import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.UserTaskFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.assertj.core.util.Arrays;
@@ -32,7 +33,8 @@ public class UserTaskServiceTest {
   @BeforeEach
   public void before() {
     client = mock(UserTaskSearchClient.class);
-    services = new UserTaskServices(mock(BrokerClient.class), client, null);
+    services =
+        new UserTaskServices(mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -18,6 +18,7 @@ import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.assertj.core.util.Arrays;
@@ -32,7 +33,8 @@ public class VariableServiceTest {
   @BeforeEach
   public void before() {
     client = mock(VariableSearchClient.class);
-    services = new VariableServices(mock(BrokerClient.class), client, null);
+    services =
+        new VariableServices(mock(BrokerClient.class), new SecurityConfiguration(), client, null);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationController.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPatchRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
-import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -25,10 +24,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @CamundaRestController
 @RequestMapping("/v2/authorizations")
 public class AuthorizationController {
-  private final AuthorizationServices<AuthorizationRecord> authorizationServices;
+  private final AuthorizationServices authorizationServices;
 
-  public AuthorizationController(
-      final AuthorizationServices<AuthorizationRecord> authorizationServices) {
+  public AuthorizationController(final AuthorizationServices authorizationServices) {
     this.authorizationServices = authorizationServices;
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/AuthorizationControllerTest.java
@@ -53,7 +53,7 @@ import org.springframework.http.ProblemDetail;
 @WebMvcTest(AuthorizationController.class)
 public class AuthorizationControllerTest extends RestControllerTest {
 
-  @MockBean private AuthorizationServices<AuthorizationRecord> authorizationServices;
+  @MockBean private AuthorizationServices authorizationServices;
 
   @BeforeEach
   void setup() {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -358,7 +359,8 @@ public class JobControllerLongPollingTest extends RestControllerTest {
     public JobServices<JobActivationResponse> jobServices(
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
-      return new JobServices<>(brokerClient, activateJobsHandler, null);
+      return new JobServices<>(
+          brokerClient, new SecurityConfiguration(), activateJobsHandler, null);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.service.JobServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
@@ -388,7 +389,8 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
     public JobServices<JobActivationResponse> jobServices(
         final BrokerClient brokerClient,
         final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
-      return new JobServices<>(brokerClient, activateJobsHandler, null);
+      return new JobServices<>(
+          brokerClient, new SecurityConfiguration(), activateJobsHandler, null);
     }
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR introduces a new configuration parameter, `camunda.security.authorizations.enabled`, which enables or disables the permission checks feature (disabled by default). 

In the SaaS, this setting will be controlled by the cluster admin via a cluster-level configuration (see image attached). Updates to the Camunda Operator and Helm charts will follow later.
![image](https://github.com/user-attachments/assets/7a4f6bb1-33a8-42e3-8e7b-07cb8e759f7a)

In V1, this setting sets the `CAMUNDA_TASKLIST_IDENTITY_RESOURCE_PERMISSIONS_ENABLED` and `CAMUNDA_OPERATE_IDENTITY_RESOURCE_PERMISSIONS_ENABLED` environment variables.

I would like to generalize this parameter to also cover the Zeebe engine (which is currently managed through `ZEEBE_BROKER_EXPERIMENTAL_ENGINE_AUTHORIZATIONS_ENABLEAUTHORIZATION`). This would streamline configuration for customers by providing a unified parameter for the full application (especially for the C8 single-app).
I still need to evaluate the feasibility of this change.

For easier review, you can refer to this commit: https://github.com/camunda/camunda/pull/23719/commits/1b61244d8dd5ba40e74c8027cd56a3b4f5d5e06c.

The other commit includes the addition of the configuration across all services and the removal of an unnecessary generic type in `AuthorizationServices`.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #23127 
