### PR TITLE
fix: integrates c8run into the core ci pipeline

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-13]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
 
       - if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -3,6 +3,9 @@ name: "C8Run: build/test"
 on:
   workflow_call:
 
+env:
+  NODE_OPTIONS: "--max_old_space_size=4096"
+
 jobs:
   test_c8run:
     strategy:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -24,6 +24,15 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup yarn
+        shell: bash
+        run: npm install -g yarn
+
       - uses: ./.github/actions/setup-zeebe
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -32,6 +32,8 @@ jobs:
 
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
+        with:
+          maven-extra-args: "-Dskip.fe.build=false"
 
       - name: upload zeebe artifact for windows to use
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -30,14 +30,32 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
-      - uses: ./.github/actions/build-frontend
-        id: build-operate-fe
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
-          directory: ./operate/client
-      - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
+          node-version: "20"
+
+      - name: Setup yarn
+        shell: bash
+        run: npm install -g yarn
+
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
         with:
           directory: ./tasklist/client
+
+      - name: Install node dependencies
+        working-directory: ./tasklist/client
+        shell: bash
+        run: yarn
+
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: ./operate/client
+
+      - name: Install node dependencies
+        working-directory: ./operate/client
+        shell: bash
+        run: yarn
 
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -32,8 +32,6 @@ jobs:
 
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-        with:
-          maven-extra-args: -T1C -PskipFrontendBuild -D skipOptimize
 
       - name: upload zeebe artifact for windows to use
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -14,7 +14,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, macos-13]
     name: C8Run Test ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 45
     steps:
 
       - if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -24,20 +24,20 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-
-      - name: Setup yarn
-        shell: bash
-        run: npm install -g yarn
-
       - uses: ./.github/actions/setup-zeebe
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+      - uses: ./.github/actions/build-frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+      - uses: ./.github/actions/build-frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
 
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -38,10 +38,6 @@ jobs:
         with:
           node-version: "20"
 
-      - name: Setup yarn
-        shell: bash
-        run: npm install -g yarn
-
       - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
         with:
           directory: ./tasklist/client
@@ -54,6 +50,10 @@ jobs:
       - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
         with:
           directory: ./operate/client
+
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: identity/client
 
       - name: Install node dependencies
         working-directory: ./operate/client
@@ -127,10 +127,6 @@ jobs:
         working-directory: ./c8run
         env:
           JAVA_VERSION: 21.0.3
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: ./.github/actions/setup-zeebe
+      - uses: ./.github/actions/setup-build
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -199,7 +199,7 @@ jobs:
           name: zeebe-build-ubuntu-latest
 
       - name: Extract zip file on Windows
-        run: Expand-Archive -Path ./zeebe-build-ubuntu-latest.zip -DestinationPath ./
+        run: tar -xf ./zeebe-build-ubuntu-latest.zip
 
       - name: Delete zip file
         run: del .\zeebe-build-ubuntu-latest.zip

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -33,12 +33,6 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
 
-      - name: build zeebe
-        uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-        with:
-          maven-extra-args: "-Dskip.fe.build=false"
-
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -33,6 +33,12 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
 
+      - name: build zeebe
+        uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: "-Dskip.fe.build=false"
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -1,10 +1,7 @@
 name: "C8Run: build/test"
 
 on:
-  push:
-    paths:
-      - "c8run/**"
-      - ".github/workflows/c8run-build.yaml"
+  workflow_call:
 
 jobs:
   test_c8run:
@@ -27,6 +24,25 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild -D skipOptimize
+
+      - name: upload zeebe artifact for windows to use
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
+        with:
+          name: zeebe-build-${{ matrix.os }}
+          path: ${{ steps.build-zeebe.outputs.distball }}
+          retention-days: 1
+          if-no-files-found: ignore
+
       - name: print architecture
         run: arch
 
@@ -42,6 +58,16 @@ jobs:
       - name: Unit tests
         run: go test
         working-directory: ./c8run
