### PR TITLE
docs: add camunda exporter configs to `broker template` and `broker standalone template`

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1015,6 +1015,7 @@
         #     prefix:
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     variableSizeThreshold: 8191
         #
         #   retention:
         #     enabled: false

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -983,6 +983,46 @@
         #     variable: true
         #     variableDocument: true
 
+      # Camunda Exporter ----------
+      # An example configuration for the camunda exporter:
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_..."
+      #
+      # camundaExporter:
+        # className: io.camunda.exporter.CamundaExporter
+        #
+        # args:
+        #   connect:
+        #     type: elasticsearch
+        #     url: http://localhost:9200
+        #     clusterName: elasticsearch
+        #     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
+        #     socketTimeout: 1000
+        #     connectTimeout: 1000
+        #     username: elastic
+        #     password: changeme
+        #     security:
+        #       enabled: false
+        #       certificatePath: /path/to/certificate
+        #       verifyHostname: true
+        #       selfSigned: false
+        #
+        #   bulk:
+        #     delay: 5
+        #     size: 1000
+        #
+        #   index:
+        #     prefix:
+        #     numberOfShards: 3
+        #     numberOfReplicas: 0
+        #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: camunda-retention-policy
+        #
+        #   createSchema: true
+
     # processing:
       # Sets the maximum number of commands that processed within one batch.
       # The processor will process until no more follow up commands are created by the initial command

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -858,6 +858,47 @@
         #     variable: true
         #     variableDocument: true
 
+      # Camunda Exporter ----------
+      # An example configuration for the camunda exporter:
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_..."
+      #
+      # camundaExporter:
+        # className: io.camunda.exporter.CamundaExporter
+        #
+        # args:
+        #   connect:
+        #     type: elasticsearch
+        #     url: http://localhost:9200
+        #     clusterName: elasticsearch
+        #     dateFormat: yyyy-MM-dd'T'HH:mm:ss.SSSZZ
+        #     socketTimeout: 1000
+        #     connectTimeout: 1000
+        #     username: elastic
+        #     password: changeme
+        #     security:
+        #       enabled: false
+        #       certificatePath: /path/to/certificate
+        #       verifyHostname: true
+        #       selfSigned: false
+        #
+        #   bulk:
+        #     delay: 5
+        #     size: 1000
+        #
+        #   index:
+        #     prefix:
+        #     numberOfShards: 3
+        #     numberOfReplicas: 0
+        #
+        #   retention:
+        #     enabled: false
+        #     minimumAge: 30d
+        #     policyName: camunda-retention-policy
+        #
+        #   createSchema: true
+
+
     # processing:
       # Sets the maximum number of commands that processed within one batch.
       # The processor will process until no more follow up commands are created by the initial command

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -890,6 +890,7 @@
         #     prefix:
         #     numberOfShards: 3
         #     numberOfReplicas: 0
+        #     variableSizeThreshold: 8191
         #
         #   retention:
         #     enabled: false

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -17,8 +17,6 @@ public class ExporterConfiguration {
   private IndexSettings index = new IndexSettings();
   private BulkConfiguration bulk = new BulkConfiguration();
   private RetentionConfiguration retention = new RetentionConfiguration();
-  private Map<String, Integer> replicasByIndexName = new HashMap<>();
-  private Map<String, Integer> shardsByIndexName = new HashMap<>();
   private boolean createSchema = true;
 
   public ConnectConfiguration getConnect() {
@@ -53,22 +51,6 @@ public class ExporterConfiguration {
     this.retention = retention;
   }
 
-  public Map<String, Integer> getReplicasByIndexName() {
-    return replicasByIndexName;
-  }
-
-  public void setReplicasByIndexName(final Map<String, Integer> replicasByIndexName) {
-    this.replicasByIndexName = replicasByIndexName;
-  }
-
-  public Map<String, Integer> getShardsByIndexName() {
-    return shardsByIndexName;
-  }
-
-  public void setShardsByIndexName(final Map<String, Integer> shardsByIndexName) {
-    this.shardsByIndexName = shardsByIndexName;
-  }
-
   public boolean isCreateSchema() {
     return createSchema;
   }
@@ -88,10 +70,6 @@ public class ExporterConfiguration {
         + bulk
         + ", retention="
         + retention
-        + ", replicasByIndexName="
-        + replicasByIndexName
-        + ", shardsByIndexName="
-        + shardsByIndexName
         + ", createSchema="
         + createSchema
         + '}';
@@ -103,6 +81,10 @@ public class ExporterConfiguration {
 
     private Integer numberOfShards = 1;
     private Integer numberOfReplicas = 0;
+
+    private Map<String, Integer> replicasByIndexName = new HashMap<>();
+    private Map<String, Integer> shardsByIndexName = new HashMap<>();
+
     private Integer variableSizeThreshold = DEFAULT_VARIABLE_SIZE_THRESHOLD;
 
     public String getPrefix() {
@@ -147,7 +129,29 @@ public class ExporterConfiguration {
           + numberOfShards
           + ", numberOfReplicas="
           + numberOfReplicas
+          + ", replicasByIndexName="
+          + replicasByIndexName
+          + ", shardsByIndexName="
+          + shardsByIndexName
+          + ", variableSizeThreshold="
+          + variableSizeThreshold
           + '}';
+    }
+
+    public Map<String, Integer> getReplicasByIndexName() {
+      return replicasByIndexName;
+    }
+
+    public void setReplicasByIndexName(final Map<String, Integer> replicasByIndexName) {
+      this.replicasByIndexName = replicasByIndexName;
+    }
+
+    public Map<String, Integer> getShardsByIndexName() {
+      return shardsByIndexName;
+    }
+
+    public void setShardsByIndexName(final Map<String, Integer> shardsByIndexName) {
+      this.shardsByIndexName = shardsByIndexName;
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -124,10 +124,12 @@ public class SchemaManager {
   private IndexSettings getIndexSettings(final String indexName) {
     final var templateReplicas =
         config
+            .getIndex()
             .getReplicasByIndexName()
             .getOrDefault(indexName, config.getIndex().getNumberOfReplicas());
     final var templateShards =
         config
+            .getIndex()
             .getShardsByIndexName()
             .getOrDefault(indexName, config.getIndex().getNumberOfShards());
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -134,8 +134,8 @@ public class SchemaManagerIT {
     final var properties = new ExporterConfiguration();
     properties.getIndex().setNumberOfReplicas(10);
     properties.getIndex().setNumberOfShards(10);
-    properties.setReplicasByIndexName(Map.of("index_name", 5));
-    properties.setShardsByIndexName(Map.of("index_name", 5));
+    properties.getIndex().setReplicasByIndexName(Map.of("index_name", 5));
+    properties.getIndex().setShardsByIndexName(Map.of("index_name", 5));
 
     final var schemaManager =
         new SchemaManager(searchEngineClient, Set.of(index), Set.of(indexTemplate), properties);


### PR DESCRIPTION
## Description

Added camunda exporter configs to `broker template` and `broker standalone template`.

**PS:** I only added the main configs that should be needed or the ones that can at least have a default value. Some configs like `index.replicasByIndexName`, `index.shardsByIndexName` and `connect.interceptorPlugins` are not documented there since it's difficult to come up with an example

## Related issues

closes #23633
