### PR TITLE
ExportHandler to capture User Task completed metrics

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -31,6 +31,7 @@ import io.camunda.exporter.handlers.MetricFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.SequenceFlowHandler;
+import io.camunda.exporter.handlers.TaskCompletedMetricHandler;
 import io.camunda.exporter.handlers.UserHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
@@ -159,6 +160,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptorsMap.get(ProcessIndex.class).getFullQualifiedName(), new XMLUtil()),
             new MetricFromProcessInstanceHandler(
                 indexDescriptorsMap.get(MetricIndex.class).getFullQualifiedName()),
+            new TaskCompletedMetricHandler(
+                indexDescriptorsMap.get(TasklistMetricIndex.class).getFullQualifiedName()),
             new FormHandler(indexDescriptorsMap.get(FormIndex.class).getFullQualifiedName()),
             new EventFromIncidentHandler(
                 templateDescriptorsMap.get(EventTemplate.class).getFullQualifiedName(), false),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TaskCompletedMetricHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TaskCompletedMetricHandler.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.entities.MetricEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.time.Instant;
+import java.util.List;
+
+public class TaskCompletedMetricHandler
+    implements ExportHandler<MetricEntity, UserTaskRecordValue> {
+
+  protected static final String EVENT_TASK_COMPLETED_BY_ASSIGNEE = "task_completed_by_assignee";
+  private final String indexName;
+
+  public TaskCompletedMetricHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER_TASK;
+  }
+
+  @Override
+  public Class<MetricEntity> getEntityType() {
+    return MetricEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserTaskRecordValue> record) {
+    return record.getIntent().name().equals(UserTaskIntent.COMPLETED.name());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserTaskRecordValue> record) {
+    return List.of(String.valueOf(record.getValue().getUserTaskKey()));
+  }
+
+  @Override
+  public MetricEntity createNewEntity(final String id) {
+    return new MetricEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<UserTaskRecordValue> record, final MetricEntity entity) {
+    entity
+        .setEvent(EVENT_TASK_COMPLETED_BY_ASSIGNEE)
+        .setEventTime(ExporterUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .setValue(record.getValue().getAssignee())
+        .setTenantId(record.getValue().getTenantId());
+  }
+
+  @Override
+  public void flush(final MetricEntity entity, final BatchRequest batchRequest) {
+    batchRequest.add(indexName, entity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TaskCompletedMetricHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/TaskCompletedMetricHandlerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.exporter.handlers.TaskCompletedMetricHandler.EVENT_TASK_COMPLETED_BY_ASSIGNEE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
+import io.camunda.webapps.schema.entities.MetricEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class TaskCompletedMetricHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-" + MetricIndex.INDEX_NAME;
+
+  private final TaskCompletedMetricHandler underTest = new TaskCompletedMetricHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER_TASK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(MetricEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserTaskRecordValue> processInstanceRecord =
+        generateRecord(UserTaskIntent.COMPLETED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(processInstanceRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecord() {
+    Arrays.stream(UserTaskIntent.values())
+        .filter(intent -> intent != UserTaskIntent.COMPLETED)
+        .map(this::generateRecord)
+        .forEach(r -> assertThat(underTest.handlesRecord(r)).isFalse());
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<UserTaskRecordValue> userTaskRecord = generateRecord(UserTaskIntent.COMPLETED);
+
+    // when
+    final var ids = underTest.generateIds(userTaskRecord);
+
+    // then
+    assertThat(ids).isNotNull();
+    assertThat(ids).containsExactly(String.valueOf(userTaskRecord.getValue().getUserTaskKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var entity = underTest.createNewEntity("id");
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntity() {
+    // given
+    final long timestamp = System.currentTimeMillis();
+    final UserTaskRecordValue recordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .build();
+    final Record<UserTaskRecordValue> userTaskRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.COMPLETED)
+                    .withTimestamp(timestamp)
+                    .withValue(recordValue));
+
+    final MetricEntity entity = new MetricEntity();
+
+    // when
+    underTest.updateEntity(userTaskRecord, entity);
+
+    // then
+    assertThat(entity.getId()).isNull();
+    assertThat(entity.getEvent()).isEqualTo(EVENT_TASK_COMPLETED_BY_ASSIGNEE);
+    assertThat(entity.getValue()).isEqualTo(String.valueOf(recordValue.getAssignee()));
+    assertThat(entity.getEventTime())
+        .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC));
+    assertThat(entity.getTenantId()).isEqualTo(recordValue.getTenantId());
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final MetricEntity inputEntity = new MetricEntity();
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+
+  private Record<UserTaskRecordValue> generateRecord(final UserTaskIntent intent) {
+    final UserTaskRecordValue userTaskRecordValue =
+        ImmutableUserTaskRecordValue.builder()
+            .from(factory.generateObject(UserTaskRecordValue.class))
+            .build();
+    return factory.generateRecord(
+        ValueType.USER_TASK, r -> r.withIntent(intent).withValue(userTaskRecordValue));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Use the new CamundaExporter to capture User Task completed events and export Tasklist Metrics from them.

ps: @marcosgvieira On Tasklist the ID of the record was never set, I used the `userTaskKey` for the entity ID over on the new exporter, makes sense to you?
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23792 
