### PR TITLE
build: update scss compiler to mute warnings

### DIFF
--- a/tasklist/client/vite.config.ts
+++ b/tasklist/client/vite.config.ts
@@ -57,6 +57,13 @@ export default defineConfig(({mode}) => ({
     banner: '/*! licenses: /assets/vendor.LICENSE.txt */',
     legalComments: 'none',
   },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
## Description

This PR [updates the SCSS compiler](https://vite.dev/config/shared-options.html#css-preprocessoroptions) in order to mute these warnings in he screenshot below.

![image](https://github.com/user-attachments/assets/c5db5e72-6593-4e40-b466-1fe4c4de95b9)

