### PR TITLE
feat: added submitCallable to ActorControl: tasks can be scheduled from outside actor

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -147,6 +147,16 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
     return actor.schedule(delay, runnable);
   }
 
+  @Override
+  public void submit(final Runnable action) {
+    actor.submit(action);
+  }
+
+  @Override
+  public <T> ActorFuture<T> submitCallable(final Callable<T> callable) {
+    return actor.submitCallable(callable);
+  }
+
   public static ActorBuilder newActor() {
     return new ActorBuilder();
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -67,6 +67,13 @@ public interface ConcurrencyControl extends Executor {
   ScheduledTimer schedule(final Duration delay, final Runnable runnable);
 
   /**
+   * @param action
+   */
+  void submit(final Runnable action);
+
+  <T> ActorFuture<T> submitCallable(final Callable<T> callable);
+
+  /**
    * Create a new future object
    *
    * @param <V> value type of future

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/RunnableActionsTest.java
@@ -150,6 +150,7 @@ public final class RunnableActionsTest {
   }
 
   private static final class Submitter extends Actor {
+    @Override
     public void submit(final Runnable r) {
       actor.submit(r);
     }


### PR DESCRIPTION
## Description
Added `submitCallable` method to `ActorControl`. While adding a simple test I noticed that both `submit` and `submitCallable` are not in `ConcurrencyControl`.
I  temporarily added them as it made testing it easier.

The implementation is mostly taken from the method `submit`, adjusting it to fill the `ActorJob` with a Callable instead.