### PR TITLE
[Backport stable/8.6] fix: Operate does not allow changing Content Security Policy header in SM

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/WebSecurityProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/WebSecurityProperties.java
@@ -51,7 +51,7 @@ public class WebSecurityProperties {
       Duration.ofDays(2 * 365 /* 2 Years */).getSeconds();
 
   public static final boolean DEFAULT_INCLUDE_SUB_DOMAINS = true;
-  private String contentSecurityPolicy = DEFAULT_SAAS_SECURITY_POLICY;
+  private String contentSecurityPolicy;
   private long httpStrictTransportSecurityMaxAgeInSeconds = DEFAULT_HSTS_MAX_AGE;
   private boolean httpStrictTransportSecurityIncludeSubDomains = DEFAULT_INCLUDE_SUB_DOMAINS;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate.webapp.security;
 
-import static io.camunda.operate.property.WebSecurityProperties.DEFAULT_SM_SECURITY_POLICY;
 import static io.camunda.operate.webapp.security.OperateURIs.*;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
@@ -25,7 +24,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.logging.LoggersEndpoint;
 import org.springframework.context.annotation.Bean;
@@ -118,11 +116,7 @@ public abstract class BaseWebConfigurer {
   protected void applySecurityHeadersSettings(final HttpSecurity http) throws Exception {
     final WebSecurityProperties webSecurityConfig = operateProperties.getWebSecurity();
 
-    // Only SaaS has CloudProperties
-    final String policyDirectives =
-        (operateProperties.getCloud().getClusterId() == null)
-            ? DEFAULT_SM_SECURITY_POLICY
-            : webSecurityConfig.getContentSecurityPolicy();
+    final String policyDirectives = getContentSecurityPolicy();
 
     http.headers(
         headers -> {
@@ -139,6 +133,17 @@ public abstract class BaseWebConfigurer {
                             webSecurityConfig.getHttpStrictTransportSecurityIncludeSubDomains());
                   });
         });
+  }
+
+  protected String getContentSecurityPolicy() {
+    if (operateProperties.getCloud().getClusterId() == null) {
+      return (webSecurityProperties.getContentSecurityPolicy() == null)
+          ? webSecurityProperties.DEFAULT_SM_SECURITY_POLICY
+          : webSecurityProperties.getContentSecurityPolicy();
+    }
+    return (webSecurityProperties.getContentSecurityPolicy() == null)
+        ? webSecurityProperties.DEFAULT_SAAS_SECURITY_POLICY
+        : webSecurityProperties.getContentSecurityPolicy();
   }
 
   protected void applySecurityFilterSettings(final HttpSecurity http) throws Exception {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -47,11 +47,17 @@ public abstract class BaseWebConfigurer {
 
   protected final Logger logger = LoggerFactory.getLogger(getClass());
 
-  @Autowired protected OperateProperties operateProperties;
-
-  @Autowired OperateProfileService errorMessageService;
-
+  protected OperateProperties operateProperties;
+  OperateProfileService errorMessageService;
   final CookieCsrfTokenRepository cookieCsrfTokenRepository = new CookieCsrfTokenRepository();
+  private final WebSecurityProperties webSecurityProperties;
+
+  public BaseWebConfigurer(
+      final OperateProperties operateProperties, final OperateProfileService errorMessageService) {
+    this.operateProperties = operateProperties;
+    this.errorMessageService = errorMessageService;
+    webSecurityProperties = operateProperties.getWebSecurity();
+  }
 
   public static void sendJSONErrorMessage(final HttpServletResponse response, final String message)
       throws IOException {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/WebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/WebSecurityConfig.java
@@ -9,8 +9,9 @@ package io.camunda.operate.webapp.security;
 
 import static io.camunda.operate.OperateProfileService.AUTH_PROFILE;
 
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -25,9 +26,19 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class WebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
 
-  @Autowired private UserDetailsService userDetailsService;
+  private final UserDetailsService userDetailsService;
+
+  public WebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer,
+      final UserDetailsService userDetailsService) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+    this.userDetailsService = userDetailsService;
+  }
 
   @Override
   protected void applyAuthenticationSettings(final AuthenticationManagerBuilder builder)

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityWebSecurityConfig.java
@@ -13,9 +13,10 @@ import static io.camunda.operate.webapp.security.OperateURIs.AUTH_WHITELIST;
 import static io.camunda.operate.webapp.security.OperateURIs.PUBLIC_API;
 import static io.camunda.operate.webapp.security.OperateURIs.ROOT;
 
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.IdentityOAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -26,7 +27,15 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class IdentityWebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected IdentityOAuth2WebConfigurer oAuth2WebConfigurer;
+  protected IdentityOAuth2WebConfigurer oAuth2WebConfigurer;
+
+  public IdentityWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final IdentityOAuth2WebConfigurer oAuth2WebConfigurer) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+  }
 
   @Override
   protected void applySecurityFilterSettings(final HttpSecurity http) throws Exception {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/ldap/LDAPWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/ldap/LDAPWebSecurityConfig.java
@@ -9,12 +9,13 @@ package io.camunda.operate.webapp.security.ldap;
 
 import static io.camunda.operate.OperateProfileService.LDAP_AUTH_PROFILE;
 
+import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.LdapProperties;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
@@ -30,8 +31,18 @@ import org.springframework.util.StringUtils;
 @EnableWebSecurity
 @Component("webSecurityConfig")
 public class LDAPWebSecurityConfig extends BaseWebConfigurer {
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
-  @Autowired private LDAPUserService userService;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  private final LDAPUserService userService;
+
+  public LDAPWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer,
+      final LDAPUserService ldapUserService) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+    userService = ldapUserService;
+  }
 
   @Override
   protected void applyAuthenticationSettings(final AuthenticationManagerBuilder auth)
