### PR TITLE
feat: change applier for starting partition scale up

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -63,7 +64,10 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.setPartitionManager(partitionManager);
             brokerStartupContext
                 .getClusterConfigurationService()
-                .registerPartitionChangeExecutor(partitionManager);
+                .registerChangeExecutors(
+                    partitionManager,
+                    // TODO: Pass an actual implementation of PartitionScalingChangeExecutor
+                    new NoopPartitionScalingChangeExecutor());
             startupFuture.complete(brokerStartupContext);
           } catch (final Exception e) {
             startupFuture.completeExceptionally(e);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterConfigurationService.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning.topology;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -17,7 +18,9 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 public interface ClusterConfigurationService extends AsyncClosable {
   PartitionDistribution getPartitionDistribution();
 
-  void registerPartitionChangeExecutor(PartitionChangeExecutor executor);
+  void registerChangeExecutors(
+      PartitionChangeExecutor partitionChangeExecutor,
+      PartitionScalingChangeExecutor partitionScalingChangeExecutor);
 
   void removePartitionChangeExecutor();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterConfigurationService.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -33,12 +34,15 @@ public class DynamicClusterConfigurationService implements ClusterConfigurationS
   }
 
   @Override
-  public void registerPartitionChangeExecutor(final PartitionChangeExecutor executor) {
+  public void registerChangeExecutors(
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
     if (clusterConfigurationManagerService != null) {
-      clusterConfigurationManagerService.registerPartitionChangeExecutor(executor);
+      clusterConfigurationManagerService.registerChangeExecutors(
+          partitionChangeExecutor, partitionScalingChangeExecutor);
     } else {
       throw new IllegalStateException(
-          "Cannot register partition change executor before the topology manager is started");
+          "Cannot register change executor before the topology manager is started");
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinatorImpl;
 import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiper;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
@@ -227,12 +228,14 @@ public final class ClusterConfigurationManagerService
     return managerActor.closeAsync().andThen(gossipActor::closeAsync, Runnable::run);
   }
 
-  public void registerPartitionChangeExecutor(
-      final PartitionChangeExecutor partitionChangeExecutor) {
-    // TODO: pass concrete TopologyMembershipChangeExecutor
+  public void registerChangeExecutors(
+      final PartitionChangeExecutor partitionChangeExecutor,
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
     clusterConfigurationManager.registerTopologyChangeAppliers(
         new ConfigurationChangeAppliersImpl(
-            partitionChangeExecutor, new NoopClusterMembershipChangeExecutor()));
+            partitionChangeExecutor,
+            new NoopClusterMembershipChangeExecutor(),
+            partitionScalingChangeExecutor));
   }
 
   public void removePartitionChangeExecutor() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -30,12 +30,15 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
 
   private final PartitionChangeExecutor partitionChangeExecutor;
   private final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor;
+  private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
 
   public ConfigurationChangeAppliersImpl(
       final PartitionChangeExecutor partitionChangeExecutor,
-      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor) {
+      final ClusterMembershipChangeExecutor clusterMembershipChangeExecutor,
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor) {
     this.partitionChangeExecutor = partitionChangeExecutor;
     this.clusterMembershipChangeExecutor = clusterMembershipChangeExecutor;
+    this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.OperationNotAllowed;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
@@ -205,7 +206,9 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
       // simulate applying changes to validate the operations
       final var topologyChangeSimulator =
           new ConfigurationChangeAppliersImpl(
-              new NoopPartitionChangeExecutor(), new NoopClusterMembershipChangeExecutor());
+              new NoopPartitionChangeExecutor(),
+              new NoopClusterMembershipChangeExecutor(),
+              new NoopPartitionScalingChangeExecutor());
       final var topologyWithPendingOperations =
           currentClusterConfiguration.startConfigurationChange(operations);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
@@ -51,14 +51,14 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
     if (partitionId > Protocol.MAXIMUM_PARTITIONS) {
       return Either.left(
           new IllegalArgumentException(
-              "Failed to bootstrap partition '{}'. Partition ID is greater than the maximum allowed partition ID '{}'"
+              "Failed to bootstrap partition '%s'. Partition ID is greater than the maximum allowed partition ID '%s'"
                   .formatted(partitionId, Protocol.MAXIMUM_PARTITIONS)));
     }
 
     if (!isLocalMemberIsActive(currentClusterConfiguration)) {
       return Either.left(
           new IllegalStateException(
-              "Expected to bootstrap partition, but the member '{}' is not active"
+              "Expected to bootstrap partition, but the member '%s' is not active"
                   .formatted(memberId)));
     }
 
@@ -69,14 +69,14 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
     if (partitionExists(currentClusterConfiguration)) {
       return Either.left(
           new IllegalStateException(
-              "Failed to bootstrap partition '{}'. Partition already exists in the cluster"
+              "Failed to bootstrap partition '%s'. Partition already exists in the cluster"
                   .formatted(partitionId)));
     }
 
     if (!isPartitionIdContiguous(currentClusterConfiguration, partitionId)) {
       return Either.left(
           new IllegalStateException(
-              "Failed to bootstrap partition '{}'. Partition ID is not contiguous"
+              "Failed to bootstrap partition '%s'. Partition ID is not contiguous"
                   .formatted(partitionId)));
     }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionScalingChangeExecutor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+
+/**
+ * An executor that supports partition scaling and monitoring progress of redistribution and
+ * relocation of data.
+ */
+public interface PartitionScalingChangeExecutor {
+  /**
+   * Initiates scaling up of partitions, i.e. starts the process of resource redistribution and data
+   * relocation. The implementation must be idempotent.
+   *
+   * @return A future that completes as soon as scaling up has started.
+   */
+  ActorFuture<Void> initiateScaleUp(int desiredPartitionCount);
+
+  final class NoopPartitionScalingChangeExecutor implements PartitionScalingChangeExecutor {
+    @Override
+    public ActorFuture<Void> initiateScaleUp(final int desiredPartitionCount) {
+      return CompletableActorFuture.completed(null);
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.Either.Left;
+import io.camunda.zeebe.util.Either.Right;
+import java.util.Set;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Starts the process of scaling up partitions. The routing state version is incremented and the
+ * request handling strategy is updated from {@link AllPartitions} to {@link ActivePartitions} one,
+ * with new partitions starting off as inactive.
+ *
+ * <p>We use the request handling strategy to detect whether scaling up is possible or not - we
+ * expect {@link AllPartitions} at the beginning, update it to {@link ActivePartitions} and finish
+ * the scaling by going back to {@link AllPartitions}. If we find anything but {@link
+ * AllPartitions}, we assume that we are already scaling up and refuse the operation.
+ */
+final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
+
+  private final PartitionScalingChangeExecutor partitionScalingChangeExecutor;
+  private final int desiredPartitionCount;
+
+  StartPartitionScaleUpApplier(
+      final PartitionScalingChangeExecutor partitionScalingChangeExecutor,
+      final int desiredPartitionCount) {
+    this.partitionScalingChangeExecutor = partitionScalingChangeExecutor;
+    this.desiredPartitionCount = desiredPartitionCount;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    if (desiredPartitionCount < Protocol.START_PARTITION_ID) {
+      return new Left<>(
+          new IllegalArgumentException(
+              "Desired partition count must be greater than %d"
+                  .formatted(Protocol.START_PARTITION_ID)));
+    }
+
+    if (desiredPartitionCount > Protocol.MAXIMUM_PARTITIONS) {
+      return new Left<>(
+          new IllegalArgumentException(
+              "Desired partition count must not exceed %d".formatted(Protocol.MAXIMUM_PARTITIONS)));
+    }
+
+    for (int partition = Protocol.START_PARTITION_ID;
+        partition <= desiredPartitionCount;
+        partition++) {
+      if (!currentClusterConfiguration.hasPartition(partition)) {
+        return new Left<>(
+            new IllegalStateException("Partition %d is not known.".formatted(partition)));
+      }
+    }
+
+    if (currentClusterConfiguration.routingState().isEmpty()) {
+      return new Left<>(
+          new IllegalStateException(
+              "Routing state is not initialized yet, scaling up is not possible."));
+    }
+    final var routing = currentClusterConfiguration.routingState().get();
+    final var requestHandling = routing.requestHandling();
+
+    return switch (requestHandling) {
+      case AllPartitions(final var currentPartitionCount) -> {
+        if (desiredPartitionCount <= currentPartitionCount) {
+          yield new Left<>(
+              new IllegalStateException(
+                  "Already routing to %d partitions, can't scale down to %d"
+                      .formatted(currentPartitionCount, desiredPartitionCount)));
+        } else {
+          yield new Right<>(UnaryOperator.identity());
+        }
+      }
+      default ->
+          new Left<>(
+              new IllegalStateException(
+                  "Cannot start scaling up because request handling strategy is not stable: %s"
+                      .formatted(requestHandling)));
+    };
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<ClusterConfiguration>>();
+
+    partitionScalingChangeExecutor
+        .initiateScaleUp(desiredPartitionCount)
+        .onComplete(
+            (ignoredResult, error) -> {
+              if (error != null) {
+                result.completeExceptionally(error);
+              } else {
+                result.complete(
+                    config ->
+                        new ClusterConfiguration(
+                            config.version(),
+                            config.members(),
+                            config.lastChange(),
+                            config.pendingChanges(),
+                            config.routingState().map(this::updateRoutingState)));
+              }
+            });
+
+    return result;
+  }
+
+  private RoutingState updateRoutingState(final RoutingState routingState) {
+    return new RoutingState(
+        routingState.version() + 1,
+        updateRequestHandling(routingState.requestHandling()),
+        routingState.messageCorrelation());
+  }
+
+  private RequestHandling updateRequestHandling(final RequestHandling requestHandling) {
+    return switch (requestHandling) {
+      case AllPartitions(final var currentPartitionCount) -> {
+        final var newPartitions =
+            IntStream.rangeClosed(currentPartitionCount + 1, desiredPartitionCount)
+                .boxed()
+                .collect(Collectors.toSet());
+        yield new ActivePartitions(currentPartitionCount, Set.of(), newPartitions);
+      }
+      default ->
+          throw new IllegalStateException(
+              "Unexpected request handling state: %s".formatted(requestHandling));
+    };
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplier.java
@@ -63,7 +63,7 @@ final class StartPartitionScaleUpApplier implements ClusterOperationApplier {
     }
 
     for (int partition = Protocol.START_PARTITION_ID;
-        partition <= desiredPartitionCount;
+        partition < Protocol.START_PARTITION_ID + desiredPartitionCount;
         partition++) {
       if (!currentClusterConfiguration.hasPartition(partition)) {
         return new Left<>(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -262,6 +262,10 @@ public record ClusterConfiguration(
             .count();
   }
 
+  public boolean hasPartition(final int partitionId) {
+    return members.values().stream().anyMatch(member -> member.hasPartition(partitionId));
+  }
+
   public int partitionCount() {
     return (int)
         members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -43,6 +43,16 @@ public sealed interface ClusterConfigurationChangeOperation {
   record MemberRemoveOperation(MemberId memberId, MemberId memberToRemove)
       implements ClusterConfigurationChangeOperation {}
 
+  /**
+   * Operation to initiate partition scale up. This instructs the cluster to redistribute resources
+   * and relocate data.
+   *
+   * @param memberId the id of the member that initiates the scale up
+   * @param desiredPartitionCount the desired partition count after scaling up
+   */
+  record StartPartitionScaleUpOperation(MemberId memberId, int desiredPartitionCount)
+      implements ClusterConfigurationChangeOperation {}
+
   sealed interface PartitionChangeOperation extends ClusterConfigurationChangeOperation {
     int partitionId();
 

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -105,6 +105,7 @@ message TopologyChangeOperation {
     PartitionDisableExporterOperation partitionDisableExporter = 9;
     PartitionEnableExporterOperation partitionEnableExporter = 10;
     PartitionBootstrapOperation partitionBootstrap = 11;
+    StartPartitionScaleUpOperation initiateScaleUpPartitions = 12;
   }
 }
 
@@ -146,6 +147,10 @@ message PartitionEnableExporterOperation {
 message PartitionBootstrapOperation {
   int32 partitionId = 1;
   int32 priority = 2;
+}
+
+message StartPartitionScaleUpOperation {
+  int32 desiredPartitionCount = 2;
 }
 
 message MemberJoinOperation {}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -16,6 +16,7 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator;
 import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -309,7 +310,8 @@ class ClusterConfigurationManagementIntegrationTest {
       startFuture.onComplete(
           (ignore, error) -> {
             if (error == null) {
-              service.registerPartitionChangeExecutor(new NoopPartitionChangeExecutor());
+              service.registerChangeExecutors(
+                  new NoopPartitionChangeExecutor(), new NoopPartitionScalingChangeExecutor());
             }
           },
           Runnable::run);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config;
 
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling;
 import java.util.stream.IntStream;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
@@ -31,6 +32,11 @@ public class RoutingStateAssert extends AbstractAssert<RoutingStateAssert, Routi
   public RoutingStateAssert hasActivatedPartitions(final int partitionCount) {
     Assertions.assertThat(actual.requestHandling().activePartitions())
         .containsExactlyElementsOf(IntStream.rangeClosed(1, partitionCount).boxed().toList());
+    return this;
+  }
+
+  public RoutingStateAssert hasRequestHandling(final RequestHandling requestHandling) {
+    Assertions.assertThat(actual.requestHandling()).isEqualTo(requestHandling);
     return this;
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/TestTopologyChangeSimulator.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.fail;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliersImpl;
 import io.camunda.zeebe.dynamic.config.changes.NoopClusterMembershipChangeExecutor;
 import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
+import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import java.util.List;
@@ -23,7 +24,9 @@ final class TestTopologyChangeSimulator {
       final List<ClusterConfigurationChangeOperation> operations) {
     final var topologyChangeSimulator =
         new ConfigurationChangeAppliersImpl(
-            new NoopPartitionChangeExecutor(), new NoopClusterMembershipChangeExecutor());
+            new NoopPartitionChangeExecutor(),
+            new NoopClusterMembershipChangeExecutor(),
+            new NoopPartitionScalingChangeExecutor());
     ClusterConfiguration newTopology = currentTopology;
     if (!operations.isEmpty()) {
       newTopology = currentTopology.startConfigurationChange(operations);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -33,7 +33,7 @@ final class ConfigurationChangeAppliersImplTest {
   void shouldReturnExpectedApplier(
       final ClusterConfigurationChangeOperation operation, final Class<?> expectedClass) {
     // given
-    final var topologyChangeAppliers = new ConfigurationChangeAppliersImpl(null, null);
+    final var topologyChangeAppliers = new ConfigurationChangeAppliersImpl(null, null, null);
 
     // when
     final var applier = topologyChangeAppliers.getApplier(operation);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
@@ -50,13 +50,16 @@ final class StartPartitionScaleUpApplierTest {
                       PartitionState.active(1, DynamicPartitionConfig.init()))));
 
   @Test
-  void shouldFailOnInvalidPartitionCounts() {
+  void shouldFailOnPartitionCountTooLow() {
     EitherAssert.assertThat(
             new StartPartitionScaleUpApplier(executor, 0).init(initialConfiguration))
         .left()
         .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class))
         .hasMessageContaining("Desired partition count must be greater than 1");
+  }
 
+  @Test
+  void shouldFailOnPartitionCountTooHigh() {
     EitherAssert.assertThat(
             new StartPartitionScaleUpApplier(executor, 100000).init(initialConfiguration))
         .left()

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/StartPartitionScaleUpApplierTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.ActivePartitions;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.RequestHandling.AllPartitions;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+final class StartPartitionScaleUpApplierTest {
+  private final PartitionScalingChangeExecutor executor =
+      mock(PartitionScalingChangeExecutor.class);
+  private final ClusterConfiguration initialConfiguration =
+      ClusterConfiguration.init()
+          .addMember(
+              MemberId.from("1"),
+              MemberState.initializeAsActive(
+                  Map.of(
+                      1,
+                      PartitionState.active(1, DynamicPartitionConfig.init()),
+                      2,
+                      PartitionState.active(1, DynamicPartitionConfig.init()),
+                      3,
+                      PartitionState.active(1, DynamicPartitionConfig.init()))));
+
+  @Test
+  void shouldFailOnInvalidPartitionCounts() {
+    EitherAssert.assertThat(
+            new StartPartitionScaleUpApplier(executor, 0).init(initialConfiguration))
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class))
+        .hasMessageContaining("Desired partition count must be greater than 1");
+
+    EitherAssert.assertThat(
+            new StartPartitionScaleUpApplier(executor, 100000).init(initialConfiguration))
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalArgumentException.class))
+        .hasMessageContaining("Desired partition count must not exceed 8192");
+  }
+
+  @Test
+  void shouldFailWhenRoutingStateIsMissing() {
+    // given - routing state not initialized
+    assertThat(initialConfiguration).returns(Optional.empty(), ClusterConfiguration::routingState);
+
+    // when - trying to init the operation
+    final var result = new StartPartitionScaleUpApplier(executor, 3).init(initialConfiguration);
+
+    // then - init fails with a useful exception
+    EitherAssert.assertThat(result)
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalStateException.class))
+        .hasMessageContaining("Routing state is not initialized yet");
+  }
+
+  @Test
+  void shouldFailWhenPartitionsAreNotAvailable() {
+    // given - cluster does not contain partition 4
+    assertThat(initialConfiguration.hasPartition(4)).isFalse();
+
+    // when - trying to init the operation to scale up to 4 partitions
+    final var result = new StartPartitionScaleUpApplier(executor, 4).init(initialConfiguration);
+
+    // then - init fails with a useful exception
+    EitherAssert.assertThat(result)
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalStateException.class))
+        .hasMessageContaining("Partition 4 is not known");
+  }
+
+  @Test
+  void shouldFailWhenRequestHandlingIsUnexpected() {
+    // given - request handling is not AllPartitions
+    final var routingState =
+        new RoutingState(1, new ActivePartitions(1, Set.of(), Set.of(2, 3)), new HashMod(1));
+    final var configuration =
+        new ClusterConfiguration(
+            initialConfiguration.version(),
+            initialConfiguration.members(),
+            initialConfiguration.lastChange(),
+            initialConfiguration.pendingChanges(),
+            Optional.of(routingState));
+
+    // when - trying to init the operation to scale up
+    final var result = new StartPartitionScaleUpApplier(executor, 3).init(configuration);
+
+    // then - init fails with a useful exception
+    EitherAssert.assertThat(result)
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalStateException.class))
+        .hasMessageContaining(
+            "Cannot start scaling up because request handling strategy is not stable");
+  }
+
+  @Test
+  void shouldFailWhenActuallyScalingDown() {
+    // given - request handling is set up for three partitions
+    final var routingState = new RoutingState(1, new AllPartitions(3), new HashMod(3));
+    final var configuration =
+        new ClusterConfiguration(
+            initialConfiguration.version(),
+            initialConfiguration.members(),
+            initialConfiguration.lastChange(),
+            initialConfiguration.pendingChanges(),
+            Optional.of(routingState));
+
+    // when - trying to init the operation to scale "up" to 2 partitions
+    final var result = new StartPartitionScaleUpApplier(executor, 2).init(configuration);
+
+    // then - init fails with a useful exception
+    EitherAssert.assertThat(result)
+        .left()
+        .asInstanceOf(InstanceOfAssertFactories.throwable(IllegalStateException.class))
+        .hasMessageContaining("Already routing to 3 partitions, can't scale down to 2");
+  }
+
+  @Test
+  void shouldForwardExecutorFailure() {
+    // given - routing state is stable, pointing at just one partition
+    final var routingState = new RoutingState(1, new AllPartitions(1), new HashMod(1));
+    final var configuration =
+        new ClusterConfiguration(
+            initialConfiguration.version(),
+            initialConfiguration.members(),
+            initialConfiguration.lastChange(),
+            initialConfiguration.pendingChanges(),
+            Optional.of(routingState));
+
+    // when - applying the operation to scale up to three once
+    final var expectedFailure = new RuntimeException("Expected failure");
+    when(executor.initiateScaleUp(anyInt()))
+        .thenReturn(CompletableActorFuture.completedExceptionally(expectedFailure));
+    final var applier = new StartPartitionScaleUpApplier(executor, 2);
+
+    // then - applier fails during apply
+    assertThat(applier.apply())
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableThat()
+        .withCause(expectedFailure);
+  }
+
+  @Test
+  void shouldCallExecutorWithDesiredPartitionCount() {
+    // given - routing state is stable, pointing at just one partition
+    final var routingState = new RoutingState(1, new AllPartitions(1), new HashMod(1));
+    final var configuration =
+        new ClusterConfiguration(
+            initialConfiguration.version(),
+            initialConfiguration.members(),
+            initialConfiguration.lastChange(),
+            initialConfiguration.pendingChanges(),
+            Optional.of(routingState));
+
+    // when - applying the operation to scale up to three once
+    when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));
+    final var updatedConfiguration =
+        runApplier(new StartPartitionScaleUpApplier(executor, 3), configuration);
+
+    // then - executor is called
+    verify(executor).initiateScaleUp(3);
+  }
+
+  @Test
+  void shouldUpdateRoutingState() {
+    // given - routing state is stable, pointing at just one partition
+    final var routingState = new RoutingState(1, new AllPartitions(1), new HashMod(1));
+    final var configuration =
+        new ClusterConfiguration(
+            initialConfiguration.version(),
+            initialConfiguration.members(),
+            initialConfiguration.lastChange(),
+            initialConfiguration.pendingChanges(),
+            Optional.of(routingState));
+
+    // when - applying the operation to scale up to three once
+    when(executor.initiateScaleUp(anyInt())).thenReturn(CompletableActorFuture.completed(null));
+    final var updatedConfiguration =
+        runApplier(new StartPartitionScaleUpApplier(executor, 3), configuration);
+
+    // then - routing state is updated
+    ClusterConfigurationAssert.assertThatClusterTopology(updatedConfiguration)
+        .routingState()
+        .hasVersion(2)
+        .hasActivatedPartitions(1)
+        .hasRequestHandling(new ActivePartitions(1, Set.of(), Set.of(2, 3)));
+  }
+
+  private static ClusterConfiguration runApplier(
+      final ClusterOperationApplier applier, final ClusterConfiguration initialConfiguration) {
+    final var initializedConfiguration =
+        applier.init(initialConfiguration).get().apply(initialConfiguration);
+    final var updater = applier.apply().join();
+    return updater.apply(initializedConfiguration);
+  }
+}


### PR DESCRIPTION
This adds a new applier, `StartPartitionScaleUpApplier` that is supposed to initiate the scale up within the engine.
It does this by updating the routing state, incrementing version and marking new partitions as initially inactive, and then calling out to a new, not yet implemented, `PartitionScalingChangeExecutor`.


Depends on https://github.com/camunda/camunda/pull/23777
Relates to https://github.com/camunda/camunda/issues/23215
