### PR TITLE
Camunda exporter invocation provider

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/DecisionExporterIT.java
@@ -9,14 +9,14 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 final class DecisionExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentExporterIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.search.entities.IncidentEntity.ErrorType;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
@@ -21,7 +21,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class IncidentExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.UserTaskFilter;
 import io.camunda.zeebe.client.api.search.response.UserTask;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class UserTaskExporterIT {
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/VariableHandlerIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/VariableHandlerIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.exporter;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
-import io.camunda.it.utils.CamundaExporterITInvocationProvider;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.search.filter.VariableFilter;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -20,7 +20,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith(CamundaExporterITInvocationProvider.class)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
 public class VariableHandlerIT {
 
   private static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191;

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerWithCamundaExporterITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerWithCamundaExporterITInvocationProvider.java
@@ -37,11 +37,11 @@ import org.testcontainers.utility.DockerImageName;
  * The tests must take this into account, as the state in Zeebe and the exporter backend is not
  * reset between test cases.
  */
-public class CamundaExporterITInvocationProvider
+public class BrokerWithCamundaExporterITInvocationProvider
     implements TestTemplateInvocationContextProvider, AfterAllCallback, BeforeAllCallback {
 
   private static final Logger LOGGER =
-      LoggerFactory.getLogger(CamundaExporterITInvocationProvider.class);
+      LoggerFactory.getLogger(BrokerWithCamundaExporterITInvocationProvider.class);
 
   private static final DockerImageName ELASTIC_IMAGE =
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
@@ -52,7 +52,7 @@ public class CamundaExporterITInvocationProvider
 
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  public CamundaExporterITInvocationProvider() {
+  public BrokerWithCamundaExporterITInvocationProvider() {
     exporterTypes = new HashMap<>();
     exporterTypes.put(
         "with-camunda-exporter-elasticsearch", ExporterType.CAMUNDA_EXPORTER_ELASTIC_SEARCH);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/IndexMappingTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class IndexMappingTest {
+
+  @Test
+  void shouldReadIndexMappingsFileCorrectly() {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_name", "alias", "index_name", "/mappings.json");
+
+    // when
+    final var indexMapping = IndexMapping.from(index, new ObjectMapper());
+
+    // then
+    assertThat(indexMapping.dynamic()).isEqualTo("strict");
+
+    assertThat(indexMapping.properties())
+        .containsExactlyInAnyOrder(
+            new IndexMappingProperty.Builder()
+                .name("hello")
+                .typeDefinition(Map.of("type", "text"))
+                .build(),
+            new IndexMappingProperty.Builder()
+                .name("world")
+                .typeDefinition(Map.of("type", "keyword"))
+                .build());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import static io.camunda.exporter.config.ConnectionTypes.ELASTICSEARCH;
+import static io.camunda.exporter.config.ConnectionTypes.OPENSEARCH;
+import static java.util.Arrays.asList;
+
+import io.camunda.exporter.config.ConnectionTypes;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
+import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public class CamundaExporterITInvocationProvider
+    implements TestTemplateInvocationContextProvider, AfterAllCallback, BeforeAllCallback {
+
+  public static final String CONFIG_PREFIX = "camunda-record";
+  private final ElasticsearchContainer elsContainer =
+      TestSupport.createDefeaultElasticsearchContainer();
+  private final OpensearchContainer<?> osContainer = TestSupport.createDefaultOpensearchContainer();
+
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  private ExporterConfiguration getConfigWithConnectionDetails(
+      final ConnectionTypes connectionType) {
+    final var config = new ExporterConfiguration();
+    config.getIndex().setPrefix(CONFIG_PREFIX);
+    config.getBulk().setSize(1); // force flushing on the first record
+    switch (connectionType) {
+      case ELASTICSEARCH -> config.getConnect().setUrl(elsContainer.getHttpHostAddress());
+      case OPENSEARCH -> config.getConnect().setUrl(osContainer.getHttpHostAddress());
+      default -> throw new IllegalArgumentException("Unknown connection type: " + connectionType);
+    }
+    config.getConnect().setType(connectionType.getType());
+    return config;
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    elsContainer.start();
+    osContainer.start();
+
+    closeables.add(elsContainer);
+    closeables.add(osContainer);
+  }
+
+  @Override
+  public boolean supportsTestTemplate(final ExtensionContext extensionContext) {
+    // we only want to template tests in the class which ask for configuration and the client
+    // adapter.
+    final var testParams = extensionContext.getTestMethod().orElseThrow().getParameters();
+    if (testParams.length != 2) {
+      return false;
+    }
+
+    return (testParams[0].getType().equals(ExporterConfiguration.class)
+        && testParams[1].getType().equals(SearchClientAdapter.class));
+  }
+
+  @Override
+  public Stream<TestTemplateInvocationContext> provideTestTemplateInvocationContexts(
+      final ExtensionContext extensionContext) {
+    final var osConfig = getConfigWithConnectionDetails(OPENSEARCH);
+    final var osClient = new OpensearchConnector(osConfig.getConnect()).createClient();
+    final var osClientAdapter = new SearchClientAdapter(osClient);
+
+    final var elsConfig = getConfigWithConnectionDetails(ELASTICSEARCH);
+    final var elsClient = new ElasticsearchConnector(elsConfig.getConnect()).createClient();
+    final var elsClientAdapter = new SearchClientAdapter(elsClient);
+
+    try {
+      elsClient.indices().delete(req -> req.index("*"));
+      elsClient.indices().deleteIndexTemplate(req -> req.name("*"));
+      osClient.indices().delete(req -> req.index("*"));
+      osClient.indices().deleteIndexTemplate(req -> req.name("*"));
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to reset container data", e);
+    }
+    return Stream.of(
+        invocationContext(osConfig, osClientAdapter),
+        invocationContext(elsConfig, elsClientAdapter));
+  }
+
+  private TestTemplateInvocationContext invocationContext(
+      final ExporterConfiguration config, final SearchClientAdapter clientAdapter) {
+    return new TestTemplateInvocationContext() {
+
+      @Override
+      public String getDisplayName(final int invocationIndex) {
+        return config.getConnect().getType();
+      }
+
+      @Override
+      public List<Extension> getAdditionalExtensions() {
+        return asList(
+            new ParameterResolver() {
+
+              @Override
+              public boolean supportsParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return parameterCtx.getParameter().getType().equals(ExporterConfiguration.class);
+              }
+
+              @Override
+              public Object resolveParameter(
+                  final ParameterContext parameterCtx, final ExtensionContext extensionCtx) {
+                return config;
+              }
+            },
+            new ParameterResolver() {
+
+              @Override
+              public boolean supportsParameter(
+                  final ParameterContext parameterContext, final ExtensionContext extensionContext)
+                  throws ParameterResolutionException {
+                return parameterContext.getParameter().getType().equals(SearchClientAdapter.class);
+              }
+
+              @Override
+              public Object resolveParameter(
+                  final ParameterContext parameterContext, final ExtensionContext extensionContext)
+                  throws ParameterResolutionException {
+                return clientAdapter;
+              }
+            });
+      }
+    };
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    closeables.parallelStream()
+        .forEach(
+            c -> {
+              try {
+                c.close();
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            });
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.utils;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.ilm.get_lifecycle.Lifecycle;
+import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplateItem;
+import co.elastic.clients.json.JsonpMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.SchemaResourceSerializer;
+import java.io.IOException;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.opensearch.indices.IndexState;
+
+public class SearchClientAdapter {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final JsonpMapper ELS_JSON_MAPPER =
+      new co.elastic.clients.json.jackson.JacksonJsonpMapper(MAPPER);
+  private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSON_MAPPER =
+      new JacksonJsonpMapper(MAPPER);
+
+  private final ElasticsearchClient elsClient;
+  private final OpenSearchClient osClient;
+
+  public SearchClientAdapter(final ElasticsearchClient elsClient) {
+    this.elsClient = elsClient;
+    osClient = null;
+  }
+
+  public SearchClientAdapter(final OpenSearchClient osClient) {
+    elsClient = null;
+    this.osClient = osClient;
+  }
+
+  private JsonNode opensearchIndexToNode(final IndexState index) throws IOException {
+    final var indexAsMap =
+        SchemaResourceSerializer.serialize(
+            JacksonJsonpGenerator::new, (gen) -> index.serialize(gen, OPENSEARCH_JSON_MAPPER));
+
+    return MAPPER.valueToTree(indexAsMap);
+  }
+
+  private JsonNode elsIndexToNode(final co.elastic.clients.elasticsearch.indices.IndexState index)
+      throws IOException {
+    final var indexAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> index.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(indexAsMap);
+  }
+
+  private JsonNode elsIndexTemplateToNode(final IndexTemplateItem indexTemplate)
+      throws IOException {
+    final var templateAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> indexTemplate.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(templateAsMap);
+  }
+
+  private JsonNode opensearchIndexTemplateToNode(
+      final org.opensearch.client.opensearch.indices.get_index_template.IndexTemplateItem
+          indexTemplate)
+      throws IOException {
+    final var templateAsMap =
+        SchemaResourceSerializer.serialize(
+            JacksonJsonpGenerator::new,
+            (gen) -> indexTemplate.serialize(gen, OPENSEARCH_JSON_MAPPER));
+
+    return MAPPER.valueToTree(templateAsMap);
+  }
+
+  private JsonNode elsPolicyToNode(final Lifecycle lifecyclePolicy) throws IOException {
+    final var policyAsMap =
+        SchemaResourceSerializer.serialize(
+            co.elastic.clients.json.jackson.JacksonJsonpGenerator::new,
+            (gen) -> lifecyclePolicy.serialize(gen, ELS_JSON_MAPPER));
+
+    return MAPPER.valueToTree(policyAsMap);
+  }
+
+  public JsonNode getIndexAsNode(final String indexName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var index = elsClient.indices().get(req -> req.index(indexName)).get(indexName);
+        return elsIndexToNode(index);
+      }
+      case "osClient" -> {
+        final var index = osClient.indices().get(req -> req.index(indexName)).get(indexName);
+        return opensearchIndexToNode(index);
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public JsonNode getPolicyAsNode(final String policyName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var policy =
+            elsClient.ilm().getLifecycle(req -> req.name(policyName)).result().get(policyName);
+
+        return elsPolicyToNode(policy);
+      }
+      case "osClient" -> {
+        final var request =
+            Requests.builder()
+                .method("GET")
+                .endpoint("_plugins/_ism/policies/" + policyName)
+                .build();
+
+        return MAPPER.readTree(osClient.generic().execute(request).getBody().get().body());
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public JsonNode getIndexTemplateAsNode(final String templateName) throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        final var template =
+            elsClient
+                .indices()
+                .getIndexTemplate(req -> req.name(templateName))
+                .indexTemplates()
+                .getFirst();
+        return elsIndexTemplateToNode(template);
+      }
+      case "osClient" -> {
+        final var template =
+            osClient
+                .indices()
+                .getIndexTemplate(req -> req.name(templateName))
+                .indexTemplates()
+                .getFirst();
+
+        return opensearchIndexTemplateToNode(template);
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+
+  public <T> T get(final String id, final String index, final Class<T> classType)
+      throws IOException {
+    switch (elsClient != null ? "elsClient" : "osClient") {
+      case "elsClient" -> {
+        return elsClient.get(r -> r.id(id).index(index), classType).source();
+      }
+      case "osClient" -> {
+        return osClient.get(r -> r.id(id).index(index), classType).source();
+      }
+      default -> throw new IllegalStateException("Must instantiate client in SearchClientAdapter");
+    }
+  }
+}


### PR DESCRIPTION
## Description

Part of a trio of PRs to implement a camunda exporter testing framework. PR 2/3

Invocation provider which tests can extend to run a test template against elasticsearch and opensearch.

Success Criteria:
- [x] Supports test templates running against and ELS and OS instance by providing configuration to connect to the ELS and OS containers.

## Related issues

relates to #23886 
