### PR TITLE
ci: add C8 API to labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -77,3 +77,8 @@ component/build-pipeline:
           - '.github/workflows/**'
           - '.github/actionlint*'
           - 'maven-settings.xml'
+component/c8-api:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'zeebe/gateway-protocol/src/main/proto/rest-api.yaml'
+          - 'zeebe/gateway-rest/**'


### PR DESCRIPTION
## Description

Adds the C8 API component label to PRs making REST resource changes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

n/a
