### PR TITLE
ci: lint OpenAPI spec on PRs

### DIFF
--- a/.github/vacuum-ruleset.yaml
+++ b/.github/vacuum-ruleset.yaml
@@ -1,0 +1,604 @@
+description: Recommended rules for a high quality specification.
+documentationUrl: https://quobix.com/vacuum/rulesets/recommended
+rules:
+    component-description:
+        category:
+            description: Documentation is really important, in OpenAPI, just about everything can and should have a description. This set of rules checks for absent descriptions, poor quality descriptions (copy/paste), or short descriptions.
+            id: descriptions
+            name: Descriptions
+        description: Component description check
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Components are the inputs and outputs of a specification. A user needs to be able to understand each component and what id does. Descriptions are critical to understanding components. Add a description!
+        id: component-description
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: oasComponentDescriptions
+        type: validation
+    description-duplication:
+        category:
+            description: Documentation is really important, in OpenAPI, just about everything can and should have a description. This set of rules checks for absent descriptions, poor quality descriptions (copy/paste), or short descriptions.
+            id: descriptions
+            name: Descriptions
+        description: Description duplication check
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Descriptions are only useful, if they are meaningful. If a description is meaningful, then it won't be something you copy and paste. Please don't duplicate descriptions, make them deliberate and meaningful.
+        id: description-duplication
+        recommended: true
+        severity: info
+        then:
+            function: oasDescriptionDuplication
+        type: validation
+    duplicated-entry-in-enum:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: Enum values must not have duplicate entry
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Enums need to be unique, you can't duplicate them in the same definition. Please remove the duplicate value.
+        id: duplicated-entry-in-enum
+        recommended: true
+        severity: error
+        then:
+            function: duplicatedEnum
+        type: validation
+    info-description:
+        category:
+            description: The info object contains licencing, contact, authorship details and more. Checks to confirm required details have been completed.
+            id: information
+            name: Contract Information
+        description: Info section is missing a description
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: The 'info' section is missing a description, surely you want people to know what this spec is all about, right?
+        id: info-description
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: infoDescription
+        type: validation
+    no-$ref-siblings:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: $ref values cannot be placed next to other properties (like a description)
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: $ref values must not be placed next to sibling nodes, There should only be a single node  when using $ref. A common mistake is adding 'description' next to a $ref. This is wrong. remove all siblings!
+        id: no-$ref-siblings
+        recommended: true
+        severity: error
+        then:
+            function: refSiblings
+        type: validation
+    no-ambiguous-paths:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Paths need to resolve unambiguously from one another
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Paths must all resolve unambiguously, they can't be confused with one another (/{id}/ambiguous and /ambiguous/{id} are the same thing. Make sure every path and the variables used are unique and do conflict with one another. Check the ordering of variables and the naming of path segments.
+        id: no-ambiguous-paths
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: noAmbiguousPaths
+        type: validation
+    no-eval-in-markdown:
+        category:
+            description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+            id: validation
+            name: Validation
+        description: Markdown descriptions must not have `eval()` statements'
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Remove all references to 'eval()' in the description. These can be used by malicious actors to embed code in contracts that is then executed when read by a browser.
+        id: no-eval-in-markdown
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: noEvalDescription
+            functionOptions:
+                pattern: eval\(
+        type: validation
+    no-http-verbs-in-path:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path segments must not contain an HTTP verb
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: When HTTP verbs (get/post/put etc) are used in path segments, it muddies the semantics of REST and creates a confusing and inconsistent experience. It's highly recommended that verbs are not used in path segments. Replace those HTTP verbs with more meaningful nouns.
+        id: no-http-verbs-in-path
+        recommended: true
+        severity: warn
+        then:
+            function: noVerbsInPath
+        type: style
+    no-script-tags-in-markdown:
+        category:
+            description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+            id: validation
+            name: Validation
+        description: Markdown descriptions must not have `<script>` tags'
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Remove all references to '<script>' tags from the description. These can be used by malicious actors to load remote code if the spec is being parsed by a browser.
+        id: no-script-tags-in-markdown
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: noEvalDescription
+            functionOptions:
+                pattern: <script
+        type: validation
+    oas-schema-check:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: All document schemas must have a valid type defined
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Make sure each schema has a value type defined. Without a type, the schema is useless
+        id: oas-schema-check
+        recommended: true
+        severity: error
+        then:
+            function: schemaTypeCheck
+        type: validation
+    oas3-api-servers:
+        category:
+            description: Validation rules make sure that certain characters or patterns have not been used that may cause issues when rendering in different types of applications.
+            id: validation
+            name: Validation
+        description: Check for valid API servers definition
+        formats:
+            - oas3
+        given: $
+        howToFix: Ensure server URIs are correct and valid, check the schemes, ensure descriptions are complete.
+        id: oas3-api-servers
+        recommended: true
+        severity: warn
+        then:
+            function: oasAPIServers
+        type: validation
+    oas3-example-external-check:
+        category:
+            description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+            id: examples
+            name: Examples
+        description: Examples cannot use both `value` and `externalValue` together.
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+        id: oas3-example-external-check
+        recommended: true
+        severity: warn
+        then:
+            function: oasExampleExternal
+        type: validation
+    oas3-missing-example:
+        category:
+            description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+            id: examples
+            name: Examples
+        description: Ensure everything that can have an example, contains one
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+        id: oas3-missing-example
+        recommended: true
+        severity: warn
+        then:
+            function: oasExampleMissing
+        type: validation
+    oas3-operation-security-defined:
+        category:
+            description: Security plays a central role in RESTful APIs. These rules make sure that the correct definitions have been used and put in the right places.
+            id: security
+            name: Security
+        description: '`security` values must match a scheme defined in components.securitySchemes'
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: When defining security values for operations, you need to ensure they match the globally defined security schemes. Check $.components.securitySchemes to make sure your values align.
+        id: oas3-operation-security-defined
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: oasOpSecurityDefined
+            functionOptions:
+                schemesPath: $.components.securitySchemes
+        type: validation
+    oas3-parameter-description:
+        category:
+            description: Documentation is really important, in OpenAPI, just about everything can and should have a description. This set of rules checks for absent descriptions, poor quality descriptions (copy/paste), or short descriptions.
+            id: descriptions
+            name: Descriptions
+        description: Parameter description checks
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: All parameters should have a description. Descriptions are critical to understanding how an API works correctly. Please add a description to all parameters.
+        id: oas3-parameter-description
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: oasParamDescriptions
+        type: style
+    oas3-schema:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: OpenAPI 3 specification is invalid
+        formats:
+            - oas3
+        given: $
+        howToFix: The schema isn't valid OpenAPI 3. Check the errors for more details
+        id: oas3-schema
+        recommended: true
+        severity: error
+        then:
+            function: oasDocumentSchema
+        type: validation
+    oas3-unused-component:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: Check for unused components and bad references
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Unused components / definitions are generally the result of the OpenAPI contract being updated without considering references. Another reference could have been updated, or an operation changed that no longer references this component. Remove this component from the spec, or re-link to it from another component or operation to fix the problem.
+        id: oas3-unused-component
+        recommended: true
+        severity: warn
+        then:
+            function: oasUnusedComponent
+        type: validation
+    oas3-valid-schema-example:
+        category:
+            description: Examples help consumers understand how API calls should look. They are really important for automated tooling for mocking and testing. These rules check examples have been added to component schemas, parameters and operations. These rules also check that examples match the schema and types provided.
+            id: examples
+            name: Examples
+        description: If an example has been used, check the schema is valid
+        formats:
+            - oas3
+            - oas3_1
+        given: $
+        howToFix: Examples are critical for consumers to be able to understand schemas and models defined by the spec. Without examples, developers can't understand the type of data the API will return in real life. Examples are turned into mocks and can provide a rich testing capability for APIs. Add detailed examples everywhere!
+        id: oas3-valid-schema-example
+        recommended: true
+        severity: warn
+        then:
+            function: oasExampleSchema
+        type: validation
+    operation-description:
+        category:
+            description: Documentation is really important, in OpenAPI, just about everything can and should have a description. This set of rules checks for absent descriptions, poor quality descriptions (copy/paste), or short descriptions.
+            id: descriptions
+            name: Descriptions
+        description: Operation description checks
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: All operations must have a description. Descriptions explain how the operation works, and how users should use it and what to expect. Operation descriptions make up the bulk of API documentation. so please, add a description!
+        id: operation-description
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: oasDescriptions
+            functionOptions:
+                minWords: "1"
+        type: validation
+    operation-operationId:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Every operation must contain an `operationId`.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Every single operation needs an operationId. It's a critical requirement to be able to identify each individual operation uniquely. Please add an operationId to the operation.
+        id: operation-operationId
+        recommended: true
+        severity: error
+        then:
+            function: oasOpId
+        type: validation
+    operation-operationId-unique:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Every operation must have unique `operationId`.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths
+        howToFix: An operationId needs to be unique, there can't be any duplicates in the document, you can't re-use them. Make sure the ID used for this operation is unique.
+        id: operation-operationId-unique
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: oasOpIdUnique
+        type: validation
+    operation-operationId-valid-in-url:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: OperationId must use URL friendly characters
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths[*][*]
+        howToFix: An operationId is critical to correct code generation and operation identification. The operationId should really be designed in a way to make it friendly when used as part of a URL. Remove non-standard URL characters.
+        id: operation-operationId-valid-in-url
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            field: operationId
+            function: pattern
+            functionOptions:
+                match: ^[A-Za-z0-9-._~:/?#\[\]@!\$&'()*+,;=]*$
+        type: validation
+    operation-parameters:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Operation parameters are unique and non-repeating.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths
+        howToFix: Make sure that all the operation parameters are unique and non-repeating, don't duplicate names, don'tre-use parameter names in the same operation.
+        id: operation-parameters
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: oasOpParams
+        type: validation
+    operation-success-response:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Operation must have at least one `2xx` or a `3xx` response.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Make sure that your operation returns a 'success' response via  2xx or 3xx response code. An API consumer will always expect a success response
+        id: operation-success-response
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            field: responses
+            function: oasOpSuccessResponse
+        type: style
+    operation-tag-defined:
+        category:
+            description: Tags are used as meta-data for operations. They are mainly used by tooling as a taxonomy mechanism to build navigation, search and more. Tags are important as they help consumers navigate the contract when using documentation, testing, code generation or analysis tools.
+            id: tags
+            name: Tags
+        description: Operation tags must be defined in global tags.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: This tag has not been defined in the global scope, you should always ensure that any tags used in operations, are defined globally in the root 'tags' definition.
+        id: operation-tag-defined
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: oasTagDefined
+        type: validation
+    operation-tags:
+        category:
+            description: Tags are used as meta-data for operations. They are mainly used by tooling as a taxonomy mechanism to build navigation, search and more. Tags are important as they help consumers navigate the contract when using documentation, testing, code generation or analysis tools.
+            id: tags
+            name: Tags
+        description: Operation `tags` are missing/empty
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Operations use tags to define the domain(s) they are apart of. Generally a single tag per operation is used, however some tools use multiple tags. The point is that you need tags! Add some tags to the operation that match the globally available ones.
+        id: operation-tags
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: oasOperationTags
+        type: validation
+    path-declarations-must-exist:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path parameter declarations must not be empty ex. `/api/{}` is invalid
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths
+        howToFix: Paths define the endpoint for operations. Without paths, there is no API. You need to add 'paths' to the root of the specification.
+        id: path-declarations-must-exist
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: pattern
+            functionOptions:
+                notMatch: '{}'
+        type: validation
+    path-keys-no-trailing-slash:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path must not end with a slash
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths
+        howToFix: Paths should not end with a trailing slash, it can confuse tooling and isn't valid as a path Remove the trailing slash from the path.
+        id: path-keys-no-trailing-slash
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: pattern
+            functionOptions:
+                notMatch: .+\/$
+        type: validation
+    path-not-include-query:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path must not include query string
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $.paths
+        howToFix: Query strings are defined as parameters for an operation, they should not be included in the path Please remove it and correctly define as a parameter.
+        id: path-not-include-query
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: pattern
+            functionOptions:
+                notMatch: \?
+        type: validation
+    path-params:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path parameters must be defined and valid.
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Path parameters need to match up with the parameters defined for the path, or in an operation that sits under that path. Make sure variable names match up and are defined correctly.
+        id: path-params
+        recommended: true
+        resolved: true
+        severity: error
+        then:
+            function: oasPathParam
+        type: validation
+    paths-kebab-case:
+        category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
+            id: operations
+            name: Operations
+        description: Path segments must only use kebab-case (no underscores or uppercase)
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Path segments should not contain any uppercase letters, punctuation or underscores. The only valid way to separate words in a segment, is to use a hyphen '-'. The elements that are violating the rule are highlighted in the violation description. These are the elements that need to change.
+        id: paths-kebab-case
+        recommended: true
+        severity: warn
+        then:
+            function: pathsKebabCase
+        type: validation
+    typed-enum:
+        category:
+            description: Schemas are how request bodies and response payloads are defined. They define the data going in and the data flowing out of an operation. These rules check for structural validity, checking types, checking required fields and validating correct use of structures.
+            id: schemas
+            name: Schemas
+        description: Enum values must respect the specified type
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        given: $
+        howToFix: Enum values lock down the number of variable inputs a parameter or schema can have. The problem here is that the Enum defined, does not match the specified type. Fix the type!
+        id: typed-enum
+        recommended: true
+        resolved: true
+        severity: warn
+        then:
+            function: typedEnum
+        type: validation

--- a/.github/workflows/vacuum.yml
+++ b/.github/workflows/vacuum.yml
@@ -1,0 +1,23 @@
+name: Vacuum OpenAPI lint
+on:
+  pull_request:
+    paths:
+      - 'zeebe/gateway-protocol/src/main/proto/rest-api.yaml'
+
+jobs:
+  lint-openapi-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - id: depth
+        name: Determine fetch depth for checkout
+        run: echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: ${{ steps.depth.outputs.depth }}
+      - name: Install Vacuum
+        run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh > /dev/null
+        shell: bash
+      - name: Run OpenAPI Linter
+        run: vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml -r .github/vacuum-ruleset.yaml -d -e 
+        shell: bash

--- a/.github/workflows/vacuum.yml
+++ b/.github/workflows/vacuum.yml
@@ -8,13 +8,9 @@ jobs:
   lint-openapi-spec:
     runs-on: ubuntu-latest
     steps:
-      - id: depth
-        name: Determine fetch depth for checkout
-        run: echo "depth=$(expr ${{ github.event.pull_request.commits }} + 1)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: ${{ steps.depth.outputs.depth }}
       - name: Install Vacuum
         run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh > /dev/null
         shell: bash

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2445,7 +2445,7 @@ paths:
                   type: string
                   description: The tenant to deploy the resources to.
               required:
-                - resource
+                - resources
       responses:
         "200":
           description: The resources are deployed.
@@ -2955,7 +2955,6 @@ components:
           format: date-time
         state:
           $ref: "#/components/schemas/ProcessInstanceStateEnum"
-          description: The state, one of ACTIVE, COMPLETED, CANCELED.
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
@@ -3030,7 +3029,6 @@ components:
           format: date-time
         state:
           $ref: "#/components/schemas/ProcessInstanceStateEnum"
-          description: The state, one of ACTIVE, COMPLETED, CANCELED.
         hasIncident:
           type: boolean
           description: Whether this process instance has a related incident or not.
@@ -3038,6 +3036,7 @@ components:
           type: string
           description: The tenant ID.
     ProcessInstanceStateEnum:
+      description: The state, one of ACTIVE, COMPLETED, CANCELED.
       enum:
         - ACTIVE
         - COMPLETED
@@ -4309,7 +4308,6 @@ components:
           description: The key of the decision instance.
         state:
           $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          description: The state of the decision instance.
         evaluationFailure:
           type: string
           description: The evaluation failure of the decision instance.
@@ -4337,7 +4335,6 @@ components:
           description: The version of the decision.
         decisionDefinitionType:
           $ref: "#/components/schemas/DecisionDefinitionTypeEnum"
-          description: The type of the decision.
         tenantId:
           type: string
           description: The tenant ID of the decision instance.
@@ -4360,7 +4357,6 @@ components:
           description: The key of the decision instance.
         state:
           $ref: "#/components/schemas/DecisionInstanceStateEnum"
-          description: The state of the decision instance.
         evaluationDate:
           type: string
           format: date-time
@@ -4392,7 +4388,6 @@ components:
           description: The version of the decision.
         decisionDefinitionType:
           $ref: "#/components/schemas/DecisionDefinitionTypeEnum"
-          description: The type of the decision.
         result:
           type: string
           description: The result of the decision instance.
@@ -4419,12 +4414,14 @@ components:
                 The matched rules of the decision instance.
 
     DecisionDefinitionTypeEnum:
+      description: The type of the decision.
       enum:
         - DECISION_TABLE
         - LITERAL_EXPRESSION
         - UNSPECIFIED
         - UNKNOWN
     DecisionInstanceStateEnum:
+      description: The state of the decision instance.
       enum:
         - EVALUATED
         - FAILED

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -50,6 +50,7 @@ paths:
     get:
       tags:
         - Cluster
+      operationId: getTopology
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
@@ -63,6 +64,7 @@ paths:
     get:
       tags:
         - License
+      operationId: getLicense
       summary: Get status of Camunda license
       description: Obtains the status of the current Camunda license
       responses:
@@ -76,6 +78,7 @@ paths:
     post:
       tags:
         - Job
+      operationId: activateJobs
       summary: Activate jobs
       description: |
         Iterate through all known partitions and activate jobs up to the requested maximum.
@@ -110,6 +113,7 @@ paths:
     post:
       tags:
         - Job
+      operationId: failJob
       summary: Fail job
       description: |
         Mark the job as failed
@@ -163,6 +167,7 @@ paths:
     post:
       tags:
         - Job
+      operationId: reportJobError
       summary: Report error for job
       description: |
         Reports a business error (i.e. non-technical) that occurs while processing a job.
@@ -216,6 +221,7 @@ paths:
     post:
       tags:
         - Job
+      operationId: completeJob
       summary: Complete job
       description: |
         Complete a job with the given payload, which allows completing the associated service task.
@@ -269,6 +275,7 @@ paths:
     patch:
       tags:
         - Job
+      operationId: updateJob
       summary: Update a job
       description: Update a job with the given key.
       parameters:
@@ -321,6 +328,7 @@ paths:
     post:
       tags:
         - Incident
+      operationId: resolveIncident
       summary: Resolve incident
       description: >
         Marks the incident as resolved; most likely a call to Update job will be necessary
@@ -359,6 +367,7 @@ paths:
     post:
       tags:
         - User task
+      operationId: completeUserTask
       summary: Complete user task
       description: Completes a user task with the given key.
       parameters:
@@ -412,6 +421,7 @@ paths:
     post:
       tags:
         - User task
+      operationId: assignUserTask
       summary: Assign user task
       description: Assigns a user task with the given key to the given assignee.
       parameters:
@@ -464,6 +474,7 @@ paths:
     get:
       tags:
         - User task
+      operationId: getUserTask
       summary: Return user task by a user task key
       description: |
         Get the user task by the user task key.
@@ -516,6 +527,7 @@ paths:
     patch:
       tags:
         - User task
+      operationId: updateUserTask
       summary: Update user task
       description: Update a user task with the given key.
       parameters:
@@ -568,6 +580,7 @@ paths:
     get:
       tags:
         - User task
+      operationId: getUserTaskForm
       summary: Return user task form
       description: |
         Get the form of a user task.
@@ -628,6 +641,7 @@ paths:
     delete:
       tags:
         - User task
+      operationId: unassignUserTask
       summary: Unassign user task
       description: Removes the assignee of a task with the given key.
       parameters:
@@ -674,6 +688,7 @@ paths:
     post:
       tags:
         - User task
+      operationId: findUserTasks
       summary: Query user tasks (alpha)
       description: |
         Search for user tasks based on given criteria.
@@ -716,6 +731,7 @@ paths:
     post:
       tags:
         - User task
+      operationId: findUserTaskVariables
       summary: Query user tasks variables (alpha)
       description: |
         Search for user tasks based on given criteria.
@@ -767,6 +783,7 @@ paths:
     post:
       tags:
         - Variable
+      operationId: findVariables
       summary: Query process and local variables (alpha)
       description: |
         Search for variables based on given criteria.
@@ -809,6 +826,7 @@ paths:
     get:
       tags:
         - Variable
+      operationId: getVariable
       summary: Return variable by a variable key
       description: |
         Get the variable by the variable key.
@@ -861,6 +879,7 @@ paths:
     put:
       tags:
         - Clock
+      operationId: pinClock
       summary: Pin internal clock (alpha)
       description: |
         Set a precise, static time for the Zeebe engine’s internal clock.
@@ -897,6 +916,7 @@ paths:
     post:
       tags:
         - Clock
+      operationId: resetClock
       summary: Reset internal clock (alpha)
       description: |
         Resets the Zeebe engine’s internal clock to the current system time, enabling it to tick in real-time.
@@ -919,6 +939,7 @@ paths:
     post:
       tags:
         - Process definition
+      operationId: findProcessDefinitions
       summary: Search process definitions (alpha)
       description: |
         Search for process definitions based on given criteria.
@@ -960,6 +981,7 @@ paths:
     get:
       tags:
         - Process definition
+      operationId: getProcessDefinition
       summary: Get process definition by key (alpha)
       description: |
         Returns process definition as JSON.
@@ -1011,6 +1033,7 @@ paths:
     get:
       tags:
         - Process definition
+      operationId: getProcessDefinitionXML
       summary: Get process definition XML (alpha)
       description: |
         Returns process definition as XML.
@@ -1070,6 +1093,7 @@ paths:
     post:
       tags:
         - Process instance
+      operationId: createProcessInstance
       summary: Create process instance
       description: |
         Creates and starts an instance of the specified process.
@@ -1115,6 +1139,7 @@ paths:
     get:
       tags:
         - Process instance
+      operationId: getProcessInstance
       summary: Get process instance (alpha)
       description: |
         Get the process instance by the process instance key.
@@ -1167,6 +1192,7 @@ paths:
     post:
       tags:
         - Process instance
+      operationId: findProcessInstances
       summary: Query process instances (alpha)
       description: |
         Search for process instances based on given criteria.
@@ -1207,6 +1233,7 @@ paths:
     post:
       tags:
         - Process instance
+      operationId: cancelProcessInstance
       summary: Cancel process instance
       description: Cancels a running process instance.
       parameters:
@@ -1248,6 +1275,7 @@ paths:
     post:
       tags:
         - Process instance
+      operationId: migrateProcessInstance
       summary: Migrate process instance
       description: |
         Migrates a process instance to a new process definition.
@@ -1296,6 +1324,7 @@ paths:
     post:
       tags:
         - Process instance
+      operationId: modifyProcessInstance
       summary: Modify process instance
       description: |
         Modifies a running process instance.
@@ -1344,6 +1373,7 @@ paths:
     post:
       tags:
         - Flow node instance
+      operationId: findFlowNodeInstances
       summary: Query flow node instances (alpha)
       description: |
         Search for flow node instances based on given criteria.
@@ -1386,6 +1416,7 @@ paths:
     get:
       tags:
         - Flow node instance
+      operationId: getFlowNodeInstance
       summary: Get flow node instance by key (alpha)
       description: |
         Returns flow node instance as JSON.
@@ -1437,6 +1468,7 @@ paths:
     post:
       tags:
         - Decision definition
+      operationId: findDecisionDefinitions
       summary: Query decision definitions (alpha)
       description: |
         Search for decision definitions based on given criteria.
@@ -1479,6 +1511,7 @@ paths:
     get:
       tags:
         - Decision definition
+      operationId: getDecisionDefinition
       summary: Get decision definition by key (alpha)
       description: |
         Returns a decision definition.
@@ -1531,6 +1564,7 @@ paths:
     get:
       tags:
         - Decision definition
+      operationId: getDecisionDefinitionXML
       summary: Get decision definition XML (alpha)
       description: |
         Returns decision definition as XML.
@@ -1583,6 +1617,7 @@ paths:
     post:
       tags:
         - Decision requirements
+      operationId: findDecisionRequirements
       summary: Query decision requirements (alpha)
       description: |
         Search for decision requirements based on given criteria.
@@ -1614,6 +1649,7 @@ paths:
     get:
       tags:
         - Decision requirements
+      operationId: getDecisionRequirements
       summary: Get decision requirements by key (alpha)
       description: |
         Returns Decision Requirements as JSON.
@@ -1666,6 +1702,7 @@ paths:
     get:
       tags:
         - Decision requirements
+      operationId: getDecisionRequirementsXML
       summary: Get decision requirements XML (alpha)
       description: |
         Returns decision requirements as XML.
@@ -1719,6 +1756,7 @@ paths:
     post:
       tags:
         - Decision instance
+      operationId: findDecisionInstances
       summary: Query decision instances (alpha)
       description: |
         Search for decision instances based on given criteria.
@@ -1762,6 +1800,7 @@ paths:
     get:
       tags:
         - Decision instance
+      operationId: getDecisionInstance
       summary: Get decision instance by key (alpha)
       description: |
         Returns a decision instance.
@@ -1815,6 +1854,7 @@ paths:
     post:
       tags:
         - Decision definition
+      operationId: evaluateDecision
       summary: Evaluate decision
       description: |
         Evaluates a decision.
@@ -1868,9 +1908,9 @@ paths:
     patch:
       tags:
         - Authorization
+      operationId: updateAuthorization
       summary: Patch authorization
       description: Manage the permissions assigned to the authorization.
-      operationId: patchAuthorization
       parameters:
         - name: ownerKey
           in: path
@@ -1935,8 +1975,8 @@ paths:
     post:
       tags:
         - User
-      summary: "Create a user"
-      operationId: "createUser"
+      operationId: createUser
+      summary: Create a user
       requestBody:
         content:
           application/json:
@@ -1986,6 +2026,7 @@ paths:
     post:
       tags:
         - Message
+      operationId: publishMessage
       summary: Publish a message
       description: |
         Publishes a single message.
@@ -2021,6 +2062,7 @@ paths:
     post:
       tags:
         - Message
+      operationId: correlateMessage
       summary: Correlate a message
       description: |
         Publishes a message and correlates it to a subscription.
@@ -2067,6 +2109,7 @@ paths:
     post:
       tags:
         - Document
+      operationId: createDocument
       summary: Upload document (alpha)
       description: |
         Upload a document to the Camunda 8 cluster.
@@ -2125,6 +2168,7 @@ paths:
     get:
       tags:
         - Document
+      operationId: getDocument
       summary: Download document (alpha)
       description: |
         Download a document from the Camunda 8 cluster.
@@ -2171,6 +2215,7 @@ paths:
     delete:
       tags:
         - Document
+      operationId: deleteDocument
       summary: Delete document (alpha)
       description: |
         Delete a document from the Camunda 8 cluster.
@@ -2213,6 +2258,7 @@ paths:
     post:
       tags:
         - Document
+      operationId: createDocumentLink
       summary: Create document link (alpha)
       description: |
         Create a link to a document in the Camunda 8 cluster.
@@ -2259,6 +2305,7 @@ paths:
     post:
       tags:
         - User
+      operationId: findUsers
       summary: "Query users (alpha)"
       description: |
         Search for users based on given criteria.
@@ -2268,7 +2315,6 @@ paths:
         See the [Camunda 8 REST API overview](/apis-tools/camunda-api-rest/camunda-api-rest-overview.md#query-api)
         for further details.
         :::
-      operationId: "findAllUsers"
       requestBody:
         content:
           application/json:
@@ -2317,6 +2363,7 @@ paths:
     post:
       tags:
         - Incident
+      operationId: findIncidents
       summary: Query incidents (alpha)
       description: |
         Search for incidents based on given criteria.
@@ -2372,6 +2419,7 @@ paths:
     get:
       tags:
         - Incident
+      operationId: getIncident
       summary: Get incident by key (alpha)
       description: |
         Returns incident as JSON.
@@ -2423,6 +2471,7 @@ paths:
     post:
       tags:
         - Resource
+      operationId: createDeployment
       summary: Deploy resources
       description: |
         Deploys one or more resources (e.g. processes, decision models, or forms).
@@ -2464,6 +2513,7 @@ paths:
     post:
       tags:
         - Resource
+      operationId: deleteResource
       summary: Delete resource
       description: |
         Deletes a deployed resource.
@@ -2512,6 +2562,7 @@ paths:
     post:
       tags:
         - Element instance
+      operationId: createElementInstanceVariables
       summary: Update element instance variables
       description: |
         Updates all the variables of a particular scope (for example, process instance, flow element instance) with the given variable data.
@@ -2553,6 +2604,7 @@ paths:
     post:
       tags:
         - Signal
+      operationId: broadcastSignal
       summary: Broadcast signal
       description: Broadcasts a signal.
       requestBody:


### PR DESCRIPTION
## Description

Run Vacuum to lint the OpenAPI spec on changes in a PR.

**What do we want to achieve with this first iteration?**

* Correct the OpenAPI file by adding operation IDs, since we generate the URLs from them. This makes the docs more stable (otherwise, the summaries are used which is very unstable).
* Create a custom Vacuum ruleset from the recommended rules.
* Adjust the recommended rules to our needs accordingly:
  * Remove OAS2 rules that don't apply (we use OAS3)
  * Raise "operation tag is not defined globally" from `warn` to `error` to keep our sidebar navigation consistent in the generated docs
* Automatically lint the OpenAPI file in PRs when it's adjusted in the PR using Vacuum
* Display the errors' details in the Vacuum log of the automated check so they can be fixed
* Don't display warnings in detail since we have too many currently which would simply clutter the check's log

**Future improvement ideas**

* Raise other rules from `warn` to `error` that are important for us, e.g. having descriptions for every part (e.g. paths and parameters)
* Display warning details as well so they can be tackled (we first need to improve the OpenAPI file and/or ruleset for this though so it's not just overwhelmingly much content)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

n/a
