### PR TITLE
feat: allow mapping between multi instance types

### DIFF
--- a/operate/client/e2e-playwright/pages/components/Diagram.ts
+++ b/operate/client/e2e-playwright/pages/components/Diagram.ts
@@ -48,6 +48,15 @@ export class Diagram {
     return this.getFlowNode(flowNodeName).click();
   }
 
+  clickSubProcess(subProcessName: string) {
+    // Click on the top left corner of the sub process.
+    // This avoids clicking on child elements inside the sub process.
+    return this.getFlowNode(subProcessName).click({
+      position: {x: 5, y: 5},
+      force: true,
+    });
+  }
+
   getFlowNode(flowNodeName: string) {
     return this.diagram
       .locator('.djs-element')

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
@@ -61,6 +61,7 @@
       <bpmn:outgoing>Flow_08q3qdg</bpmn:outgoing>
       <bpmn:outgoing>Flow_17wkkw8</bpmn:outgoing>
       <bpmn:outgoing>Flow_13sckg7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0jv6wo5</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0qko2kt" sourceRef="Gateway_2" targetRef="EndEvent_1" />
     <bpmn:endEvent id="Event_2">
@@ -124,6 +125,7 @@
       <bpmn:incoming>Flow_0vt5svt</bpmn:incoming>
       <bpmn:incoming>Flow_1k08s0c</bpmn:incoming>
       <bpmn:incoming>Flow_19gk47y</bpmn:incoming>
+      <bpmn:incoming>Flow_0nmo857</bpmn:incoming>
       <bpmn:outgoing>Flow_0qko2kt</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1o99cpi" sourceRef="TaskB" targetRef="TimerIntermediateCatch" />
@@ -351,6 +353,37 @@
     </bpmn:subProcess>
     <bpmn:sequenceFlow id="Flow_13sckg7" sourceRef="Gateway_1" targetRef="SubProcess" />
     <bpmn:sequenceFlow id="Flow_19gk47y" sourceRef="SubProcess" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0jv6wo5" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess" />
+    <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
+      <bpmn:incoming>Flow_0jv6wo5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0nmo857</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[1,2]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:serviceTask id="MultiInstanceTask" name="Multi instance task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_00irh9p</bpmn:incoming>
+        <bpmn:outgoing>Flow_10r7wrx</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[1,2]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="Event_0lqkl4x">
+        <bpmn:incoming>Flow_10r7wrx</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_10r7wrx" sourceRef="MultiInstanceTask" targetRef="Event_0lqkl4x" />
+      <bpmn:startEvent id="Event_1b83nzw">
+        <bpmn:outgoing>Flow_00irh9p</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0nmo857" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_2" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -557,6 +590,44 @@
       <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
         <dc:Bounds x="845" y="1705" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1490" y="790" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="1782" y="872" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="1620" y="850" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="1530" y="872" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1506" y="915" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="1782" y="942" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="1672" y="912" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1650" y="955" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="1566" y="890" />
+        <di:waypoint x="1620" y="890" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="1720" y="890" />
+        <di:waypoint x="1782" y="890" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="1690" y="948" />
+        <di:waypoint x="1690" y="960" />
+        <di:waypoint x="1782" y="960" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
         <dc:Bounds x="472" y="1922" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -572,9 +643,6 @@
       <bpmndi:BPMNShape id="Activity_1lb6pou_di" bpmnElement="SubProcess" isExpanded="true">
         <dc:Bounds x="382" y="2030" width="423" height="350" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1d78vu4_di" bpmnElement="ErrorEndEvent">
-        <dc:Bounds x="672" y="2072" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1v2yf5g" bpmnElement="SubProcessStartEvent">
         <dc:Bounds x="459" y="2072" width="36" height="36" />
@@ -604,47 +672,34 @@
         <di:waypoint x="630" y="2253" />
         <di:waypoint x="672" y="2253" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1d78vu4_di" bpmnElement="ErrorEndEvent">
+        <dc:Bounds x="672" y="2072" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1w9iwsx_di" bpmnElement="Flow_1w9iwsx">
         <di:waypoint x="495" y="2090" />
         <di:waypoint x="672" y="2090" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1490" y="790" width="350" height="200" />
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+        <dc:Bounds x="459" y="2440" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="1782" y="872" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
+        <dc:Bounds x="499" y="2522" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="1620" y="850" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
+        <dc:Bounds x="739" y="2522" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="1530" y="872" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1506" y="915" width="85" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="587" y="2500" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="1782" y="942" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="1672" y="912" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1650" y="955" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="1720" y="890" />
-        <di:waypoint x="1782" y="890" />
+      <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
+        <di:waypoint x="535" y="2540" />
+        <di:waypoint x="587" y="2540" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="1566" y="890" />
-        <di:waypoint x="1620" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="1690" y="948" />
-        <di:waypoint x="1690" y="960" />
-        <di:waypoint x="1782" y="960" />
+      <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
+        <di:waypoint x="687" y="2540" />
+        <di:waypoint x="739" y="2540" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
         <dc:Bounds x="492" y="532" width="36" height="36" />
@@ -902,6 +957,16 @@
       <bpmndi:BPMNEdge id="Flow_19gk47y_di" bpmnElement="Flow_19gk47y">
         <di:waypoint x="805" y="2205" />
         <di:waypoint x="970" y="2205" />
+        <di:waypoint x="970" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jv6wo5_di" bpmnElement="Flow_0jv6wo5">
+        <di:waypoint x="330" y="163" />
+        <di:waypoint x="330" y="2540" />
+        <di:waypoint x="459" y="2540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nmo857_di" bpmnElement="Flow_0nmo857">
+        <di:waypoint x="809" y="2540" />
+        <di:waypoint x="970" y="2540" />
         <di:waypoint x="970" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
@@ -119,6 +119,7 @@
       <bpmn:outgoing>Flow_1lx7h0o</bpmn:outgoing>
       <bpmn:outgoing>Flow_1ggtty0</bpmn:outgoing>
       <bpmn:outgoing>Flow_030xtpk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_17bv8lx</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_05ul9v8" sourceRef="Gateway_1" targetRef="TaskA" />
     <bpmn:sequenceFlow id="Flow_0jjil6z" sourceRef="Gateway_1" targetRef="TaskB" />
@@ -157,6 +158,7 @@
       <bpmn:incoming>Flow_06rofsk</bpmn:incoming>
       <bpmn:incoming>Flow_0i6qn1g</bpmn:incoming>
       <bpmn:incoming>Flow_0teqyyg</bpmn:incoming>
+      <bpmn:incoming>Flow_0hb1y3g</bpmn:incoming>
       <bpmn:outgoing>Flow_1xou7mm</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1bvocj3" sourceRef="TimerIntermediateCatch" targetRef="Gateway_2" />
@@ -358,6 +360,37 @@
     </bpmn:subProcess>
     <bpmn:sequenceFlow id="Flow_030xtpk" sourceRef="Gateway_1" targetRef="SubProcess" />
     <bpmn:sequenceFlow id="Flow_0teqyyg" sourceRef="SubProcess" targetRef="Gateway_2" />
+    <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
+      <bpmn:incoming>Flow_17bv8lx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hb1y3g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[1,2,3,4]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1b83nzw">
+        <bpmn:outgoing>Flow_00irh9p</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_0lqkl4x">
+        <bpmn:incoming>Flow_10r7wrx</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="MultiInstanceTask" name="Multi instance task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_00irh9p</bpmn:incoming>
+        <bpmn:outgoing>Flow_10r7wrx</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[1,2,3,4]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask" />
+      <bpmn:sequenceFlow id="Flow_10r7wrx" sourceRef="MultiInstanceTask" targetRef="Event_0lqkl4x" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_17bv8lx" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0hb1y3g" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_2" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -662,6 +695,28 @@
         <di:waypoint x="463" y="2110" />
         <di:waypoint x="640" y="2110" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+        <dc:Bounds x="475" y="2460" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
+        <dc:Bounds x="515" y="2542" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
+        <dc:Bounds x="755" y="2542" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="603" y="2520" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
+        <di:waypoint x="551" y="2560" />
+        <di:waypoint x="603" y="2560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
+        <di:waypoint x="703" y="2560" />
+        <di:waypoint x="755" y="2560" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
         <dc:Bounds x="452" y="1041" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -922,6 +977,16 @@
       <bpmndi:BPMNEdge id="Flow_0teqyyg_di" bpmnElement="Flow_0teqyyg">
         <di:waypoint x="773" y="2225" />
         <di:waypoint x="1000" y="2225" />
+        <di:waypoint x="1000" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17bv8lx_di" bpmnElement="Flow_17bv8lx">
+        <di:waypoint x="310" y="163" />
+        <di:waypoint x="310" y="2560" />
+        <di:waypoint x="475" y="2560" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hb1y3g_di" bpmnElement="Flow_0hb1y3g">
+        <di:waypoint x="825" y="2560" />
+        <di:waypoint x="1000" y="2560" />
         <di:waypoint x="1000" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
@@ -146,6 +146,7 @@
       <bpmn:outgoing>Flow_0796mcu</bpmn:outgoing>
       <bpmn:outgoing>Flow_0t0hay3</bpmn:outgoing>
       <bpmn:outgoing>Flow_0hc14mk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0xxd8dc</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_2">
       <bpmn:incoming>Flow_0hxjz3q</bpmn:incoming>
@@ -162,6 +163,7 @@
       <bpmn:incoming>Flow_0i5udyk</bpmn:incoming>
       <bpmn:incoming>Flow_06eifq9</bpmn:incoming>
       <bpmn:incoming>Flow_1brhss6</bpmn:incoming>
+      <bpmn:incoming>Flow_1mxprri</bpmn:incoming>
       <bpmn:outgoing>Flow_1ibxab9</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0lyxcbw" sourceRef="TaskB2" targetRef="TimerIntermediateCatch2" />
@@ -366,6 +368,37 @@
     </bpmn:subProcess>
     <bpmn:sequenceFlow id="Flow_0hc14mk" sourceRef="Gateway_1" targetRef="SubProcess" />
     <bpmn:sequenceFlow id="Flow_1brhss6" sourceRef="SubProcess" targetRef="Gateway_2" />
+    <bpmn:subProcess id="MultiInstanceSubProcess2" name="Multi instance sub process 2">
+      <bpmn:incoming>Flow_0xxd8dc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mxprri</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[1]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1b83nzw">
+        <bpmn:outgoing>Flow_00irh9p</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_0lqkl4x">
+        <bpmn:incoming>Flow_10r7wrx</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="MultiInstanceTask2" name="Multi instance task 2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_00irh9p</bpmn:incoming>
+        <bpmn:outgoing>Flow_10r7wrx</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[1]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask2" />
+      <bpmn:sequenceFlow id="Flow_10r7wrx" sourceRef="MultiInstanceTask2" targetRef="Event_0lqkl4x" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0xxd8dc" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_1mxprri" sourceRef="MultiInstanceSubProcess2" targetRef="Gateway_2" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -688,6 +721,28 @@
         <di:waypoint x="423" y="2110" />
         <di:waypoint x="600" y="2110" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2" isExpanded="true">
+        <dc:Bounds x="510" y="2440" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
+        <dc:Bounds x="550" y="2522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
+        <dc:Bounds x="790" y="2522" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask2">
+        <dc:Bounds x="638" y="2500" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
+        <di:waypoint x="586" y="2540" />
+        <di:waypoint x="638" y="2540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
+        <di:waypoint x="738" y="2540" />
+        <di:waypoint x="790" y="2540" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting2">
         <dc:Bounds x="412" y="1041" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -952,6 +1007,16 @@
       <bpmndi:BPMNEdge id="Flow_1brhss6_di" bpmnElement="Flow_1brhss6">
         <di:waypoint x="733" y="2225" />
         <di:waypoint x="1130" y="2225" />
+        <di:waypoint x="1130" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xxd8dc_di" bpmnElement="Flow_0xxd8dc">
+        <di:waypoint x="290" y="163" />
+        <di:waypoint x="290" y="2540" />
+        <di:waypoint x="510" y="2540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mxprri_di" bpmnElement="Flow_1mxprri">
+        <di:waypoint x="860" y="2540" />
+        <di:waypoint x="1130" y="2540" />
         <di:waypoint x="1130" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -55,6 +55,8 @@ const {
   SignalStartEvent,
   ErrorEventSubProcess,
   ErrorStartEvent,
+  MultiInstanceSubProcess,
+  MultiInstanceTask,
 } = elements;
 
 /**
@@ -100,8 +102,8 @@ describe('MigrationView/BottomPanel', () => {
     expect(screen.getByText(ErrorEventSubProcess.name)).toBeInTheDocument();
     expect(screen.getByText(ErrorStartEvent.name)).toBeInTheDocument();
 
-    // expect table to have 1 header + 29 content rows
-    expect(screen.getAllByRole('row')).toHaveLength(30);
+    // expect table to have 1 header + 31 content rows
+    expect(screen.getAllByRole('row')).toHaveLength(32);
   });
 
   it.each([
@@ -176,6 +178,7 @@ describe('MigrationView/BottomPanel', () => {
     {source: TimerStartEvent, target: TimerIntermediateCatch},
     {source: SignalIntermediateCatch, target: SignalBoundaryEvent},
     {source: MessageIntermediateCatch, target: SignalIntermediateCatch},
+    {source: MultiInstanceTask, target: SendTask},
   ])(
     'should not allow $source.type -> $target.type mapping',
     async ({source, target}) => {
@@ -284,6 +287,9 @@ describe('MigrationView/BottomPanel', () => {
     const comboboxErrorStartEvent = await screen.findByLabelText(
       new RegExp(`target flow node for ${ErrorStartEvent.name}`, 'i'),
     );
+    const comboboxMultiInstanceSubProcess = await screen.findByLabelText(
+      new RegExp(`target flow node for ${MultiInstanceSubProcess.name}`, 'i'),
+    );
 
     screen.getByRole('button', {name: /fetch target process/i}).click();
 
@@ -328,9 +334,13 @@ describe('MigrationView/BottomPanel', () => {
     expect(comboboxSignalEventSubProcess).toHaveValue(SignalEventSubProcess.id);
     expect(comboboxErrorEventSubProcess).toHaveValue(ErrorEventSubProcess.id);
 
+    // Expect auto-mapping (same multi instance type)
+    expect(comboboxMultiInstanceSubProcess).toHaveValue(
+      MultiInstanceSubProcess.id,
+    );
+
     // Expect no auto-mapping (flow node does not exist in target)
     expect(comboboxShippingSubProcess).toHaveValue('');
-    expect(comboboxShippingSubProcess).toBeDisabled();
 
     expect(comboboxMessageNonInterrupting).toHaveValue('');
     expect(comboboxMessageNonInterrupting).toBeEnabled();
@@ -531,8 +541,8 @@ describe('MigrationView/BottomPanel', () => {
       }),
     ).toBeVisible();
 
-    // Expect all 29 rows to be visible (+1 header row)
-    expect(await screen.findAllByRole('row')).toHaveLength(30);
+    // Expect all 31 rows to be visible (+1 header row)
+    expect(await screen.findAllByRole('row')).toHaveLength(32);
 
     // Toggle on unmapped flow nodes
     await user.click(screen.getByLabelText(/show only not mapped/i));
@@ -601,9 +611,12 @@ describe('MigrationView/BottomPanel', () => {
     expect(
       screen.queryByText(getMatcherFunction(ErrorEventSubProcess.name)),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(getMatcherFunction(MultiInstanceSubProcess.name)),
+    ).not.toBeInTheDocument();
 
-    // Expect 6 not mapped rows (+1 header row)
-    expect(await screen.findAllByRole('row')).toHaveLength(8);
+    // Expect 8 not mapped rows (+1 header row)
+    expect(await screen.findAllByRole('row')).toHaveLength(9);
 
     // Expect the following rows to be visible (because they're not mapped)
     expect(
@@ -621,7 +634,9 @@ describe('MigrationView/BottomPanel', () => {
     expect(
       screen.getByText(getMatcherFunction(TimerInterrupting.name)),
     ).toBeInTheDocument();
-
+    expect(
+      screen.getByText(getMatcherFunction(MultiInstanceTask.name)),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(getMatcherFunction(TaskY.name)),
     ).toBeInTheDocument();
@@ -633,6 +648,6 @@ describe('MigrationView/BottomPanel', () => {
     await user.click(screen.getByLabelText(/show only not mapped/i));
 
     // Expect all rows to be visible again
-    expect(await screen.findAllByRole('row')).toHaveLength(30);
+    expect(await screen.findAllByRole('row')).toHaveLength(32);
   });
 });

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/mocks.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/tests/mocks.tsx
@@ -159,6 +159,16 @@ const elements = {
     name: 'Error start event',
     type: 'ErrorStartEvent',
   },
+  MultiInstanceSubProcess: {
+    id: 'MultiInstanceSubProcess',
+    name: 'Multi instance sub process',
+    type: 'MultiInstanceSubProcess',
+  },
+  MultiInstanceTask: {
+    id: 'MultiInstanceTask',
+    name: 'Multi instance task',
+    type: 'MultiInstanceTask',
+  },
 };
 
 type Props = {

--- a/operate/client/src/modules/components/Popover/ArrowPopover.tsx
+++ b/operate/client/src/modules/components/Popover/ArrowPopover.tsx
@@ -13,6 +13,7 @@ import {
   Placement,
   autoUpdate,
   Middleware,
+  shift,
 } from '@floating-ui/react-dom';
 
 import {useEffect, useLayoutEffect, useRef, useState} from 'react';
@@ -63,7 +64,11 @@ const ArrowPopover: React.FC<Props> = ({
     refs: {floating, setFloating},
   } = useFloating({
     placement,
-    middleware: [...middlewareOptions, arrow({element: arrowElementRef})],
+    middleware: [
+      ...middlewareOptions,
+      shift({padding: {top: 47}}), // 47px = Operate app header height
+      arrow({element: arrowElementRef}),
+    ],
     whileElementsMounted: autoUpdatePosition ? autoUpdate : undefined,
     elements: {
       reference: referenceElement,

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
@@ -61,6 +61,7 @@
       <bpmn:outgoing>Flow_0ditevp</bpmn:outgoing>
       <bpmn:outgoing>Flow_0xpveg6</bpmn:outgoing>
       <bpmn:outgoing>Flow_0q96oby</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0wcd3tb</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_0wzi4n5">
       <bpmn:incoming>Flow_1c5723c</bpmn:incoming>
@@ -69,6 +70,7 @@
       <bpmn:incoming>Flow_1m8j611</bpmn:incoming>
       <bpmn:incoming>Flow_0cxvor3</bpmn:incoming>
       <bpmn:incoming>Flow_1k3ci9e</bpmn:incoming>
+      <bpmn:incoming>Flow_1strf32</bpmn:incoming>
       <bpmn:outgoing>Flow_0xq0gk6</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:task id="TaskA" name="Task A">
@@ -310,6 +312,34 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0vvjz29" sourceRef="SignalStartEvent" targetRef="Event_17jemlq" />
     </bpmn:subProcess>
+    <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
+      <bpmn:incoming>Flow_0wcd3tb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1strf32</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[0,1]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1h0ogsg">
+        <bpmn:outgoing>Flow_0r04elp</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0r04elp" sourceRef="Event_1h0ogsg" targetRef="MultiInstanceTask" />
+      <bpmn:intermediateThrowEvent id="Event_0wkcj6b">
+        <bpmn:incoming>Flow_11iclr2</bpmn:incoming>
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_11iclr2" sourceRef="MultiInstanceTask" targetRef="Event_0wkcj6b" />
+      <bpmn:serviceTask id="MultiInstanceTask" name="Multi instance task">
+        <bpmn:incoming>Flow_0r04elp</bpmn:incoming>
+        <bpmn:outgoing>Flow_11iclr2</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[0,1,2]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0wcd3tb" sourceRef="Gateway_1fr6z3f" targetRef="MultiInstanceSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1strf32" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_0wzi4n5" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -563,6 +593,27 @@
         <di:waypoint x="686" y="1140" />
         <di:waypoint x="863" y="1140" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_08z0m7c_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+        <dc:Bounds x="1080" y="1070" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h0ogsg_di" bpmnElement="Event_1h0ogsg">
+        <dc:Bounds x="1120" y="1152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wkcj6b_di" bpmnElement="Event_0wkcj6b">
+        <dc:Bounds x="1372" y="1152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1q1er9n_di" bpmnElement="MultiInstanceTask">
+        <dc:Bounds x="1210" y="1130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0r04elp_di" bpmnElement="Flow_0r04elp">
+        <di:waypoint x="1156" y="1170" />
+        <di:waypoint x="1210" y="1170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11iclr2_di" bpmnElement="Flow_11iclr2">
+        <di:waypoint x="1310" y="1170" />
+        <di:waypoint x="1372" y="1170" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0ztghtl_di" bpmnElement="SignalBoundaryEvent">
         <dc:Bounds x="1772" y="642" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -797,6 +848,16 @@
         <di:waypoint x="1820" y="620" />
         <di:waypoint x="1900" y="620" />
         <di:waypoint x="1900" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wcd3tb_di" bpmnElement="Flow_0wcd3tb">
+        <di:waypoint x="1040" y="163" />
+        <di:waypoint x="1040" y="1170" />
+        <di:waypoint x="1080" y="1170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1strf32_di" bpmnElement="Flow_1strf32">
+        <di:waypoint x="1430" y="1170" />
+        <di:waypoint x="1480" y="1170" />
+        <di:waypoint x="1480" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration_v2.bpmn
@@ -45,6 +45,8 @@
       <bpmn:outgoing>Flow_0k6h50o</bpmn:outgoing>
       <bpmn:outgoing>Flow_1dj6oc6</bpmn:outgoing>
       <bpmn:outgoing>Flow_0jgmxvl</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ww4tx0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1l6gojp</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:parallelGateway id="Gateway_0wzi4n5">
       <bpmn:incoming>Flow_10w6zi2</bpmn:incoming>
@@ -52,6 +54,8 @@
       <bpmn:incoming>Flow_0w9awk1</bpmn:incoming>
       <bpmn:incoming>Flow_0ff6mia</bpmn:incoming>
       <bpmn:incoming>Flow_02hggoh</bpmn:incoming>
+      <bpmn:incoming>Flow_0kehygf</bpmn:incoming>
+      <bpmn:incoming>Flow_0xowmx0</bpmn:incoming>
       <bpmn:outgoing>Flow_0r0cpho</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:task id="TaskA" name="Task A">
@@ -229,6 +233,63 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0vvjz29" sourceRef="SignalStartEvent" targetRef="Event_17jemlq" />
     </bpmn:subProcess>
+    <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
+      <bpmn:incoming>Flow_0ww4tx0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0kehygf</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[0,1]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_1h0ogsg">
+        <bpmn:outgoing>Flow_0r04elp</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0r04elp" sourceRef="Event_1h0ogsg" targetRef="ParallelTask" />
+      <bpmn:sequenceFlow id="Flow_11iclr2" sourceRef="ParallelTask" targetRef="SequentialTask" />
+      <bpmn:sequenceFlow id="Flow_19n3spx" sourceRef="SequentialTask" targetRef="Event_1vzofg9" />
+      <bpmn:endEvent id="Event_1vzofg9">
+        <bpmn:incoming>Flow_19n3spx</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="SequentialTask" name="Sequential task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_11iclr2</bpmn:incoming>
+        <bpmn:outgoing>Flow_19n3spx</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics isSequential="true">
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[0]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="ParallelTask" name="Parallel task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="foo" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0r04elp</bpmn:incoming>
+        <bpmn:outgoing>Flow_11iclr2</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:extensionElements>
+            <zeebe:loopCharacteristics inputCollection="=[0,1]" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_0ww4tx0" sourceRef="Gateway_1fr6z3f" targetRef="MultiInstanceSubProcess" />
+    <bpmn:sequenceFlow id="Flow_0kehygf" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_0wzi4n5" />
+    <bpmn:subProcess id="SubProcess" name="Sub Process">
+      <bpmn:incoming>Flow_1l6gojp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xowmx0</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1qgy57q">
+        <bpmn:outgoing>Flow_1ut40vs</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1ut40vs" sourceRef="Event_1qgy57q" targetRef="Event_0ehvu0y" />
+      <bpmn:endEvent id="Event_0ehvu0y">
+        <bpmn:incoming>Flow_1ut40vs</bpmn:incoming>
+      </bpmn:endEvent>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1l6gojp" sourceRef="Gateway_1fr6z3f" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow_0xowmx0" sourceRef="SubProcess" targetRef="Gateway_0wzi4n5" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -430,6 +491,48 @@
         <di:waypoint x="395" y="1220" />
         <di:waypoint x="572" y="1220" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_08z0m7c_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
+        <dc:Bounds x="820" y="850" width="380" height="180" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h0ogsg_di" bpmnElement="Event_1h0ogsg">
+        <dc:Bounds x="840" y="932" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vzofg9_di" bpmnElement="Event_1vzofg9">
+        <dc:Bounds x="1142" y="932" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10all1n_di" bpmnElement="SequentialTask">
+        <dc:Bounds x="1020" y="910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1snp5dt_di" bpmnElement="ParallelTask">
+        <dc:Bounds x="900" y="910" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0r04elp_di" bpmnElement="Flow_0r04elp">
+        <di:waypoint x="876" y="950" />
+        <di:waypoint x="900" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11iclr2_di" bpmnElement="Flow_11iclr2">
+        <di:waypoint x="1000" y="950" />
+        <di:waypoint x="1020" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19n3spx_di" bpmnElement="Flow_19n3spx">
+        <di:waypoint x="1120" y="950" />
+        <di:waypoint x="1142" y="950" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1fwm0ra_di" bpmnElement="SubProcess" isExpanded="true">
+        <dc:Bounds x="825" y="1060" width="370" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1qgy57q_di" bpmnElement="Event_1qgy57q">
+        <dc:Bounds x="865" y="1142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ehvu0y_di" bpmnElement="Event_0ehvu0y">
+        <dc:Bounds x="1112" y="1142" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1ut40vs_di" bpmnElement="Flow_1ut40vs">
+        <di:waypoint x="901" y="1160" />
+        <di:waypoint x="1112" y="1160" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0ztghtl_di" bpmnElement="SignalBoundaryEvent">
         <dc:Bounds x="1012" y="772" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -592,6 +695,26 @@
       <bpmndi:BPMNEdge id="Flow_02hggoh_di" bpmnElement="Flow_02hggoh">
         <di:waypoint x="1060" y="750" />
         <di:waypoint x="1220" y="750" />
+        <di:waypoint x="1220" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ww4tx0_di" bpmnElement="Flow_0ww4tx0">
+        <di:waypoint x="800" y="163" />
+        <di:waypoint x="800" y="940" />
+        <di:waypoint x="820" y="940" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kehygf_di" bpmnElement="Flow_0kehygf">
+        <di:waypoint x="1200" y="940" />
+        <di:waypoint x="1220" y="940" />
+        <di:waypoint x="1220" y="163" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1l6gojp_di" bpmnElement="Flow_1l6gojp">
+        <di:waypoint x="800" y="163" />
+        <di:waypoint x="800" y="1160" />
+        <di:waypoint x="825" y="1160" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xowmx0_di" bpmnElement="Flow_0xowmx0">
+        <di:waypoint x="1195" y="1160" />
+        <di:waypoint x="1220" y="1160" />
         <di:waypoint x="1220" y="163" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>

--- a/operate/client/src/modules/stores/processInstanceMigrationMapping.test.ts
+++ b/operate/client/src/modules/stores/processInstanceMigrationMapping.test.ts
@@ -20,62 +20,6 @@ jest.mock('modules/stores/processes/processes.migration', () => ({
   },
 }));
 
-/**
- * In these tests a migration mapping from orderProcess.bpmn to orderProcess_v2.bpmn is tested
- *
- * orderProcess.bpmn contains:
- * - checkPayment (service task)
- * - ExclusiveGateway
- * - requestForPayment (service task)
- * - shipArticles (user task)
- * - MessageInterrupting (event)
- * - TimerInterrupting (event)
- * - MessageNonInterrupting (event)
- * - TimerNonInterrupting (event)
- * - MessageIntermediateCatch (event)
- * - TimerIntermediateCatch (event)
- * - MessageEventSubProcess
- * - TimerEventSubProcess
- * - ErrorEventSubProcess
- * - MessageStartEvent
- * - TimerStartEvent
- * - ErrorStartEvent
- * - MessageReceiveTask
- * - BusinessRuleTask
- * - SendTask
- * - ScriptTask
- * - EventBasedGateway
- * - IntermediateTimerEvent
- * - SignalEventSubProcess
- * - SignalStartEvent
- * - SignalIntermediateCatch
- * - SignalBoundaryEvent
- *
- * orderProcess_v2.bpmn contains:
- * - checkPayment (service task)
- * - ExclusiveGateway
- * - requestForPayment (user task)
- * - shipArticles (user task)
- * - MessageInterrupting (event)
- * - TimerNonInterrupting (event)
- * - MessageIntermediateCatch (event)
- * - MessageEventSubProcess (sub process)
- * - TimerEventSubProcess (sub process)
- * - ErrorEventSubProcess (sub process)
- * - MessageStartEvent
- * - TimerStartEvent
- * - ErrorStartEvent
- * - MessageReceiveTask
- * - BusinessRuleTask
- * - SendTask
- * - ScriptTask
- * - EventBasedGateway
- * - IntermediateTimerEvent
- * - SignalEventSubProcess
- * - SignalStartEvent
- * - SignalIntermediateCatch
- * - SignalBoundaryEvent
- */
 describe('processInstanceMigrationMappingStore', () => {
   afterEach(() => {
     processInstanceMigrationMappingStore.reset();
@@ -190,6 +134,10 @@ describe('processInstanceMigrationMappingStore', () => {
         id: 'SignalStartEvent',
         type: 'bpmn:StartEvent',
       },
+      {
+        id: 'MultiInstanceSubProcess',
+        type: 'bpmn:SubProcess',
+      },
     ]);
 
     expect(isAutoMappable('checkPayment')).toBe(true);
@@ -212,6 +160,7 @@ describe('processInstanceMigrationMappingStore', () => {
     expect(isAutoMappable('SignalStartEvent')).toBe(true);
     expect(isAutoMappable('ErrorEventSubProcess')).toBe(true);
     expect(isAutoMappable('ErrorStartEvent')).toBe(true);
+    expect(isAutoMappable('MultiInstanceSubProcess')).toBe(true);
 
     expect(isAutoMappable('requestForPayment')).toBe(false);
     expect(isAutoMappable('TimerInterrupting')).toBe(false);
@@ -297,7 +246,7 @@ describe('processInstanceMigrationMappingStore', () => {
           id: 'shippingSubProcess',
           name: 'Shipping Sub Process',
         },
-        selectableTargetFlowNodes: [],
+        selectableTargetFlowNodes: [{id: 'SubProcess', name: 'Sub Process'}],
       },
       {
         sourceFlowNode: {
@@ -611,6 +560,30 @@ describe('processInstanceMigrationMappingStore', () => {
           {
             id: 'SignalStartEvent',
             name: 'Signal start event',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'MultiInstanceSubProcess',
+          name: 'Multi instance sub process',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'MultiInstanceSubProcess',
+            name: 'Multi instance sub process',
+          },
+        ],
+      },
+      {
+        sourceFlowNode: {
+          id: 'MultiInstanceTask',
+          name: 'Multi instance task',
+        },
+        selectableTargetFlowNodes: [
+          {
+            id: 'ParallelTask',
+            name: 'Parallel task',
           },
         ],
       },

--- a/operate/client/src/modules/stores/processInstanceMigrationMapping.ts
+++ b/operate/client/src/modules/stores/processInstanceMigrationMapping.ts
@@ -13,6 +13,8 @@ import {hasType} from 'modules/bpmn-js/utils/hasType';
 import {getEventType} from 'modules/bpmn-js/utils/getEventType';
 import {getEventSubProcessType} from 'modules/bpmn-js/utils/getEventSubProcessType';
 import {isEventSubProcess} from 'modules/bpmn-js/utils/isEventSubProcess';
+import {isMultiInstance} from 'modules/bpmn-js/utils/isMultiInstance';
+import {getMultiInstanceType} from 'modules/bpmn-js/utils/getMultiInstanceType';
 
 type State = {
   isMappedFilterEnabled: boolean;
@@ -109,6 +111,21 @@ class ProcessInstanceMigrationMappingStore {
                   isEventSubProcess({businessObject: targetFlowNode}))
               ) {
                 return false;
+              }
+
+              /**
+               * Allow mapping only between the same multi instance types,
+               * e.g. sequential multi instance task -> sequential multi instance task
+               */
+              if (
+                isMultiInstance(sourceFlowNode) ||
+                isMultiInstance(targetFlowNode)
+              ) {
+                return (
+                  sourceFlowNode.$type === targetFlowNode.$type &&
+                  getMultiInstanceType(sourceFlowNode) ===
+                    getMultiInstanceType(targetFlowNode)
+                );
               }
 
               /**

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
@@ -63,6 +63,8 @@ describe('stores/processXml/processXml.migration.source', () => {
       'SignalBoundaryEvent',
       'SignalEventSubProcess',
       'SignalStartEvent',
+      'MultiInstanceSubProcess',
+      'MultiInstanceTask',
     ]);
   });
 

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
@@ -72,6 +72,8 @@ describe('stores/processXml/processXml.migration.target', () => {
       'SignalBoundaryEvent',
       'SignalEventSubProcess',
       'SignalStartEvent',
+      'MultiInstanceSubProcess',
+      'MultiInstanceTask',
     ]);
   });
 
@@ -153,6 +155,8 @@ describe('stores/processXml/processXml.migration.target', () => {
       'SignalBoundaryEvent',
       'SignalEventSubProcess',
       'SignalStartEvent',
+      'MultiInstanceSubProcess',
+      'MultiInstanceTask',
     ]);
   });
 });


### PR DESCRIPTION
## Description

Mapping multi instance elements already worked. This PR adds some restrictions:

- prevent mapping multi instance and non-multi instance elements
- prevent mapping different multi instance types (sequential -> parallel)
- fix metadata popover positioning because it let an e2e test fail
- add e2e test function for clicking sub processes
- add test coverage

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23878 
