### PR TITLE
fix: Fix WebSecurityConfig unauthenticated paths

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -35,7 +35,18 @@ import org.springframework.security.web.SecurityFilterChain;
 @Profile("auth-basic|auth-oidc")
 public class WebSecurityConfig {
   public static final String[] UNAUTHENTICATED_PATHS =
-      new String[] {"/login**", "/logout**", "/error**", "/actuator**"};
+      new String[] {
+        "/login",
+        "/logout",
+        // endpoint for failure forwarding
+        "/error",
+        // all actuator endpoints
+        "/actuator/**",
+        // endpoints defined in BrokerHealthRoutes
+        "/ready",
+        "/health",
+        "/startup"
+      };
   private static final Logger LOG = LoggerFactory.getLogger(WebSecurityConfig.class);
 
   @Bean


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I was writing an integration test with `auth-oidc` profile enabled and I have noticed that the `requestMatchers` defined in `WebSecurityConfig` were not properly working.
For instance, `/actuator**` was not matching `/actuator/health` and `/error**` was not matching `/error`.
The `AntPathRequestMatcher` used by default, only matches `/actuatorSomething` with `/actuator**` pattern , same for `/error**`.
I also added the endpoints defined in https://github.com/camunda/camunda/blob/main/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
