### PR TITLE
[CPT] Print process instance data if a test fails

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -88,6 +88,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <!--  test scope  -->
 
     <dependency>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -22,10 +22,14 @@ import io.camunda.process.test.impl.containers.CamundaContainer;
 import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
 import io.camunda.process.test.impl.runtime.CamundaContainerRuntimeBuilder;
+import io.camunda.process.test.impl.testresult.CamundaProcessTestResultCollector;
+import io.camunda.process.test.impl.testresult.CamundaProcessTestResultPrinter;
+import io.camunda.process.test.impl.testresult.ProcessTestResult;
 import io.camunda.zeebe.client.ZeebeClient;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -67,11 +71,16 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
   private final List<ZeebeClient> createdClients = new ArrayList<>();
 
   private final CamundaContainerRuntimeBuilder containerRuntimeBuilder;
+  private final CamundaProcessTestResultPrinter processTestResultPrinter;
 
   private CamundaContainerRuntime containerRuntime;
+  private CamundaProcessTestResultCollector processTestResultCollector;
 
-  CamundaProcessTestExtension(final CamundaContainerRuntimeBuilder containerRuntimeBuilder) {
+  CamundaProcessTestExtension(
+      final CamundaContainerRuntimeBuilder containerRuntimeBuilder,
+      final Consumer<String> testResultPrintStream) {
     this.containerRuntimeBuilder = containerRuntimeBuilder;
+    processTestResultPrinter = new CamundaProcessTestResultPrinter(testResultPrintStream);
   }
 
   /**
@@ -90,7 +99,7 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
    * </pre>
    */
   public CamundaProcessTestExtension() {
-    this(CamundaContainerRuntime.newBuilder());
+    this(CamundaContainerRuntime.newBuilder(), System.err::println);
   }
 
   @Override
@@ -123,6 +132,9 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
     // initialize assertions
     final CamundaDataSource dataSource = createDataSource(containerRuntime);
     CamundaAssert.initialize(dataSource);
+
+    // initialize result collector
+    processTestResultCollector = new CamundaProcessTestResultCollector(dataSource);
   }
 
   private <T> void injectField(
@@ -160,12 +172,24 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
 
   @Override
   public void afterEach(final ExtensionContext extensionContext) throws Exception {
+    // collect test results
+    final ProcessTestResult testResult = processTestResultCollector.collect();
+
     // reset assertions
     CamundaAssert.reset();
     // close all created clients
     createdClients.forEach(ZeebeClient::close);
     // close the runtime
     containerRuntime.close();
+
+    // print test results
+    if (isTestFailed(extensionContext)) {
+      processTestResultPrinter.print(testResult);
+    }
+  }
+
+  private static boolean isTestFailed(final ExtensionContext extensionContext) {
+    return extensionContext.getExecutionException().isPresent();
   }
 
   // ============ Configuration options =================

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -17,6 +17,7 @@ package io.camunda.process.test.impl.assertions;
 
 import io.camunda.process.test.impl.client.CamundaApiClient;
 import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
+import io.camunda.process.test.impl.client.IncidentDto;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
 import io.camunda.process.test.impl.client.VariableDto;
 import java.io.IOException;
@@ -44,5 +45,13 @@ public class CamundaDataSource {
   public List<VariableDto> getVariablesByProcessInstanceKey(final long processInstanceKey)
       throws IOException {
     return camundaApiClient.findVariablesByProcessInstanceKey(processInstanceKey).getItems();
+  }
+
+  public List<ProcessInstanceDto> findProcessInstances() throws IOException {
+    return camundaApiClient.findProcessInstances().getItems();
+  }
+
+  public IncidentDto getIncidentByKey(final long incidentKey) throws IOException {
+    return camundaApiClient.getIncidentByKey(incidentKey);
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaApiClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaApiClient.java
@@ -35,8 +35,10 @@ public class CamundaApiClient {
 
   // Operate v1 endpoints
   private static final String PROCESS_INSTANCE_GET_ENDPOINT = "/v1/process-instances/%d";
+  private static final String PROCESS_INSTANCE_SEARCH_ENDPOINT = "/v1/process-instances/search";
   private static final String FLOW_NODE_INSTANCES_SEARCH_ENDPOINT = "/v1/flownode-instances/search";
   private static final String VARIABLES_SEARCH_ENDPOINT = "/v1/variables/search";
+  private static final String INCIDENTS_GET_ENDPOINT = "/v1/incidents/%d";
 
   private final ObjectMapper objectMapper =
       new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -100,6 +102,14 @@ public class CamundaApiClient {
     return objectMapper.readValue(body, ProcessInstanceDto.class);
   }
 
+  public SearchProcessInstanceResponseDto findProcessInstances() throws IOException {
+    ensureAuthenticated();
+
+    final String requestBody = "{}";
+    final String responseBody = sendPostRequest(PROCESS_INSTANCE_SEARCH_ENDPOINT, requestBody);
+    return objectMapper.readValue(responseBody, SearchProcessInstanceResponseDto.class);
+  }
+
   public FlowNodeInstancesResponseDto findFlowNodeInstancesByProcessInstanceKey(
       final long processInstanceKey) throws IOException {
     ensureAuthenticated();
@@ -120,6 +130,13 @@ public class CamundaApiClient {
             processInstanceKey, processInstanceKey);
     final String responseBody = sendPostRequest(VARIABLES_SEARCH_ENDPOINT, requestBody);
     return objectMapper.readValue(responseBody, VariableResponseDto.class);
+  }
+
+  public IncidentDto getIncidentByKey(final long incidentKey) throws IOException {
+    ensureAuthenticated();
+
+    final String body = sendGetRequest(String.format(INCIDENTS_GET_ENDPOINT, incidentKey));
+    return objectMapper.readValue(body, IncidentDto.class);
   }
 
   private String sendGetRequest(final String endpoint) throws IOException {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/IncidentDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/IncidentDto.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class IncidentDto {
+  private long key;
+  private String type;
+  private String message;
+
+  public long getKey() {
+    return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/SearchProcessInstanceResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/SearchProcessInstanceResponseDto.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+import java.util.List;
+
+public class SearchProcessInstanceResponseDto {
+
+  private List<ProcessInstanceDto> items;
+  private long total;
+
+  public List<ProcessInstanceDto> getItems() {
+    return items;
+  }
+
+  public void setItems(final List<ProcessInstanceDto> items) {
+    this.items = items;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  public void setTotal(final long total) {
+    this.total = total;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/CamundaContainer.java
@@ -32,7 +32,7 @@ public class CamundaContainer extends GenericContainer<CamundaContainer> {
   private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
   private static final String READY_ENDPOINT = "/ready";
 
-  private static final String ACTIVE_SPRING_PROFILES = "operate,tasklist,broker,dev,dev-data,auth";
+  private static final String ACTIVE_SPRING_PROFILES = "operate,tasklist,broker,auth";
 
   private static final String GRPC_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_GATEWAY_API;
   private static final String REST_API = "localhost:" + ContainerRuntimePorts.CAMUNDA_REST_API;

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultCollector.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
+import io.camunda.process.test.impl.client.IncidentDto;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.VariableDto;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CamundaProcessTestResultCollector {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(CamundaProcessTestResultCollector.class);
+
+  private final CamundaDataSource dataSource;
+
+  public CamundaProcessTestResultCollector(final CamundaDataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  public ProcessTestResult collect() {
+    final ProcessTestResult result = new ProcessTestResult();
+
+    try {
+      final List<ProcessInstanceResult> processInstanceResults =
+          dataSource.findProcessInstances().stream()
+              .map(this::collectProcessInstanceResult)
+              .collect(Collectors.toList());
+      result.setProcessInstanceTestResults(processInstanceResults);
+    } catch (final IOException e) {
+      LOG.warn("Failed to collect the process instance results.", e);
+    }
+
+    return result;
+  }
+
+  private ProcessInstanceResult collectProcessInstanceResult(
+      final ProcessInstanceDto processInstance) {
+    final ProcessInstanceResult result = new ProcessInstanceResult();
+
+    final long processInstanceKey = processInstance.getKey();
+
+    result.setProcessInstanceKey(processInstanceKey);
+    result.setProcessId(processInstance.getBpmnProcessId());
+    result.setVariables(collectVariables(processInstanceKey));
+    result.setOpenIncidents(collectOpenIncidents(processInstanceKey));
+
+    return result;
+  }
+
+  private Map<String, String> collectVariables(final long processInstanceKey) {
+    try {
+      return dataSource.getVariablesByProcessInstanceKey(processInstanceKey).stream()
+          .collect(Collectors.toMap(VariableDto::getName, VariableDto::getValue));
+    } catch (final IOException e) {
+      LOG.warn("Failed to collect process instance variables for key '{}'", processInstanceKey, e);
+    }
+    return Collections.emptyMap();
+  }
+
+  private List<OpenIncident> collectOpenIncidents(final long processInstanceKey) {
+    try {
+      return dataSource.getFlowNodeInstancesByProcessInstanceKey(processInstanceKey).stream()
+          .filter(FlowNodeInstanceDto::isIncident)
+          .map(this::getIncident)
+          .collect(Collectors.toList());
+    } catch (final IOException e) {
+      LOG.warn(
+          "Failed to collect incidents for process instance with key '{}'", processInstanceKey, e);
+    }
+    return Collections.emptyList();
+  }
+
+  private OpenIncident getIncident(final FlowNodeInstanceDto flowNodeInstance) {
+    final OpenIncident openIncident = new OpenIncident();
+    openIncident.setFlowNodeId(flowNodeInstance.getFlowNodeId());
+
+    try {
+      final IncidentDto incident = dataSource.getIncidentByKey(flowNodeInstance.getIncidentKey());
+      openIncident.setType(incident.getType());
+      openIncident.setMessage(incident.getMessage());
+
+    } catch (final IOException e) {
+      openIncident.setType("?");
+      openIncident.setMessage("?");
+    }
+    return openIncident;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/CamundaProcessTestResultPrinter.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+
+public class CamundaProcessTestResultPrinter {
+
+  private static final String NO_ENTRIES = "<None>";
+  private static final int MAX_VALUE_LENGTH = 500;
+
+  private final Consumer<String> printStream;
+
+  public CamundaProcessTestResultPrinter(final Consumer<String> printStream) {
+    this.printStream = printStream;
+  }
+
+  public void print(final ProcessTestResult result) {
+    final String formattedResult = formatResult(result);
+    printStream.accept(formattedResult);
+  }
+
+  private String formatResult(final ProcessTestResult result) {
+    return "Process test results:\n"
+        + "=====================\n\n"
+        + formatProcessInstances(result.getProcessInstanceTestResults())
+        + "\n"
+        + "=====================\n";
+  }
+
+  private static String formatProcessInstances(
+      final List<ProcessInstanceResult> processInstanceResults) {
+    return processInstanceResults.stream()
+        .map(CamundaProcessTestResultPrinter::formatProcessInstance)
+        .collect(Collectors.joining("\n---------------------\n\n"));
+  }
+
+  private static String formatProcessInstance(final ProcessInstanceResult result) {
+    final String formattedProcessInstance =
+        String.format(
+            "Process instance: %d [process-id: '%s']",
+            result.getProcessInstanceKey(), result.getProcessId());
+
+    return formattedProcessInstance
+        + "\n\n"
+        + "Variables:\n"
+        + formatVariables(result.getVariables())
+        + "\n\n"
+        + "Open incidents:\n"
+        + formatIncidents(result.getOpenIncidents());
+  }
+
+  private static String formatVariables(final Map<String, String> variables) {
+    if (variables.isEmpty()) {
+      return NO_ENTRIES;
+    } else {
+      return variables.entrySet().stream()
+          .map(variable -> formatVariable(variable.getKey(), variable.getValue()))
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  private static String formatVariable(final String key, final String value) {
+    return String.format("- '%s': %s", key, abbreviate(value));
+  }
+
+  private static String abbreviate(final String value) {
+    return StringUtils.abbreviate(value, MAX_VALUE_LENGTH);
+  }
+
+  private static String formatIncidents(final List<OpenIncident> incidents) {
+    if (incidents.isEmpty()) {
+      return NO_ENTRIES;
+    } else {
+      return incidents.stream()
+          .map(CamundaProcessTestResultPrinter::formatIncident)
+          .collect(Collectors.joining("\n"));
+    }
+  }
+
+  private static String formatIncident(final OpenIncident incident) {
+    return String.format(
+        "- '%s' [type: %s] \"%s\"",
+        incident.getFlowNodeId(), incident.getType(), abbreviate(incident.getMessage()));
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/OpenIncident.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/OpenIncident.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+public class OpenIncident {
+  private String type;
+  private String message;
+
+  private String flowNodeId;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(final String message) {
+    this.message = message;
+  }
+
+  public String getFlowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessInstanceResult.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ProcessInstanceResult {
+
+  private long processInstanceKey;
+  private String processId;
+
+  private Map<String, String> variables = new HashMap<>();
+
+  private List<OpenIncident> openIncidents = new ArrayList<>();
+
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public String getProcessId() {
+    return processId;
+  }
+
+  public void setProcessId(final String processId) {
+    this.processId = processId;
+  }
+
+  public Map<String, String> getVariables() {
+    return variables;
+  }
+
+  public void setVariables(final Map<String, String> variables) {
+    this.variables = variables;
+  }
+
+  public List<OpenIncident> getOpenIncidents() {
+    return openIncidents;
+  }
+
+  public void setOpenIncidents(final List<OpenIncident> openIncidents) {
+    this.openIncidents = openIncidents;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessTestResult.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/testresult/ProcessTestResult.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProcessTestResult {
+
+  private List<ProcessInstanceResult> processInstanceResults = new ArrayList<>();
+
+  public List<ProcessInstanceResult> getProcessInstanceTestResults() {
+    return processInstanceResults;
+  }
+
+  public void setProcessInstanceTestResults(
+      final List<ProcessInstanceResult> processInstanceResults) {
+    this.processInstanceResults = processInstanceResults;
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -145,10 +145,7 @@ public class VariableAssertTest {
                   CamundaAssert.assertThat(processInstanceEvent)
                       .hasVariableNames("a", "b", "c", "d"))
           .hasMessage(
-              "Process instance [key: %d] should have the variables ['a', 'b', 'c', 'd'] but ['c', 'd'] don't exist. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': 1\n"
-                  + "\t- 'b': 2",
+              "Process instance [key: %d] should have the variables ['a', 'b', 'c', 'd'] but ['c', 'd'] don't exist.",
               PROCESS_INSTANCE_KEY);
     }
   }
@@ -227,10 +224,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("c", 3))
           .hasMessage(
-              "Process instance [key: %d] should have a variable 'c' with value '3' but the variable doesn't exist. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': 1\n"
-                  + "\t- 'b': 2",
+              "Process instance [key: %d] should have a variable 'c' with value '3' but the variable doesn't exist.",
               PROCESS_INSTANCE_KEY);
     }
 
@@ -250,10 +244,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 2))
           .hasMessage(
-              "Process instance [key: %d] should have a variable 'a' with value '2' but was '1'. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': 1\n"
-                  + "\t- 'b': 2",
+              "Process instance [key: %d] should have a variable 'a' with value '2' but was '1'.",
               PROCESS_INSTANCE_KEY);
     }
 
@@ -273,9 +264,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", -1))
           .hasMessage(
-              "Process instance [key: %d] should have a variable 'a' with value '-1' but was '%s'. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': %s",
+              "Process instance [key: %d] should have a variable 'a' with value '-1' but was '%s'.",
               PROCESS_INSTANCE_KEY, variableValue, variableValue);
     }
   }
@@ -369,10 +358,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
           .hasMessage(
-              "Process instance [key: %d] should have the variables {\"a\":1,\"c\":3} but ['c'] don't match. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': 1\n"
-                  + "\t- 'b': 2",
+              "Process instance [key: %d] should have the variables {\"a\":1,\"c\":3} but was {\"a\":1}. The variables ['c'] don't exist.",
               PROCESS_INSTANCE_KEY);
     }
 
@@ -397,11 +383,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
           .hasMessage(
-              "Process instance [key: %d] should have the variables {\"a\":1,\"b\":1} but ['b'] don't match. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': 1\n"
-                  + "\t- 'b': 2\n"
-                  + "\t- 'c': 3",
+              "Process instance [key: %d] should have the variables {\"a\":1,\"b\":1} but was {\"a\":1,\"b\":2}.",
               PROCESS_INSTANCE_KEY);
     }
 
@@ -424,9 +406,7 @@ public class VariableAssertTest {
       Assertions.assertThatThrownBy(
               () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
           .hasMessage(
-              "Process instance [key: %d] should have the variables {\"a\":-1} but ['a'] don't match. "
-                  + "All process instance variables:\n"
-                  + "\t- 'a': %s",
+              "Process instance [key: %d] should have the variables {\"a\":-1} but was {\"a\":%s}.",
               PROCESS_INSTANCE_KEY, variableValue);
     }
   }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultCollectorTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
+import io.camunda.process.test.impl.client.IncidentDto;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.VariableDto;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class CamundaProcessResultCollectorTest {
+
+  @Mock private CamundaDataSource camundaDataSource;
+
+  private CamundaProcessTestResultCollector resultCollector;
+
+  @BeforeEach
+  void configureMocks() {
+    resultCollector = new CamundaProcessTestResultCollector(camundaDataSource);
+  }
+
+  @Test
+  void shouldReturnEmptyResult() throws IOException {
+    // given
+    when(camundaDataSource.findProcessInstances()).thenReturn(Collections.emptyList());
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceTestResults()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnEmptyResultIfDataSourceThrowsException() throws IOException {
+    // given
+    doThrow(new IOException("expected failure")).when(camundaDataSource).findProcessInstances();
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceTestResults()).isEmpty();
+  }
+
+  @Test
+  void shouldReturnProcessInstances() throws IOException {
+    // given
+    final ProcessInstanceDto processInstance1 = newProcessInstance(1L, "process-a");
+    final ProcessInstanceDto processInstance2 = newProcessInstance(2L, "process-b");
+    when(camundaDataSource.findProcessInstances())
+        .thenReturn(Arrays.asList(processInstance1, processInstance2));
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result.getProcessInstanceTestResults())
+        .hasSize(2)
+        .extracting(
+            ProcessInstanceResult::getProcessInstanceKey, ProcessInstanceResult::getProcessId)
+        .contains(tuple(1L, "process-a"), tuple(2L, "process-b"));
+
+    assertThat(result.getProcessInstanceTestResults())
+        .allMatch(processInstanceResult -> processInstanceResult.getVariables().isEmpty())
+        .allMatch(processInstanceResult -> processInstanceResult.getOpenIncidents().isEmpty());
+  }
+
+  @Test
+  void shouldReturnProcessInstanceVariables() throws IOException {
+    // given
+    final ProcessInstanceDto processInstance1 = newProcessInstance(1L, "process-a");
+    final ProcessInstanceDto processInstance2 = newProcessInstance(2L, "process-b");
+    when(camundaDataSource.findProcessInstances())
+        .thenReturn(Arrays.asList(processInstance1, processInstance2));
+
+    final VariableDto variable1 = newVariable("var-1", "1");
+    final VariableDto variable2 = newVariable("var-2", "2");
+    when(camundaDataSource.getVariablesByProcessInstanceKey(processInstance1.getKey()))
+        .thenReturn(Arrays.asList(variable1, variable2));
+
+    final VariableDto variable3 = newVariable("var-3", "3");
+    when(camundaDataSource.getVariablesByProcessInstanceKey(processInstance2.getKey()))
+        .thenReturn(Collections.singletonList(variable3));
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result.getProcessInstanceTestResults()).hasSize(2);
+
+    assertThat(result.getProcessInstanceTestResults().get(0).getVariables())
+        .hasSize(2)
+        .containsEntry("var-1", "1")
+        .containsEntry("var-2", "2");
+
+    assertThat(result.getProcessInstanceTestResults().get(1).getVariables())
+        .hasSize(1)
+        .containsEntry("var-3", "3");
+  }
+
+  @Test
+  void shouldReturnOpenIncidents() throws IOException {
+    // given
+    final ProcessInstanceDto processInstance1 = newProcessInstance(1L, "process-a");
+    final ProcessInstanceDto processInstance2 = newProcessInstance(2L, "process-b");
+    when(camundaDataSource.findProcessInstances())
+        .thenReturn(Arrays.asList(processInstance1, processInstance2));
+
+    final FlowNodeInstanceDto flowNodeInstance1 = newFlowNodeInstance("task-a", "A");
+    flowNodeInstance1.setIncident(true);
+    flowNodeInstance1.setIncidentKey(10L);
+
+    final FlowNodeInstanceDto flowNodeInstance2 = newFlowNodeInstance("task-b", "B");
+    flowNodeInstance2.setIncident(true);
+    flowNodeInstance2.setIncidentKey(11L);
+
+    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(processInstance1.getKey()))
+        .thenReturn(Arrays.asList(flowNodeInstance1, flowNodeInstance2));
+
+    final FlowNodeInstanceDto flowNodeInstance3 = newFlowNodeInstance("task-c", "C");
+    flowNodeInstance3.setIncident(true);
+    flowNodeInstance3.setIncidentKey(12L);
+
+    final FlowNodeInstanceDto flowNodeInstance4 = newFlowNodeInstance("task-d", "D");
+    flowNodeInstance4.setIncident(false);
+
+    when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(processInstance2.getKey()))
+        .thenReturn(Arrays.asList(flowNodeInstance3, flowNodeInstance4));
+
+    final IncidentDto incident1 = newIncident("JOB_NO_RETRIES", "No retries left.");
+    final IncidentDto incident2 =
+        newIncident("EXTRACT_VALUE_ERROR", "Failed to evaluate expression.");
+    final IncidentDto incident3 =
+        newIncident("UNHANDLED_ERROR_EVENT", "No error catch event found.");
+
+    when(camundaDataSource.getIncidentByKey(flowNodeInstance1.getIncidentKey()))
+        .thenReturn(incident1);
+    when(camundaDataSource.getIncidentByKey(flowNodeInstance2.getIncidentKey()))
+        .thenReturn(incident2);
+    when(camundaDataSource.getIncidentByKey(flowNodeInstance3.getIncidentKey()))
+        .thenReturn(incident3);
+
+    // when
+    final ProcessTestResult result = resultCollector.collect();
+
+    // then
+    assertThat(result.getProcessInstanceTestResults()).hasSize(2);
+
+    assertThat(result.getProcessInstanceTestResults().get(0).getOpenIncidents())
+        .hasSize(2)
+        .extracting(OpenIncident::getType, OpenIncident::getMessage, OpenIncident::getFlowNodeId)
+        .contains(
+            tuple("JOB_NO_RETRIES", "No retries left.", "task-a"),
+            tuple("EXTRACT_VALUE_ERROR", "Failed to evaluate expression.", "task-b"));
+
+    assertThat(result.getProcessInstanceTestResults().get(1).getOpenIncidents())
+        .hasSize(1)
+        .extracting(OpenIncident::getType, OpenIncident::getMessage, OpenIncident::getFlowNodeId)
+        .contains(tuple("UNHANDLED_ERROR_EVENT", "No error catch event found.", "task-c"));
+  }
+
+  private static ProcessInstanceDto newProcessInstance(
+      final long processInstanceKey, final String processId) {
+    final ProcessInstanceDto processInstance = new ProcessInstanceDto();
+    processInstance.setKey(processInstanceKey);
+    processInstance.setBpmnProcessId(processId);
+    return processInstance;
+  }
+
+  private static VariableDto newVariable(final String variableName, final String variableValue) {
+    final VariableDto variable = new VariableDto();
+    variable.setName(variableName);
+    variable.setValue(variableValue);
+    return variable;
+  }
+
+  private static FlowNodeInstanceDto newFlowNodeInstance(
+      final String nodeId, final String nodeName) {
+    final FlowNodeInstanceDto flowNodeInstance = new FlowNodeInstanceDto();
+    flowNodeInstance.setFlowNodeId(nodeId);
+    flowNodeInstance.setFlowNodeName(nodeName);
+    return flowNodeInstance;
+  }
+
+  private static IncidentDto newIncident(final String type, final String message) {
+    final IncidentDto incident = new IncidentDto();
+    incident.setType(type);
+    incident.setMessage(message);
+    return incident;
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/impl/testresult/CamundaProcessResultPrinterTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.testresult;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.Test;
+
+public class CamundaProcessResultPrinterTest {
+
+  @Test
+  void shouldPrintEmptyResult() {
+    // given
+    final ProcessTestResult emptyTestResult = new ProcessTestResult();
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(emptyTestResult);
+
+    // then
+    assertThat(outputBuilder.toString())
+        .isEqualTo(
+            "Process test results:\n"
+                + "=====================\n"
+                + "\n\n"
+                + "=====================\n");
+  }
+
+  @Test
+  void shouldPrintProcessInstances() {
+    // given
+    final ProcessTestResult processTestResult = new ProcessTestResult();
+    final ProcessInstanceResult processInstance1 = newProcessInstance(1L, "process-a");
+    final ProcessInstanceResult processInstance2 = newProcessInstance(2L, "process-b");
+
+    processTestResult.setProcessInstanceTestResults(
+        Arrays.asList(processInstance1, processInstance2));
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(processTestResult);
+
+    // then
+    assertThat(outputBuilder.toString())
+        .isEqualTo(
+            "Process test results:\n"
+                + "=====================\n"
+                + "\n"
+                + "Process instance: 1 [process-id: 'process-a']\n"
+                + "\n"
+                + "Variables:\n"
+                + "<None>\n"
+                + "\n"
+                + "Open incidents:\n"
+                + "<None>\n"
+                + "---------------------\n"
+                + "\n"
+                + "Process instance: 2 [process-id: 'process-b']\n"
+                + "\n"
+                + "Variables:\n"
+                + "<None>\n"
+                + "\n"
+                + "Open incidents:\n"
+                + "<None>\n"
+                + "=====================\n");
+  }
+
+  @Test
+  void shouldPrintProcessInstanceVariables() {
+    // given
+    final ProcessTestResult processTestResult = new ProcessTestResult();
+
+    final ProcessInstanceResult processInstance1 = newProcessInstance(1L, "process-a");
+    final Map<String, String> variables1 = new HashMap<>();
+    variables1.put("var-1", "1");
+    processInstance1.setVariables(variables1);
+
+    final ProcessInstanceResult processInstance2 = newProcessInstance(2L, "process-b");
+    final Map<String, String> variables2 = new HashMap<>();
+    variables2.put("var-2", "2");
+    processInstance2.setVariables(variables2);
+
+    processTestResult.setProcessInstanceTestResults(
+        Arrays.asList(processInstance1, processInstance2));
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(processTestResult);
+
+    // then
+    assertThat(outputBuilder.toString())
+        .containsSubsequence(
+            "Process instance: 1 [process-id: 'process-a']\n",
+            "Variables:\n",
+            "- 'var-1': 1\n",
+            "Process instance: 2 [process-id: 'process-b']\n",
+            "Variables:\n",
+            "- 'var-2': 2\n");
+  }
+
+  @Test
+  void shouldPrintOpenIncidents() {
+    // given
+    final ProcessTestResult processTestResult = new ProcessTestResult();
+
+    final ProcessInstanceResult processInstance1 = newProcessInstance(1L, "process-a");
+    final OpenIncident incident1 = newOpenIncident("JOB_NO_RETRIES", "No retries left.", "task-a");
+    final OpenIncident incident2 =
+        newOpenIncident("EXTRACT_VALUE_ERROR", "Failed to evaluate expression.", "task-b");
+    processInstance1.setOpenIncidents(Arrays.asList(incident1, incident2));
+
+    final ProcessInstanceResult processInstance2 = newProcessInstance(2L, "process-b");
+    final OpenIncident incident3 =
+        newOpenIncident("UNHANDLED_ERROR_EVENT", "No error catch event found.", "task-c");
+    processInstance2.setOpenIncidents(Collections.singletonList(incident3));
+
+    processTestResult.setProcessInstanceTestResults(
+        Arrays.asList(processInstance1, processInstance2));
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(processTestResult);
+
+    // then
+    assertThat(outputBuilder.toString())
+        .containsSubsequence(
+            "Process instance: 1 [process-id: 'process-a']\n",
+            "Open incidents:\n",
+            "- 'task-a' [type: JOB_NO_RETRIES] \"No retries left.\"\n",
+            "- 'task-b' [type: EXTRACT_VALUE_ERROR] \"Failed to evaluate expression.\"\n",
+            "Process instance: 2 [process-id: 'process-b']\n",
+            "Open incidents:\n",
+            "- 'task-c' [type: UNHANDLED_ERROR_EVENT] \"No error catch event found.\"\n");
+  }
+
+  @Test
+  void shouldAbbreviateBigVariableValue() {
+    // given
+    final ProcessTestResult processTestResult = new ProcessTestResult();
+    final ProcessInstanceResult processInstance = newProcessInstance(1L, "process-a");
+    final Map<String, String> variables = new HashMap<>();
+
+    final String bigVariableValue = StringUtils.repeat("x", 1000);
+    variables.put("var", bigVariableValue);
+
+    processInstance.setVariables(variables);
+    processTestResult.setProcessInstanceTestResults(Collections.singletonList(processInstance));
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(processTestResult);
+
+    // then
+    final String expectedVariableValue = StringUtils.abbreviate(bigVariableValue, 500);
+    assertThat(outputBuilder.toString())
+        .containsSequence("Variables:\n", "- 'var': " + expectedVariableValue);
+  }
+
+  @Test
+  void shouldAbbreviateBigIncidentMessage() {
+    // given
+    final ProcessTestResult processTestResult = new ProcessTestResult();
+    final ProcessInstanceResult processInstance = newProcessInstance(1L, "process-a");
+
+    final String bigIncidentMessage = StringUtils.repeat("x", 1000);
+    final OpenIncident incident = newOpenIncident("JOB_NO_RETRIES", bigIncidentMessage, "task-a");
+
+    processInstance.setOpenIncidents(Collections.singletonList(incident));
+    processTestResult.setProcessInstanceTestResults(Collections.singletonList(processInstance));
+
+    // when
+    final StringBuilder outputBuilder = new StringBuilder();
+    final CamundaProcessTestResultPrinter resultPrinter =
+        new CamundaProcessTestResultPrinter(outputBuilder::append);
+
+    resultPrinter.print(processTestResult);
+
+    // then
+    final String expectedIncidentMessage = StringUtils.abbreviate(bigIncidentMessage, 500);
+    assertThat(outputBuilder.toString())
+        .containsSequence(
+            "Open incidents:\n", "- 'task-a' [type: JOB_NO_RETRIES] \"" + expectedIncidentMessage);
+  }
+
+  private static ProcessInstanceResult newProcessInstance(
+      final long processInstanceKey, final String processId) {
+    final ProcessInstanceResult processInstance = new ProcessInstanceResult();
+    processInstance.setProcessInstanceKey(processInstanceKey);
+    processInstance.setProcessId(processId);
+    return processInstance;
+  }
+
+  private static OpenIncident newOpenIncident(
+      final String type, final String message, final String flowNodeId) {
+    final OpenIncident incident = new OpenIncident();
+    incident.setType(type);
+    incident.setMessage(message);
+    incident.setFlowNodeId(flowNodeId);
+    return incident;
+  }
+}


### PR DESCRIPTION
## Description

If a test fails, the extension/execution listener prints the following data:
- All process instances with key and process-id
- All (global) process instance variables 
- Open incidents

Reviewer notes:
- The JUnit TestWatcher could be a good fit but this doesn't work with the Spring execution listener.
- We can use the process test result later to generate the process coverage report.  

Test output:

```
08:12:56.349 [main] INFO  io.camunda.process.test.impl.runtime.CamundaContainerRuntime - Starting Camunda container runtime
08:13:30.884 [main] INFO  io.camunda.process.test.impl.runtime.CamundaContainerRuntime - Camunda container runtime started in PT34.528894661S
08:13:42.657 [main] INFO  io.camunda.process.test.impl.runtime.CamundaContainerRuntime - Stopping Camunda container runtime
08:13:43.878 [main] INFO  io.camunda.process.test.impl.runtime.CamundaContainerRuntime - Camunda container runtime stopped in PT1.221388236S
Process test results:
=====================

Process instance: 2251799813685251 [process-id: 'process']

Variables:
- 'status': "active"

Open incidents:
- 'task' [type: EXTRACT_VALUE_ERROR] "Expected result of the expression 'due_date' to be one of '[DURATION, PERIOD, STRING]', but was 'NULL'. The evaluation reported the following warnings:
[NO_VARIABLE_FOUND] No variable found with name 'due_date'"
=====================


java.lang.AssertionError: Process instance [key: 2251799813685251] should be completed but was active.

```

## Related issues

closes #23092 
