### PR TITLE
fix: fixes to run Camunda exporter and importer together

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
@@ -118,12 +118,12 @@ public class StatefulRestTemplate extends RestTemplate {
   public <T> RequestCallback httpEntityCallback(final Object requestBody, final Type responseType) {
     final HttpEntity httpEntity;
     if (requestBody != null) {
-      if (!(requestBody instanceof HttpEntity<?>)) {
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add(CSRF_TOKEN_HEADER_NAME, csrfToken);
-        httpEntity = new HttpEntity(requestBody, headers);
+      final HttpHeaders headers = new HttpHeaders();
+      headers.add(CSRF_TOKEN_HEADER_NAME, csrfToken);
+      if (requestBody instanceof HttpEntity<?>) {
+        httpEntity = new HttpEntity(((HttpEntity<?>) requestBody).getBody(), headers);
       } else {
-        httpEntity = (HttpEntity) requestBody;
+        httpEntity = new HttpEntity(requestBody, headers);
       }
     } else {
       httpEntity = null;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
@@ -22,6 +22,7 @@ import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.TestElasticsearchSchemaManager;
 import io.camunda.operate.qa.util.TestOpensearchSchemaManager;
+import io.camunda.operate.qa.util.TestSchemaManager;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchIndexOperations;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -52,7 +53,6 @@ import org.springframework.test.context.junit4.SpringRunner;
       TestOpensearchSchemaManager.class,
       RichOpenSearchClient.class,
       OpensearchConnector.class,
-      IndexDescriptor.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,
       JacksonConfig.class,
@@ -74,6 +74,10 @@ public class IndexOldSchemaValidatorIT {
 
   @Autowired OperateProperties operateProperties;
 
+  @Autowired IndexPrefixHolder indexPrefixHolder;
+
+  @Autowired TestSchemaManager schemaManager;
+
   private String operatePrefix;
 
   private List<String> allIndexNames;
@@ -85,10 +89,9 @@ public class IndexOldSchemaValidatorIT {
 
   @Before
   public void setUp() {
-    operatePrefix =
-        DatabaseInfo.isOpensearch()
-            ? operateProperties.getOpensearch().getIndexPrefix()
-            : operateProperties.getElasticsearch().getIndexPrefix();
+    schemaManager.setIndexPrefix(indexPrefixHolder.createNewIndexPrefix());
+    operatePrefix = indexPrefixHolder.getIndexPrefix();
+
     allIndexNames =
         indexDescriptors.stream()
             .map(IndexDescriptor::getFullQualifiedName)

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -63,7 +63,7 @@ public interface SchemaManager {
   Map<String, IndexMapping> getIndexMappings(String indexNamePattern);
 
   /**
-   * @deprecated schema manager is happening in Zeebe exporter now
+   * @deprecated schema manager is happening in Camunda exporter now
    */
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaManager.java
@@ -62,6 +62,9 @@ public interface SchemaManager {
 
   Map<String, IndexMapping> getIndexMappings(String indexNamePattern);
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
   void updateSchema(Map<IndexDescriptor, Set<IndexMappingProperty>> newFields);
 
   IndexMapping getExpectedIndexFields(IndexDescriptor indexDescriptor);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -11,12 +11,8 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.migration.Migrator;
-import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import jakarta.annotation.PostConstruct;
-import java.util.Map;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,9 +43,9 @@ public class SchemaStartup {
       LOGGER.info("SchemaStartup started.");
       LOGGER.info("SchemaStartup: validate index versions.");
       schemaValidator.validateIndexVersions();
-      LOGGER.info("SchemaStartup: validate index mappings.");
-      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields =
-          schemaValidator.validateIndexMappings();
+      //      LOGGER.info("SchemaStartup: validate index mappings.");
+      //      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields =
+      //          schemaValidator.validateIndexMappings();
       final boolean createSchema =
           DatabaseInfo.isOpensearch()
               ? operateProperties.getOpensearch().isCreateSchema()
@@ -63,18 +59,19 @@ public class SchemaStartup {
             "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
       }
 
-      if (!newFields.isEmpty()) {
-        if (createSchema) {
-          schemaManager.updateSchema(newFields);
-        } else {
-          LOGGER.info(
-              "SchemaStartup: schema won't be updated as schema creation is disabled in configuration.");
-        }
-      }
-      if (migrationProperties.isMigrationEnabled()) {
-        LOGGER.info("SchemaStartup: migrate schema.");
-        migrator.migrateData();
-      }
+      //      if (!newFields.isEmpty()) {
+      //        if (createSchema) {
+      //          schemaManager.updateSchema(newFields);
+      //        } else {
+      //          LOGGER.info(
+      //              "SchemaStartup: schema won't be updated as schema creation is disabled in
+      // configuration.");
+      //        }
+      //      }
+      //      if (migrationProperties.isMigrationEnabled()) {
+      //        LOGGER.info("SchemaStartup: migrate schema.");
+      //        migrator.migrateData();
+      //      }
       LOGGER.info("SchemaStartup finished.");
     } catch (final Exception ex) {
       LOGGER.error("Schema startup failed: " + ex.getMessage(), ex);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/SchemaStartup.java
@@ -43,9 +43,6 @@ public class SchemaStartup {
       LOGGER.info("SchemaStartup started.");
       LOGGER.info("SchemaStartup: validate index versions.");
       schemaValidator.validateIndexVersions();
-      //      LOGGER.info("SchemaStartup: validate index mappings.");
-      //      final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields =
-      //          schemaValidator.validateIndexMappings();
       final boolean createSchema =
           DatabaseInfo.isOpensearch()
               ? operateProperties.getOpensearch().isCreateSchema()
@@ -58,20 +55,6 @@ public class SchemaStartup {
         LOGGER.info(
             "SchemaStartup: schema won't be created, it either already exist, or schema creation is disabled in configuration.");
       }
-
-      //      if (!newFields.isEmpty()) {
-      //        if (createSchema) {
-      //          schemaManager.updateSchema(newFields);
-      //        } else {
-      //          LOGGER.info(
-      //              "SchemaStartup: schema won't be updated as schema creation is disabled in
-      // configuration.");
-      //        }
-      //      }
-      //      if (migrationProperties.isMigrationEnabled()) {
-      //        LOGGER.info("SchemaStartup: migrate schema.");
-      //        migrator.migrateData();
-      //      }
       LOGGER.info("SchemaStartup finished.");
     } catch (final Exception ex) {
       LOGGER.error("Schema startup failed: " + ex.getMessage(), ex);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -218,6 +218,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     return retryElasticsearchClient.getIndexMappings(indexName);
   }
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
+  @Deprecated
   @Override
   public void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
     for (final Map.Entry<IndexDescriptor, Set<IndexMappingProperty>> indexNewFields :

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
  * schema provided by a schema manager. Tries to detect source/previous schema if not provided.
  *
  * @deprecated Old-style migration that is not supported anymore. Moreover, schema manager is *
- *     happening in Zeebe exporter now.
+ *     happening in Camunda exporter now.
  */
 @Component
 @Configuration

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
@@ -41,9 +41,13 @@ import org.springframework.stereotype.Component;
 /**
  * Migrates an operate schema from one version to another. Requires an already created destination
  * schema provided by a schema manager. Tries to detect source/previous schema if not provided.
+ *
+ * @deprecated Old-style migration that is not supported anymore. Moreover, schema manager is *
+ *     happening in Zeebe exporter now.
  */
 @Component
 @Configuration
+@Deprecated
 public class Migrator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(Migrator.class);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
@@ -59,7 +59,7 @@ public class SchemaMigration implements CommandLineRunner {
 
   @Override
   public void run(final String... args) {
-    LOGGER.info("SchemaMigration finished.");
+    // calls postconstruct method of SchemaStartup
   }
 
   public static class ApplicationErrorListener

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -263,6 +263,10 @@ public class OpensearchSchemaManager implements SchemaManager {
     return richOpenSearchClient.index().getIndexMappings(indexNamePattern);
   }
 
+  /**
+   * @deprecated schema manager is happening in Zeebe exporter now
+   */
+  @Deprecated
   @Override
   public void updateSchema(final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields) {
     for (final Map.Entry<IndexDescriptor, Set<IndexMappingProperty>> indexNewFields :

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-authorizations.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-authorizations.json
@@ -15,6 +15,7 @@
         "type": "keyword"
       },
       "permissions": {
+        "type": "object",
         "properties": {
           "type": {
             "type": "keyword"

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
@@ -31,19 +31,20 @@
       "versionTag": {
         "type": "keyword"
       },
-			"flowNodes": {
-              "properties": {
-                "id": {
-                  "type": "keyword"
-                },
-                "name": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "tenantId": {
-              "type": "keyword"
-            }
+      "flowNodes": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
         }
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
     }
+  }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-decision-instance.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-decision-instance.json
@@ -80,6 +80,7 @@
         "type": "keyword"
       },
       "evaluatedInputs": {
+        "type": "object",
         "properties": {
           "id": {
             "type": "keyword"
@@ -94,6 +95,7 @@
         }
       },
       "evaluatedOutputs": {
+        "type": "object",
         "properties": {
           "id": {
             "type": "keyword"

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-event.json
@@ -7,6 +7,7 @@
 				"type": "date"
 			},
 			"metadata": {
+        "type": "object",
 				"properties": {
 					"jobRetries": {
 						"type": "integer"

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandler.java
@@ -89,8 +89,8 @@ public class FlowNodeInstanceProcessInstanceHandler
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
     // Parent tree path is intentionally not calculated here
-    entity.setTreePath(null);
-    entity.setLevel(0);
+    entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
+    entity.setLevel(1);
 
     final OffsetDateTime recordTime =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandler.java
@@ -88,7 +88,9 @@ public class FlowNodeInstanceProcessInstanceHandler
     entity.setBpmnProcessId(recordValue.getBpmnProcessId());
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
-    // Parent tree path is intentionally not calculated here
+    // Parent tree path is intentionally not calculated here, we set the value as if the instance is
+    // on the 1st level
+    // will be changed within https://github.com/camunda/camunda/issues/18378
     entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
     entity.setLevel(1);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceProcessInstanceHandlerTest.java
@@ -223,8 +223,13 @@ public class FlowNodeInstanceProcessInstanceHandlerTest {
         .isEqualTo(processInstanceRecordValue.getBpmnProcessId());
     assertThat(flowNodeInstanceEntity.getTenantId())
         .isEqualTo(processInstanceRecordValue.getTenantId());
-    assertThat(flowNodeInstanceEntity.getTreePath()).isNull();
-    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(0);
+    assertThat(flowNodeInstanceEntity.getTreePath())
+        .isEqualTo(
+            String.format(
+                "%s/%s",
+                processInstanceRecordValue.getProcessInstanceKey(),
+                flowNodeInstanceEntity.getId()));
+    assertThat(flowNodeInstanceEntity.getLevel()).isEqualTo(1);
     assertThat(flowNodeInstanceEntity.getState()).isEqualTo(FlowNodeState.ACTIVE);
     assertThat(flowNodeInstanceEntity.getEndDate()).isNull();
     assertThat(flowNodeInstanceEntity.getStartDate())

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -93,20 +93,20 @@ public class ElasticsearchExporter implements Exporter {
 
   @Override
   public void close() {
+    if (client != null) {
+      try {
+        flush();
+        updateLastExportedPosition();
+      } catch (final Exception e) {
+        log.warn("Failed to flush records before closing exporter.", e);
+      }
 
-    try {
-      flush();
-      updateLastExportedPosition();
-    } catch (final Exception e) {
-      log.warn("Failed to flush records before closing exporter.", e);
+      try {
+        client.close();
+      } catch (final Exception e) {
+        log.warn("Failed to close elasticsearch client", e);
+      }
     }
-
-    try {
-      client.close();
-    } catch (final Exception e) {
-      log.warn("Failed to close elasticsearch client", e);
-    }
-
     try {
       pluginRepository.close();
     } catch (final Exception e) {


### PR DESCRIPTION
* fix flow node instance handler so that Instance history is shown in UI
* fix index definition jsons to declare `type:object` so that validation is not failing
* comment out and deprecate all migration and data update functionality, will be removed later
* fix close method in `ElasticsearchExporter`
* fix CSRF token in test data creation

To test I'm running `StandaloneCamunda` with the following parameters:
```
CAMUNDA_DATABASE_CLUSTERNAME=docker-cluster;
CAMUNDA_DATABASE_TYPE=elasticsearch;
CAMUNDA_DATABASE_URL=http://elasticsearch:9200;
CAMUNDA_OPERATE_ELASTICSEARCH_CREATESCHEMA=true;
CAMUNDA_OPERATE_IMPORTERENABLED=false;
CAMUNDA_OPERATE_MIGRATION_MIGRATIONENABLED=false;
CAMUNDA_REST_QUERY_ENABLED=true;
SPRING_PROFILES_ACTIVE=broker,operate,dev-data;
ZEEBE_BROKER_EXPORTERS_CAMUNDA_ARGS_CONNECT_URL=http://localhost:9200;
ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME=io.camunda.exporter.CamundaExporter;
ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL=http://localhost:9200;
ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME=io.camunda.zeebe.exporter.ElasticsearchExporter
ZEEBE_GATEWAY_CLUSTER_INITIALCONTACTPOINTS=zeebe:26502
```

relates to #22897