### PR TITLE
build: fix package name for some classes in optimize-upgrade

### DIFF
--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/db/index/UpdateLogEntryIndex.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/db/index/UpdateLogEntryIndex.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.es.index;
+package io.camunda.optimize.upgrade.db.index;
 
 import static io.camunda.optimize.service.db.DatabaseConstants.UPDATE_LOG_ENTRY_INDEX_NAME;
 

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/es/index/UpdateLogEntryIndexES.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/es/index/UpdateLogEntryIndexES.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateLogEntryIndexES
-    extends io.camunda.optimize.upgrade.es.index.UpdateLogEntryIndex<IndexSettings.Builder> {
+    extends io.camunda.optimize.upgrade.db.index.UpdateLogEntryIndex<IndexSettings.Builder> {
 
   @Override
   public IndexSettings.Builder addStaticSetting(

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/os/index/UpdateLogEntryIndexOS.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/os/index/UpdateLogEntryIndexOS.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.optimize.upgrade.os.index;
 
-import io.camunda.optimize.upgrade.es.index.UpdateLogEntryIndex;
+import io.camunda.optimize.upgrade.db.index.UpdateLogEntryIndex;
 import org.opensearch.client.opensearch.indices.IndexSettings;
 import org.opensearch.client.opensearch.indices.IndexSettings.Builder;
 import org.springframework.stereotype.Component;

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogService.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogService.java
@@ -9,8 +9,8 @@ package io.camunda.optimize.upgrade.service;
 
 import io.camunda.optimize.service.security.util.LocalDateUtil;
 import io.camunda.optimize.upgrade.db.SchemaUpgradeClient;
+import io.camunda.optimize.upgrade.db.index.UpdateLogEntryIndex;
 import io.camunda.optimize.upgrade.es.SchemaUpgradeClientES;
-import io.camunda.optimize.upgrade.es.index.UpdateLogEntryIndex;
 import io.camunda.optimize.upgrade.es.index.UpdateLogEntryIndexES;
 import io.camunda.optimize.upgrade.os.SchemaUpgradeClientOS;
 import io.camunda.optimize.upgrade.os.index.UpdateLogEntryIndexOS;

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/AbstractUpgradeIT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/AbstractUpgradeIT.java
@@ -42,7 +42,7 @@ import io.camunda.optimize.test.it.extension.DatabaseIntegrationTestExtension;
 import io.camunda.optimize.test.it.extension.IntegrationTestConfigurationUtil;
 import io.camunda.optimize.test.it.extension.MockServerUtil;
 import io.camunda.optimize.upgrade.db.IndexLookupUtilIncludingTestIndices;
-import io.camunda.optimize.upgrade.es.index.UpdateLogEntryIndex;
+import io.camunda.optimize.upgrade.db.index.UpdateLogEntryIndex;
 import io.camunda.optimize.upgrade.es.indices.RenameFieldTestIndexES;
 import io.camunda.optimize.upgrade.es.indices.UserTestIndexES;
 import io.camunda.optimize.upgrade.es.indices.UserTestUpdatedMappingIndexES;


### PR DESCRIPTION
## Description

Some classes in optimize-upgrade are naming the package differently than their directory path.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
