### PR TITLE
ci: run operate update screenshots workflow on PRs

### DIFF
--- a/.github/workflows/operate-update-docs-screenshots.yml
+++ b/.github/workflows/operate-update-docs-screenshots.yml
@@ -1,5 +1,22 @@
 name: Operate Update screenshots
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "main"
+    paths:
+      - ".github/workflows/operate-update-docs-screenshots.yml"
+      - "operate/client/**"
+  pull_request:
+    paths:
+      - ".github/workflows/operate-update-docs-screenshots.yml"
+      - "operate/client/**"
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   test:


### PR DESCRIPTION
## Description

- Runs `Operate update screenshots` workflow on pull requests to keep screenshots updated alongside E2E tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
