### PR TITLE
refactor: descriptive request handling in dynamic configuration

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -37,7 +37,6 @@ import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
-import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.Mixed;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
 import io.camunda.zeebe.management.cluster.Error;
@@ -57,7 +56,6 @@ import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.RequestHandling;
 import io.camunda.zeebe.management.cluster.RequestHandlingActivePartitions;
 import io.camunda.zeebe.management.cluster.RequestHandlingAllPartitions;
-import io.camunda.zeebe.management.cluster.RequestHandlingMixed;
 import io.camunda.zeebe.management.cluster.TopologyChange;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
@@ -311,17 +309,16 @@ final class ClusterApiUtils {
   private static RequestHandling mapRequestHanding(
       final RoutingState.RequestHandling requestHandling) {
     return switch (requestHandling) {
-      case ActivePartitions(final var activePartitions, final var inactivePartitions) ->
+      case ActivePartitions(
+              final var basePartitionCount,
+              final var additionalActivePartitions,
+              final var inactivePartitions) ->
           new RequestHandlingActivePartitions(
-              new ArrayList<>(activePartitions), new ArrayList<>(inactivePartitions));
+              basePartitionCount,
+              new ArrayList<>(additionalActivePartitions),
+              new ArrayList<>(inactivePartitions));
       case AllPartitions(final var partitionCount) ->
           new RequestHandlingAllPartitions(partitionCount);
-      case Mixed(final var base, final var additional) ->
-          new RequestHandlingMixed(
-              new RequestHandlingAllPartitions(base.partitionCount()),
-              new RequestHandlingActivePartitions(
-                  new ArrayList<>(additional.activePartitions()),
-                  new ArrayList<>(additional.inactivePartitions())));
     };
   }
 

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -142,7 +142,7 @@ schemas:
     type: object
     required:
       - version
-      - activePartitions
+      - requestHandling
       - messageCorrelation
     properties:
       version:
@@ -150,6 +150,47 @@ schemas:
         format: int64
         description: The version of the routing state
         example: 1
+      requestHandling:
+        $ref: "components.yaml#/schemas/RequestHandling"
+      messageCorrelation:
+        $ref: "components.yaml#/schemas/MessageCorrelation"
+
+  RequestHandling:
+    description: The request handling strategy
+    oneOf:
+      - $ref: "components.yaml#/schemas/RequestHandlingAllPartitions"
+      - $ref: "components.yaml#/schemas/RequestHandlingActivePartitions"
+      - $ref: "components.yaml#/schemas/RequestHandlingMixed"
+    discriminator:
+      propertyName: strategy
+      mapping:
+        AllPartitions: "components.yaml#/schemas/RequestHandlingAllPartitions"
+        ActivePartitions: "components.yaml#/schemas/RequestHandlingActivePartitions"
+        Mixed: "components.yaml#/schemas/RequestHandlingMixed"
+
+  RequestHandlingAllPartitions:
+    description: Requests are handled by all partitions
+    type: object
+    required:
+      - partitionCount
+    properties:
+      strategy:
+        type: string
+      partitionCount:
+        type: integer
+        format: int32
+        description: The number of partitions
+        example: 3
+
+  RequestHandlingActivePartitions:
+    description: Requests are only handled by active partitions, inactive partitions are excluded
+    type: object
+    required:
+      - activePartitions
+      - inactivePartitions
+    properties:
+      strategy:
+        type: string
       activePartitions:
         type: array
         description: The list of active partitions that accept round-robin requests
@@ -157,9 +198,27 @@ schemas:
         items:
           type: integer
           format: int32
-      messageCorrelation:
-        $ref: "components.yaml#/schemas/MessageCorrelation"
+      inactivePartitions:
+        type: array
+        description: The list of active partitions that accept round-robin requests
+        example: [ 1, 2, 3 ]
+        items:
+          type: integer
+          format: int32
 
+  RequestHandlingMixed:
+    description: Requests are only handled by active partitions, inactive partitions are excluded
+    type: object
+    required:
+      - base
+      - additional
+    properties:
+      strategy:
+        type: string
+      base:
+        $ref: "components.yaml#/schemas/RequestHandlingAllPartitions"
+      additional:
+        $ref: "components.yaml#/schemas/RequestHandlingActivePartitions"
 
   MessageCorrelation:
     description: The message correlation strategy

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -160,13 +160,11 @@ schemas:
     oneOf:
       - $ref: "components.yaml#/schemas/RequestHandlingAllPartitions"
       - $ref: "components.yaml#/schemas/RequestHandlingActivePartitions"
