### PR TITLE
feat: introduce form related fields in process index

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
@@ -179,7 +179,7 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
     return this;
   }
 
-  public String getFormKey() {
+  public String getFormId() {
     return formId;
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ProcessEntity.java
@@ -20,6 +20,8 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
   private String bpmnXml;
   private String resourceName;
   private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
+  private String formId;
+  private Boolean isPublic;
   private String tenantId = DEFAULT_TENANT_ID;
 
   public String getName() {
@@ -49,7 +51,9 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
         bpmnXml,
         resourceName,
         flowNodes,
-        tenantId);
+        tenantId,
+        formId,
+        isPublic);
   }
 
   @Override
@@ -71,7 +75,9 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
         && Objects.equals(bpmnXml, that.bpmnXml)
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(flowNodes, that.flowNodes)
-        && Objects.equals(tenantId, that.tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(formId, that.formId)
+        && Objects.equals(isPublic, that.isPublic);
   }
 
   @Override
@@ -96,6 +102,10 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
         + '\''
         + ", flowNodes="
         + flowNodes
+        + ", formId="
+        + formId
+        + ", isPublic="
+        + isPublic
         + ", tenantId='"
         + tenantId
         + '\''
@@ -166,6 +176,24 @@ public class ProcessEntity extends OperateZeebeEntity<ProcessEntity> {
 
   public ProcessEntity setTenantId(final String tenantId) {
     this.tenantId = tenantId;
+    return this;
+  }
+
+  public String getFormKey() {
+    return formId;
+  }
+
+  public ProcessEntity setFormId(final String formId) {
+    this.formId = formId;
+    return this;
+  }
+
+  public Boolean getIsPublic() {
+    return isPublic;
+  }
+
+  public ProcessEntity setIsPublic(final Boolean isPublic) {
+    this.isPublic = isPublic;
     return this;
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/operate-process.json
@@ -1,49 +1,55 @@
 {
-	"mappings": {
+  "mappings": {
     "dynamic": "strict",
-		"properties": {
-			"bpmnProcessId": {
-				"type": "keyword",
-				"eager_global_ordinals": true
-			},
-			"bpmnXml": {
-				"type": "text",
-				"index": false
-			},
-			"id": {
-				"type": "keyword"
-			},
-			"key": {
-				"type": "keyword"
-			},
-			"name": {
-				"type": "keyword"
-			},
-			"partitionId": {
-				"type": "integer"
-			},
-			"resourceName": {
-				"type": "keyword"
-			},
-			"version": {
-				"type": "long"
-			},
+    "properties": {
+      "bpmnProcessId": {
+        "type": "keyword",
+        "eager_global_ordinals": true
+      },
+      "bpmnXml": {
+        "type": "text",
+        "index": false
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "key": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "keyword"
+      },
+      "partitionId": {
+        "type": "integer"
+      },
+      "resourceName": {
+        "type": "keyword"
+      },
+      "version": {
+        "type": "long"
+      },
       "versionTag": {
         "type": "keyword"
       },
-			"flowNodes": {
-              "properties": {
-                "id": {
-                  "type": "keyword"
-                },
-                "name": {
-                  "type": "keyword"
-                }
-              }
-            },
-            "tenantId": {
-              "type": "keyword"
-            }
+      "flowNodes": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
         }
+      },
+      "isPublic": {
+        "type": "boolean"
+      },
+      "formId": {
+        "type": "keyword"
+      },
+      "tenantId": {
+        "type": "keyword"
+      }
     }
+  }
 }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-process.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/operate-process.json
@@ -42,6 +42,12 @@
           }
         }
       },
+      "isPublic": {
+        "type": "boolean"
+      },
+      "formId": {
+        "type": "keyword"
+      },
       "tenantId": {
         "type": "keyword"
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -83,7 +83,7 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
                 .setName(processEntity.getName())
                 .setFlowNodes(processEntity.getFlowNodes())
                 .setVersionTag(processEntity.getVersionTag())
-                .setFormId(processEntity.getFormKey())
+                .setFormId(processEntity.getFormId())
                 .setIsPublic(processEntity.getIsPublic()));
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -82,7 +82,9 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
             entity
                 .setName(processEntity.getName())
                 .setFlowNodes(processEntity.getFlowNodes())
