### PR TITLE
Allow cancelling banned instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -137,7 +137,7 @@ public class Engine implements RecordProcessor {
               || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
               || intent == ProcessInstanceBatchIntent.TERMINATE;
 
-      if (noBanCheckNeeded || (banned && commandAllowedForBanned) || !banned) {
+      if (noBanCheckNeeded || !banned || commandAllowedForBanned) {
         currentProcessor.processRecord(record);
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -125,8 +125,7 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      final var shouldProcess = shouldProcessCommand(typedCommand);
-      if (shouldProcess) {
+      if (shouldProcessCommand(typedCommand)) {
         currentProcessor.processRecord(record);
       }
     }
@@ -178,8 +177,7 @@ public class Engine implements RecordProcessor {
             || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
             || intent == ProcessInstanceBatchIntent.TERMINATE;
 
-    final var shouldProcess = noBanCheckNeeded || !banned || commandAllowedForBanned;
-    return shouldProcess;
+    return noBanCheckNeeded || !banned || commandAllowedForBanned;
   }
 
   private void handleUnexpectedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -125,19 +125,7 @@ public class Engine implements RecordProcessor {
         return processingResultBuilder.build();
       }
 
-      // There is no ban check needed if the intent is not instance related
-      // nor if the intent is to create new instances, which can't be banned yet
-      final Intent intent = typedCommand.getIntent();
-      final boolean noBanCheckNeeded =
-          !(intent instanceof ProcessInstanceRelatedIntent)
-              || intent instanceof ProcessInstanceCreationIntent;
-      final boolean banned = processingState.getBannedInstanceState().isBanned(typedCommand);
-      final boolean commandAllowedForBanned =
-          intent == ProcessInstanceIntent.CANCEL
-              || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
-              || intent == ProcessInstanceBatchIntent.TERMINATE;
-
-      final var shouldProcess = noBanCheckNeeded || !banned || commandAllowedForBanned;
+      final var shouldProcess = shouldProcessCommand(typedCommand);
       if (shouldProcess) {
         currentProcessor.processRecord(record);
       }
@@ -175,6 +163,23 @@ public class Engine implements RecordProcessor {
       }
     }
     return processingResultBuilder.build();
+  }
+
+  private boolean shouldProcessCommand(final TypedRecord<?> typedCommand) {
+    // There is no ban check needed if the intent is not instance related
+    // nor if the intent is to create new instances, which can't be banned yet
+    final Intent intent = typedCommand.getIntent();
+    final boolean noBanCheckNeeded =
+        !(intent instanceof ProcessInstanceRelatedIntent)
+            || intent instanceof ProcessInstanceCreationIntent;
+    final boolean banned = processingState.getBannedInstanceState().isBanned(typedCommand);
+    final boolean commandAllowedForBanned =
+        intent == ProcessInstanceIntent.CANCEL
+            || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
+            || intent == ProcessInstanceBatchIntent.TERMINATE;
+
+    final var shouldProcess = noBanCheckNeeded || !banned || commandAllowedForBanned;
+    return shouldProcess;
   }
 
   private void handleUnexpectedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -182,12 +182,10 @@ public class Engine implements RecordProcessor {
       return true;
     }
 
-    final boolean commandAllowedForBanned =
-        intent == ProcessInstanceIntent.CANCEL
-            || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
-            || intent == ProcessInstanceBatchIntent.TERMINATE;
-
-    return commandAllowedForBanned;
+    // Commands allowed to be processed on banned instances
+    return intent == ProcessInstanceIntent.CANCEL
+        || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
+        || intent == ProcessInstanceBatchIntent.TERMINATE;
   }
 
   private void handleUnexpectedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -127,7 +127,7 @@ public class Engine implements RecordProcessor {
 
       // There is no ban check needed if the intent is not instance related
       // nor if the intent is to create new instances, which can't be banned yet
-      final Intent intent = record.getIntent();
+      final Intent intent = typedCommand.getIntent();
       final boolean noBanCheckNeeded =
           !(intent instanceof ProcessInstanceRelatedIntent)
               || intent instanceof ProcessInstanceCreationIntent;
@@ -137,7 +137,8 @@ public class Engine implements RecordProcessor {
               || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
               || intent == ProcessInstanceBatchIntent.TERMINATE;
 
-      if (noBanCheckNeeded || !banned || commandAllowedForBanned) {
+      final var shouldProcess = noBanCheckNeeded || !banned || commandAllowedForBanned;
+      if (shouldProcess) {
         currentProcessor.processRecord(record);
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -171,13 +171,23 @@ public class Engine implements RecordProcessor {
     final boolean noBanCheckNeeded =
         !(intent instanceof ProcessInstanceRelatedIntent)
             || intent instanceof ProcessInstanceCreationIntent;
+
+    if (noBanCheckNeeded) {
+      return true;
+    }
+
     final boolean banned = processingState.getBannedInstanceState().isBanned(typedCommand);
+
+    if (!banned) {
+      return true;
+    }
+
     final boolean commandAllowedForBanned =
         intent == ProcessInstanceIntent.CANCEL
             || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
             || intent == ProcessInstanceBatchIntent.TERMINATE;
 
-    return noBanCheckNeeded || !banned || commandAllowedForBanned;
+    return commandAllowedForBanned;
   }
 
   private void handleUnexpectedError(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -23,7 +23,10 @@ import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceRelatedIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.ProcessingResult;
@@ -124,10 +127,17 @@ public class Engine implements RecordProcessor {
 
       // There is no ban check needed if the intent is not instance related
       // nor if the intent is to create new instances, which can't be banned yet
+      final Intent intent = record.getIntent();
       final boolean noBanCheckNeeded =
-          !(record.getIntent() instanceof ProcessInstanceRelatedIntent)
-              || record.getIntent() instanceof ProcessInstanceCreationIntent;
-      if (noBanCheckNeeded || !processingState.getBannedInstanceState().isBanned(typedCommand)) {
+          !(intent instanceof ProcessInstanceRelatedIntent)
+              || intent instanceof ProcessInstanceCreationIntent;
+      final boolean banned = processingState.getBannedInstanceState().isBanned(typedCommand);
+      final boolean commandAllowedForBanned =
+          intent == ProcessInstanceIntent.CANCEL
+              || intent == ProcessInstanceIntent.TERMINATE_ELEMENT
+              || intent == ProcessInstanceBatchIntent.TERMINATE;
+
+      if (noBanCheckNeeded || (banned && commandAllowedForBanned) || !banned) {
         currentProcessor.processRecord(record);
       }
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.zeebe.it.management;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -84,7 +84,6 @@ final class BannedInstanceIT {
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
                 .withRecordKey(processInstanceKey)
-                .limit(1)
                 .exists())
         .describedAs("Expected to find cancel command for process instance")
         .isTrue();
@@ -203,17 +202,24 @@ final class BannedInstanceIT {
     // then
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
-                .withProcessInstanceKey(processInstanceKey))
-        .isNotNull();
+                .withRecordKey(processInstanceKey)
+                .exists())
+        .describedAs("Expected to find cancel command for process instance")
+        .isTrue();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
-                .withProcessInstanceKey(processInstanceKey))
-        .isNotNull();
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .exists())
+        .describedAs("Expected to find terminated event for process instance")
+        .isTrue();
 
     assertThat(
             RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
-                .withRecordKey(incident.getKey()))
-        .isNotNull();
+                .withRecordKey(incident.getKey())
+                .exists())
+        .describedAs("Expected to find resolved incident for process instance")
+        .isTrue();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -47,7 +47,7 @@ final class BannedInstanceIT {
   }
 
   @Test
-  public void shouldCancelProcessInstanceWhenInstanceIsBanned() {
+  public void shouldAllowCancelProcessInstanceWhenInstanceIsBanned() {
     // given
     final var processId = helper.getBpmnProcessId();
     client
@@ -155,7 +155,7 @@ final class BannedInstanceIT {
   }
 
   @Test
-  public void shouldCancelBannedInstanceWithIncident() {
+  public void shouldAllowCancelBannedInstanceWithIncident() {
     // given
     final var processId = helper.getBpmnProcessId();
     client

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -140,7 +140,8 @@ final class BannedInstanceIT {
 
     RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
         .withProcessInstanceKey(processInstanceKey)
-        .withElementType(BpmnElementType.PROCESS);
+        .withElementType(BpmnElementType.PROCESS)
+        .await();
 
     clock.addTime(new AddTimeRequest(Duration.ofMinutes(15).toMillis()));
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -147,8 +147,10 @@ final class BannedInstanceIT {
 
     // then
     assertThat(
-            RecordingExporter.timerRecords(TimerIntent.TRIGGER)
-                .withProcessInstanceKey(processInstanceKey)
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .timerRecords()
+                .withIntent(TimerIntent.TRIGGER)
                 .exists())
         .describedAs(
             "Expected not to find trigger event for timer because the process instance is terminated")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -38,19 +38,19 @@ final class BannedInstanceIT {
   public static final String PROCESS_ID = "process";
 
   @TestZeebe
-  private final TestStandaloneBroker zeebe =
+  private static final TestStandaloneBroker ZEEBE =
       new TestStandaloneBroker()
           .withRecordingExporter(true)
           .withProperty("zeebe.clock.controlled", true);
 
-  private final BanningActuator actuator = BanningActuator.of(zeebe);
-  private final ActorClockActuator clock = ActorClockActuator.of(zeebe);
+  private final BanningActuator actuator = BanningActuator.of(ZEEBE);
+  private final ActorClockActuator clock = ActorClockActuator.of(ZEEBE);
 
   @AutoCloseResource private ZeebeClient client;
 
   @BeforeEach
   void beforeEach() {
-    client = zeebe.newClientBuilder().build();
+    client = ZEEBE.newClientBuilder().build();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.qa.util.actuator.BanningActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -82,10 +81,6 @@ final class BannedInstanceIT {
     client.newCancelInstanceCommand(processInstanceKey).send().join();
 
     // then
-
-    final Record<ProcessInstanceRecordValue> first =
-        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL).limit(1).getFirst();
-
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
                 .withRecordKey(processInstanceKey)
@@ -136,6 +131,10 @@ final class BannedInstanceIT {
     // when
     actuator.ban(processInstanceKey);
     client.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.PROCESS);
 
     final long secondProcessInstanceKey =
         client

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/BannedInstanceIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.processing;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.qa.util.actuator.BanningActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.Rule;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@AutoCloseResources
+@ZeebeIntegration
+final class BannedInstanceIT {
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  private final BanningActuator actuator = BanningActuator.of(zeebe);
+
+  @AutoCloseResource private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = zeebe.newClientBuilder().build();
+  }
+
+  @Test
+  public void shouldCancelProcessInstanceWhenInstanceIsBanned() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("start")
+                .serviceTask("task", t -> t.zeebeJobType("type"))
+                .endEvent("end")
+                .done(),
+            "process1.bpmn")
+        .send()
+        .join();
+
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    // when
+    actuator.ban(processInstanceKey);
+    client.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
+                .withProcessInstanceKey(processInstanceKey))
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstanceKey))
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey))
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldNotTriggerTimerEventWhenInstanceIsBanned() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("start")
+                .intermediateCatchEvent("timer", b -> b.timerWithDurationExpression("duration"))
+                .endEvent("end")
+                .done(),
+            "process1.bpmn")
+        .send()
+        .join();
+
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(Map.of("duration", "PT2S"))
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    RecordingExporter.timerRecords()
+        .withIntents(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    actuator.ban(processInstanceKey);
+    client.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    final long secondProcessInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variable("duration", "PT3S")
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+        .withProcessInstanceKey(secondProcessInstanceKey)
+        .await();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.timerRecords()
+                .limit(
+                    t ->
+                        t.getValue().getProcessInstanceKey() == secondProcessInstanceKey
+                            && t.getIntent() == TimerIntent.TRIGGERED)
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(t -> t.getIntent() == TimerIntent.TRIGGER)
+                .onlyCommands())
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldCancelBannedInstanceWithIncident() {
+    // given
+    final var processId = helper.getBpmnProcessId();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask(
+                    "A",
+                    b ->
+                        b.zeebeJobType("jobTypeA")
+                            .zeebeInputExpression("assert(x, x != null)", "y"))
+                .endEvent()
+                .done(),
+            "process1.bpmn")
+        .send()
+        .join();
+
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+    actuator.ban(processInstanceKey);
+    client.newCancelInstanceCommand(processInstanceKey).send().join();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
+                .withProcessInstanceKey(processInstanceKey))
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_TERMINATED)
+                .withProcessInstanceKey(processInstanceKey))
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.RESOLVED)
+                .withRecordKey(incident.getKey()))
+        .isNotNull();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

