### PR TITLE
Check permissions on resource deletion

### DIFF
--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
@@ -12,5 +12,8 @@ public enum PermissionType {
   READ,
   READ_INSTANCE,
   UPDATE,
-  DELETE
+  DELETE,
+  DELETE_PROCESS,
+  DELETE_DRD,
+  DELETE_FORM
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -203,7 +203,8 @@ public final class EngineProcessors {
         writers,
         processingState,
         commandDistributionBehavior,
-        bpmnBehaviors);
+        bpmnBehaviors,
+        authCheckBehavior);
     addSignalBroadcastProcessors(
         typedRecordProcessors,
         bpmnBehaviors,
@@ -437,14 +438,16 @@ public final class EngineProcessors {
       final Writers writers,
       final MutableProcessingState processingState,
       final CommandDistributionBehavior commandDistributionBehavior,
-      final BpmnBehaviors bpmnBehaviors) {
+      final BpmnBehaviors bpmnBehaviors,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     final var resourceDeletionProcessor =
         new ResourceDeletionDeleteProcessor(
             writers,
             processingState.getKeyGenerator(),
             processingState,
             commandDistributionBehavior,
-            bpmnBehaviors);
+            bpmnBehaviors,
+            authCheckBehavior);
     typedRecordProcessors.onCommand(
         ValueType.RESOURCE_DELETION, ResourceDeletionIntent.DELETE, resourceDeletionProcessor);
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3590,6 +3590,9 @@ components:
           - READ
           - UPDATE
           - DELETE
+          - DELETE_PROCESS
+          - DELETE_DRD
+          - DELETE_FORM
     ResourceTypeEnum:
       description: The type of resource to add/remove permissions to/from.
       enum:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/AuthorizationRequestValidator.java
@@ -13,11 +13,24 @@ import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
 
 import io.camunda.zeebe.gateway.protocol.rest.AuthorizationPatchRequest;
 import io.camunda.zeebe.gateway.protocol.rest.PermissionDTO;
+import io.camunda.zeebe.gateway.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.http.ProblemDetail;
 
 public final class AuthorizationRequestValidator {
+
+  public static final String PERMISSION_TYPE_NOT_ALLOWED =
+      "Permission type '%s' is allowed for resource type '%s'";
+  private static final Map<PermissionTypeEnum, ResourceTypeEnum>
+      RESOURCE_SPECIFIC_PERMISSION_TYPES =
+          Map.of(
+              PermissionTypeEnum.DELETE_PROCESS, ResourceTypeEnum.DEPLOYMENT,
+              PermissionTypeEnum.DELETE_DRD, ResourceTypeEnum.DEPLOYMENT,
+              PermissionTypeEnum.DELETE_FORM, ResourceTypeEnum.DEPLOYMENT);
+
   public static Optional<ProblemDetail> validateAuthorizationAssignRequest(
       final AuthorizationPatchRequest authorizationPatchRequest) {
     return validate(
@@ -36,19 +49,35 @@ public final class AuthorizationRequestValidator {
           } else {
             authorizationPatchRequest
                 .getPermissions()
-                .forEach(permission -> validatePermission(permission, violations));
+                .forEach(
+                    permission ->
+                        validatePermission(
+                            permission, violations, authorizationPatchRequest.getResourceType()));
           }
         });
   }
 
   private static void validatePermission(
-      final PermissionDTO permission, final List<String> violations) {
+      final PermissionDTO permission,
+      final List<String> violations,
+      final ResourceTypeEnum resourceType) {
     if (permission.getPermissionType() == null) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("permissionType"));
     } else if (permission.getResourceIds() == null || permission.getResourceIds().isEmpty()) {
       violations.add(
           ERROR_MESSAGE_EMPTY_NESTED_ATTRIBUTE.formatted(
               "resourceIds", permission.getPermissionType()));
+    } else if (isPermissionTypeAllowed(permission, resourceType)) {
+      violations.add(
+          PERMISSION_TYPE_NOT_ALLOWED.formatted(
+              permission.getPermissionType().name(), resourceType.name()));
     }
+  }
+
+  private static boolean isPermissionTypeAllowed(
+      final PermissionDTO permission, final ResourceTypeEnum resourceType) {
+    return RESOURCE_SPECIFIC_PERMISSION_TYPES.getOrDefault(
+            permission.getPermissionType(), resourceType)
+        != resourceType;
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -218,6 +218,36 @@ public class AuthorizationControllerTest extends RestControllerTest {
                         new PermissionDTO()
                             .permissionType(PermissionTypeEnum.CREATE)
                             .resourceIds(List.of()))),
