### PR TITLE
fix: write response for COMPLETE user task command with correct request metadata

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -478,6 +478,7 @@ public final class EngineProcessors {
     final var userTaskProcessor =
         new UserTaskProcessor(
             processingState,
+            processingState.getUserTaskState(),
             processingState.getKeyGenerator(),
             bpmnBehaviors,
             writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -86,7 +86,7 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
 
     // It's important to retrieve the user task record request metadata before appending the
     // "COMPLETED" event, as it will be cleared by the "COMPLETED" event applier
-    final var recordRequestMetadata = userTaskState.getRecordRequestMetadata(userTaskKey);
+    final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);
     completeElementInstance(userTaskRecord);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedV2Applier.java
@@ -31,6 +31,7 @@ public final class UserTaskCompletedV2Applier
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.delete(key);
     userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
 
     final long elementInstanceKey = value.getElementInstanceKey();
     final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.instance.UserTaskIntermediateStateValue;
+import io.camunda.zeebe.engine.state.instance.UserTaskRecordRequestMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import java.util.Map;
+import java.util.Optional;
 
 public interface UserTaskState {
 
@@ -20,6 +22,8 @@ public interface UserTaskState {
   UserTaskRecord getUserTask(final long userTaskKey, final Map<String, Object> authorizations);
 
   UserTaskIntermediateStateValue getIntermediateState(final long userTaskKey);
+
+  Optional<UserTaskRecordRequestMetadata> getRecordRequestMetadata(final long userTaskKey);
 
   enum LifecycleState {
     NOT_FOUND((byte) 0),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -23,7 +23,7 @@ public interface UserTaskState {
 
   UserTaskIntermediateStateValue getIntermediateState(final long userTaskKey);
 
-  Optional<UserTaskRecordRequestMetadata> getRecordRequestMetadata(final long userTaskKey);
+  Optional<UserTaskRecordRequestMetadata> findRecordRequestMetadata(final long userTaskKey);
 
   enum LifecycleState {
     NOT_FOUND((byte) 0),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
@@ -167,7 +167,7 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
-  public Optional<UserTaskRecordRequestMetadata> getRecordRequestMetadata(final long key) {
+  public Optional<UserTaskRecordRequestMetadata> findRecordRequestMetadata(final long key) {
     userTaskKey.wrapLong(key);
     return Optional.ofNullable(userTasksRecordRequestMetadataColumnFamily.get(userTaskKey));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/UserTaskRecordRequestMetadata.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/UserTaskRecordRequestMetadata.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.instance;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+/**
+ * This class represents the metadata needed to properly finalize the original user task command
+ * after task listener execution.
+ *
+ * <p>It is used to persist the original request's metadata fields such as:
+ *
+ * <ul>
+ *   <li>{@code requestId}: The identifier of the original request that triggered the user task
+ *       completion.
+ *   <li>{@code requestStreamId}: The stream ID associated with the original request.
+ *   <li>{@code intent}: The original command (e.g., {@code COMPLETE} user task command).
+ * </ul>
+ *
+ * <p>This metadata is crucial for ensuring that after all task listener jobs are processed, the
+ * engine can respond appropriately to the original command request.
+ */
+public class UserTaskRecordRequestMetadata extends UnpackedObject implements DbValue {
+
+  private final EnumProperty<UserTaskIntent> intentProperty =
+      new EnumProperty<>("intent", UserTaskIntent.class);
+  private final LongProperty requestIdProperty = new LongProperty("requestId", -1);
+  private final IntegerProperty requestStreamIdProperty =
+      new IntegerProperty("requestStreamId", -1);
+
+  public UserTaskRecordRequestMetadata() {
+    super(3);
+    declareProperty(intentProperty)
+        .declareProperty(requestIdProperty)
+        .declareProperty(requestStreamIdProperty);
+  }
+
+  public UserTaskIntent getIntent() {
+    return intentProperty.getValue();
+  }
+
+  public UserTaskRecordRequestMetadata setIntent(final UserTaskIntent intent) {
+    intentProperty.setValue(intent);
+    return this;
+  }
+
+  public long getRequestId() {
+    return requestIdProperty.getValue();
+  }
+
+  public UserTaskRecordRequestMetadata setRequestId(final long requestId) {
+    requestIdProperty.setValue(requestId);
+    return this;
+  }
+
+  public int getRequestStreamId() {
+    return requestStreamIdProperty.getValue();
+  }
+
+  public UserTaskRecordRequestMetadata setRequestStreamId(final int requestStreamId) {
+    requestStreamIdProperty.setValue(requestStreamId);
+    return this;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.instance.UserTaskRecordRequestMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 
 public interface MutableUserTaskState extends UserTaskState {
@@ -23,4 +24,9 @@ public interface MutableUserTaskState extends UserTaskState {
   void storeIntermediateState(final UserTaskRecord userTask, final LifecycleState lifecycleState);
 
   void deleteIntermediateState(final long userTaskKey);
+
+  void storeRecordRequestMetadata(
+      final long userTaskKey, final UserTaskRecordRequestMetadata recordRequestMetadata);
+
+  void deleteRecordRequestMetadata(final long userTaskKey);
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -209,7 +209,9 @@ public enum ZbColumnFamilies implements EnumValue {
   USER_TASK_INTERMEDIATE_STATES(106),
 
   MAPPINGS(107),
-  CLAIM_BY_KEY(108);
+  CLAIM_BY_KEY(108),
+
+  USER_TASK_RECORD_REQUEST_METADATA(109);
 
   private final int value;
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.it.util.RecordingJobHandler;
+import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ZeebeIntegration
+@AutoCloseResources
+public class UserTaskListenersTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskListenersTest.class);
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource private ZeebeClient client;
+  private List<JobWorker> workers;
+
+  private ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  void init() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    workers = new ArrayList<>();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @AfterEach
+  void tearDown() {
+    workers.forEach(JobWorker::close);
+  }
+
+  @Test
+  void shouldCompleteUserTaskWithCompleteTaskListener() {
+    // given
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            t -> t.zeebeTaskListener(l -> l.complete().type("my_listener")));
+
+    // open worker for `my_listener` task listener job
+    final RecordingJobHandler jbHandler = new RecordingJobHandler();
+    workers.add(client.newWorker().jobType("my_listener").handler(jbHandler).open());
+
+    // when: invoke complete user task command
+    final var completeUserTaskFuture =
+        client
+            .newUserTaskCompleteCommand(userTaskKey)
+            .send()
+            .thenAccept(
+                ok -> LOGGER.info("User task with key: '{}' completed successfully.", userTaskKey))
+            .exceptionally(
+                throwable -> {
+                  fail(
+                      "Failed to complete user task with key: '%d' due to error:"
+                          .formatted(userTaskKey),
+                      throwable);
+                  return null;
+                })
+            .toCompletableFuture();
+
+    waitUntil(() -> !jbHandler.getHandledJobs().isEmpty());
+
+    final var listenerJob = jbHandler.getHandledJob("my_listener");
+
+    // complete task listener job
+    client.newCompleteCommand(listenerJob).send().join();
+
+    // wait for `complete` user task command completion
+    completeUserTaskFuture.join();
+
+    // then
+    ZeebeAssertHelper.assertUserTaskCompleted(
+        userTaskKey,
+        (userTask) -> {
+          assertThat(userTask.getVariables()).isEmpty();
+          assertThat(userTask.getAction()).isEqualTo("complete");
+        });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -54,6 +54,7 @@ public class UserTaskListenersTest {
   @AfterEach
   void tearDown() {
     workers.forEach(JobWorker::close);
+    workers.clear();
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
@@ -45,6 +45,13 @@ public final class RecordingJobHandler implements JobHandler {
     return handledJobs;
   }
 
+  public ActivatedJob getHandledJob(final String jobType) {
+    return handledJobs.stream()
+        .filter(j -> j.getType().equals(jobType))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No job found with type " + jobType));
+  }
+
   public void clear() {
     handledJobs.clear();
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeResourcesHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeResourcesHelper.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
@@ -189,12 +191,21 @@ public class ZeebeResourcesHelper implements CloseableSilently {
         .getProcessInstanceKey();
   }
 
+  public long createSingleUserTask(final UnaryOperator<UserTaskBuilder> userTaskBuilderFunction) {
+    return createSingleUserTask("", userTaskBuilderFunction);
+  }
+
   public long createSingleUserTask() {
     return createSingleUserTask("");
   }
 
   public long createSingleUserTask(final String tenantId) {
-    final var modelInstance = createSingleUserTaskModelInstance();
+    return createSingleUserTask(tenantId, UnaryOperator.identity());
+  }
+
+  public long createSingleUserTask(
+      final String tenantId, final UnaryOperator<UserTaskBuilder> userTaskBuilderFunction) {
+    final var modelInstance = createSingleUserTaskModelInstance(userTaskBuilderFunction);
     final var processDefinitionKey = deployProcess(modelInstance, tenantId);
     final var processInstanceKey = createProcessInstance(processDefinitionKey, "{}", tenantId);
     final var userTaskKey =
@@ -209,10 +220,11 @@ public class ZeebeResourcesHelper implements CloseableSilently {
     return userTaskKey;
   }
 
-  public BpmnModelInstance createSingleUserTaskModelInstance() {
+  public BpmnModelInstance createSingleUserTaskModelInstance(
+      final UnaryOperator<UserTaskBuilder> userTaskBuilderFunction) {
     return Bpmn.createExecutableProcess("process")
         .startEvent("start")
-        .userTask("task")
+        .userTask("task", t -> userTaskBuilderFunction.apply(t.zeebeUserTask()))
         .zeebeUserTask()
         .endEvent("end")
         .done();


### PR DESCRIPTION
## Description
When the `client.newUserTaskCompleteCommand(userTaskKey).send().join()` method is invoked, it results in a timeout error despite the user task completing successfully. This occurs because the engine uses the `requestId` and `requestStreamId` from the `COMPLETE_TASK_LISTENER` command instead of the original `COMPLETE` command when finalizing the user task.

### Fix:
This PR implements the following changes:
1. Persists the `requestId` and `requestStreamId` from the original `COMPLETE` user task command from `UserTaskProcessor`:
> Note: Generally, persistence logic should be handled via `*Applier` classes. However, since this involves
> request-related data - in the case of command reconstruction, new request values will be produced anyway,
> so the invocation of persistence logic for request metadata from `UserTaskProcessor` is acceptable.
> This approach has precedent in `ProcessInstanceCreationCreateWithResultProcessor` also.

2. Uses the original `COMPLETE` command request metadata after all task listener jobs are completed to send the correct response.
   This ensures that the request metadata is available to finalize the original command after processing
   all task listeners, allowing the engine to respond correctly to the request.

These changes prevent the timeout error and ensure that the client receives the appropriate success response when all task listeners have finished executing and the user task is completed.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23925
