### PR TITLE
Always upload artifacts on flaky test encounter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "unit tests"
       - name: Observe build status
@@ -268,7 +268,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[IT] ${{ matrix.name }}"
       - name: Observe build status
@@ -615,7 +615,7 @@ jobs:
       - name: Configure Maven
         uses: ./.github/actions/setup-maven-cache
         with:
-          maven-cache-key-modifier: snapshots    
+          maven-cache-key-modifier: snapshots
       # compile and generate-sources to ensure that the Javadoc can be properly generated; compile is
       # necessary when using annotation preprocessors for code generation, as otherwise the symbols are
       # not resolve-able by the Javadoc generator

--- a/.github/workflows/rdbms-integration-test.yml
+++ b/.github/workflows/rdbms-integration-test.yml
@@ -56,7 +56,7 @@ jobs:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[IT] RDBMS"
       - name: Observe build status

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -54,6 +54,8 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
           platforms: linux/${{ matrix.arch }}
           push: false
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Run smoke test on ${{ matrix.arch }}
         env:
           # For non Linux runners there is no container available for testing, see build-zeebe-docker job
@@ -66,9 +68,16 @@ jobs:
           -D excludedGroups=$EXCLUDED_TEST_GROUPS
           -f zeebe
           verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
       - name: Observe build status
@@ -107,6 +116,7 @@ jobs:
           test
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
+        id: analyze-test-run
         if: always()
         uses: ./.github/actions/analyze-test-runs
         with:
@@ -115,7 +125,7 @@ jobs:
           skipSummary: true
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: Property Tests
       - name: Observe build status
@@ -157,6 +167,7 @@ jobs:
         env:
           LARGE_STATE_CONTROLLER_PERFORMANCE_TEST_SIZE_GB: "4"
       - name: Analyze Test Runs
+        id: analyze-test-run
         if: always()
         uses: ./.github/actions/analyze-test-runs
         with:
@@ -174,7 +185,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: Performance Tests
       - name: Observe build status
@@ -217,6 +228,7 @@ jobs:
           test
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs
+        id: analyze-test-run
         if: always()
         uses: ./.github/actions/analyze-test-runs
         with:
@@ -225,7 +237,7 @@ jobs:
           skipSummary: true
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
-        if: ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() || steps.analyze-test-run.outputs.flakyTests != '' }}
         with:
           name: Strace Tests
       - name: Observe build status


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The job doesn't fail when a flaky test is encountered. As a result these artifacts didn't get uploaded anymore. Adding this condition makes it so the artifacts are always uploaded if a flaky tests is encountered.

Example build where the artifacts are uploaded on a successful job: https://github.com/camunda/camunda/actions/runs/11499226356

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23986 