@@ -59,7 +70,7 @@ public class LDAPWebSecurityConfig extends BaseWebConfigurer {
   }
 
   private void setUpActiveDirectoryLDAP(
-      AuthenticationManagerBuilder auth, LdapProperties ldapConfig) {
+      final AuthenticationManagerBuilder auth, final LdapProperties ldapConfig) {
     final ActiveDirectoryLdapAuthenticationProvider adLDAPProvider =
         new ActiveDirectoryLdapAuthenticationProvider(
             ldapConfig.getDomain(), ldapConfig.getUrl(), ldapConfig.getBaseDn());
@@ -70,8 +81,8 @@ public class LDAPWebSecurityConfig extends BaseWebConfigurer {
     auth.authenticationProvider(adLDAPProvider);
   }
 
-  private void setupStandardLDAP(AuthenticationManagerBuilder auth, LdapProperties ldapConfig)
-      throws Exception {
+  private void setupStandardLDAP(
+      final AuthenticationManagerBuilder auth, final LdapProperties ldapConfig) throws Exception {
     auth.ldapAuthentication()
         .userDnPatterns(ldapConfig.getUserDnPatterns())
         .userSearchFilter(ldapConfig.getUserSearchFilter())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOWebSecurityConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOWebSecurityConfig.java
@@ -14,9 +14,10 @@ import static io.camunda.operate.webapp.security.OperateURIs.PUBLIC_API;
 import static io.camunda.operate.webapp.security.OperateURIs.ROOT;
 
 import com.auth0.AuthenticationController;
+import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.BaseWebConfigurer;
 import io.camunda.operate.webapp.security.oauth2.OAuth2WebConfigurer;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -30,7 +31,15 @@ import org.springframework.stereotype.Component;
 @Component("webSecurityConfig")
 public class SSOWebSecurityConfig extends BaseWebConfigurer {
 
-  @Autowired protected OAuth2WebConfigurer oAuth2WebConfigurer;
+  protected OAuth2WebConfigurer oAuth2WebConfigurer;
+
+  public SSOWebSecurityConfig(
+      final OperateProperties operateProperties,
+      final OperateProfileService errorMessageService,
+      final OAuth2WebConfigurer oAuth2WebConfigurer) {
+    super(operateProperties, errorMessageService);
+    this.oAuth2WebConfigurer = oAuth2WebConfigurer;
+  }
 
   @Bean
   public AuthenticationController authenticationController() {


### PR DESCRIPTION
# Description
Backport of #23608 to `stable/8.6`.

relates to camunda/camunda#21741
original author: @kristinkomschow