### PR TITLE
feat: write command to trigger engine scale up

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -47,7 +47,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getGatewayBrokerTransport(),
             brokerStartupContext.getJobStreamService().jobStreamer(),
             brokerStartupContext.getClusterConfigurationService(),
-            brokerStartupContext.getMeterRegistry());
+            brokerStartupContext.getMeterRegistry(),
+            brokerStartupContext.getBrokerClient());
     concurrencyControl.run(
         () -> {
           try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -11,7 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
-import io.camunda.zeebe.dynamic.config.changes.PartitionScalingChangeExecutor.NoopPartitionScalingChangeExecutor;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -65,10 +64,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.setPartitionManager(partitionManager);
             brokerStartupContext
                 .getClusterConfigurationService()
-                .registerChangeExecutors(
-                    partitionManager,
-                    // TODO: Pass an actual implementation of PartitionScalingChangeExecutor
-                    new NoopPartitionScalingChangeExecutor());
+                .registerChangeExecutors(partitionManager, partitionManager);
             startupFuture.complete(brokerStartupContext);
           } catch (final Exception e) {
             startupFuture.completeExceptionally(e);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerPartitionScaleUpRequest;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -530,6 +531,13 @@ public final class PartitionManagerImpl
                     new RuntimeException(
                         "Request resulted in an error: %s".formatted(response.getError())));
                 return;
+              }
+
+              if (response.isRejection()
+                  && response.getRejection().type() == RejectionType.ALREADY_EXISTS) {
+                LOGGER.debug(
+                    "Scale up request already succeeded before: {}", response.getRejection());
+                result.complete(null);
               }
 
               if (response.isRejection()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -51,15 +51,7 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
       return;
     }
 
-    if (scaleUp.getDesiredPartitionCount() <= scaleUp.getCurrentPartitionCount()) {
-      final var reason = "Desired partition count must be greater than current partition count";
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
-      return;
-    }
-
-    if (scaleUp.getDesiredPartitionCount() < Protocol.START_PARTITION_ID
-        || scaleUp.getCurrentPartitionCount() < Protocol.START_PARTITION_ID) {
+    if (scaleUp.getDesiredPartitionCount() < Protocol.START_PARTITION_ID) {
       final var reason = "Partition count must be at least 1";
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
       rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -20,6 +20,10 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
   private final KeyGenerator keyGenerator;
@@ -43,25 +47,11 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
   public void processRecord(final TypedRecord<ScaleRecord> command) {
     final var scaleUp = command.getValue();
 
-    if (!routingState.isInitialized()) {
-      final var reason =
-          "Routing state is not initialized, partition scaling is probably disabled.";
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
-      return;
-    }
-
-    if (scaleUp.getDesiredPartitionCount() < Protocol.START_PARTITION_ID) {
-      final var reason = "Partition count must be at least 1";
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
-      return;
-    }
-
-    if (scaleUp.getDesiredPartitionCount() > Protocol.MAXIMUM_PARTITIONS) {
-      final var reason = "Partition count must be at most " + Protocol.MAXIMUM_PARTITIONS;
-      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_ARGUMENT, reason);
-      rejectionWriter.appendRejection(command, RejectionType.INVALID_ARGUMENT, reason);
+    final var optionalRejection = validateCommand(command);
+    if (optionalRejection.isPresent()) {
+      final var rejection = optionalRejection.get();
+      rejectionWriter.appendRejection(command, rejection.type(), rejection.reason());
+      responseWriter.writeRejectionOnCommand(command, rejection.type(), rejection.reason());
       return;
     }
 
@@ -71,4 +61,69 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
 
     stateWriter.appendFollowUpEvent(scalingKey, ScaleIntent.SCALED_UP, new ScaleRecord());
   }
+
+  private Optional<Rejection> validateCommand(final TypedRecord<ScaleRecord> command) {
+    if (!routingState.isInitialized()) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.INVALID_STATE,
+              "Routing state is not initialized, partition scaling is probably disabled."));
+    }
+
+    final var requestedPartitionCount = command.getValue().getDesiredPartitionCount();
+    final var currentPartitionsInRoutingState = routingState.currentPartitions();
+    final var desiredPartitionsInRoutingState = routingState.desiredPartitions();
+
+    final var allPartitionsInRoutingState = new HashSet<>();
+    allPartitionsInRoutingState.addAll(currentPartitionsInRoutingState);
+    allPartitionsInRoutingState.addAll(desiredPartitionsInRoutingState);
+
+    final var requestedPartitions =
+        IntStream.range(
+                Protocol.START_PARTITION_ID, Protocol.START_PARTITION_ID + requestedPartitionCount)
+            .boxed()
+            .collect(Collectors.toSet());
+
+    if (requestedPartitionCount < Protocol.START_PARTITION_ID) {
+      return Optional.of(
+          new Rejection(RejectionType.INVALID_ARGUMENT, "Partition count must be at least 1"));
+    }
+
+    if (requestedPartitionCount > Protocol.MAXIMUM_PARTITIONS) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.INVALID_ARGUMENT,
+              "Partition count must be at most " + Protocol.MAXIMUM_PARTITIONS));
+    }
+
+    if (allPartitionsInRoutingState.equals(requestedPartitions)) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.ALREADY_EXISTS, "The desired partition count was already requested"));
+    }
+
+    if (!desiredPartitionsInRoutingState.isEmpty()) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.INVALID_STATE,
+              "The desired partition count conflicts with the current state"));
+    }
+
+    if (currentPartitionsInRoutingState.equals(requestedPartitions)) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.ALREADY_EXISTS, "The desired partition count was already active"));
+    }
+
+    if (!requestedPartitions.containsAll(currentPartitionsInRoutingState)) {
+      return Optional.of(
+          new Rejection(
+              RejectionType.INVALID_STATE,
+              "The desired partition count is smaller than the currently active partitions"));
+    }
+
+    return Optional.empty();
+  }
+
+  private record Rejection(RejectionType type, String reason) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -104,12 +104,6 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
               "The desired partition count conflicts with the current state"));
     }
 