-            "No resourceIds provided in 'CREATE'."));
+            "No resourceIds provided in 'CREATE'."),
+        Arguments.of(
+            new AuthorizationPatchRequest()
+                .action(ActionEnum.ADD)
+                .resourceType(ResourceTypeEnum.USER)
+                .permissions(
+                    List.of(
+                        new PermissionDTO()
+                            .permissionType(PermissionTypeEnum.DELETE_PROCESS)
+                            .resourceIds(List.of("resourceId")))),
+            "Permission type 'DELETE_PROCESS' is allowed for resource type 'USER'."),
+        Arguments.of(
+            new AuthorizationPatchRequest()
+                .action(ActionEnum.ADD)
+                .resourceType(ResourceTypeEnum.USER)
+                .permissions(
+                    List.of(
+                        new PermissionDTO()
+                            .permissionType(PermissionTypeEnum.DELETE_DRD)
+                            .resourceIds(List.of("resourceId")))),
+            "Permission type 'DELETE_DRD' is allowed for resource type 'USER'."),
+        Arguments.of(
+            new AuthorizationPatchRequest()
+                .action(ActionEnum.ADD)
+                .resourceType(ResourceTypeEnum.USER)
+                .permissions(
+                    List.of(
+                        new PermissionDTO()
+                            .permissionType(PermissionTypeEnum.DELETE_FORM)
+                            .resourceIds(List.of("resourceId")))),
+            "Permission type 'DELETE_FORM' is allowed for resource type 'USER'."));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ResourceDeletionAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ResourceDeletionAuthorizationIT.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@AutoCloseResources
+@Testcontainers
+@ZeebeIntegration
+public class ResourceDeletionAuthorizationIT {
+
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withBrokerConfig(
+              b -> b.getExperimental().getEngine().getAuthorizations().setEnableAuthorization(true))
+          .withAdditionalProfile(Profile.AUTH_BASIC);
+
+  private static AuthorizationsUtil authUtil;
+  private static ZeebeClient defaultUserClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    BROKER.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    BROKER.start();
+
+    final var defaultUsername = "demo";
+    defaultUserClient = createClient(BROKER, defaultUsername, "demo");
+    authUtil = new AuthorizationsUtil(BROKER, defaultUserClient, CONTAINER.getHttpHostAddress());
+
+    authUtil.awaitUserExistsInElasticsearch(defaultUsername);
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteProcessDefinitionWithDefaultUser() {
+    // given
+    final var processDefinitionKey = deployProcessDefinition(Strings.newRandomValidBpmnId());
+
+    // when
+    final var response =
+        defaultUserClient.newDeleteResourceCommand(processDefinitionKey).send().join();
+
+    // then
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteProcessDefinitionWithPermissions() {
+    // given
+    final var processId = Strings.newRandomValidBpmnId();
+    final var processDefinitionKey = deployProcessDefinition(processId);
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUserWithPermissions(
+        username,
+        password,
+        new Permissions(
+            ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.DELETE_PROCESS, List.of(processId)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(processDefinitionKey).send().join();
+
+      // then
+      assertThat(response).isNull();
+    }
+  }
+
+  @Test
+  void shouldBeUnAuthorizedToDeleteProcessDefinitionWithPermissions() {
+    // given
+    final var processDefinitionKey = deployProcessDefinition(Strings.newRandomValidBpmnId());
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUser(username, password);
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(processDefinitionKey).send();
+
+      // then
+      assertThatThrownBy(response::join)
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("title: UNAUTHORIZED")
+          .hasMessageContaining("status: 401")
+          .hasMessageContaining(
+              "Unauthorized to perform operation 'DELETE_PROCESS' on resource 'DEPLOYMENT'");
+    }
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteDrdWithDefaultUser() {
+    // given
+    final var drdKey = deployDrd();
+
+    // when
+    final var response = defaultUserClient.newDeleteResourceCommand(drdKey).send().join();
+
+    // then
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteDrdWithPermissions() {
+    // given
+    final var drdId = "force_users";
+    final var drdKey = deployDrd();
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUserWithPermissions(
+        username,
+        password,
+        new Permissions(
+            ResourceTypeEnum.DEPLOYMENT,
+            io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.DELETE_DRD,
+            List.of(drdId)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(drdKey).send().join();
+
+      // then
+      assertThat(response).isNull();
+    }
+  }
+
+  @Test
+  void shouldBeUnAuthorizedToDeleteDrdWithPermissions() {
+    // given
+    final var drdKey = deployDrd();
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUser(username, password);
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(drdKey).send();
+
+      // then
+      assertThatThrownBy(response::join)
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("title: UNAUTHORIZED")
+          .hasMessageContaining("status: 401")
+          .hasMessageContaining(
+              "Unauthorized to perform operation 'DELETE_DRD' on resource 'DEPLOYMENT'");
+    }
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteFormWithDefaultUser() {
+    // given
+    final var formKey = deployForm();
+
+    // when
+    final var response = defaultUserClient.newDeleteResourceCommand(formKey).send().join();
+
+    // then
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToDeleteFormWithPermissions() {
+    // given
+    final var formId = "Form_0w7r08e";
+    final var formKey = deployForm();
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUserWithPermissions(
+        username,
+        password,
+        new Permissions(
+            ResourceTypeEnum.DEPLOYMENT, PermissionTypeEnum.DELETE_FORM, List.of(formId)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(formKey).send().join();
+
+      // then
+      assertThat(response).isNull();
+    }
+  }
+
+  @Test
+  void shouldBeUnAuthorizedToDeleteFormWithPermissions() {
+    // given
+    final var formKey = deployForm();
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUser(username, password);
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response = client.newDeleteResourceCommand(formKey).send();
+
+      // then
+      assertThatThrownBy(response::join)
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("title: UNAUTHORIZED")
+          .hasMessageContaining("status: 401")
+          .hasMessageContaining(
+              "Unauthorized to perform operation 'DELETE_FORM' on resource 'DEPLOYMENT'");
+    }
+  }
+
+  private static long deployProcessDefinition(final String processId) {
+    return defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(), "process.bpmn")
+        .send()
+        .join()
+        .getProcesses()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private static long deployDrd() {
+    return defaultUserClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("dmn/drg-force-user.dmn")
+        .send()
+        .join()
+        .getDecisionRequirements()
+        .getFirst()
+        .getDecisionRequirementsKey();
+  }
+
+  private static long deployForm() {
+    return defaultUserClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath("form/test-form-1.form")
+        .send()
+        .join()
+        .getForm()
+        .getFirst()
+        .getFormKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds permission checks on resource deletion. Also adds an IT to verify them.

This PR introduced new PermissionTypes. I've had to add these to the OpenAPI spec and added a test to verify they can only be used in combination with the `DEPLOYMENT` resource type.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22594
