### PR TITLE
[Backport stable/operate-8.5] fix: Operate does not allow changing Content Security Policy header in SM

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/WebSecurityProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/WebSecurityProperties.java
@@ -60,7 +60,7 @@ public class WebSecurityProperties {
       Duration.ofDays(2 * 365 /* 2 Years */).getSeconds();
 
   public static final boolean DEFAULT_INCLUDE_SUB_DOMAINS = true;
-  private String contentSecurityPolicy = DEFAULT_SAAS_SECURITY_POLICY;
+  private String contentSecurityPolicy;
   private long httpStrictTransportSecurityMaxAgeInSeconds = DEFAULT_HSTS_MAX_AGE;
   private boolean httpStrictTransportSecurityIncludeSubDomains = DEFAULT_INCLUDE_SUB_DOMAINS;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -16,7 +16,6 @@
  */
 package io.camunda.operate.webapp.security;
 
-import static io.camunda.operate.property.WebSecurityProperties.DEFAULT_SM_SECURITY_POLICY;
 import static io.camunda.operate.webapp.security.OperateURIs.*;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -34,7 +33,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.context.annotation.Bean;
@@ -147,6 +145,17 @@ public abstract class BaseWebConfigurer {
                             webSecurityConfig.getHttpStrictTransportSecurityIncludeSubDomains());
                   });
         });
