### PR TITLE
test: remove usage of @Before annotation

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -34,13 +33,13 @@ import org.junit.rules.TestWatcher;
 public class AddEntityRoleMultiPartitionTest {
 
   private static final int PARTITION_COUNT = 3;
-  private static long userKey;
   @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
 
-  @Before
-  public void setUp() {
-    userKey =
+  @Test
+  public void shouldDistributeRoleAddEntityCommand() {
+    // when
+    final var userKey =
         engine
             .user()
             .newUser("foo")
@@ -49,11 +48,6 @@ public class AddEntityRoleMultiPartitionTest {
             .withPassword("zabraboof")
             .create()
             .getKey();
-  }
-
-  @Test
-  public void shouldDistributeRoleAddEntityCommand() {
-    // when
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
     engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
@@ -101,6 +95,15 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
     engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
@@ -117,6 +120,15 @@ public class AddEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -39,11 +38,10 @@ public class AddPermissionAuthorizationMultiPartitionTest {
   @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
-  private long ownerKey;
-
-  @Before
-  public void setUp() {
-    ownerKey =
+  @Test
+  public void shouldTestLifecycle() {
+    // when
+    final var ownerKey =
         engine
             .user()
             .newUser("foo")
@@ -52,11 +50,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
             .withPassword("zabraboof")
             .create()
             .getKey();
-  }
 
-  @Test
-  public void shouldTestLifecycle() {
-    // when
     engine
         .authorization()
         .permission()
@@ -110,6 +104,15 @@ public class AddPermissionAuthorizationMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
+    final var ownerKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     engine
         .authorization()
         .permission()
@@ -131,6 +134,15 @@ public class AddPermissionAuthorizationMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
+    final var ownerKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
@@ -26,7 +26,6 @@ import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -34,13 +33,13 @@ import org.junit.rules.TestWatcher;
 public class RemoveEntityRoleMultiPartitionTest {
 
   private static final int PARTITION_COUNT = 3;
-  private static long userKey;
   @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
   @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
 
-  @Before
-  public void setUp() {
-    userKey =
+  @Test
+  public void shouldDistributeRoleRemoveEntityCommand() {
+    // when
+    final var userKey =
         engine
             .user()
             .newUser("foo")
@@ -49,11 +48,6 @@ public class RemoveEntityRoleMultiPartitionTest {
             .withPassword("zabraboof")
             .create()
             .getKey();
-  }
-
-  @Test
-  public void shouldDistributeRoleRemoveEntityCommand() {
-    // when
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
     engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
@@ -107,6 +101,15 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void shouldDistributeInIdentityQueue() {
     // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getValue().getRoleKey();
     engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
@@ -129,6 +132,15 @@ public class RemoveEntityRoleMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the user creation distribution is intercepted
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptUserCreateForPartition(partitionId);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Usage of `@Before` in those test class can lead to unexpected behaviour of tests, especially when they run on sequence multiple times.

## Related issues

closes #
