### PR TITLE
docs: drop notice about c8run SDK auth issue

### DIFF
--- a/c8run/README.md
+++ b/c8run/README.md
@@ -54,9 +54,3 @@ Refer to https://docs.camunda.io/docs/guides/getting-started-java-spring/ for he
 
 -------------------------------------------
 ```
-
-## Important Notice: C8SM Run + Spring SDK Authentication Issue
-
-We are currently addressing an issue with Camunda 8.6 that affects authentication for the Spring Boot SDK and C8SM Run. This issue may prevent successful API access and process deployment in 8.6.
-
-A patch to fix this bug is in progress and will be released shortly. Full functionality is expected soon. We appreciate your patience and understanding.

--- a/c8run/README.md
+++ b/c8run/README.md
@@ -54,3 +54,4 @@ Refer to https://docs.camunda.io/docs/guides/getting-started-java-spring/ for he
 
 -------------------------------------------
 ```
+


### PR DESCRIPTION
## Description

the patch for the c8run SDK auth issue is released so there is no longer a need for this notice.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
