### PR TITLE
test: filter for FlowNodeInstance with incident

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -89,9 +89,9 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
     flowNodeInstance = allFlowNodeInstances.getFirst();
     flowNodeInstanceWithIncident =
         allFlowNodeInstances.stream()
-            .filter(f -> f.getIncidentKey() != null)
+            .filter(FlowNodeInstance::getIncident)
             .findFirst()
-            .orElse(null);
+            .orElseThrow();
   }
 
   @AfterAll


### PR DESCRIPTION
## Description

* Filter for `FlowNodeInstance` that has `incident = true` instead of one that has an incident key. The test seems to fail because the flow node instance can have an incident key but `incident = false` as those fields are apparently decoupled. The test case then uses the `hasIncident` value for querying with that value being `false`. Thus, we find all 20 flow node instances.
* We now throw an exception in case of no flowNode with `hasIncident = true` is found.

## Related issues

closes #23978
