### PR TITLE
fix: c8run run java --version as two separate args

### DIFF
--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -178,7 +178,7 @@ func main() {
 	if baseCommand == "start" {
 		javaVersion := os.Getenv("JAVA_VERSION")
 		if javaVersion == "" {
-			javaVersionCmd := exec.Command(javaBinary + " --version")
+			javaVersionCmd := exec.Command("cmd", "/C", javaBinary + " --version")
 			var out strings.Builder
                         var stderr strings.Builder
 			javaVersionCmd.Stdout = &out


### PR DESCRIPTION
## Description

closes #23786 

We were getting the following error:

```
errl: exec: "java --version": executable file not found in %PATH%
```

We want "java" to be ran as though it is it's own binary, with `--version` being an argument of that binary. This PR wraps that call with `cmd /c` so that I can pass in the argument.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