-      - $ref: "components.yaml#/schemas/RequestHandlingMixed"
     discriminator:
       propertyName: strategy
       mapping:
         AllPartitions: "components.yaml#/schemas/RequestHandlingAllPartitions"
         ActivePartitions: "components.yaml#/schemas/RequestHandlingActivePartitions"
-        Mixed: "components.yaml#/schemas/RequestHandlingMixed"
 
   RequestHandlingAllPartitions:
     description: Requests are handled by all partitions
@@ -186,39 +184,31 @@ schemas:
     description: Requests are only handled by active partitions, inactive partitions are excluded
     type: object
     required:
-      - activePartitions
+      - basePartitionCount
+      - additionalActivePartitions
       - inactivePartitions
     properties:
       strategy:
         type: string
-      activePartitions:
+      basePartitionCount:
+        type: integer
+        format: int32
+        description: Contiguous range of partitions (1..=N) that are active.
+        example: 3
+      additionalActivePartitions:
         type: array
-        description: The list of active partitions that accept round-robin requests
-        example: [ 1, 2, 3 ]
+        description: A list of additional, active partitions that also accept round-robin requests
+        example: [ 4, 5 ]
         items:
           type: integer
           format: int32
       inactivePartitions:
         type: array
-        description: The list of active partitions that accept round-robin requests
-        example: [ 1, 2, 3 ]
+        description: A list of inactive partitions that do not accept round-robing requests
+        example: [ 6, 7 ]
         items:
           type: integer
           format: int32
-
-  RequestHandlingMixed:
-    description: Requests are only handled by active partitions, inactive partitions are excluded
-    type: object
-    required:
-      - base
-      - additional
-    properties:
-      strategy:
-        type: string
-      base:
-        $ref: "components.yaml#/schemas/RequestHandlingAllPartitions"
-      additional:
-        $ref: "components.yaml#/schemas/RequestHandlingActivePartitions"
 
   MessageCorrelation:
     description: The message correlation strategy

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -65,7 +66,8 @@ public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy
 
     final var newPartitionRing =
         routingState
-            .map(RoutingState::activePartitions)
+            .map(RoutingState::requestHandling)
+            .map(RequestHandling::activePartitions)
             .map(PartitionRing::of)
             .orElseGet(() -> PartitionRing.all(topologyManager.getTopology().getPartitionsCount()));
     final var newValue = new VersionedPartitionRing(expectedVersion, newPartitionRing);

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -93,7 +93,7 @@ final class RoundRobinDispatchStrategyTest {
                 Optional.of(
                     new RoutingState(
                         1,
-                        new ActivePartitions(Set.of(1, 3), Set.of()),
+                        new ActivePartitions(1, Set.of(3), Set.of()),
                         new MessageCorrelation.HashMod(3)))));
 
     // when - then
@@ -119,7 +119,7 @@ final class RoundRobinDispatchStrategyTest {
             Optional.of(
                 new RoutingState(
                     1,
-                    new ActivePartitions(Set.of(1, 3), Set.of()),
+                    new ActivePartitions(1, Set.of(3), Set.of()),
                     new MessageCorrelation.HashMod(1)))));
 
     // then

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategyTest.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -63,7 +65,8 @@ final class RoundRobinDispatchStrategyTest {
                 Map.of(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(new RoutingState(1, Set.of(1, 2), new MessageCorrelation.HashMod(2)))));
+                Optional.of(
+                    new RoutingState(1, new AllPartitions(2), new MessageCorrelation.HashMod(2)))));
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -87,7 +90,11 @@ final class RoundRobinDispatchStrategyTest {
                 Map.of(),
                 Optional.empty(),
                 Optional.empty(),
-                Optional.of(new RoutingState(1, Set.of(1, 3), new MessageCorrelation.HashMod(3)))));
+                Optional.of(
+                    new RoutingState(
+                        1,
+                        new ActivePartitions(Set.of(1, 3), Set.of()),
+                        new MessageCorrelation.HashMod(3)))));
 
     // when - then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -109,7 +116,11 @@ final class RoundRobinDispatchStrategyTest {
             Map.of(),
             Optional.empty(),
             Optional.empty(),