+
+      - name: Copy zeebe build
+        run: cp $distball ./c8run/
+        env:
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+
+      - name: Get version number from zeebe archive
+        run: echo CAMUNDA_VERSION=$( echo $distball | grep -o 'camunda-zeebe-.*' | sed 's/camunda-zeebe-//' | sed 's/\.tar\.gz//') >> $GITHUB_ENV
+        env:
+          distball: ${{ steps.build-zeebe.outputs.distball }}
 
       - name: make a package
         run: ./c8run package
@@ -119,6 +145,7 @@ jobs:
     name: C8Run Test Windows
     runs-on: windows-latest
     timeout-minutes: 15
+    needs: [test_c8run]
     steps:
       - uses: actions/checkout@v4
 
@@ -131,19 +158,40 @@ jobs:
         run: go build
         working-directory: .\c8run
 
+      - name: ls
+        run: ls
+        working-directory: .\c8run
+
+      - uses: actions/download-artifact@v4
+        name: download zeebe build
+        with:
+          path: .\
+          name: zeebe-build-ubuntu-latest
+
+      - name: Extract zip file on Windows
+        run: Expand-Archive -Path ./zeebe-build-ubuntu-latest.zip -DestinationPath ./
+
+      - name: Delete zip file
+        run: del .\zeebe-build-ubuntu-latest.zip
+
+      - name: List inner zip file
+        id: list-inner-zip
+        run: |
+          $innerZip = Get-ChildItem -Path ./extracted -Filter *.zip | Select-Object -First 1
+          echo "CAMUNDA_ZEEBE_ZIP=$($innerZip.Name)" >> $env:GITHUB_ENV
+        shell: pwsh
+
+      - name: Get version number from zeebe archive
+        run: |
+          $distball = $env:CAMUNDA_ZEEBE_ZIP
+          $version = $distball -replace '.*camunda-zeebe-', '' -replace '\.tar\.gz', ''
+          echo "CAMUNDA_VERSION=$version" >> $env:GITHUB_ENV
+
       - name: make a package
         run: .\c8run.exe package
         working-directory: .\c8run
         env:
           GH_TOKEN: ${{ github.token }}
-
-      - name: ls
-        run: ls
-        working-directory: .\c8run
-
-      - name: ls
-        run: ls
-        working-directory: .\c8run\elasticsearch-8.13.4
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -29,9 +29,9 @@ jobs:
 
       - uses: ./.github/actions/setup-build
         with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -199,10 +199,10 @@ jobs:
           name: zeebe-build-ubuntu-latest
 
       - name: Extract zip file on Windows
-        run: tar -xf ./zeebe-build-ubuntu-latest.zip
+        run: tar -xf ..\zeebe-build-ubuntu-latest.zip
 
       - name: Delete zip file
-        run: del .\zeebe-build-ubuntu-latest.zip
+        run: del ..\zeebe-build-ubuntu-latest.zip
 
       - name: List inner zip file
         id: list-inner-zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -887,5 +887,4 @@ jobs:
 
   c8run-build-test:
     name: Deploy c8run
-    needs: [ docker-checks ]
     uses: ./.github/workflows/c8run-build.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,3 +888,4 @@ jobs:
   c8run-build-test:
     name: Deploy c8run
     uses: ./.github/workflows/c8run-build.yaml
+    inherit: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -748,6 +748,7 @@ jobs:
       - protobuf-checks
       - tasklist-frontend-tests
       - zeebe-ci
+      - c8run-build-test
     steps:
       - uses: actions/checkout@v4
       - name: Check for aborted jobs
@@ -833,7 +834,7 @@ jobs:
 
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ docker-checks, check-results ]
+    needs: [ check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions: {}  # GITHUB_TOKEN unused in this job
@@ -883,3 +884,8 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+  c8run-build-test:
+    name: Deploy c8run
+    needs: [ docker-checks ]
+    uses: ./.github/workflows/c8run-build.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,4 +888,4 @@ jobs:
   c8run-build-test:
     name: Deploy c8run
     uses: ./.github/workflows/c8run-build.yaml
-    inherit: true
+    secrets: inherit


### PR DESCRIPTION
## Description

https://github.com/camunda/camunda/issues/23586

This patch changes the build/test process for c8run by building a version of the camunda core that is representative of the current git hash, as opposed to downloading a static version of the camunda core.  

I will also make it upload the c8run assets to the github release of the camunda core for releases, although that change is not yet implemented.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
