### PR TITLE
Remove the need for ES/OS cluster monitor privileges in Tasklist

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/es/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/es/ElasticsearchConnector.java
@@ -286,6 +286,10 @@ public class ElasticsearchConnector {
 
   public boolean checkHealth(final ElasticsearchClient elasticsearchClient) {
     final ElasticsearchProperties elsConfig = tasklistProperties.getElasticsearch();
+    if (!elsConfig.isHealthCheckEnabled()) {
+      LOGGER.debug("Elasticsearch health check is disabled");
+      return true;
+    }
     try {
       return RetryOperation.<Boolean>newBuilder()
           .noOfRetry(50)
@@ -312,6 +316,10 @@ public class ElasticsearchConnector {
 
   public boolean checkHealth(final RestHighLevelClient esClient) {
     final ElasticsearchProperties elsConfig = tasklistProperties.getElasticsearch();
+    if (!elsConfig.isHealthCheckEnabled()) {
+      LOGGER.debug("Elasticsearch health check is disabled");
+      return true;
+    }
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(elsConfig);
     return Failsafe.with(retryPolicy)
         .get(

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -426,6 +426,10 @@ public class OpenSearchConnector {
 
   public boolean checkHealth(final OpenSearchClient osClient) {
     final OpenSearchProperties osConfig = tasklistProperties.getOpenSearch();
+    if (!osConfig.isHealthCheckEnabled()) {
+      LOGGER.debug("Opensearch health check is disabled");
+      return true;
+    }
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
         .get(
@@ -438,6 +442,10 @@ public class OpenSearchConnector {
 
   public boolean checkHealth(final OpenSearchAsyncClient osAsyncClient) {
     final OpenSearchProperties osConfig = tasklistProperties.getOpenSearch();
+    if (!osConfig.isHealthCheckEnabled()) {
+      LOGGER.debug("Opensearch health check is disabled");
+      return true;
+    }
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
         .get(

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/ElasticsearchProperties.java
@@ -43,6 +43,8 @@ public class ElasticsearchProperties {
   private String username;
   private String password;
 
+  private boolean healthCheckEnabled = true;
+
   @NestedConfigurationProperty private SslProperties ssl;
 
   private List<PluginConfiguration> interceptorPlugins;
@@ -159,6 +161,14 @@ public class ElasticsearchProperties {
 
   public void setConnectTimeout(final Integer connectTimeout) {
     this.connectTimeout = connectTimeout;
+  }
+
+  public boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
   }
 
   public SslProperties getSsl() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -45,6 +45,7 @@ public class OpenSearchProperties {
 
   private boolean awsEnabled = false;
 
+  private boolean healthCheckEnabled = true;
   @NestedConfigurationProperty private SslProperties ssl;
 
   private List<PluginConfiguration> interceptorPlugins;
@@ -185,5 +186,13 @@ public class OpenSearchProperties {
 
   public void setAwsEnabled(final boolean awsEnabled) {
     this.awsEnabled = awsEnabled;
+  }
+
+  public boolean isHealthCheckEnabled() {
+    return healthCheckEnabled;
+  }
+
+  public void setHealthCheckEnabled(final boolean healthCheckEnabled) {
+    this.healthCheckEnabled = healthCheckEnabled;
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
@@ -55,6 +55,11 @@ public class IndexSchemaValidatorElasticSearch extends IndexSchemaValidatorUtil
   }
 
   @Override
+  public boolean isHealthCheckEnabled() {
+    return tasklistProperties.getElasticsearch().isHealthCheckEnabled();
+  }
+
+  @Override
   public boolean hasAnyTasklistIndices() {
     final Set<String> indices =
         retryElasticsearchClient.getIndexNames(

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/management/SearchEngineHealthIndicator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/management/SearchEngineHealthIndicator.java
@@ -30,7 +30,7 @@ public class SearchEngineHealthIndicator implements HealthIndicator {
   @Override
   public Health health() {
     LOGGER.debug("Search engine check is called");
-    if (indexSchemaValidator.schemaExists()) {
+    if (!indexSchemaValidator.isHealthCheckEnabled() || indexSchemaValidator.schemaExists()) {
       return Health.up().build();
     } else {
       return Health.down().build();

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/IndexSchemaValidatorOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/IndexSchemaValidatorOpenSearch.java
@@ -56,6 +56,11 @@ public class IndexSchemaValidatorOpenSearch extends IndexSchemaValidatorUtil
   }
 
   @Override
+  public boolean isHealthCheckEnabled() {
+    return tasklistProperties.getOpenSearch().isHealthCheckEnabled();
+  }
+
+  @Override
   public boolean hasAnyTasklistIndices() {
     final Set<String> indices =
         retryOpenSearchClient.getIndexNames(

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/IndexSchemaValidator.java
@@ -15,6 +15,8 @@ import java.util.Set;
 
 public interface IndexSchemaValidator {
 
+  boolean isHealthCheckEnabled();
+
   boolean hasAnyTasklistIndices();
 
   boolean schemaExists();

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -485,6 +485,17 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -95,6 +95,7 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
               "camunda.tasklist.elasticsearch.username=elastic",
               "camunda.tasklist.elasticsearch.password=changeme",
               "camunda.tasklist.elasticsearch.clusterName=docker-cluster",
+              "camunda.tasklist.elasticsearch.url=" + elsUrl,
               "camunda.tasklist.zeebeElasticsearch.url=" + elsUrl,
               "camunda.tasklist.zeebeElasticsearch.username=elastic",
               "camunda.tasklist.zeebeElasticsearch.password=changeme",

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.security.IndicesPrivileges;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.tasklist.management.SearchEngineHealthIndicator;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.qa.util.TestElasticsearchSchemaManager;
+import io.camunda.tasklist.qa.util.TestUtil;
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.webapp.security.WebSecurityConfig;
+import io.camunda.tasklist.webapp.security.oauth.OAuth2WebConfigurer;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalManagementPort;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+    classes = {
+      TestElasticsearchSchemaManager.class,
+      TestApplication.class,
+      SearchEngineHealthIndicator.class,
+      WebSecurityConfig.class,
+      OAuth2WebConfigurer.class,
+      RetryElasticsearchClient.class,
+    },
+    properties = {
+      TasklistProperties.PREFIX + ".importer.startLoadingDataOnStartup = false",
+      TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false"
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ContextConfiguration(
+    initializers = {
+      ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT.ElasticsearchStarter.class
+    })
+public class ElasticsearchConnectorBasicAuthNoClusterPrivilegesIT extends TasklistIntegrationTest {
+
+  private static final String ES_ADMIN_USER = "elastic";
+  private static final String ES_ADMIN_PASSWORD = "changeme";
+  static ElasticsearchContainer elasticsearch =
+      new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:8.15.2")
+          .withEnv(Map.of("xpack.security.enabled", "true", "ELASTIC_PASSWORD", ES_ADMIN_PASSWORD))
+          .withExposedPorts(9200);
+  private static final String TASKLIST_ES_USER = "tasklist_user";
+  private static final String TASKLIST_ES_PASSWORD = "tasklist_pwd";
+  @Autowired RestHighLevelClient tasklistEsClient;
+
+  @Autowired RestHighLevelClient tasklistZeebeEsClient;
+
+  @Autowired private TestRestTemplate testRestTemplate;
+
+  @LocalManagementPort private int managementPort;
+
+  @BeforeAll
+  public static void beforeClass() {
+    assumeTrue(TestUtil.isElasticSearch());
+  }
+
+  @Test
+  public void canConnect() {
+    assertThat(tasklistEsClient).isNotNull();
+    assertThat(tasklistZeebeEsClient).isNotNull();
+    final var healthCheck =
+        testRestTemplate.getForEntity(
+            "http://localhost:" + managementPort + "/actuator/health", Map.class);
+    assertThat(healthCheck.getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(healthCheck.getBody()).containsEntry("status", "UP");
+  }
+
+  static class ElasticsearchStarter
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+    @Override
+    public void initialize(final ConfigurableApplicationContext applicationContext) {
+      elasticsearch.start();
+
+      createElasticsearchRoleAndUser();
+
+      final String elsUrl = String.format("http://%s", elasticsearch.getHttpHostAddress());
+      TestPropertyValues.of(
+              "camunda.tasklist.elasticsearch.username=" + TASKLIST_ES_USER,
+              "camunda.tasklist.elasticsearch.password=" + TASKLIST_ES_PASSWORD,
+              "camunda.tasklist.elasticsearch.clusterName=docker-cluster",
+              "camunda.tasklist.elasticsearch.url=" + elsUrl,
+              "camunda.tasklist.zeebeElasticsearch.url=" + elsUrl,
+              "camunda.tasklist.zeebeElasticsearch.username=" + TASKLIST_ES_USER,
+              "camunda.tasklist.zeebeElasticsearch.password=" + TASKLIST_ES_PASSWORD,
+              "camunda.tasklist.zeebeElasticsearch.clusterName=docker-cluster",
+              "camunda.tasklist.zeebeElasticsearch.prefix=zeebe-record",
+              "camunda.tasklist.elasticsearch.healthCheckEnabled=false")
+          .applyTo(applicationContext.getEnvironment());
+    }
+
+    private void createElasticsearchRoleAndUser() {
+      try {
+        final ElasticsearchClient elasticsearchClient = createAdminElasticsearchClient();
+        final String tasklistEsRole = "tasklist_role";
+        elasticsearchClient
+            .security()
+            .putRole(
+                role ->
+                    role.name(tasklistEsRole)
+                        .indices(
+                            IndicesPrivileges.of(
+                                index ->
+                                    index
+                                        .names("tasklist*")
+                                        .privileges(
+                                            "create_index",
+                                            "delete_index",
+                                            "read",
+                                            "write",
+                                            "manage",
+                                            "manage_ilm")
+                                        .allowRestrictedIndices(false)),
+                            IndicesPrivileges.of(
+                                index -> index.names("zeebe*").privileges("read"))));
+        elasticsearchClient
+            .security()
+            .putUser(
+                user ->
+                    user.username(TASKLIST_ES_USER)
+                        .password(TASKLIST_ES_PASSWORD)
+                        .roles(tasklistEsRole));
+      } catch (final IOException | URISyntaxException e) {
+        fail(e);
+      }
+    }
+
+    private ElasticsearchClient createAdminElasticsearchClient() throws URISyntaxException {
+      final var credentialProvider = new BasicCredentialsProvider();
+      credentialProvider.setCredentials(
+          AuthScope.ANY, new UsernamePasswordCredentials(ES_ADMIN_USER, ES_ADMIN_PASSWORD));
+      final URI uri = new URI("http://" + elasticsearch.getHttpHostAddress());
+      return new ElasticsearchClient(
+          new RestClientTransport(
+              RestClient.builder(new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme()))
+                  .setHttpClientConfigCallback(
+                      httpClientBuilder ->
+                          httpClientBuilder.setDefaultCredentialsProvider(credentialProvider))
+                  .build(),
+              new JacksonJsonpMapper()));
+    }
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* Configuration parameters `camunda.tasklist.elasticsearch.healthCheckEnabled` and `camunda.tasklist.opensearch.healthCheckEnabled` to disable the health check queries that requires cluster monitor privileges
* To test:
1. Enable security pack in Elasticsearch container: `xpack.security.enabled=true`
2. Set a password the admin `elastic` user: `ELASTIC_PASSWORD=elastic`
3. Create a role in Elasticsearch
```
curl -u elastic:elastic -X PUT "http://localhost:9200/_security/role/tasklist_index_management_role" -H 'Content-Type: application/json' -d'
{               
  "indices": [
    {
      "names": [ "tasklist*" ],
      "privileges": [
        "create_index",
        "delete_index",
        "read",
        "write",
        "manage",
        "manage_ilm"
      ]
    }, {
      "names": ["zeebe*"], 
      "privileges": ["read"]
     }
  ],
  "cluster": []
}
'
```
4. Create a user that has the role created above
```
curl -u elastic:elastic -X POST "http://localhost:9200/_security/user/tasklist_user" -H 'Content-Type: application/json' -d'
{                          
  "password" : "tasklist",
  "roles" : [ "tasklist_index_management_role" ],
  "full_name" : "Index Manager User",
  "enabled" : true
}
'
```
5. Set the following env parameters for Tasklist:
```
      - camunda.tasklist.elasticsearch.username=tasklist_user
      - camunda.tasklist.elasticsearch.password=tasklist
      - camunda.tasklist.zeebeelasticsearch.username=tasklist_user
      - camunda.tasklist.zeebeelasticsearch.password=tasklist
      - camunda.tasklist.elasticsearch.healthCheckEnabled=false
      - camunda.tasklist.elasticsearch.createschema=false
      - camunda.tasklist.migration.migrationEnabled=false // for 8.5 only
```
6. Set the following env parameters for Zeebe
```
      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_AUTHENTICATION_USERNAME=elastic
      - ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_AUTHENTICATION_PASSWORD=elastic
```
7. Make sure that Tasklist starts and health checks are passing `GET /actuator/health`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23094
