### PR TITLE
Exporter test framework

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
@@ -9,14 +9,14 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 final class DecisionExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
@@ -21,7 +21,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class IncidentExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.UserTaskFilter;
 import io.camunda.zeebe.client.api.search.response.UserTask;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class UserTaskExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/VariableHandlerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/VariableHandlerIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.VariableFilter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -20,7 +20,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class VariableHandlerIT {
 
   private static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191;

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerWithCamundaExporterITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerWithCamundaExporterITInvocationProvider.java
@@ -37,11 +37,11 @@ import org.testcontainers.utility.DockerImageName;
  * The tests must take this into account, as the state in Zeebe and the exporter backend is not
  * reset between test cases.
  */
-public class CamundaExporterITInvocationProvider
+public class BrokerWithCamundaExporterITInvocationProvider
     implements TestTemplateInvocationContextProvider, AfterAllCallback, BeforeAllCallback {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(CamundaExporterITInvocationProvider.class);
+      LoggerFactory.getLogger(BrokerWithCamundaExporterITInvocationProvider.class);
 
   private static final DockerImageName ELASTIC_IMAGE =
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
@@ -52,7 +52,7 @@ public class CamundaExporterITInvocationProvider
 
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  public CamundaExporterITInvocationProvider() {
+  public BrokerWithCamundaExporterITInvocationProvider() {
     exporterTypes = new HashMap<>();
     exporterTypes.put(
         "with-camunda-exporter-elasticsearch", ExporterType.CAMUNDA_EXPORTER_ELASTIC_SEARCH);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -27,10 +27,10 @@ import io.camunda.exporter.schema.SchemaTestUtil;
 import io.camunda.exporter.utils.CamundaExporterITInvocationProvider;
 import io.camunda.exporter.utils.SearchClientAdapter;
 import io.camunda.exporter.utils.TestSupport;
+import io.camunda.security.entity.Permission;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
-import io.camunda.webapps.schema.entities.usermanagement.Permission;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -349,7 +349,7 @@ final class CamundaExporterIT {
         .map(
             permissionValue ->
                 new Permission(
-                    permissionValue.getPermissionType().name(), permissionValue.getResourceIds()))
+                    permissionValue.getPermissionType(), permissionValue.getResourceIds()))
         .collect(Collectors.toList());
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -8,7 +8,9 @@
 package io.camunda.exporter;
 
 import static io.camunda.exporter.schema.SchemaTestUtil.mappingsMatch;
+import static io.camunda.exporter.utils.CamundaExporterITInvocationProvider.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
@@ -19,22 +21,17 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import com.fasterxml.jackson.databind.JsonNode;
-import io.camunda.exporter.config.ConfigValidator;
+import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SchemaTestUtil;
 import io.camunda.exporter.utils.CamundaExporterITInvocationProvider;
 import io.camunda.exporter.utils.SearchClientAdapter;
 import io.camunda.exporter.utils.TestSupport;
-import io.camunda.search.connect.es.ElasticsearchConnector;
-import io.camunda.search.connect.os.OpensearchConnector;
-import io.camunda.security.entity.Permission;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.webapps.schema.entities.usermanagement.Permission;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
-import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
@@ -50,24 +47,19 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
-import org.assertj.core.api.Assertions;
+import java.util.stream.Stream;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * This is a smoke test to verify that the exporter can connect to an Elasticsearch instance and
@@ -77,73 +69,36 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @ExtendWith(CamundaExporterITInvocationProvider.class)
 final class CamundaExporterIT {
 
-  private static final ExporterConfiguration CONFIG = new ExporterConfiguration();
-  private final ExporterTestController controller = new ExporterTestController();
   private final ProtocolFactory factory = new ProtocolFactory();
   private IndexDescriptor index;
   private IndexTemplateDescriptor indexTemplate;
 
   @BeforeEach
-  void beforeEach() throws IOException {
-    CONFIG.getIndex().setPrefix("camunda-record");
-    CONFIG.getIndex().setNumberOfShards(1);
-    CONFIG.getIndex().setNumberOfReplicas(0);
-
-    CONFIG.getBulk().setSize(1); // force flushing on the first record
-
-    CONFIG.setCreateSchema(false);
-    CONFIG.getRetention().setEnabled(false);
-    CONFIG.getRetention().setMinimumAge("30d");
-
+  void beforeEach() {
     indexTemplate =
         SchemaTestUtil.mockIndexTemplate(
             "index_name",
             "test*",
             "template_alias",
             Collections.emptyList(),
-            CONFIG.getIndex().getPrefix() + "template_name",
+            CONFIG_PREFIX + "-template_name",
             "/mappings.json");
 
     index =
         SchemaTestUtil.mockIndex(
-            CONFIG.getIndex().getPrefix() + "qualified_name",
-            "alias",
-            "index_name",
-            "/mappings.json");
+            CONFIG_PREFIX + "-qualified_name", "alias", "index_name", "/mappings.json");
 
     when(indexTemplate.getFullQualifiedName())
-        .thenReturn(CONFIG.getIndex().getPrefix() + "template_index_qualified_name");
+        .thenReturn(CONFIG_PREFIX + "-template_index_qualified_name");
   }
 
-  @Test
-  void shouldPeriodicallyFlushBasedOnConfiguration() {
+  @TestTemplate
+  void shouldUpdateExporterPositionAfterFlushing(
+      final ExporterConfiguration config, final SearchClientAdapter ignored) {
     // given
-    final var duration = 2;
-    CONFIG.getBulk().setDelay(duration);
+    final var exporter = new CamundaExporter(mockResourceProvider(Set.of(), Set.of(), config));
 
-    final var exporter = new CamundaExporter();
-
-    final var context =
-        new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
-
-    exporter.configure(context);
-
-    // when
-    final var spiedController = spy(controller);
-    exporter.open(spiedController);
-
-    spiedController.runScheduledTasks(Duration.ofSeconds(duration));
-
-    // then
-    verify(spiedController, times(2)).scheduleCancellableTask(eq(Duration.ofSeconds(2)), any());
-  }
-
-  void shouldUpdateExporterPositionAfterFlushing() {
-    // given
-    final var exporter = new CamundaExporter(mockResourceProvider(Set.of(), Set.of()));
-
-    final var context = getContext();
+    final var context = getContextFromConfig(config);
     exporter.configure(context);
 
     final var exporterController = new ExporterTestController();
@@ -159,113 +114,103 @@ final class CamundaExporterIT {
     assertThat(exporterController.getPosition()).isEqualTo(record.getPosition());
   }
 
-  private Exporter startExporter() {
-    final var exporter =
-        new CamundaExporter(mockResourceProvider(Set.of(index), Set.of(indexTemplate)));
+  @TestTemplate
+  void shouldExportRecordOnceBulkSizeReached(
+      final ExporterConfiguration config, final SearchClientAdapter ignored) {
+    // given
+    config.getBulk().setSize(2);
+    final var exporter = new CamundaExporter(mockResourceProvider(Set.of(), Set.of(), config));
 
-    final var context = getContext();
+    final var context = getContextFromConfig(config);
+    exporter.configure(context);
+    final var controllerSpy = spy(new ExporterTestController());
+    exporter.open(controllerSpy);
+
+    // when
+    final var record = factory.generateRecord(ValueType.USER);
+    final var record2 = factory.generateRecord(ValueType.USER);
+
+    exporter.export(record);
+    exporter.export(record2);
+    // then
+    verify(controllerSpy, never()).updateLastExportedRecordPosition(record.getPosition());
+    verify(controllerSpy).updateLastExportedRecordPosition(record2.getPosition());
+  }
+
+  @ParameterizedTest
+  @MethodSource("containerProvider")
+  void shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater(
+      final GenericContainer<?> container) {
+    // given
+    final var config = getConnectConfigForContainer(container);
+    final var exporter = new CamundaExporter(mockResourceProvider(Set.of(), Set.of(), config));
+
+    final var context = getContextFromConfig(config);
+    final ExporterTestController controller = Mockito.spy(new ExporterTestController());
+
     exporter.configure(context);
     exporter.open(controller);
 
-    return exporter;
+    // when
+    final var currentPort = container.getFirstMappedPort();
+    container.stop();
+    Awaitility.await().until(() -> !container.isRunning());
+
+    final Record<UserRecordValue> record = factory.generateRecord(ValueType.USER);
+
+    assertThatThrownBy(() -> exporter.export(record))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining("Connection refused");
+
+    // starts the container on the same port again
+    container
+        .withEnv("discovery.type", "single-node")
+        .setPortBindings(List.of(currentPort + ":9200"));
+    container.start();
+
+    final Record<UserRecordValue> record2 = factory.generateRecord(ValueType.USER);
+    exporter.export(record2);
+
+    Awaitility.await()
+        .untilAsserted(() -> assertThat(controller.getPosition()).isEqualTo(record2.getPosition()));
   }
 
-  private List<Permission> extractPermissions(final AuthorizationRecordValue record) {
-    return record.getPermissions().stream()
-        .map(
-            permissionValue ->
-                new Permission(
-                    permissionValue.getPermissionType(), permissionValue.getResourceIds()))
-        .collect(Collectors.toList());
-  }
-
-  private Context getContext() {
-    return new ExporterTestContext()
-        .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
-  }
-
-  private ExporterResourceProvider mockResourceProvider(
-      final Set<IndexDescriptor> indexDescriptors,
-      final Set<IndexTemplateDescriptor> templateDescriptors) {
-    final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
-    provider.init(CONFIG);
-    when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
-    when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);
-
-    return provider;
-  }
-
-  void shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
-      final Callable<JsonNode> getIndex, final Callable<JsonNode> getTemplate) throws Exception {
+  @TestTemplate
+  void shouldPeriodicallyFlushBasedOnConfiguration(
+      final ExporterConfiguration config, final SearchClientAdapter ignored) {
     // given
-    CONFIG.setCreateSchema(true);
+    final var duration = 2;
+    config.getBulk().setDelay(duration);
 
-    final var exporter1 = startExporter();
-    final var exporter2 = startExporter();
-
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    final var exporter = createExporter(Set.of(), Set.of(), config);
 
     // when
-    exporter1.open(controller);
-    exporter2.open(controller);
+    final ExporterTestController controller = new ExporterTestController();
+    final var spiedController = spy(controller);
+    exporter.open(spiedController);
+
+    spiedController.runScheduledTasks(Duration.ofSeconds(duration));
 
     // then
-    final var retrievedIndex = getIndex.call();
-    final var retrievedIndexTemplate = getTemplate.call();
-
-    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
-        .isTrue();
-    assertThat(
-            mappingsMatch(
-                retrievedIndexTemplate.at("/index_template/template/mappings"),
-                "/mappings-added-property.json"))
-        .isTrue();
+    verify(spiedController, times(2)).scheduleCancellableTask(eq(Duration.ofSeconds(2)), any());
   }
 
-  void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
-      final Callable<JsonNode> getIndex, final Callable<JsonNode> getTemplate) throws Exception {
-    // given
-    CONFIG.setCreateSchema(true);
-    final var updatedExporter = startExporter();
-    final var oldExporter = startExporter();
-
-    // when
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
-
-    updatedExporter.open(controller);
-
-    when(index.getMappingsClasspathFilename()).thenReturn("/mappings.json");
-    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings.json");
-
-    oldExporter.open(controller);
-
-    // then
-    final var retrievedIndex = getIndex.call();
-    final var retrievedIndexTemplate = getTemplate.call();
-
-    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
-        .isTrue();
-    assertThat(
-            mappingsMatch(
-                retrievedIndexTemplate.at("/index_template/template/mappings"),
-                "/mappings-added-property.json"))
-        .isTrue();
-  }
-
+  @TestTemplate
   void shouldExportUserRecord(
-      final Callable<UserEntity> getResponse, final Record<UserRecordValue> record)
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws Exception {
     // given
-    CONFIG.setCreateSchema(true);
-    final var exporter = startExporter();
+    final var exporter = createExporter(Set.of(), Set.of(), config);
 
     // when
+    final Record<UserRecordValue> record = factory.generateRecord(ValueType.USER);
+    final String recordId = String.valueOf(record.getKey());
     exporter.export(record);
 
     // then
-    final var responseUserEntity = getResponse.call();
+    final var responseUserEntity =
+        clientAdapter.get(
+            recordId, config.getIndex().getPrefix() + "-identity-users-8.7.0_", UserEntity.class);
 
     assertThat(responseUserEntity)
         .describedAs("User entity is updated correctly from the user record")
@@ -278,19 +223,24 @@ final class CamundaExporterIT {
             String.valueOf(record.getKey()));
   }
 
+  @TestTemplate
   void shouldExportAuthorizationRecord(
-      final Callable<AuthorizationEntity> getResponse,
-      final Record<AuthorizationRecordValue> record)
-      throws Exception {
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+      throws IOException {
     // given
-    CONFIG.setCreateSchema(true);
-    final var exporter = startExporter();
+    final var exporter = createExporter(Set.of(), Set.of(), config);
 
     // when
+    final Record<AuthorizationRecordValue> record = factory.generateRecord(ValueType.AUTHORIZATION);
+    final var recordId = String.valueOf(record.getKey());
     exporter.export(record);
 
     // then
-    final var responseAuthorizationEntity = getResponse.call();
+    final var responseAuthorizationEntity =
+        clientAdapter.get(
+            recordId,
+            config.getIndex().getPrefix() + "-identity-authorizations-8.7.0_",
+            AuthorizationEntity.class);
 
     assertThat(responseAuthorizationEntity)
         .describedAs("Authorization entity is updated correctly from the authorization record")
@@ -308,267 +258,128 @@ final class CamundaExporterIT {
             String.valueOf(record.getKey()));
   }
 
-  void shouldExportRecordOnceBulkSizeReached() {
+  @TestTemplate
+  void shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
     // given
-    CONFIG.getBulk().setSize(2);
-    CONFIG.setCreateSchema(true);
-    final var exporter = new CamundaExporter();
+    final var exporter1 = createExporter(Set.of(index), Set.of(indexTemplate), config);
+    final var exporter2 = createExporter(Set.of(index), Set.of(indexTemplate), config);
 
-    final var context = getContext();
-    exporter.configure(context);
-    final var controllerSpy = spy(controller);
-    exporter.open(controllerSpy);
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
 
     // when
-    final var record = factory.generateRecord(ValueType.USER);
-    final var record2 = factory.generateRecord(ValueType.USER);
+    exporter1.open(new ExporterTestController());
+    exporter2.open(new ExporterTestController());
 
-    exporter.export(record);
-    exporter.export(record2);
     // then
-    verify(controllerSpy, never()).updateLastExportedRecordPosition(record.getPosition());
-    verify(controllerSpy).updateLastExportedRecordPosition(record2.getPosition());
+    final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    final var retrievedIndexTemplate =
+        clientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+
+    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
+        .isTrue();
+    assertThat(
+            mappingsMatch(
+                retrievedIndexTemplate.at("/index_template/template/mappings"),
+                "/mappings-added-property.json"))
+        .isTrue();
   }
 
-  void shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater(
-      final GenericContainer<?> container, final Callable<Long> getTotalUsers) {
+  @TestTemplate
+  void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
+      throws Exception {
     // given
-    final var exporter = new CamundaExporter();
-
-    final var context =
-        new ExporterTestContext()
-            .setConfiguration(
-                new ExporterTestConfiguration<>(CONFIG.getConnect().getType(), CONFIG));
-
-    exporter.configure(context);
-    exporter.open(controller);
+    final var updatedExporter = createExporter(Set.of(index), Set.of(indexTemplate), config);
+    final var oldExporter = createExporter(Set.of(index), Set.of(indexTemplate), config);
 
     // when
-    final var currentPort = container.getFirstMappedPort();
-    container.stop();
-    Awaitility.await().until(() -> !container.isRunning());
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings-added-property.json");
 
-    final Record<UserRecordValue> record = factory.generateRecord(ValueType.USER);
+    updatedExporter.open(new ExporterTestController());
 
-    Assertions.assertThatThrownBy(() -> exporter.export(record))
-        .isInstanceOf(ExporterException.class)
-        .hasMessageContaining("Connection refused");
+    when(index.getMappingsClasspathFilename()).thenReturn("/mappings.json");
+    when(indexTemplate.getMappingsClasspathFilename()).thenReturn("/mappings.json");
 
-    // starts the container on the same port again
-    container
-        .withEnv("discovery.type", "single-node")
-        .setPortBindings(List.of(currentPort + ":9200"));
+    oldExporter.open(new ExporterTestController());
+
+    // then
+    final var retrievedIndex = clientAdapter.getIndexAsNode(index.getFullQualifiedName());
+    final var retrievedIndexTemplate =
+        clientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName());
+
+    assertThat(mappingsMatch(retrievedIndex.get("mappings"), "/mappings-added-property.json"))
+        .isTrue();
+    assertThat(
+            mappingsMatch(
+                retrievedIndexTemplate.at("/index_template/template/mappings"),
+                "/mappings-added-property.json"))
+        .isTrue();
+  }
+
+  private static Stream<Arguments> containerProvider() {
+    return Stream.of(
+        Arguments.of(TestSupport.createDefeaultElasticsearchContainer()),
+        Arguments.of(TestSupport.createDefaultOpensearchContainer()));
+  }
+
+  private ExporterConfiguration getConnectConfigForContainer(final GenericContainer<?> container) {
     container.start();
+    Awaitility.await().until(container::isRunning);
 
-    final Record<UserRecordValue> record2 = factory.generateRecord(ValueType.USER);
-    exporter.export(record2);
+    final var config = new ExporterConfiguration();
+    config.getConnect().setUrl("http://localhost:" + container.getFirstMappedPort());
+    config.getBulk().setSize(1);
 
-    Awaitility.await().until(() -> getTotalUsers.call() == 2L);
+    if (container.getDockerImageName().contains(ConnectionTypes.ELASTICSEARCH.getType())) {
+      config.getConnect().setType(ConnectionTypes.ELASTICSEARCH.getType());
+    }
 
-    container.setPortBindings(List.of());
+    if (container.getDockerImageName().contains(ConnectionTypes.OPENSEARCH.getType())) {
+      config.getConnect().setType(ConnectionTypes.OPENSEARCH.getType());
+    }
+    return config;
   }
 
-  @Test
-  void shouldValidateConfigWhenExporterConfigures() {
-    final var exporter = new CamundaExporter();
-    final var context =
-        new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("elastic", CONFIG));
-
-    try (final var mockedStatic = Mockito.mockStatic(ConfigValidator.class)) {
-      exporter.configure(context);
-
-      mockedStatic.verify(
-          () -> ConfigValidator.validate(any(ExporterConfiguration.class)), times(1));
-    }
+  private List<Permission> extractPermissions(final AuthorizationRecordValue record) {
+    return record.getPermissions().stream()
+        .map(
+            permissionValue ->
+                new Permission(
+                    permissionValue.getPermissionType().name(), permissionValue.getResourceIds()))
+        .collect(Collectors.toList());
   }
 
-  @Nested
-  @Testcontainers
-  class ElasticsearchBackedExporter {
-    @Container
-    private static final ElasticsearchContainer CONTAINER =
-        TestSupport.createDefeaultElasticsearchContainer();
-
-    private static ElasticsearchClient client;
-    private static final SearchClientAdapter elsClientAdapter = new SearchClientAdapter(client);
-    private final ProtocolFactory factory = new ProtocolFactory();
-
-    @BeforeEach
-    public void beforeEach() throws IOException {
-      client.indices().delete(req -> req.index("*"));
-      client.indices().deleteIndexTemplate(req -> req.name("*"));
-    }
-
-    @BeforeAll
-    public static void init() {
-      CONFIG.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-      CONFIG.getConnect().setType("elasticsearch");
-      client = new ElasticsearchConnector(CONFIG.getConnect()).createClient();
-    }
-
-    @Test
-    void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws Exception {
-      CamundaExporterIT.this.shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
-          () -> elsClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
-          () -> elsClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
-    }
-
-    @Test
-    void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws Exception {
-      CamundaExporterIT.this.shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
-          () -> elsClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
-          () -> elsClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
-    }
-
-    @Test
-    void shouldExportUserRecord() throws Exception {
-      final Record<UserRecordValue> record = factory.generateRecord(ValueType.USER);
-
-      final var recordId = String.valueOf(record.getKey());
-
-      CamundaExporterIT.this.shouldExportUserRecord(
-          () ->
-              client
-                  .get(
-                      b -> b.id(recordId).index("camunda-record-identity-users-8.7.0_"),
-                      UserEntity.class)
-                  .source(),
-          record);
-    }
-
-    @Test
-    void shouldExportAuthorizationRecord() throws Exception {
-      final Record<AuthorizationRecordValue> record =
-          factory.generateRecord(ValueType.AUTHORIZATION);
-      final var recordId = String.valueOf(record.getKey());
-
-      CamundaExporterIT.this.shouldExportAuthorizationRecord(
-          () ->
-              client
-                  .get(
-                      b -> b.id(recordId).index("camunda-record-identity-authorizations-8.7.0_"),
-                      AuthorizationEntity.class)
-                  .source(),
-          record);
-    }
-
-    @Test
-    void shouldExportRecordOnceBulkSizeReached() {
-      CamundaExporterIT.this.shouldExportRecordOnceBulkSizeReached();
-    }
-
-    @Test
-    void shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater() {
-      CamundaExporterIT.this
-          .shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater(
-              CONTAINER,
-              () ->
-                  client
-                      .search(
-                          s -> s.index("camunda-record-identity-users-8.7.0_"), UserEntity.class)
-                      .hits()
-                      .total()
-                      .value());
-    }
-
-    @Test
-    void shouldUpdateExporterPositionAfterFlushing() {
-      CamundaExporterIT.this.shouldUpdateExporterPositionAfterFlushing();
-    }
+  private Context getContextFromConfig(final ExporterConfiguration config) {
+    return new ExporterTestContext()
+        .setConfiguration(new ExporterTestConfiguration<>(config.getConnect().getType(), config));
   }
 
-  @Nested
-  @Testcontainers
-  class OpensearchBackedExporter {
-    @Container
-    private static final OpensearchContainer<?> CONTAINER =
-        TestSupport.createDefaultOpensearchContainer();
+  private CamundaExporter createExporter(
+      final Set<IndexDescriptor> indexDescriptors,
+      final Set<IndexTemplateDescriptor> templateDescriptors,
+      final ExporterConfiguration config) {
+    final var exporter =
+        new CamundaExporter(mockResourceProvider(indexDescriptors, templateDescriptors, config));
+    exporter.configure(getContextFromConfig(config));
+    exporter.open(new ExporterTestController());
 
-    private static OpenSearchClient client;
-    private static final SearchClientAdapter osClientAdapter = new SearchClientAdapter(client);
-    private final ProtocolFactory factory = new ProtocolFactory();
+    return exporter;
+  }
 
-    @BeforeEach
-    public void beforeEach() throws IOException {
-      client.indices().delete(req -> req.index(CONFIG.getIndex().getPrefix() + "*"));
-      client.indices().deleteIndexTemplate(req -> req.name("*"));
-    }
+  private ExporterResourceProvider mockResourceProvider(
+      final Set<IndexDescriptor> indexDescriptors,
+      final Set<IndexTemplateDescriptor> templateDescriptors,
+      final ExporterConfiguration config) {
+    final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
+    provider.init(config);
 
-    @BeforeAll
-    public static void init() {
-      CONFIG.getConnect().setUrl(CONTAINER.getHttpHostAddress());
-      CONFIG.getConnect().setType("opensearch");
-      client = new OpensearchConnector(CONFIG.getConnect()).createClient();
-    }
+    when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
+    when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);
 
-    @Test
-    void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws Exception {
-      CamundaExporterIT.this.shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
-          () -> osClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
-          () -> osClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
-    }
-
-    @Test
-    void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws Exception {
-      CamundaExporterIT.this.shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
-          () -> osClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
-          () -> osClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
-    }
-
-    @Test
-    void shouldExportUserRecord() throws Exception {
-      final Record<UserRecordValue> record = factory.generateRecord(ValueType.USER);
-      final var recordId = String.valueOf(record.getKey());
-
-      CamundaExporterIT.this.shouldExportUserRecord(
-          () ->
-              client
-                  .get(
-                      b -> b.id(recordId).index("camunda-record-identity-users-8.7.0_"),
-                      UserEntity.class)
-                  .source(),
-          record);
-    }
-
-    @Test
-    void shouldExportAuthorizationRecord() throws Exception {
-      final Record<AuthorizationRecordValue> record =
-          factory.generateRecord(ValueType.AUTHORIZATION);
-      final var recordId = String.valueOf(record.getKey());
-
-      CamundaExporterIT.this.shouldExportAuthorizationRecord(
-          () ->
-              client
-                  .get(
-                      b -> b.id(recordId).index("camunda-record-identity-authorizations-8.7.0_"),
-                      AuthorizationEntity.class)
-                  .source(),
-          record);
-    }
-
-    @Test
-    void shouldExportRecordOnceBulkSizeReached() {
-      CamundaExporterIT.this.shouldExportRecordOnceBulkSizeReached();
-    }
-
-    @Test
-    void shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater() {
-      CamundaExporterIT.this
-          .shouldExportRecordIfElasticsearchIsNotInitiallyReachableButThenIsReachableLater(
-              CONTAINER,
-              () ->
-                  client
-                      .search(
-                          s -> s.index("camunda-record-identity-users-8.7.0_"), UserEntity.class)
-                      .hits()
-                      .total()
-                      .value());
-    }
-
-    @Test
-    void shouldUpdateExporterPositionAfterFlushing() {
-      CamundaExporterIT.this.shouldUpdateExporterPositionAfterFlushing();
-    }
+    return provider;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -7,10 +7,6 @@
  */
 package io.camunda.exporter;
 
-import static io.camunda.exporter.schema.SchemaTestUtil.getElsIndexAsNode;
-import static io.camunda.exporter.schema.SchemaTestUtil.getElsIndexTemplateAsNode;
-import static io.camunda.exporter.schema.SchemaTestUtil.getOpensearchIndexAsNode;
-import static io.camunda.exporter.schema.SchemaTestUtil.getOpensearchIndexTemplateAsNode;
 import static io.camunda.exporter.schema.SchemaTestUtil.mappingsMatch;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -28,6 +24,7 @@ import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SchemaTestUtil;
+import io.camunda.exporter.utils.SearchClientAdapter;
 import io.camunda.exporter.utils.TestSupport;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
@@ -377,6 +374,7 @@ final class CamundaExporterIT {
         TestSupport.createDefeaultElasticsearchContainer();
 
     private static ElasticsearchClient client;
+    private static final SearchClientAdapter elsClientAdapter = new SearchClientAdapter(client);
     private final ProtocolFactory factory = new ProtocolFactory();
 
     @BeforeEach
@@ -395,15 +393,15 @@ final class CamundaExporterIT {
     @Test
     void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws Exception {
       CamundaExporterIT.this.shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
-          () -> getElsIndexAsNode(index.getFullQualifiedName(), client),
-          () -> getElsIndexTemplateAsNode(indexTemplate.getTemplateName(), client));
+          () -> elsClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
+          () -> elsClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
     }
 
     @Test
     void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws Exception {
       CamundaExporterIT.this.shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
-          () -> getElsIndexAsNode(index.getFullQualifiedName(), client),
-          () -> getElsIndexTemplateAsNode(indexTemplate.getTemplateName(), client));
+          () -> elsClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
+          () -> elsClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
     }
 
     @Test
@@ -471,6 +469,7 @@ final class CamundaExporterIT {
         TestSupport.createDefaultOpensearchContainer();
 
     private static OpenSearchClient client;
+    private static final SearchClientAdapter osClientAdapter = new SearchClientAdapter(client);
     private final ProtocolFactory factory = new ProtocolFactory();
 
     @BeforeEach
@@ -489,15 +488,15 @@ final class CamundaExporterIT {
     @Test
     void shouldHaveCorrectSchemaUpdatesWithMultipleExporters() throws Exception {
       CamundaExporterIT.this.shouldHaveCorrectSchemaUpdatesWithMultipleExporters(
-          () -> getOpensearchIndexAsNode(index.getFullQualifiedName(), client),
-          () -> getOpensearchIndexTemplateAsNode(indexTemplate.getTemplateName(), client));
+          () -> osClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
+          () -> osClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
     }
 
     @Test
     void shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted() throws Exception {
       CamundaExporterIT.this.shouldNotErrorIfOldExporterRestartsWhileNewExporterHasAlreadyStarted(
-          () -> getOpensearchIndexAsNode(index.getFullQualifiedName(), client),
-          () -> getOpensearchIndexTemplateAsNode(indexTemplate.getTemplateName(), client));
+          () -> osClientAdapter.getIndexAsNode(index.getFullQualifiedName()),
+          () -> osClientAdapter.getIndexTemplateAsNode(indexTemplate.getTemplateName()));
     }
 
     @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.config;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.exporter.api.ExporterException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ConfigValidatorTest {
+  private static ExporterConfiguration CONFIG = new ExporterConfiguration();
+
+  @BeforeEach
+  void reset() {
+    CONFIG = new ExporterConfiguration();
+  }
+
+  @Test
+  void shouldRejectWrongConnectionType() {
+    // given
+    CONFIG.getConnect().setType("mysql");
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+  }
+
+  @Test
+  void shouldNotAllowUnderscoreInIndexPrefix() {
+    // given
+    CONFIG.getIndex().setPrefix("i_am_invalid");
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(ints = {-1, 0})
+  void shouldForbidNonPositiveNumberOfShards(final int invalidNumberOfShards) {
+    // given
+    CONFIG.getIndex().setNumberOfShards(invalidNumberOfShards);
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @ValueSource(strings = {"1", "-1", "1ms"})
+  void shouldNotAllowInvalidMinimumAge(final String invalidMinAge) {
+    // given
+    CONFIG.getRetention().setMinimumAge(invalidMinAge);
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(CONFIG))
+        .isInstanceOf(ExporterException.class)
+        .hasMessageContaining("must match pattern '^[0-9]+[dhms]$'")
+        .hasMessageContaining("minimumAge '" + invalidMinAge + "'");
+  }
+
+  @Test
+  void shouldForbidNegativeNumberOfReplicas() {
+    // given
+    CONFIG.getIndex().setNumberOfReplicas(-1);
+
+    // when - then
+    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -16,49 +16,49 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class ConfigValidatorTest {
-  private static ExporterConfiguration CONFIG = new ExporterConfiguration();
+  private static ExporterConfiguration config = new ExporterConfiguration();
 
   @BeforeEach
   void reset() {
-    CONFIG = new ExporterConfiguration();
+    config = new ExporterConfiguration();
   }
 
   @Test
   void shouldRejectWrongConnectionType() {
     // given
-    CONFIG.getConnect().setType("mysql");
+    config.getConnect().setType("mysql");
 
     // when - then
-    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+    assertThatCode(() -> ConfigValidator.validate(config)).isInstanceOf(ExporterException.class);
   }
 
   @Test
   void shouldNotAllowUnderscoreInIndexPrefix() {
     // given
-    CONFIG.getIndex().setPrefix("i_am_invalid");
+    config.getIndex().setPrefix("i_am_invalid");
 
     // when - then
-    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+    assertThatCode(() -> ConfigValidator.validate(config)).isInstanceOf(ExporterException.class);
   }
 
   @ParameterizedTest(name = "{0}")
   @ValueSource(ints = {-1, 0})
   void shouldForbidNonPositiveNumberOfShards(final int invalidNumberOfShards) {
     // given
-    CONFIG.getIndex().setNumberOfShards(invalidNumberOfShards);
+    config.getIndex().setNumberOfShards(invalidNumberOfShards);
 
     // when - then
-    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+    assertThatCode(() -> ConfigValidator.validate(config)).isInstanceOf(ExporterException.class);
   }
 
   @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {"1", "-1", "1ms"})
   void shouldNotAllowInvalidMinimumAge(final String invalidMinAge) {
     // given
-    CONFIG.getRetention().setMinimumAge(invalidMinAge);
+    config.getRetention().setMinimumAge(invalidMinAge);
 
     // when - then
-    assertThatCode(() -> ConfigValidator.validate(CONFIG))
+    assertThatCode(() -> ConfigValidator.validate(config))
         .isInstanceOf(ExporterException.class)
         .hasMessageContaining("must match pattern '^[0-9]+[dhms]$'")
         .hasMessageContaining("minimumAge '" + invalidMinAge + "'");
@@ -67,9 +67,9 @@ public class ConfigValidatorTest {
   @Test
   void shouldForbidNegativeNumberOfReplicas() {
     // given
-    CONFIG.getIndex().setNumberOfReplicas(-1);
+    config.getIndex().setNumberOfReplicas(-1);
 
     // when - then
-    assertThatCode(() -> ConfigValidator.validate(CONFIG)).isInstanceOf(ExporterException.class);
+    assertThatCode(() -> ConfigValidator.validate(config)).isInstanceOf(ExporterException.class);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class IndexMappingTest {
+
+  @Test
+  void shouldReadIndexMappingsFileCorrectly() {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
+
+    // when
+    final var indexMapping = IndexMapping.from(index, new ObjectMapper());
+
+    // then
+    assertThat(indexMapping.dynamic()).isEqualTo("strict");
+
+    assertThat(indexMapping.properties())
+        .containsExactlyInAnyOrder(
+            new IndexMappingProperty.Builder()
+                .name("hello")
+                .typeDefinition(Map.of("type", "text"))
+                .build(),
+            new IndexMappingProperty.Builder()
+                .name("world")
+                .typeDefinition(Map.of("type", "keyword"))
+                .build());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -70,11 +71,14 @@ public class SchemaManagerIT {
   }
 
   @BeforeEach
-  public void refresh() throws IOException {
-    elsClient.indices().delete(req -> req.index("*"));
-    elsClient.indices().deleteIndexTemplate(req -> req.name("*"));
-    osClient.indices().delete(req -> req.index(config.getIndex().getPrefix() + "*"));
-    osClient.indices().deleteIndexTemplate(req -> req.name("*"));
+  public void refresh(final TestInfo testInfo) throws IOException {
+    if (testInfo.getDisplayName().contains("elasticsearch")) {
+      elsClient.indices().delete(req -> req.index("*"));
+      elsClient.indices().deleteIndexTemplate(req -> req.name("*"));
+    } else if (testInfo.getDisplayName().contains("opensearch")) {
+      osClient.indices().delete(req -> req.index(config.getIndex().getPrefix() + "*"));
+      osClient.indices().deleteIndexTemplate(req -> req.name("*"));
+    }
     config = new ExporterConfiguration();
 
     indexTemplate =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaTestUtil.java
@@ -11,24 +11,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
-import co.elastic.clients.elasticsearch.ilm.get_lifecycle.Lifecycle;
-import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplateItem;
 import co.elastic.clients.json.JsonpMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.exporter.SchemaResourceSerializer;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch.indices.IndexState;
 
 public final class SchemaTestUtil {
 
@@ -108,93 +101,6 @@ public final class SchemaTestUtil {
               expectedMappings, new TypeReference<Map<String, Map<String, Object>>>() {});
       return (Map<String, Map<String, Object>>) jsonMap.get("mappings").get("properties");
     }
-  }
-
-  public static JsonNode opensearchIndexToNode(final IndexState index) throws IOException {
-    final var indexAsMap =
-        SchemaResourceSerializer.serialize(
-            JacksonJsonpGenerator::new, (gen) -> index.serialize(gen, OPENSEARCH_JSON_MAPPER));
-
-    return MAPPER.valueToTree(indexAsMap);
-  }
-
-  public static JsonNode elsIndexToNode(
-      final co.elastic.clients.elasticsearch.indices.IndexState index) throws IOException {
-    final var indexAsMap =
-        SchemaResourceSerializer.serialize(
-            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
-            (gen) -> index.serialize(gen, ELS_JSON_MAPPER));
-
-    return MAPPER.valueToTree(indexAsMap);
-  }
-
-  public static JsonNode elsIndexTemplateToNode(final IndexTemplateItem indexTemplate)
-      throws IOException {
-    final var templateAsMap =
-        SchemaResourceSerializer.serialize(
-            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
-            (gen) -> indexTemplate.serialize(gen, ELS_JSON_MAPPER));
-
-    return MAPPER.valueToTree(templateAsMap);
-  }
-
-  public static JsonNode opensearchIndexTemplateToNode(
-      final org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem
-          indexTemplate)
-      throws IOException {
-    final var templateAsMap =
-        SchemaResourceSerializer.serialize(
-            JacksonJsonpGenerator::new,
-            (gen) -> indexTemplate.serialize(gen, OPENSEARCH_JSON_MAPPER));
-
-    return MAPPER.valueToTree(templateAsMap);
-  }
-
-  public static JsonNode elsPolicyToNode(final Lifecycle lifecyclePolicy) throws IOException {
-    final var policyAsMap =
-        SchemaResourceSerializer.serialize(
-            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
-            (gen) -> lifecyclePolicy.serialize(gen, ELS_JSON_MAPPER));
-
-    return MAPPER.valueToTree(policyAsMap);
-  }
-
-  public static JsonNode getOpensearchIndexAsNode(
-      final String indexName, final OpenSearchClient client) throws IOException {
-    final var updatedIndex = client.indices().get(req -> req.index(indexName)).get(indexName);
-
-    return opensearchIndexToNode(updatedIndex);
-  }
-
-  public static JsonNode getOpensearchIndexTemplateAsNode(
-      final String templateName, final OpenSearchClient client) throws IOException {
-    final var template =
-        client
-            .indices()
-            .getIndexTemplate(req -> req.name(templateName))
-            .indexTemplates()
-            .getFirst();
-
-    return opensearchIndexTemplateToNode(template);
-  }
-
-  public static JsonNode getElsIndexAsNode(final String indexName, final ElasticsearchClient client)
-      throws IOException {
-    final var updatedIndex = client.indices().get(req -> req.index(indexName)).get(indexName);
-
-    return elsIndexToNode(updatedIndex);
-  }
-
-  public static JsonNode getElsIndexTemplateAsNode(
-      final String templateName, final ElasticsearchClient client) throws IOException {
-    final var template =
-        client
-            .indices()
-            .getIndexTemplate(req -> req.name(templateName))
-            .indexTemplates()
-            .getFirst();
-
-    return elsIndexTemplateToNode(template);
   }
 
   public static boolean mappingsMatch(final JsonNode mappings, final String fileName)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -45,10 +45,10 @@ public class CamundaExporterITInvocationProvider
     final var config = new ExporterConfiguration();
     config.getIndex().setPrefix(CONFIG_PREFIX);
     config.getBulk().setSize(1); // force flushing on the first record
-    switch (connectionType) {
-      case ELASTICSEARCH -> config.getConnect().setUrl(elsContainer.getHttpHostAddress());
-      case OPENSEARCH -> config.getConnect().setUrl(osContainer.getHttpHostAddress());
-      default -> throw new IllegalArgumentException("Unknown connection type: " + connectionType);
+    if (connectionType == ELASTICSEARCH) {
+      config.getConnect().setUrl(elsContainer.getHttpHostAddress());
+    } else if (connectionType == OPENSEARCH) {
+      config.getConnect().setUrl(osContainer.getHttpHostAddress());
     }
     config.getConnect().setType(connectionType.getType());
     return config;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import static io.camunda.exporter.config.ConnectionTypes.ELASTICSEARCH;
+import static io.camunda.exporter.config.ConnectionTypes.OPENSEARCH;
+import static java.util.Arrays.asList;
+
+import io.camunda.exporter.config.ConnectionTypes;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public class CamundaExporterITInvocationProvider
+    implements TestTemplateInvocationContextProvider, AfterAllCallback, BeforeAllCallback {
+
+  public static final String CONFIG_PREFIX = "camunda-record";
+  private final ElasticsearchContainer elsContainer =
+      TestSupport.createDefeaultElasticsearchContainer();
+  private final OpensearchContainer<?> osContainer = TestSupport.createDefaultOpensearchContainer();
+
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  private ExporterConfiguration getConfigWithConnectionDetails(
+      final ConnectionTypes connectionType) {
+    final var config = new ExporterConfiguration();
+    config.getIndex().setPrefix(CONFIG_PREFIX);
+    config.getBulk().setSize(1); // force flushing on the first record
+    switch (connectionType) {
+      case ELASTICSEARCH -> config.getConnect().setUrl(elsContainer.getHttpHostAddress());
+      case OPENSEARCH -> config.getConnect().setUrl(osContainer.getHttpHostAddress());
+      default -> throw new IllegalArgumentException("Unknown connection type: " + connectionType);
+    }
+    config.getConnect().setType(connectionType.getType());
+    return config;
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    elsContainer.start();
+    osContainer.start();
+
+    closeables.add(elsContainer);
+    closeables.add(osContainer);
+  }
+
+  @Override
+  public boolean supportsTestTemplate(final ExtensionContext extensionContext) {
+    // we only want to template tests in the class which ask for configuration and the client
+    // adapter.
+    final var testParams = extensionContext.getTestMethod().orElseThrow().getParameters();
+    if (testParams.length != 2) {
+      return false;
+    }
+
+    return (testParams[0].getType().equals(ExporterConfiguration.class)
+        && testParams[1].getType().equals(SearchClientAdapter.class));
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      final ExtensionContext extensionContext) {
+    final var osConfig = getConfigWithConnectionDetails(OPENSEARCH);
+    final var osClient = new OpensearchConnector(osConfig.getConnect()).createClient();
+    final var osClientAdapter = new SearchClientAdapter(osClient);
+
+    final var elsConfig = getConfigWithConnectionDetails(ELASTICSEARCH);
+    final var elsClient = new ElasticsearchConnector(elsConfig.getConnect()).createClient();
+    final var elsClientAdapter = new SearchClientAdapter(elsClient);
+
+    try {
+      elsClient.indices().delete(req -> req.index("*"));
+      elsClient.indices().deleteIndexTemplate(req -> req.name("*"));
+      osClient.indices().delete(req -> req.index("*"));
+      osClient.indices().deleteIndexTemplate(req -> req.name("*"));
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to reset container data", e);
+    }
+    return Stream.of(
+        invocationContext(osConfig, osClientAdapter),
+        invocationContext(elsConfig, elsClientAdapter));
+  }
+
+  private TestTemplateInvocationContext invocationContext(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter) {
+    return new TestTemplateInvocationContext() {
+
+      @Override
+      public String getDisplayName(final int invocationIndex) {
+        return config.getConnect().getType();
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return asList(
+            new ParameterResolver() {
+
+              @Override
+              public boolean supportsParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return parameterCtx.getParameter().getType().equals(ExporterConfiguration.class);
+              }
+
+              @Override
+              public Object resolveParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return config;
+              }
+            },
+            new ParameterResolver() {
+
+              @Override
+              public boolean supportsParameter(
+                  final ParameterContext parameterContext, final ExtensionContext extensionContext)
+                  throws ParameterResolutionException {
+                return parameterContext.getParameter().getType().equals(SearchClientAdapter.class);
+              }
+
+              @Override
+              public Object resolveParameter(
+                  final ParameterContext parameterContext, final ExtensionContext extensionContext)
+                  throws ParameterResolutionException {
+                return clientAdapter;
+              }
+            });
+      }
+    };
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    closeables.parallelStream()
+        .forEach(
+            c -> {
+              try {
+                c.close();
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.ilm.get_lifecycle.Lifecycle;
+import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplateItem;
+import co.elastic.clients.json.JsonpMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.SchemaResourceSerializer;
+import java.io.IOException;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.indices.IndexState;
+
+public class SearchClientAdapter {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final JsonpMapper ELS_JSON_MAPPER =
+      new co.elastic.clients.json.jackson.JacksonJsonpMapper(MAPPER);
+  private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSON_MAPPER =
+      new JacksonJsonpMapper(MAPPER);
+
+  private final ElasticsearchClient elsClient;
+  private final OpenSearchClient osClient;
+
+  public SearchClientAdapter(final ElasticsearchClient elsClient) {
+    this.elsClient = elsClient;
+    osClient = null;
+  }
+
+  public SearchClientAdapter(final OpenSearchClient osClient) {
+    elsClient = null;
+    this.osClient = osClient;
+  }
+
+  private JsonNode opensearchIndexToNode(final IndexState index) throws IOException {
+    final var indexAsMap =
+        SchemaResourceSerializer.serialize(
+            JacksonJsonpGenerator::new, (gen) -> index.serialize(gen, OPENSEARCH_JSON_MAPPER));
+
+    return MAPPER.valueToTree(indexAsMap);
+  }
+
+  private JsonNode elsIndexToNode(final co.elastic.clients.elasticsearch.indices.IndexState index)
+      throws IOException {
+    final var indexAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> index.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(indexAsMap);
+  }
+
+  private JsonNode elsIndexTemplateToNode(final IndexTemplateItem indexTemplate)
+      throws IOException {
+    final var templateAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> indexTemplate.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(templateAsMap);
+  }
+
+  private JsonNode opensearchIndexTemplateToNode(
+      final org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem
+          indexTemplate)
+      throws IOException {
+    final var templateAsMap =
+        SchemaResourceSerializer.serialize(
+            JacksonJsonpGenerator::new,
+            (gen) -> indexTemplate.serialize(gen, OPENSEARCH_JSON_MAPPER));
+
+    return MAPPER.valueToTree(templateAsMap);
+  }
+
+  private JsonNode elsPolicyToNode(final Lifecycle lifecyclePolicy) throws IOException {
+    final var policyAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> lifecyclePolicy.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(policyAsMap);
+  }
+
+  public JsonNode getIndexAsNode(final String indexName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var index = elsClient.indices().get(req -> req.index(indexName)).get(indexName);
+        return elsIndexToNode(index);
+      }
+      case "osClient" -> {
+        final var index = osClient.indices().get(req -> req.index(indexName)).get(indexName);
+        return opensearchIndexToNode(index);
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public JsonNode getPolicyAsNode(final String policyName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var policy =
+            elsClient.ilm().getLifecycle(req -> req.name(policyName)).result().get(policyName);
+
+        return elsPolicyToNode(policy);
+      }
+      case "osClient" -> {
+        final var request =
+            Requests.builder()
+                .method("GET")
+                .endpoint("_plugins/_ism/policies/" + policyName)
+                .build();
+
+        return MAPPER.readTree(osClient.generic().execute(request).getBody().get().body());
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public JsonNode getIndexTemplateAsNode(final String templateName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var template =
+            elsClient
+                .indices()
+                .getIndexTemplate(req -> req.name(templateName))
+                .indexTemplates()
+                .getFirst();
+        return elsIndexTemplateToNode(template);
+      }
+      case "osClient" -> {
+        final var template =
+            osClient
+                .indices()
+                .getIndexTemplate(req -> req.name(templateName))
+                .indexTemplates()
+                .getFirst();
+
+        return opensearchIndexTemplateToNode(template);
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public <T> T get(final String id, final String index, final Class<T> classType)
+      throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        return elsClient.get(r -> r.id(id).index(index), classType).source();
+      }
+      case "osClient" -> {
+        return osClient.get(r -> r.id(id).index(index), classType).source();
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Part of a trio of PRs to implement a camunda exporter testing framework. PR 3/3

Create the `CamundaExporterITInvocationProvider` which provides a framework for running test templates against both elasticsearch(ELS) and opensearch(OS).

This also involves refactoring the `CamundaExporterIT` tests to use this framework.

Success Critieria:
- [x] Invocation provider which starts both ELS and OS and can verify the engine state. (PR 2/3)
- [x] Client adapter for both ELS and OS such that test templates can query documents and indices. (PR 1/3)
- [x] Refactor `CamundaExporterIT` so tests use the invocation provider.  

## Related issues

closes #23886 