-                .setVersionTag(processEntity.getVersionTag()));
+                .setVersionTag(processEntity.getVersionTag())
+                .setFormId(processEntity.getFormKey())
+                .setIsPublic(processEntity.getIsPublic()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
@@ -66,6 +66,8 @@ public class XMLUtil {
       }
       final ProcessEntity processEntity = processEntityOpt.get();
       processEntity.setVersionTag(handler.versionTag);
+      processEntity.setIsPublic(handler.isPublic);
+      processEntity.setFormId(handler.formId);
       final Set<String> processChildrenIds = handler.getProcessChildrenIds(bpmnProcessId);
       is = new ByteArrayInputStream(byteArray);
       final BpmnModelInstance modelInstance = Bpmn.readModelFromStream(is);
@@ -96,6 +98,8 @@ public class XMLUtil {
     private String currentProcessId = null;
     private boolean isStartEvent = false;
     private String versionTag = null;
+    private boolean isPublic = false;
+    private String formId = null;
 
     @Override
     public void startElement(
@@ -110,26 +114,24 @@ public class XMLUtil {
             new ProcessEntity().setBpmnProcessId(elementId).setName(attributes.getValue("name")));
         processChildrenIds.put(elementId, new LinkedHashSet<>());
         currentProcessId = elementId;
-      } else if (currentProcessId != null && elementId != null) {
-        processChildrenIds.get(currentProcessId).add(elementId);
       } else if (startEventElement.equalsIgnoreCase(localName)) {
         isStartEvent = true;
+      } else if (currentProcessId != null && elementId != null) {
+        processChildrenIds.get(currentProcessId).add(elementId);
       } else if ("versionTag".equalsIgnoreCase(localName)) {
         versionTag = attributes.getValue("value");
       } else if (isStartEvent) {
         if (formDefinitionProperty.equalsIgnoreCase(localName)) {
-          /* TODO: Parse property in operate-process once Tasklist fields have been added
           if (attributes.getValue("formKey") != null) {
+            formId = attributes.getValue("formKey");
           }
-          */
         } else if ("property".equalsIgnoreCase(localName)) {
           final String name = attributes.getValue("name");
           final String value = attributes.getValue("value");
-          /* TODO: Parse property in operate-process once Tasklist fields have been added
           if (publicAccess.equalsIgnoreCase(name)
               && Boolean.TRUE.toString().equalsIgnoreCase(value)) {
-
-          } */
+            isPublic = true;
+          }
         }
       }
     }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -134,5 +134,46 @@ public class ProcessHandlerTest {
     assertThat(processEntity.getBpmnXml())
         .isEqualTo(new String(processRecordValue.getResource(), StandardCharsets.UTF_8));
     assertThat(processEntity.getTenantId()).isEqualTo(processRecordValue.getTenantId());
+    assertThat(processEntity.getIsPublic()).isFalse();
+    assertThat(processEntity.getFormKey()).isNull();
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordWithForm() throws IOException {
+    // given
+
+    final long expectedId = 123;
+    final var resource = getClass().getClassLoader().getResource("process/form-process.bpmn");
+    assertThat(resource).isNotNull();
+    final ImmutableProcess processRecordValue =
+        ImmutableProcess.builder()
+            .from(factory.generateObject(ImmutableProcess.class))
+            .withProcessDefinitionKey(expectedId)
+            .withBpmnProcessId("testProcessId")
+            .withResource(Files.readAllBytes(Path.of(resource.getPath())))
+            .build();
+
+    final Record<Process> processRecord =
+        factory.generateRecord(
+            ValueType.DECISION,
+            r -> r.withIntent(ProcessIntent.CREATED).withValue(processRecordValue));
+
+    // when
+    final ProcessEntity processEntity = new ProcessEntity();
+    underTest.updateEntity(processRecord, processEntity);
+
+    // then
+    assertThat(processEntity.getId()).isEqualTo(String.valueOf(expectedId));
+    assertThat(processEntity.getKey()).isEqualTo(expectedId);
+    assertThat(processEntity.getName()).isEqualTo("testProcessName");
+    assertThat(processEntity.getBpmnProcessId()).isEqualTo("testProcessId");
+    assertThat(processEntity.getVersionTag()).isEqualTo("processTag");
+    assertThat(processEntity.getVersion()).isEqualTo(processRecordValue.getVersion());
+    assertThat(processEntity.getResourceName()).isEqualTo(processRecordValue.getResourceName());
+    assertThat(processEntity.getBpmnXml())
+        .isEqualTo(new String(processRecordValue.getResource(), StandardCharsets.UTF_8));
+    assertThat(processEntity.getTenantId()).isEqualTo(processRecordValue.getTenantId());
+    assertThat(processEntity.getIsPublic()).isTrue();
+    assertThat(processEntity.getFormKey()).isNotNull();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -135,7 +135,7 @@ public class ProcessHandlerTest {
         .isEqualTo(new String(processRecordValue.getResource(), StandardCharsets.UTF_8));
     assertThat(processEntity.getTenantId()).isEqualTo(processRecordValue.getTenantId());
     assertThat(processEntity.getIsPublic()).isFalse();
-    assertThat(processEntity.getFormKey()).isNull();
+    assertThat(processEntity.getFormId()).isNull();
   }
 
   @Test
@@ -174,6 +174,6 @@ public class ProcessHandlerTest {
         .isEqualTo(new String(processRecordValue.getResource(), StandardCharsets.UTF_8));
     assertThat(processEntity.getTenantId()).isEqualTo(processRecordValue.getTenantId());
     assertThat(processEntity.getIsPublic()).isTrue();
-    assertThat(processEntity.getFormKey()).isNotNull();
+    assertThat(processEntity.getFormId()).isNotNull();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/resources/process/form-process.bpmn
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/process/form-process.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1podyfa" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+  <bpmn:process id="testProcessId" name="testProcessName" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="processTag" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="startEvent" name="start">
+      <bpmn:extensionElements>
+        <zeebe:formDefinition formKey="testForm" />
+        <zeebe:properties>
+          <zeebe:property name="publicAccess" value="true" />
+        </zeebe:properties>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0nn8ukk</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="endEvent" name="end">
+      <bpmn:incoming>Flow_0nn8ukk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0nn8ukk" sourceRef="startEvent" targetRef="endEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="testProcessId">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="startEvent">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="125" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1v78bxg_di" bpmnElement="endEvent">
+        <dc:Bounds x="242" y="82" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="251" y="125" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0nn8ukk_di" bpmnElement="Flow_0nn8ukk">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="242" y="100" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Introduce the `formId` and the `isPublic` fields over the `operate-process` index along with the respective chagnes to the ProcessHandler

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23043
