### PR TITLE
docs: adjust tag order in OpenAPI spec

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -23,6 +23,28 @@ servers:
         default: http
         description: The schema of the Camunda 8 REST API server.
 
+tags:
+  - name: Authorization
+  - name: Clock
+  - name: Cluster
+  - name: Decision definition
+  - name: Decision instance
+  - name: Decision requirements
+  - name: Document
+  - name: Element instance
+  - name: Flow node instance
+  - name: Incident
+  - name: Job
+  - name: License
+  - name: Message
+  - name: Process definition
+  - name: Process instance
+  - name: Resource
+  - name: Signal
+  - name: User
+  - name: User task
+  - name: Variable
+
 paths:
   /topology:
     get:
@@ -1994,7 +2016,7 @@ paths:
   /documents:
     post:
       tags:
-        - Documents
+        - Document
       summary: Upload document (alpha)
       description: |
         Upload a document to the Camunda 8 cluster.
@@ -2052,7 +2074,7 @@ paths:
   /documents/{documentId}:
     get:
       tags:
-        - Documents
+        - Document
       summary: Download document (alpha)
       description: |
         Download a document from the Camunda 8 cluster.
@@ -2098,7 +2120,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
     delete:
       tags:
-        - Documents
+        - Document
       summary: Delete document (alpha)
       description: |
         Delete a document from the Camunda 8 cluster.
@@ -2140,7 +2162,7 @@ paths:
   /document/{documentId}/links:
     post:
       tags:
-        - Documents
+        - Document
       summary: Create document link (alpha)
       description: |
         Create a link to a document in the Camunda 8 cluster.


### PR DESCRIPTION
## Description

Specifying the tags contained in the spec in an alphabetical order on a global level aligns them in the generated documentation as well.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

n/a