### PR TITLE
feat: Create `zeebe.processing.scheduling.duration` metric

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -245,8 +245,10 @@ public class ProcessingScheduleServiceImpl
 
     @Override
     public void run() {
-      metrics.observeScheduledTaskExecution(clock.millis() - scheduledTime);
+      final long taskStart = clock.millis();
+      metrics.observeScheduledTaskDelay(taskStart - scheduledTime);
       runnable.run();
+      metrics.observeScheduledTaskDuration(clock.millis() - taskStart);
     }
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -415,6 +415,7 @@ class ProcessingScheduleServiceTest {
     assertThat(registry.getMeters()).isNotEmpty();
     assertThat(registry.get("zeebe.processing.scheduling.tasks").gauge().value()).isEqualTo(0);
     assertThat(registry.get("zeebe.processing.scheduling.delay").timer().count()).isEqualTo(0);
+    assertThat(registry.get("zeebe.processing.scheduling.duration").timer().count()).isEqualTo(0);
   }
 
   @Test
@@ -470,6 +471,7 @@ class ProcessingScheduleServiceTest {
     assertThat(registry.get("zeebe.processing.scheduling.delay").timer().count()).isEqualTo(1);
     assertThat(registry.get("zeebe.processing.scheduling.delay").timer().max(TimeUnit.MINUTES))
         .isCloseTo(1, Percentage.withPercentage(20));
+    assertThat(registry.get("zeebe.processing.scheduling.duration").timer().count()).isEqualTo(1);
   }
 
   /**


### PR DESCRIPTION
## Description

Create new `zeebe.processing.scheduling.duration` metric to track how long scheduled tasks take to run and whether any of them blocks the actor excessively.

## Checklist

## Related issues

closes #17002