-    if (currentPartitionsInRoutingState.equals(requestedPartitions)) {
-      return Optional.of(
-          new Rejection(
-              RejectionType.ALREADY_EXISTS, "The desired partition count was already active"));
-    }
-
     if (!requestedPartitions.containsAll(currentPartitionsInRoutingState)) {
       return Optional.of(
           new Rejection(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScaleUpProcessor.java
@@ -101,7 +101,7 @@ public class ScaleUpProcessor implements TypedRecordProcessor<ScaleRecord> {
       return Optional.of(
           new Rejection(
               RejectionType.INVALID_STATE,
-              "The desired partition count conflicts with the current state"));
+              "The desired partition count conflicts with the current state. This should not happen, is there a concurrent scaling operation?"));
     }
 
     if (!requestedPartitions.containsAll(currentPartitionsInRoutingState)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingUpApplier.java
@@ -11,8 +11,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableRoutingState;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import io.camunda.zeebe.util.PartitionUtil;
 
 public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRecord> {
   final MutableRoutingState routingState;
@@ -24,8 +23,7 @@ public class ScalingUpApplier implements TypedEventApplier<ScaleIntent, ScaleRec
   @Override
   public void applyState(final long key, final ScaleRecord value) {
     final var partitionCount = value.getDesiredPartitionCount();
-    final var partitions =
-        IntStream.rangeClosed(1, partitionCount).boxed().collect(Collectors.toUnmodifiableSet());
+    final var partitions = PartitionUtil.allPartitions(partitionCount);
 
     routingState.setDesiredPartitions(partitions);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/RoutingState.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.engine.state.immutable;
 import java.util.Set;
 
 public interface RoutingState {
-  Set<Integer> partitions();
+  Set<Integer> currentPartitions();
+
+  Set<Integer> desiredPartitions();
 
   MessageCorrelation messageCorrelation();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/DbRoutingState.java
@@ -35,9 +35,19 @@ public final class DbRoutingState implements MutableRoutingState {
   }
 
   @Override
-  public Set<Integer> partitions() {
+  public Set<Integer> currentPartitions() {
     key.wrapString(CURRENT_KEY);
     return columnFamily.get(key).getPartitions();
+  }
+
+  @Override
+  public Set<Integer> desiredPartitions() {
+    key.wrapString(DESIRED_KEY);
+    final var desiredRoutingInfo = columnFamily.get(key);
+    if (desiredRoutingInfo == null) {
+      return Set.of();
+    }
+    return desiredRoutingInfo.getPartitions();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/routing/RoutingInfo.java
@@ -84,7 +84,7 @@ public interface RoutingInfo {
       if (!routingState.isInitialized()) {
         return fallback.partitions();
       }
-      return routingState.partitions();
+      return routingState.currentPartitions();
     }
 
     @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -46,9 +46,7 @@ public class ScaleUpTest {
     initRoutingState();
     final var command =
         RecordToWrite.command()
-            .scale(
-                ScaleIntent.SCALE_UP,
-                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(3));
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
 
     // when
     engine.writeRecords(command);
@@ -64,9 +62,7 @@ public class ScaleUpTest {
     initRoutingState();
     final var command =
         RecordToWrite.command()
-            .scale(
-                ScaleIntent.SCALE_UP,
-                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(3));
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
 
     // when
     engine.writeRecords(command);
@@ -84,9 +80,7 @@ public class ScaleUpTest {
     // given
     final var command =
         RecordToWrite.command()
-            .scale(
-                ScaleIntent.SCALE_UP,
-                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(3));
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(3));
 
     // when
     engine.writeRecords(command);
@@ -128,9 +122,7 @@ public class ScaleUpTest {
     initRoutingState();
     final var command =
         RecordToWrite.command()
-            .scale(
-                ScaleIntent.SCALE_UP,
-                new ScaleRecord().setCurrentPartitionCount(1).setDesiredPartitionCount(10000));
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(10000));
 
     // when
     engine.writeRecords(command);
@@ -151,9 +143,7 @@ public class ScaleUpTest {
     initRoutingState();
     final var command =
         RecordToWrite.command()
-            .scale(
-                ScaleIntent.SCALE_UP,
-                new ScaleRecord().setCurrentPartitionCount(3).setDesiredPartitionCount(1));
+            .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(1));
 
     // when
     engine.writeRecords(command);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -111,8 +111,7 @@ public class ScaleUpTest {
             rejection -> {
               assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
               assertThat(rejection.getRejectionReason())
-                  .isEqualTo(
-                      "Desired partition count must be greater than current partition count");
+                  .isEqualTo("Partition count must be at least 1");
             });
   }
 
@@ -140,7 +139,7 @@ public class ScaleUpTest {
   @Test
   public void shouldRejectScaleDown() {
     // given
-    initRoutingState();
+    ((MutableRoutingState) engine.getProcessingState().getRoutingState()).initializeRoutingInfo(2);
     final var command =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(1));
@@ -152,10 +151,10 @@ public class ScaleUpTest {
     assertThat(RecordingExporter.scaleRecords().onlyCommandRejections().findFirst())
         .hasValueSatisfying(
             rejection -> {
-              assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_ARGUMENT);
+              assertThat(rejection.getRejectionType()).isEqualTo(RejectionType.INVALID_STATE);
               assertThat(rejection.getRejectionReason())
                   .isEqualTo(
-                      "Desired partition count must be greater than current partition count");
+                      "The desired partition count is smaller than the currently active partitions");
             });
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/RoutingInfoMigrationTest.java
@@ -63,7 +63,7 @@ final class RoutingInfoMigrationTest {
     // then
     final var updatedRoutingState = context.processingState().getRoutingState();
     assertThat(updatedRoutingState.isInitialized()).isTrue();
-    assertThat(updatedRoutingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(updatedRoutingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(updatedRoutingState.messageCorrelation())
         .isEqualTo(new MessageCorrelation.HashMod(3));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/routing/DbRoutingStateTest.java
@@ -38,7 +38,7 @@ final class DbRoutingStateTest {
 
     // then
     assertThat(routingState.isInitialized()).isTrue();
-    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(routingState.messageCorrelation())
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(3));
   }
@@ -48,13 +48,13 @@ final class DbRoutingStateTest {
     // given
     final var routingState = processingState.getRoutingState();
     routingState.initializeRoutingInfo(1);
-    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1);
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1);
 
     // when
     routingState.setDesiredPartitions(Set.of(1, 2, 3));
 
     // then
-    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1);
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1);
     assertThat(routingState.messageCorrelation())
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(1));
 
@@ -62,7 +62,7 @@ final class DbRoutingStateTest {
     routingState.arriveAtDesiredState();
 
     // then
-    assertThat(routingState.partitions()).containsExactlyInAnyOrder(1, 2, 3);
+    assertThat(routingState.currentPartitions()).containsExactlyInAnyOrder(1, 2, 3);
     assertThat(routingState.messageCorrelation())
         .isEqualTo(new RoutingState.MessageCorrelation.HashMod(1));
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionScaleUpRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPartitionScaleUpRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public final class BrokerPartitionScaleUpRequest extends BrokerExecuteCommand<ScaleRecord> {
+
+  private final ScaleRecord requestDto = new ScaleRecord();
+
+  public BrokerPartitionScaleUpRequest(final int desiredPartitionCount) {
+    super(ValueType.SCALE, ScaleIntent.SCALE_UP);
+    requestDto.setDesiredPartitionCount(desiredPartitionCount);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected ScaleRecord toResponseDto(final DirectBuffer buffer) {
+    final var responseDto = new ScaleRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/ScaleRecord.java
@@ -12,19 +12,12 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 
 public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue {
-  private final IntegerProperty currentPartitionCountProp =
-      new IntegerProperty("getCurrentPartitionCount", -1);
   private final IntegerProperty desiredPartitionCountProp =
-      new IntegerProperty("getDesiredPartitionCount", -1);
+      new IntegerProperty("desiredPartitionCount", -1);
 
   public ScaleRecord() {
-    super(2);
-    declareProperty(currentPartitionCountProp).declareProperty(desiredPartitionCountProp);
-  }
-
-  @Override
-  public int getCurrentPartitionCount() {
-    return currentPartitionCountProp.getValue();
+    super(1);
+    declareProperty(desiredPartitionCountProp);
   }
 
   @Override
@@ -34,11 +27,6 @@ public class ScaleRecord extends UnifiedRecordValue implements ScaleRecordValue 
 
   public ScaleRecord setDesiredPartitionCount(final int desiredPartitionCount) {
     desiredPartitionCountProp.setValue(desiredPartitionCount);
-    return this;
-  }
-
-  public ScaleRecord setCurrentPartitionCount(final int currentPartitionCount) {
-    currentPartitionCountProp.setValue(currentPartitionCount);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2764,18 +2764,15 @@ final class JsonSerializableToJsonTest {
         (Supplier<ScaleRecord>) ScaleRecord::new,
         """
         {
-          "currentPartitionCount": -1,
           "desiredPartitionCount": -1
         }
         """
       },
       {
         "ScaleRecord",
-        (Supplier<ScaleRecord>)
-            () -> new ScaleRecord().setCurrentPartitionCount(3).setDesiredPartitionCount(5),
+        (Supplier<ScaleRecord>) () -> new ScaleRecord().setDesiredPartitionCount(5),
         """
         {
-         "currentPartitionCount": 3,
          "desiredPartitionCount": 5
         }
         """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/ScaleRecordValue.java
@@ -22,7 +22,5 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableScaleRecordValue.Builder.class)
 public interface ScaleRecordValue extends RecordValue {
-  int getCurrentPartitionCount();
-
   int getDesiredPartitionCount();
 }

--- a/zeebe/util/pom.xml
+++ b/zeebe/util/pom.xml
@@ -17,6 +17,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/PartitionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/PartitionUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import io.camunda.zeebe.protocol.Protocol;
+import org.agrona.collections.IntHashSet;
+
+public final class PartitionUtil {
+  private PartitionUtil() {}
+
+  /**
+   * Returns a set of all partitions from {@link Protocol#START_PARTITION_ID} to {@code
+   * numPartitions}.
+   */
+  public static IntHashSet allPartitions(final int numPartitions) {
+    requireValidPartitionId(numPartitions);
+    final var partitions = new IntHashSet(numPartitions);
+    for (int i = Protocol.START_PARTITION_ID;
+        i < Protocol.START_PARTITION_ID + numPartitions;
+        i++) {
+      partitions.add(i);
+    }
+    return partitions;
+  }
+
+  /**
+   * Throws if the partition is outside the range of {@link Protocol#START_PARTITION_ID} to {@link
+   * Protocol#MAXIMUM_PARTITIONS}
+   */
+  public static void requireValidPartitionId(final int partitionId) {
+    if (partitionId < Protocol.START_PARTITION_ID) {
+      throw new IllegalArgumentException(
+          "Partition id " + partitionId + " must be >= " + Protocol.START_PARTITION_ID);
+    }
+    if (partitionId > Protocol.MAXIMUM_PARTITIONS) {
+      throw new IllegalArgumentException(
+          "Partition id " + partitionId + " must be <= " + Protocol.MAXIMUM_PARTITIONS);
+    }
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/PartitionUtilTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/PartitionUtilTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+final class PartitionUtilTest {
+
+  @Test
+  void shouldReturnAllPartitions() {
+    // when
+    final var partitions = PartitionUtil.allPartitions(5);
+
+    // then
+    assertThat(partitions).containsExactlyInAnyOrder(1, 2, 3, 4, 5);
+  }
+
+  @Test
+  void shouldFailForTooManyPartitions() {
+    assertThatCode(() -> PartitionUtil.allPartitions(10_000))
+        .hasMessage("Partition id 10000 must be <= 8192");
+  }
+
+  @Test
+  void shouldFailForTooFewPartitions() {
+    assertThatCode(() -> PartitionUtil.allPartitions(0)).hasMessage("Partition id 0 must be >= 1");
+  }
+}


### PR DESCRIPTION
This implements the scaling change executor by sending a scale up command to partition 1.
The scale up command was simplified, only carrying the desired partition count now.

When a redundant (i.e. duplicated) scale up command is processed, the command is rejected. This is treated as a successful request to achieve idempotency of the change operation.

:warning: There is no end-to-end test for this because right now, the cluster change operation is not generated. Once that is done, we can write and end-to-end test.

closes #23215