+  }
+
+  protected String getContentSecurityPolicy() {
+    if (operateProperties.getCloud().getClusterId() == null) {
+      return (webSecurityProperties.getContentSecurityPolicy() == null)
+          ? webSecurityProperties.DEFAULT_SM_SECURITY_POLICY
+          : webSecurityProperties.getContentSecurityPolicy();
+    }
+    return (webSecurityProperties.getContentSecurityPolicy() == null)
+        ? webSecurityProperties.DEFAULT_SAAS_SECURITY_POLICY
+        : webSecurityProperties.getContentSecurityPolicy();
   }
 
   protected void applySecurityFilterSettings(final HttpSecurity http) throws Exception {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -125,10 +125,7 @@ public abstract class BaseWebConfigurer {
   protected void applySecurityHeadersSettings(final HttpSecurity http) throws Exception {
     final WebSecurityProperties webSecurityConfig = operateProperties.getWebSecurity();
     // Only SaaS has CloudProperties
-    final String policyDirectives =
-        (operateProperties.getCloud().getClusterId() == null)
-            ? DEFAULT_SM_SECURITY_POLICY
-            : webSecurityConfig.getContentSecurityPolicy();
+    final String policyDirectives = getContentSecurityPolicy();
 
     http.headers(
         headers -> {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -124,7 +124,7 @@ public abstract class BaseWebConfigurer {
 
   protected void applySecurityHeadersSettings(final HttpSecurity http) throws Exception {
     final WebSecurityProperties webSecurityConfig = operateProperties.getWebSecurity();
-    // Only SaaS has CloudProperties
+
     final String policyDirectives = getContentSecurityPolicy();
 
     http.headers(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -56,11 +56,17 @@ public abstract class BaseWebConfigurer {
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-  @Autowired protected OperateProperties operateProperties;
-
-  @Autowired OperateProfileService errorMessageService;
-
+  protected OperateProperties operateProperties;
+  OperateProfileService errorMessageService;
   final CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+  private final WebSecurityProperties webSecurityProperties;
+
+  public BaseWebConfigurer(
+      final OperateProperties operateProperties, final OperateProfileService errorMessageService) {
+    this.operateProperties = operateProperties;
+    this.errorMessageService = errorMessageService;
+    webSecurityProperties = operateProperties.getWebSecurity();
+  }
 
   public static void sendJSONErrorMessage(final HttpServletResponse response, final String message)
       throws IOException {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/WebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/WebSecurityConfig.java
@@ -18,8 +18,9 @@ package io.camunda.operate.webapp.security;
 
 import static io.camunda.operate.OperateProfileService.AUTH_PROFILE;
 
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -34,9 +35,19 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class WebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
 
-  @Autowired private UserDetailsService userDetailsService;
+  private final UserDetailsService userDetailsService;
+
+  public WebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer,
+      final UserDetailsService userDetailsService) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+    this.userDetailsService = userDetailsService;
+  }
 
   @Override
   protected void applyAuthenticationSettings(final AuthenticationManagerBuilder builder)

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityWebSecurityConfig.java
@@ -22,9 +22,10 @@ import static io.camunda.operate.webapp.security.OperateURIs.AUTH_WHITELIST;
 import static io.camunda.operate.webapp.security.OperateURIs.PUBLIC_API;
 import static io.camunda.operate.webapp.security.OperateURIs.ROOT;
 
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.IdentityOAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -35,7 +36,15 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class IdentityWebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected IdentityOAuth2WebConfigurer oAuth2WebConfigurer;
+  protected IdentityOAuth2WebConfigurer oAuth2WebConfigurer;
+
+  public IdentityWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final IdentityOAuth2WebConfigurer oAuth2WebConfigurer) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+  }
 
   @Override
   protected void applySecurityFilterSettings(final HttpSecurity http) throws Exception {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/ldap/LDAPWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/ldap/LDAPWebSecurityConfig.java
@@ -18,12 +18,13 @@ package io.camunda.operate.webapp.security.ldap;
 
 import static io.camunda.operate.OperateProfileService.LDAP_AUTH_PROFILE;
 
+import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.LdapProperties;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -39,8 +40,18 @@ import org.springframework.util.StringUtils;
 @EnableWebSecurity
 @Component("webSecurityConfig")
 public class LDAPWebSecurityConfig extends BaseWebConfigurer {
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
-  @Autowired private LDAPUserService userService;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  private final LDAPUserService userService;
+
+  public LDAPWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer,
+      final LDAPUserService ldapUserService) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+    userService = ldapUserService;
+  }
 
   @Override
   protected void applyAuthenticationSettings(final AuthenticationManagerBuilder auth)
@@ -68,7 +79,7 @@ public class LDAPWebSecurityConfig extends BaseWebConfigurer {
   }
 
   private void setUpActiveDirectoryLDAP(
-      AuthenticationManagerBuilder auth, LdapProperties ldapConfig) {
+      final AuthenticationManagerBuilder auth, final LdapProperties ldapConfig) {
     final ActiveDirectoryLdapAuthenticationProvider adLDAPProvider =
         new ActiveDirectoryLdapAuthenticationProvider(
             ldapConfig.getDomain(), ldapConfig.getUrl(), ldapConfig.getBaseDn());
@@ -79,8 +90,8 @@ public class LDAPWebSecurityConfig extends BaseWebConfigurer {
     auth.authenticationProvider(adLDAPProvider);
   }
 
-  private void setupStandardLDAP(AuthenticationManagerBuilder auth, LdapProperties ldapConfig)
-      throws Exception {
+  private void setupStandardLDAP(
+      final AuthenticationManagerBuilder auth, final LdapProperties ldapConfig) throws Exception {
     auth.ldapAuthentication()
         .userDnPatterns(ldapConfig.getUserDnPatterns())
         .userSearchFilter(ldapConfig.getUserSearchFilter())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOWebSecurityConfig.java
@@ -23,9 +23,10 @@ import static io.camunda.operate.webapp.security.OperateURIs.PUBLIC_API;
 import static io.camunda.operate.webapp.security.OperateURIs.ROOT;
 
 import com.auth0.AuthenticationController;
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -39,7 +40,15 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class SSOWebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
+
+  public SSOWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+  }
 
   @Bean
   public AuthenticationController authenticationController() {

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/security/WebSecurityConfigTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/security/WebSecurityConfigTest.java
@@ -16,9 +16,8 @@
  */
 package io.camunda.operate.webapp.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.operate.property.CloudProperties;
@@ -27,7 +26,6 @@ import io.camunda.operate.property.WebSecurityProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -35,34 +33,54 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 @ExtendWith(MockitoExtension.class)
 public class WebSecurityConfigTest {
 
+  private WebSecurityConfig underTest;
   @Mock private OperateProperties operateProperties;
-  @InjectMocks private WebSecurityConfig underTest;
-  private CloudProperties cloudProperties;
+  @Mock private CloudProperties cloudProperties;
   private WebSecurityProperties webSecurityProperties;
-  private HttpSecurity http;
+  @Mock private HttpSecurity http;
 
   @BeforeEach
   public void setUp() {
-    cloudProperties = mock(CloudProperties.class);
-    webSecurityProperties = mock(WebSecurityProperties.class);
-    http = mock(HttpSecurity.class);
+    webSecurityProperties = new WebSecurityProperties();
     when(operateProperties.getCloud()).thenReturn(cloudProperties);
     when(operateProperties.getWebSecurity()).thenReturn(webSecurityProperties);
+    underTest = new WebSecurityConfig(operateProperties, mock(), mock(), mock());
   }
 
   @Test
-  public void testSaasSCPHeaders() throws Exception {
+  public void testSaasSCPHeadersDefault() throws Exception {
     when(cloudProperties.getClusterId()).thenReturn("Id");
-    underTest.applySecurityHeadersSettings(http);
 
-    verify(webSecurityProperties, times(1)).getContentSecurityPolicy();
+    final String scpHeader = underTest.getContentSecurityPolicy();
+
+    assertEquals(WebSecurityProperties.DEFAULT_SAAS_SECURITY_POLICY, scpHeader);
   }
 
   @Test
-  public void testSMSCPHeaders() throws Exception {
-    when(cloudProperties.getClusterId()).thenReturn(null);
-    underTest.applySecurityHeadersSettings(http);
+  public void testSaasSCPHeadersCustom() throws Exception {
+    final String customPolicy = "custom";
+    when(cloudProperties.getClusterId()).thenReturn("Id");
+    webSecurityProperties.setContentSecurityPolicy(customPolicy);
 
-    verify(webSecurityProperties, times(0)).getContentSecurityPolicy();
+    final String scpHeader = underTest.getContentSecurityPolicy();
+
+    assertEquals(customPolicy, scpHeader);
+  }
+
+  @Test
+  public void testSmCSPHeadersDefault() throws Exception {
+    final String scpHeader = underTest.getContentSecurityPolicy();
+
+    assertEquals(WebSecurityProperties.DEFAULT_SM_SECURITY_POLICY, scpHeader);
+  }
+
+  @Test
+  public void testSmCSPHeadersCustom() throws Exception {
+    final String customPolicy = "custom";
+    webSecurityProperties.setContentSecurityPolicy(customPolicy);
+
+    final String scpHeader = underTest.getContentSecurityPolicy();
+
+    assertEquals(customPolicy, scpHeader);
   }
 }


### PR DESCRIPTION
# Description
Backport of #23608 to `stable/operate-8.5`.

relates to camunda/camunda#21741
original author: @kristinkomschow