### PR TITLE
fix: clean up database management in Operate

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
@@ -118,12 +118,12 @@ public class StatefulRestTemplate extends RestTemplate {
   public <T> RequestCallback httpEntityCallback(final Object requestBody, final Type responseType) {
     final HttpEntity httpEntity;
     if (requestBody != null) {
-      if (!(requestBody instanceof HttpEntity<?>)) {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add(CSRF_TOKEN_HEADER_NAME, csrfToken);
-        httpEntity = new HttpEntity(requestBody, headers);
+      final HttpHeaders headers = new HttpHeaders();
+      headers.add(CSRF_TOKEN_HEADER_NAME, csrfToken);
+      if (requestBody instanceof HttpEntity<?>) {
+        httpEntity = new HttpEntity(((HttpEntity<?>) requestBody).getBody(), headers);
       } else {
-        httpEntity = (HttpEntity) requestBody;
+        httpEntity = new HttpEntity(requestBody, headers);
       }
     } else {
       httpEntity = null;

--- a/operate/qa/migration-tests/migration-test/src/test/java/io/camunda/operate/qa/migration/util/MigrationRunner.java
+++ b/operate/qa/migration-tests/migration-test/src/test/java/io/camunda/operate/qa/migration/util/MigrationRunner.java
@@ -41,21 +41,21 @@ public class MigrationRunner {
 
   @PostConstruct
   private void init() {
-    initTestFixtureMap();
-    selectAndRunTestFixtures();
-    runMigration();
+    //    initTestFixtureMap();
+    //    selectAndRunTestFixtures();
+    //    runMigration();
   }
 
   private void initTestFixtureMap() {
     testFixtureMap = new HashMap<>();
-    for (TestFixture testFixture : testFixtures) {
+    for (final TestFixture testFixture : testFixtures) {
       testFixtureMap.put(testFixture.getVersion(), testFixture);
     }
   }
 
   private void selectAndRunTestFixtures() {
     LOGGER.info("Upgrade path under test: {}", upgradePath);
-    for (String version : upgradePath) {
+    for (final String version : upgradePath) {
       final TestFixture testFixture = testFixtureMap.get(version);
       if (testFixture == null) {
         throw new RuntimeException("No test fixture found for version " + version);
@@ -74,7 +74,7 @@ public class MigrationRunner {
       args[2] = "--camunda.operate.zeebeelasticsearch.host=" + testContext.getExternalElsHost();
       args[3] = "--camunda.operate.zeebeelasticsearch.port=" + testContext.getExternalElsPort();
       SchemaMigration.main(args);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new RuntimeException(e);
     }
   }

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestOpensearchSchemaManager.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestOpensearchSchemaManager.java
@@ -10,10 +10,10 @@ package io.camunda.operate.qa.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedIndex;
+import io.camunda.operate.schema.OperateManagedTemplate;
 import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,8 +35,8 @@ public class TestOpensearchSchemaManager extends OpensearchSchemaManager
   public TestOpensearchSchemaManager(
       final OperateProperties operateProperties,
       final RichOpenSearchClient richOpenSearchClient,
-      final List<IndexTemplateDescriptor> templateDescriptors,
-      final List<IndexDescriptor> indexDescriptors,
+      final List<OperateManagedTemplate> templateDescriptors,
+      final List<OperateManagedIndex> indexDescriptors,
       @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     super(
         operateProperties,

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
@@ -15,6 +15,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.migration.SemanticVersion;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+import jakarta.annotation.PostConstruct;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -31,11 +32,16 @@ public class IndexSchemaValidator {
 
   private static final Pattern VERSION_PATTERN = Pattern.compile(".*-(\\d+\\.\\d+\\.\\d+.*)_.*");
 
-  @Autowired Set<IndexDescriptor> indexDescriptors;
-
+  @Autowired Set<OperateManagedDataStructure> operateManagedIndices;
   @Autowired SchemaManager schemaManager;
-
+  private Set<IndexDescriptor> indexDescriptors;
   @Autowired private OperateProperties operateProperties;
+
+  @PostConstruct
+  public void setup() {
+    indexDescriptors =
+        operateManagedIndices.stream().map(IndexDescriptor.class::cast).collect(Collectors.toSet());
+  }
 
   private Set<String> getAllIndexNamesForIndex(final String index) {
     final String indexPattern = String.format("%s-%s*", getIndexPrefix(), index);
@@ -148,7 +154,9 @@ public class IndexSchemaValidator {
    * @return newFields map with the new field definitions per index
    * @throws OperateRuntimeException in case some fields would need to be deleted or have different
    *     settings
+   * @deprecated schema manager is happening in Zeebe exporter now
    */
+  @Deprecated
   public Map<IndexDescriptor, Set<IndexMappingProperty>> validateIndexMappings() {
     final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields = new HashMap<>();
     final Map<String, IndexMapping> indexMappings =

--- a/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedDataStructure.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedDataStructure.java
@@ -5,8 +5,6 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.store;
+package io.camunda.operate.schema;
 
-public interface ZeebeStore {
-  void refreshIndex(String indexPattern);
-}
+public interface OperateManagedDataStructure {}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedIndex.java
@@ -5,8 +5,6 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.store;
+package io.camunda.operate.schema;
 
-public interface ZeebeStore {
-  void refreshIndex(String indexPattern);
-}
+public interface OperateManagedIndex extends OperateManagedDataStructure {}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/OperateManagedTemplate.java
@@ -5,8 +5,6 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.operate.store;
+package io.camunda.operate.schema;
 
-public interface ZeebeStore {
-  void refreshIndex(String indexPattern);
-}
+public interface OperateManagedTemplate extends OperateManagedDataStructure {}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -62,6 +62,10 @@ public interface SchemaManager {
 
   Map<String, IndexMapping> getIndexMappings(String indexNamePattern);
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
+  @Deprecated
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 
   IndexMapping getExpectedIndexFields(IndexDescriptor indexDescriptor);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -11,12 +11,8 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.migration.Migrator;
-import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import jakarta.annotation.PostConstruct;
-import java.util.Map;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,9 +43,6 @@ public class SchemaStartup {
       LOGGER.info("SchemaStartup started.");
       LOGGER.info("SchemaStartup: validate index versions.");
       schemaValidator.validateIndexVersions();
-      LOGGER.info("SchemaStartup: validate index mappings.");
-      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields =
-          schemaValidator.validateIndexMappings();
       final boolean createSchema =
           DatabaseInfo.isOpensearch()
               ? operateProperties.getOpensearch().isCreateSchema()
@@ -61,19 +54,6 @@ public class SchemaStartup {
       } else {
         LOGGER.info(
             "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
-      }
-
-      if (!newFields.isEmpty()) {
-        if (createSchema) {
-          schemaManager.updateSchema(newFields);
-        } else {
-          LOGGER.info(
-              "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
-        }
-      }
-      if (migrationProperties.isMigrationEnabled()) {
-        LOGGER.info("SchemaStartup: migrate schema.");
-        migrator.migrateData();
       }
       LOGGER.info("SchemaStartup finished.");
     } catch (final Exception ex) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -15,10 +15,11 @@ import io.camunda.operate.property.OperateElasticsearchProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
+import io.camunda.operate.schema.OperateManagedIndex;
+import io.camunda.operate.schema.OperateManagedTemplate;
 import io.camunda.operate.schema.SchemaManager;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
 import io.camunda.operate.util.ElasticsearchJSONUtil;
-import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
@@ -70,8 +71,8 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Autowired protected RetryElasticsearchClient retryElasticsearchClient;
   @Autowired protected OperateProperties operateProperties;
-  @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
-  @Autowired private List<IndexTemplateDescriptor> templateDescriptors;
+  @Autowired private List<OperateManagedIndex> indexDescriptors;
+  @Autowired private List<OperateManagedTemplate> templateDescriptors;
 
   @Autowired
   @Qualifier("operateObjectMapper")
@@ -218,6 +219,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     return retryElasticsearchClient.getIndexMappings(indexName);
   }
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
+  @Deprecated
   @Override
   public void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
     for (final Map.Entry<IndexDescriptor, Set<IndexMappingProperty>> indexNewFields :
@@ -331,11 +336,13 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     templateDescriptors.forEach(this::createTemplate);
   }
 
-  private void createIndex(final IndexDescriptor indexDescriptor) {
+  private void createIndex(final OperateManagedIndex index) {
+    final IndexDescriptor indexDescriptor = (IndexDescriptor) index;
     createIndex(indexDescriptor, indexDescriptor.getSchemaClasspathFilename());
   }
 
-  private void createTemplate(final IndexTemplateDescriptor templateDescriptor) {
+  private void createTemplate(final OperateManagedTemplate template) {
+    final IndexTemplateDescriptor templateDescriptor = (IndexTemplateDescriptor) template;
     createTemplate(templateDescriptor, null);
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/ImportPositionIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/ImportPositionIndex.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.indices;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedIndex;
 import io.camunda.operate.schema.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
@@ -16,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ImportPositionIndex extends OperateIndexDescriptor implements Prio1Backup {
+public class ImportPositionIndex extends OperateIndexDescriptor
+    implements Prio1Backup, OperateManagedIndex {
 
   public static final String INDEX_NAME = "import-position";
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/MigrationRepositoryIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/MigrationRepositoryIndex.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.indices;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedIndex;
 import io.camunda.operate.schema.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
@@ -16,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class MigrationRepositoryIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class MigrationRepositoryIndex extends OperateIndexDescriptor
+    implements Prio4Backup, OperateManagedIndex {
 
   public static final String INDEX_NAME = "migration-steps-repository";
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/OperateWebSessionIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/OperateWebSessionIndex.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.indices;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedIndex;
 import io.camunda.operate.schema.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
@@ -16,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OperateWebSessionIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class OperateWebSessionIndex extends OperateIndexDescriptor
+    implements Prio4Backup, OperateManagedIndex {
 
   public static final String ID = "id";
   public static final String CREATION_TIME = "creationTime";

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.indices;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedIndex;
 import io.camunda.operate.schema.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
@@ -16,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class UserIndex extends OperateIndexDescriptor implements Prio4Backup, OperateManagedIndex {
 
   public static final String INDEX_NAME = "user";
   public static final String ID = "id";

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
@@ -41,9 +41,13 @@ import org.springframework.stereotype.Component;
 /**
  * Migrates an operate schema from one version to another. Requires an already created destination
  * schema provided by a schema manager. Tries to detect source/previous schema if not provided.
+ *
+ * @deprecated Old-style migration that is not supported anymore. Moreover, schema manager is
+ *     happening in Zeebe exporter now.
  */
 @Component
 @Configuration
+@Deprecated
 public class Migrator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Migrator.class);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
@@ -59,7 +59,7 @@ public class SchemaMigration implements CommandLineRunner {
 
   @Override
   public void run(final String... args) {
-    LOGGER.info("SchemaMigration finished.");
+    // calls postconstruct method of SchemaStartup
   }
 
   public static class ApplicationErrorListener

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -19,6 +19,8 @@ import io.camunda.operate.property.OperateOpensearchProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
+import io.camunda.operate.schema.OperateManagedIndex;
+import io.camunda.operate.schema.OperateManagedTemplate;
 import io.camunda.operate.schema.SchemaManager;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.LambdaExceptionUtil;
@@ -70,16 +72,16 @@ public class OpensearchSchemaManager implements SchemaManager {
   private final ObjectMapper objectMapper;
   private final JsonbJsonpMapper jsonpMapper = new JsonbJsonpMapper();
 
-  private final List<IndexTemplateDescriptor> templateDescriptors;
+  private final List<OperateManagedTemplate> templateDescriptors;
 
-  private final List<IndexDescriptor> indexDescriptors;
+  private final List<OperateManagedIndex> indexDescriptors;
 
   @Autowired
   public OpensearchSchemaManager(
       final OperateProperties operateProperties,
       final RichOpenSearchClient richOpenSearchClient,
-      final List<IndexTemplateDescriptor> templateDescriptors,
-      final List<IndexDescriptor> indexDescriptors,
+      final List<OperateManagedTemplate> templateDescriptors,
+      final List<OperateManagedIndex> indexDescriptors,
       @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     super();
     this.operateProperties = operateProperties;
@@ -263,6 +265,10 @@ public class OpensearchSchemaManager implements SchemaManager {
     return richOpenSearchClient.index().getIndexMappings(indexNamePattern);
   }
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
+  @Deprecated
   @Override
   public void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
     for (final Map.Entry<IndexDescriptor, Set<IndexMappingProperty>> indexNewFields :
@@ -396,8 +402,9 @@ public class OpensearchSchemaManager implements SchemaManager {
     return null;
   }
 
-  private void createTemplate(final IndexTemplateDescriptor templateDescriptor) {
+  private void createTemplate(final OperateManagedTemplate template) {
 
+    final IndexTemplateDescriptor templateDescriptor = (IndexTemplateDescriptor) template;
     final String json = readTemplateJson(templateDescriptor.getSchemaClasspathFilename());
 
     final PutIndexTemplateRequest indexTemplateRequest =
@@ -482,7 +489,8 @@ public class OpensearchSchemaManager implements SchemaManager {
     }
   }
 
-  private void createIndex(final IndexDescriptor indexDescriptor) {
+  private void createIndex(final OperateManagedIndex index) {
+    final IndexDescriptor indexDescriptor = (IndexDescriptor) index;
     createIndex(indexDescriptor, indexDescriptor.getSchemaClasspathFilename());
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/BatchOperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/BatchOperationTemplate.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.templates;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedTemplate;
 import io.camunda.operate.schema.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import jakarta.annotation.PostConstruct;
@@ -16,7 +17,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class BatchOperationTemplate extends OperateTemplateDescriptor implements Prio3Backup {
+public class BatchOperationTemplate extends OperateTemplateDescriptor
+    implements Prio3Backup, OperateManagedTemplate {
 
   public static final String INDEX_NAME = "batch-operation";
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
@@ -9,6 +9,7 @@ package io.camunda.operate.schema.templates;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.OperateManagedTemplate;
 import io.camunda.operate.schema.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
@@ -18,7 +19,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class OperationTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio3Backup, OperateManagedTemplate {
 
   public static final String INDEX_NAME = "operation";
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchZeebeStore.java
@@ -10,13 +10,10 @@ package io.camunda.operate.store.elasticsearch;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
-import java.io.IOException;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.indices.GetIndexRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +34,7 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public void refreshIndex(String indexPattern) {
+  public void refreshIndex(final String indexPattern) {
     final RefreshRequest refreshRequest = new RefreshRequest(indexPattern);
     try {
       final RefreshResponse refresh =
@@ -45,26 +42,8 @@ public class ElasticsearchZeebeStore implements ZeebeStore {
       if (refresh.getFailedShards() > 0) {
         LOGGER.warn("Unable to refresh indices: {}", indexPattern);
       }
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
-    }
-  }
-
-  @Override
-  public boolean zeebeIndicesExists(String indexPattern) {
-    try {
-      final GetIndexRequest request = new GetIndexRequest(indexPattern);
-      request.indicesOptions(IndicesOptions.fromOptions(true, false, true, false));
-      final boolean exists = zeebeEsClient.indices().exists(request, RequestOptions.DEFAULT);
-      if (exists) {
-        LOGGER.debug("Data already exists in Zeebe.");
-      }
-      return exists;
-    } catch (IOException io) {
-      LOGGER.debug(
-          "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
-          io.getMessage());
-      return false;
     }
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchZeebeStore.java
@@ -9,7 +9,6 @@ package io.camunda.operate.store.opensearch;
 
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.store.ZeebeStore;
-import java.io.IOException;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,34 +28,14 @@ public class OpensearchZeebeStore implements ZeebeStore {
   private OpenSearchClient openSearchClient;
 
   @Override
-  public void refreshIndex(String indexPattern) {
+  public void refreshIndex(final String indexPattern) {
     try {
       final var response = openSearchClient.indices().refresh(r -> r.index(indexPattern));
       if (!response.shards().failures().isEmpty()) {
         LOGGER.warn("Unable to refresh indices: {}", indexPattern);
       }
-    } catch (Exception ex) {
+    } catch (final Exception ex) {
       LOGGER.warn(String.format("Unable to refresh indices: %s", indexPattern), ex);
-    }
-  }
-
-  @Override
-  public boolean zeebeIndicesExists(String indexPattern) {
-    try {
-      final var exists =
-          openSearchClient
-              .indices()
-              .exists(r -> r.index(indexPattern).allowNoIndices(false).ignoreUnavailable(true))
-              .value();
-      if (exists) {
-        LOGGER.debug("Data already exists in Zeebe.");
-      }
-      return exists;
-    } catch (IOException io) {
-      LOGGER.debug(
-          "Error occurred while checking existence of data in Zeebe: {}. Demo data won't be created.",
-          io.getMessage());
-      return false;
     }
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
@@ -31,19 +31,20 @@
       "versionTag": {
         "type": "keyword"
       },
-			"flowNodes": {
-              "properties": {
-                "id": {
-                  "type": "keyword"
-                },
-                "name": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "tenantId": {
-              "type": "keyword"
-            }
+      "flowNodes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
         }
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
+    }
     }
 }


### PR DESCRIPTION
Different fixes to clean up schema creation in Operate:
* criterion to create test data: there is no data in `operate-process` index
* fix CSRF token in test data creation
* comment out and deprecate all migration and data update functionality, will be removed later
* introduce new marker interfaces for indices and templates that are still managed by Operate
* make index and template descriptors implement the new interfaces
* adjust SchemaManager and related classes to use new interfaces instead of `Index-/TemplateDescriptor`

closes #22897