After this PR, users will be able to cancel banned instances. Therefore, they will be able to get rid of unnecessarily written timer records.

In addition to automated test cases, following cases are tested manually:

- Throw exception in the ProcessProcessor onTerminate method for the first call. Observe rejection
for the first call. Then, send cancellation command again. Expect that the banned process instance
is cancelled on the second command.
- Throw exception in the ProcessInstanceStateTransitionGuard checkStateTransition method `case:
TERMINATE_ELEMENT` for the first call. Observe rejection for the first call. Then, send
cancellation command again. Expect that the banned process instance is cancelled on the second
command.
- Create a looping process with 120000 timer instances created. Cancel the process and observe that
the cancellation works with huge amount of timers. Will therefore work for banned instances with
huge number of timer instances created. (the test setup for the support case)


Cases above are tested to verify if something goes wrong with the cancellation, they can be retried (in case they are not a persistent bug that needs to be resolved with a bugfix).

### Motivation for choosing cancellation as a solution

We chose cancellation as a solution for cleaning up banned instances because of following reasons:

- Easier to implement
- State cleanup will be handled gracefully
- No need to maintain a separate code piece to cleanup the state
- Users will now have control over banned instances. For example, they can get rid of banned instances stuck (shown as active forever) in Operate UI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #14213 
closes #12772 
