### PR TITLE
pg-fixes-completion-variables

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskVariableEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskVariableEntity.java
@@ -8,7 +8,6 @@
 package io.camunda.webapps.schema.entities.tasklist;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.camunda.webapps.schema.entities.operate.VariableEntity;
 
 public class TaskVariableEntity extends TasklistEntity<TaskVariableEntity> {
 
@@ -31,23 +30,12 @@ public class TaskVariableEntity extends TasklistEntity<TaskVariableEntity> {
   private Long processInstanceId;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  private Long position;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
 
   public TaskVariableEntity() {}
-
-  public TaskVariableEntity(final VariableEntity entity) {
-    setKey(entity.getKey());
-    setId(entity.getId());
-    setPartitionId(entity.getPartitionId());
-    setTenantId(entity.getTenantId());
-    name = entity.getName();
-    value = entity.getValue();
-    fullValue = entity.getFullValue();
-    isTruncated = entity.getIsPreview();
-    scopeKey = entity.getScopeKey();
-    processInstanceId = entity.getProcessInstanceKey();
-    join = new TaskJoinRelationship();
-  }
 
   public String getName() {
     return name;
@@ -112,26 +100,12 @@ public class TaskVariableEntity extends TasklistEntity<TaskVariableEntity> {
     return this;
   }
 
-  public static TaskVariableEntity createFrom(
-      final String tenantId,
-      final String id,
-      final String name,
-      final String value,
-      final Long scopeKey,
-      final int variableSizeThreshold,
-      final TaskJoinRelationship joinRelationship) {
-    final TaskVariableEntity entity = new TaskVariableEntity().setId(id).setName(name);
-    if (value.length() > variableSizeThreshold) {
-      entity.setValue(value.substring(0, variableSizeThreshold));
-      entity.setFullValue(value);
-      entity.setIsTruncated(true);
-    } else {
-      entity.setIsTruncated(false);
-      entity.setValue(value);
-    }
-    entity.setScopeKey(scopeKey);
-    entity.setTenantId(tenantId);
-    entity.setJoin(joinRelationship);
-    return entity;
+  public Long getPosition() {
+    return position;
+  }
+
+  public TaskVariableEntity setPosition(final Long position) {
+    this.position = position;
+    return this;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -33,6 +33,7 @@ import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.SequenceFlowHandler;
 import io.camunda.exporter.handlers.TaskCompletedMetricHandler;
 import io.camunda.exporter.handlers.UserHandler;
+import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
@@ -176,6 +177,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new UserTaskProcessInstanceHandler(
                 templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName()),
             new UserTaskVariableHandler(
+                templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName(),
+                configuration.getIndex().getVariableSizeThreshold()),
+            new UserTaskCompletionVariableHandler(
                 templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()));
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -55,7 +55,7 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
     entity
         .setVersion((long) value.getVersion())
         .setKey(value.getFormKey())
-        .setBpmnId(value.getResourceName())
+        .setBpmnId(value.getFormId())
         .setSchema(new String(value.getResource(), StandardCharsets.UTF_8))
         .setTenantId(value.getTenantId())
         .setIsDeleted(record.getIntent().name().equals(FormIntent.DELETED.name()));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserTaskCompletionVariableHandler
+    implements ExportHandler<TaskVariableEntity, UserTaskRecordValue> {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);
+
+  private static final String ID_PATTERN = "%s-%s";
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  protected final int variableSizeThreshold;
+  private final String indexName;
+
+  public UserTaskCompletionVariableHandler(
+      final String indexName, final int variableSizeThreshold) {
+    this.indexName = indexName;
+    this.variableSizeThreshold = variableSizeThreshold;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER_TASK;
+  }
+
+  @Override
+  public Class<TaskVariableEntity> getEntityType() {
+    return TaskVariableEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserTaskRecordValue> record) {
+    return UserTaskIntent.COMPLETED.name().equals(record.getIntent().name())
+        && record.getValue().getVariables() != null
+        && !record.getValue().getVariables().isEmpty();
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserTaskRecordValue> record) {
+    final List<String> variableIds = new ArrayList<>();
+    record
+        .getValue()
+        .getVariables()
+        .keySet()
+        .forEach(
+            variableName ->
+                variableIds.add(
+                    ID_PATTERN.formatted(record.getValue().getElementInstanceKey(), variableName)));
+    return variableIds;
+  }
+
+  @Override
+  public TaskVariableEntity createNewEntity(final String id) {
+    return new TaskVariableEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<UserTaskRecordValue> record, final TaskVariableEntity entity) {
+    final String variableName = entity.getId().split("-")[1];
+    entity
+        .setPartitionId(record.getPartitionId())
+        .setPosition(record.getPosition())
+        .setName(variableName)
+        .setTenantId(record.getValue().getTenantId())
+        .setKey(record.getKey())
+        .setProcessInstanceId(record.getValue().getProcessInstanceKey())
+        .setScopeKey(record.getValue().getElementInstanceKey());
+
+    String variableStringValue = "";
+    final Object variableValue = record.getValue().getVariables().get(variableName);
+    try {
+      variableStringValue = MAPPER.writeValueAsString(variableValue);
+    } catch (final JsonProcessingException e) {
+      LOGGER.error(
+          String.format(
+              "Failed to parse variable '%s' value as string '%s'", variableName, variableValue),
+          e);
+    }
+
+    if (variableStringValue.length() > variableSizeThreshold) {
+      entity.setValue(variableStringValue.substring(0, variableSizeThreshold));
+      entity.setFullValue(variableStringValue);
+      entity.setIsTruncated(true);
+    } else {
+      entity.setValue(variableStringValue);
+      entity.setFullValue(null);
+      entity.setIsTruncated(false);
+    }
+
+    final TaskJoinRelationship joinRelationship = new TaskJoinRelationship();
+    joinRelationship.setParent(entity.getScopeKey());
+    joinRelationship.setName(TaskJoinRelationshipType.TASK_VARIABLE.getType());
+    entity.setJoin(joinRelationship);
+  }
+
+  @Override
+  public void flush(final TaskVariableEntity entity, final BatchRequest batchRequest) {
+    final Map<String, Object> updateFields = new HashMap<>();
+
+    updateFields.put(TaskTemplate.VARIABLE_VALUE, entity.getValue());
+    updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, entity.getFullValue());
+    updateFields.put(TaskTemplate.IS_TRUNCATED, entity.getIsTruncated());
+    updateFields.put(TaskTemplate.JOIN_FIELD_NAME, entity.getJoin());
+
+    batchRequest.upsertWithRouting(
+        indexName, entity.getId(), entity, updateFields, String.valueOf(entity.getScopeKey()));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -29,8 +29,8 @@ public class UserTaskVariableHandler
   private static final Logger LOG = LoggerFactory.getLogger(UserTaskVariableHandler.class);
 
   private static final String ID_PATTERN = "%s-%s";
+  protected final int variableSizeThreshold;
   private final String indexName;
-  private final int variableSizeThreshold;
 
   public UserTaskVariableHandler(final String indexName, final int variableSizeThreshold) {
     this.indexName = indexName;
@@ -68,6 +68,7 @@ public class UserTaskVariableHandler
       final Record<VariableRecordValue> record, final TaskVariableEntity entity) {
     entity
         .setPartitionId(record.getPartitionId())
+        .setPosition(record.getPosition())
         .setTenantId(record.getValue().getTenantId())
         .setKey(record.getKey())
         .setProcessInstanceId(record.getValue().getProcessInstanceKey())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -144,7 +144,7 @@ public class FormHandlerTest {
     assertThat(formEntity.getKey()).isEqualTo(formKey);
     assertThat(formEntity.getIsDeleted()).isTrue();
     assertThat(formEntity.getVersion()).isEqualTo(formValue.getVersion());
-    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getResourceName());
+    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getFormId());
     assertThat(formEntity.getSchema())
         .isEqualTo(new String(formValue.getResource(), StandardCharsets.UTF_8));
     assertThat(formEntity.getTenantId()).isEqualTo(formValue.getTenantId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -23,7 +23,7 @@ import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
-public class FormHanlderTest {
+public class FormHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-form";
@@ -114,7 +114,7 @@ public class FormHanlderTest {
     // then
     assertThat(formEntity.getKey()).isEqualTo(formKey);
     assertThat(formEntity.getVersion()).isEqualTo(formValue.getVersion());
-    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getResourceName());
+    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getFormId());
     assertThat(formEntity.getSchema())
         .isEqualTo(new String(formValue.getResource(), StandardCharsets.UTF_8));
     assertThat(formEntity.getTenantId()).isEqualTo(formValue.getTenantId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class UserTaskCompletionVariableHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-tasklist-task";
+  private final UserTaskCompletionVariableHandler underTest =
+      new UserTaskCompletionVariableHandler(indexName, 100);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER_TASK);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(TaskVariableEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserTaskRecordValue> variableRecord =
+        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.COMPLETED));
+
+    // when - then
+    assertThat(underTest.handlesRecord(variableRecord)).isTrue();
+  }
+
+  @Test
+  void shouldNotHandleRecord() {
+    // given
+    Arrays.stream(UserTaskIntent.values())
+        .filter(intent -> !intent.name().equals(UserTaskIntent.COMPLETED.name()))
+        .forEach(
+            intent -> {
+              final Record<UserTaskRecordValue> variableRecord =
+                  factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(intent));
+              // when - then
+              assertThat(underTest.handlesRecord(variableRecord)).isFalse();
+            });
+  }
+
+  @Test
+  void shouldNotHandleRecordWithNullVariables() {
+    // given
+    final Record<UserTaskRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.COMPLETED)
+                    .withValue(ImmutableUserTaskRecordValue.builder().build()));
+    // when - then
+    assertThat(underTest.handlesRecord(variableRecord)).isFalse();
+  }
+
+  @Test
+  void shouldNotHandleRecordWithEmptyVariables() {
+    // given
+    final Record<UserTaskRecordValue> variableRecord =
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.COMPLETED)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder().withVariables(Map.of()).build()));
+    // when - then
+    assertThat(underTest.handlesRecord(variableRecord)).isFalse();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final long elementInstanceKey = 123L;
+    final Record<UserTaskRecordValue> variableRecord =
+        generateRecordWithVariables(elementInstanceKey, Map.of("var1", "val1", "var2", 2));
+    // when
+    final var idList = underTest.generateIds(variableRecord);
+
+    // then
+    assertThat(idList)
+        .containsExactlyInAnyOrder(
+            elementInstanceKey + "-" + "var1", elementInstanceKey + "-" + "var2");
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final var join = new TaskJoinRelationship();
+    join.setName(TaskJoinRelationshipType.TASK_VARIABLE.getType());
+    join.setParent(123L);
+    final TaskVariableEntity inputEntity =
+        new TaskVariableEntity()
+            .setId("111")
+            .setValue("value")
+            .setIsTruncated(false)
+            .setScopeKey(123L)
+            .setJoin(join);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+    updateFieldsMap.put(TaskTemplate.VARIABLE_FULL_VALUE, null);
+    updateFieldsMap.put(TaskTemplate.VARIABLE_VALUE, "value");
+    updateFieldsMap.put(TaskTemplate.IS_TRUNCATED, false);
+    updateFieldsMap.put(TaskTemplate.JOIN_FIELD_NAME, join);
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            inputEntity.getId(),
+            inputEntity,
+            updateFieldsMap,
+            String.valueOf(inputEntity.getScopeKey()));
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForTaskScopedVariable() {
+    // given
+    final long scopeKey = 456;
+    final var taskRecord = generateRecordWithVariables(scopeKey, Map.of("var1", "val1"));
+
+    // when
+    final TaskVariableEntity variableEntity =
+        new TaskVariableEntity().setId(scopeKey + "-" + "var1");
+    underTest.updateEntity(taskRecord, variableEntity);
+
+    // then
+    assertThat(variableEntity.getId()).isEqualTo(scopeKey + "-" + "var1");
+    assertThat(variableEntity.getKey()).isEqualTo(taskRecord.getKey());
+    assertThat(variableEntity.getName()).isEqualTo("var1");
+    assertThat(variableEntity.getScopeKey()).isEqualTo(scopeKey);
+    assertThat(variableEntity.getTenantId()).isEqualTo(taskRecord.getValue().getTenantId());
+    assertThat(variableEntity.getPosition()).isEqualTo(taskRecord.getPosition());
+    assertThat(variableEntity.getValue()).isEqualTo("\"val1\"");
+    assertThat(variableEntity.getProcessInstanceId())
+        .isEqualTo(taskRecord.getValue().getProcessInstanceKey());
+    assertThat(variableEntity.getIsTruncated()).isFalse();
+    assertThat(variableEntity.getFullValue()).isNull();
+    assertThat(variableEntity.getJoin()).isNotNull();
+    assertThat(variableEntity.getJoin().getParent()).isEqualTo(scopeKey);
+    assertThat(variableEntity.getJoin().getName())
+        .isEqualTo(TaskJoinRelationshipType.TASK_VARIABLE.getType());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordWithFullValue() {
+    // given
+    final long scopeKey = 456;
+    final var taskRecord =
+        generateRecordWithVariables(
+            scopeKey, Map.of("var1", "v".repeat(underTest.variableSizeThreshold) + 1));
+
+    // when
+    final TaskVariableEntity variableEntity =
+        new TaskVariableEntity().setId(scopeKey + "-" + "var1");
+    underTest.updateEntity(taskRecord, variableEntity);
+
+    // then
+    assertThat(variableEntity.getValue())
+        .isEqualTo("\"" + "v".repeat(underTest.variableSizeThreshold - 1));
+    assertThat(variableEntity.getFullValue())
+        .isEqualTo("\"" + "v".repeat(underTest.variableSizeThreshold + 1) + "\"");
+    assertThat(variableEntity.getIsTruncated()).isTrue();
+  }
+
+  private Record<UserTaskRecordValue> generateRecordWithVariables(
+      final long elementInstanceKey, final Map<String, Object> variables) {
+    return factory.generateRecord(
+        ValueType.USER_TASK,
+        r ->
+            r.withIntent(UserTaskIntent.COMPLETED)
+                .withValue(
+                    ImmutableUserTaskRecordValue.builder()
+                        .from(factory.generateObject(UserTaskRecordValue.class))
+                        .withElementInstanceKey(elementInstanceKey)
+                        .withVariables(variables)
+                        .build()));
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -49,7 +49,14 @@ public class UserTaskCompletionVariableHandlerTest {
   void shouldHandleRecord() {
     // given
     final Record<UserTaskRecordValue> variableRecord =
-        factory.generateRecord(ValueType.USER_TASK, r -> r.withIntent(UserTaskIntent.COMPLETED));
+        factory.generateRecord(
+            ValueType.USER_TASK,
+            r ->
+                r.withIntent(UserTaskIntent.COMPLETED)
+                    .withValue(
+                        ImmutableUserTaskRecordValue.builder()
+                            .withVariables(Map.of("var", "varVal"))
+                            .build()));
 
     // when - then
     assertThat(underTest.handlesRecord(variableRecord)).isTrue();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -190,7 +190,7 @@ public class UserTaskCompletionVariableHandlerTest {
     final long scopeKey = 456;
     final var taskRecord =
         generateRecordWithVariables(
-            scopeKey, Map.of("var1", "v".repeat(underTest.variableSizeThreshold) + 1));
+            scopeKey, Map.of("var1", "v".repeat(underTest.variableSizeThreshold + 1)));
 
     // when
     final TaskVariableEntity variableEntity =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -30,11 +30,9 @@ import org.junit.jupiter.api.Test;
 
 public class UserTaskVariableHandlerTest {
 
-  private static final int VARIABLE_SIZE_THRESHOLD = 100;
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-tasklist-task";
-  private final UserTaskVariableHandler underTest =
-      new UserTaskVariableHandler(indexName, VARIABLE_SIZE_THRESHOLD);
+  private final UserTaskVariableHandler underTest = new UserTaskVariableHandler(indexName, 100);
 
   @Test
   void testGetHandledValueType() {
@@ -76,7 +74,7 @@ public class UserTaskVariableHandlerTest {
     final String name = "name";
     final Record<VariableRecordValue> processInstanceRecord =
         factory.generateRecord(
-            ValueType.PROCESS_INSTANCE,
+            ValueType.VARIABLE,
             r ->
                 r.withIntent(VariableIntent.CREATED)
                     .withValue(
@@ -139,7 +137,7 @@ public class UserTaskVariableHandlerTest {
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
-            .withValue("v".repeat(VARIABLE_SIZE_THRESHOLD))
+            .withValue("v".repeat(underTest.variableSizeThreshold))
             .withProcessInstanceKey(processInstanceKey)
             .withScopeKey(variableScopeKey)
             .build();
@@ -165,6 +163,7 @@ public class UserTaskVariableHandlerTest {
     assertThat(variableEntity.getProcessInstanceId()).isEqualTo(processInstanceKey);
     assertThat(variableEntity.getIsTruncated()).isFalse();
     assertThat(variableEntity.getFullValue()).isNull();
+    assertThat(variableEntity.getPosition()).isEqualTo(variableRecord.getPosition());
     assertThat(variableEntity.getJoin()).isNotNull();
     assertThat(variableEntity.getJoin().getParent()).isEqualTo(variableRecordValue.getScopeKey());
     assertThat(variableEntity.getJoin().getName())
@@ -178,7 +177,7 @@ public class UserTaskVariableHandlerTest {
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
-            .withValue("v".repeat(VARIABLE_SIZE_THRESHOLD))
+            .withValue("v".repeat(underTest.variableSizeThreshold))
             .withProcessInstanceKey(processInstanceKey)
             .withScopeKey(processInstanceKey)
             .build();
@@ -204,6 +203,7 @@ public class UserTaskVariableHandlerTest {
     assertThat(variableEntity.getProcessInstanceId()).isEqualTo(processInstanceKey);
     assertThat(variableEntity.getIsTruncated()).isFalse();
     assertThat(variableEntity.getFullValue()).isNull();
+    assertThat(variableEntity.getPosition()).isEqualTo(variableRecord.getPosition());
     assertThat(variableEntity.getJoin()).isNotNull();
     assertThat(variableEntity.getJoin().getParent()).isEqualTo(variableRecordValue.getScopeKey());
     assertThat(variableEntity.getJoin().getName())
@@ -216,7 +216,7 @@ public class UserTaskVariableHandlerTest {
     final VariableRecordValue variableRecordValue =
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
-            .withValue("v".repeat(VARIABLE_SIZE_THRESHOLD + 1))
+            .withValue("v".repeat(underTest.variableSizeThreshold + 1))
             .build();
 
     final Record<VariableRecordValue> variableRecord =
@@ -229,8 +229,9 @@ public class UserTaskVariableHandlerTest {
     underTest.updateEntity(variableRecord, variableEntity);
 
     // then
-    assertThat(variableEntity.getValue()).isEqualTo("v".repeat(VARIABLE_SIZE_THRESHOLD));
-    assertThat(variableEntity.getFullValue()).isEqualTo("v".repeat(VARIABLE_SIZE_THRESHOLD + 1));
+    assertThat(variableEntity.getValue()).isEqualTo("v".repeat(underTest.variableSizeThreshold));
+    assertThat(variableEntity.getFullValue())
+        .isEqualTo("v".repeat(underTest.variableSizeThreshold + 1));
     assertThat(variableEntity.getIsTruncated()).isTrue();
   }
 }


### PR DESCRIPTION
## Description
- Implement the UserTaskCompletionVariableHandler to capture variables during user task completion in order to set correct relationship in the `tasklist-task` index.
- Include `position` field in TaskVariableEntity
- [bugfix] Use `formId` instead of `deployedResourceName` for FormHandler

<!-- Describe the goal and purpose of this PR. -->