-            Optional.of(new RoutingState(1, Set.of(1, 3), new MessageCorrelation.HashMod(1)))));
+            Optional.of(
+                new RoutingState(
+                    1,
+                    new ActivePartitions(Set.of(1, 3), Set.of()),
+                    new MessageCorrelation.HashMod(1)))));
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(1);
@@ -122,7 +133,8 @@ final class RoundRobinDispatchStrategyTest {
             Map.of(),
             Optional.empty(),
             Optional.empty(),
-            Optional.of(new RoutingState(2, Set.of(1, 2, 3), new MessageCorrelation.HashMod(1)))));
+            Optional.of(
+                new RoutingState(2, new AllPartitions(3), new MessageCorrelation.HashMod(1)))));
 
     // then
     assertThat(dispatchStrategy.determinePartition(topologyManager)).isEqualTo(3);

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -27,20 +27,15 @@ message RequestHandling {
   oneof strategy {
     AllPartitions allPartitions = 1;
     ActivePartitions activePartitions = 2;
-    Mixed mixedPartitions = 3;
   }
 
   message AllPartitions {
     sint32 partitionCount = 1;
   }
   message ActivePartitions {
-    repeated sint32 activePartitions = 1;
-    repeated sint32 inactivePartitions = 2;
-  }
-
-  message Mixed {
-    AllPartitions base = 1;
-    ActivePartitions additional = 2;
+    sint32 basePartitionCount = 1;
+    repeated sint32 additionalActivePartitions = 2;
+    repeated sint32 inactivePartitions = 3;
   }
 }
 

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -19,8 +19,29 @@ message ClusterTopology {
 
 message RoutingState {
   int64  version = 1;
-  repeated sint32 activePartitions = 2;
+  RequestHandling requestHandling = 2;
   MessageCorrelation messageCorrelation = 3;
+}
+
+message RequestHandling {
+  oneof strategy {
+    AllPartitions allPartitions = 1;
+    ActivePartitions activePartitions = 2;
+    Mixed mixedPartitions = 3;
+  }
+
+  message AllPartitions {
+    sint32 partitionCount = 1;
+  }
+  message ActivePartitions {
+    repeated sint32 activePartitions = 1;
+    repeated sint32 inactivePartitions = 2;
+  }
+
+  message Mixed {
+    AllPartitions base = 1;
+    ActivePartitions additional = 2;
+  }
 }
 
 message MessageCorrelation {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -46,12 +46,9 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
         // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
         // ordered collection. We are not interested in the order of the partitions, so we ignore
         // it here.
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.activePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additionalActivePartitions")
         .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additional.activePartitions")
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additional.inactivePartitions")
         .isEqualTo(updatedTopology);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -46,7 +46,12 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
         // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
         // ordered collection. We are not interested in the order of the partitions, so we ignore
         // it here.
-        .ignoringCollectionOrderInFields("routingState.value.activePartitions")
+        .ignoringCollectionOrderInFields("routingState.value.requestHandling.activePartitions")
+        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additional.activePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additional.inactivePartitions")
         .isEqualTo(updatedTopology);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
@@ -29,7 +29,7 @@ public class RoutingStateAssert extends AbstractAssert<RoutingStateAssert, Routi
   }
 
   public RoutingStateAssert hasActivatedPartitions(final int partitionCount) {
-    Assertions.assertThat(actual.activePartitions())
+    Assertions.assertThat(actual.requestHandling().activePartitions())
         .containsExactlyElementsOf(IntStream.rangeClosed(1, partitionCount).boxed().toList());
     return this;
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -37,7 +37,12 @@ final class ProtoBufSerializerPropertyTest {
         // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
         // ordered collection. We are not interested in the order of the partitions, so we ignore
         // it here.
-        .ignoringCollectionOrderInFields("routingState.value.activePartitions")
+        .ignoringCollectionOrderInFields("routingState.value.requestHandling.activePartitions")
+        .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additional.activePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additional.inactivePartitions")
         .isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerPropertyTest.java
@@ -37,12 +37,9 @@ final class ProtoBufSerializerPropertyTest {
         // The type of generated `activePartitions` is `LinkedHashSet`, which AssertJ treats as an
         // ordered collection. We are not interested in the order of the partitions, so we ignore
         // it here.
-        .ignoringCollectionOrderInFields("routingState.value.requestHandling.activePartitions")
+        .ignoringCollectionOrderInFields(
+            "routingState.value.requestHandling.additionalActivePartitions")
         .ignoringCollectionOrderInFields("routingState.value.requestHandling.inactivePartitions")
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additional.activePartitions")
-        .ignoringCollectionOrderInFields(
-            "routingState.value.requestHandling.additional.inactivePartitions")
         .isEqualTo(clusterConfiguration);
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -18,11 +18,11 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ClusterConfigurationTest {
@@ -337,12 +337,13 @@ class ClusterConfigurationTest {
   @Test
   void shouldMergeRoutingState() {
     // given
-    final var oldRoutingState = Optional.of(new RoutingState(1, Set.of(1, 2, 3), new HashMod(3)));
+    final var oldRoutingState =
+        Optional.of(new RoutingState(1, new AllPartitions(3), new HashMod(3)));
     final var oldConfig =
         new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), oldRoutingState);
 
     final var newRoutingState =
-        Optional.of(new RoutingState(2, Set.of(1, 2, 3, 4), new HashMod(4)));
+        Optional.of(new RoutingState(2, new AllPartitions(4), new HashMod(4)));
     final var newConfig =
         new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), newRoutingState);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -16,6 +16,8 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.util.ReflectUtil;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -65,6 +67,19 @@ public final class ClusterTopologyDomain extends DomainContextBase {
     return Arbitraries.of(
             ReflectUtil.implementationsOfSealedInterface(RequestHandling.class).toList())
         .flatMap(Arbitraries::forType);
+  }
+
+  @Provide
+  Arbitrary<AllPartitions> allPartitions() {
+    return Arbitraries.integers().between(1, 5).map(AllPartitions::new);
+  }
+
+  @Provide
+  Arbitrary<ActivePartitions> activePartitions() {
+    final var activePartitions = Arbitraries.integers().between(1, 5).set();
+    final var inactivePartitions = Arbitraries.integers().between(6, 10).set();
+
+    return Combinators.combine(activePartitions, inactivePartitions).as(ActivePartitions::new);
   }
 
   @Provide

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import io.camunda.zeebe.util.ReflectUtil;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
@@ -55,9 +56,15 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<RoutingState> routingStates() {
     final var version = Arbitraries.longs().greaterOrEqual(0);
-    final var activePartitions = Arbitraries.integers().greaterOrEqual(1).set().ofMaxSize(10);
-    return Combinators.combine(version, activePartitions, messageCorrelation())
+    return Combinators.combine(version, requestHandling(), messageCorrelation())
         .as(RoutingState::new);
+  }
+
+  @Provide
+  Arbitrary<RequestHandling> requestHandling() {
+    return Arbitraries.of(
+            ReflectUtil.implementationsOfSealedInterface(RequestHandling.class).toList())
+        .flatMap(Arbitraries::forType);
   }
 
   @Provide

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -76,10 +76,12 @@ public final class ClusterTopologyDomain extends DomainContextBase {
 
   @Provide
   Arbitrary<ActivePartitions> activePartitions() {
-    final var activePartitions = Arbitraries.integers().between(1, 5).set();
-    final var inactivePartitions = Arbitraries.integers().between(6, 10).set();
+    final var basePartitionCount = Arbitraries.integers().between(1, 3);
+    final var activePartitions = Arbitraries.integers().between(4, 8).set();
+    final var inactivePartitions = Arbitraries.integers().between(9, 12).set();
 
-    return Combinators.combine(activePartitions, inactivePartitions).as(ActivePartitions::new);
+    return Combinators.combine(basePartitionCount, activePartitions, inactivePartitions)
+        .as(ActivePartitions::new);
   }
 
   @Provide

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -55,7 +56,7 @@ final class PublishMessageDispatchStrategyTest {
 
     // when -- Routing state is available in cluster configuration
     final var routingState =
-        new RoutingState(1, Set.of(1, 2, 3), new HashMod(messagePartitionCount));
+        new RoutingState(1, new AllPartitions(3), new HashMod(messagePartitionCount));
     final var clusterConfiguration =
         new ClusterConfiguration(
             1, Map.of(), Optional.empty(), Optional.empty(), Optional.of(routingState));

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -65,7 +65,10 @@ final class ClusterEndpointResponseIT {
             ],
             "routing": {
               "version": 1,
-              "activePartitions": [1],
+              "requestHandling": {
+                "strategy": "AllPartitions",
+                "partitionCount": 1
+              },
               "messageCorrelation": {
                 "strategy": "HashMod",
                 "partitionCount": 1


### PR DESCRIPTION
This changes the cluster configuration to be more descriptive on request handling. Where we previously only had a simple
 set of active partitions, we can now differentiate between different cases such as:
 - All partitions from 1..=partitionCount handle requests
 - All partitions from 1..=partitionCount handle requests, with some additional active partitions and some inactive ones.

 This makes it easier to keep track of the routing state during scale up (and later scale down). In particular, this
 allows idempotent scale up operations because we can now update the routing state immediately to reflect new
 partitions, something that wasn't possible when we only listed active partitions.

BREAKING CHANGE: This breaks compatibility, but only if the experimental feature flag for partition scaling is enabled. This is allowed for now.

Relates to https://github.com/camunda/camunda/issues/23215