### PR TITLE
Add Mapping to Role on Role.ADD_ENTITY command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -32,6 +33,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
 
   private final RoleState roleState;
   private final UserState userState;
+  private final MappingState mappingState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -42,12 +44,14 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   public RoleAddEntityProcessor(
       final RoleState roleState,
       final UserState userState,
+      final MappingState mappingState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.roleState = roleState;
     this.userState = userState;
+    this.mappingState = mappingState;
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -112,6 +116,9 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
   private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
     if (EntityType.USER == entityType) {
       return userState.getUser(entityKey).isPresent();
+    }
+    if (EntityType.MAPPING == entityType) {
+      return mappingState.get(entityKey).isPresent();
     }
     return false;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
@@ -47,6 +47,7 @@ public class RoleProcessors {
         new RoleAddEntityProcessor(
             processingState.getRoleState(),
             processingState.getUserState(),
+            processingState.getMappingState(),
             authCheckBehavior,
             keyGenerator,
             writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -465,9 +465,7 @@ public final class EventAppliers implements EventApplier {
         RoleIntent.CREATED,
         new RoleCreatedApplier(state.getRoleState(), state.getAuthorizationState()));
     register(RoleIntent.UPDATED, new RoleUpdatedApplier(state.getRoleState()));
-    register(
-        RoleIntent.ENTITY_ADDED,
-        new RoleEntityAddedApplier(state.getRoleState(), state.getUserState()));
+    register(RoleIntent.ENTITY_ADDED, new RoleEntityAddedApplier(state));
     register(
         RoleIntent.ENTITY_REMOVED,
         new RoleEntityRemovedApplier(state.getRoleState(), state.getUserState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
@@ -35,9 +35,9 @@ public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, Rol
       case MAPPING -> mappingState.addRole(value.getEntityKey(), value.getRoleKey());
       default ->
           throw new IllegalStateException(
-              "Unknown or unsupported entity type: '"
-                  + value.getEntityType()
-                  + "'. Please contact support for clarification.");
+              String.format(
+                  "Expected to add entity '%d' to role '%d', but entities of type '%s' cannot be added to roles",
+                  value.getEntityKey(), value.getRoleKey(), value.getEntityType()));
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityAddedApplier.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
@@ -31,11 +30,14 @@ public class RoleEntityAddedApplier implements TypedEventApplier<RoleIntent, Rol
   @Override
   public void applyState(final long key, final RoleRecord value) {
     roleState.addEntity(value);
-    if (EntityType.USER.equals(value.getEntityType())) {
-      userState.addRole(value.getEntityKey(), value.getRoleKey());
-    }
-    if (EntityType.MAPPING.equals(value.getEntityType())) {
-      mappingState.addRole(value.getEntityKey(), value.getRoleKey());
+    switch (value.getEntityType()) {
+      case USER -> userState.addRole(value.getEntityKey(), value.getRoleKey());
+      case MAPPING -> mappingState.addRole(value.getEntityKey(), value.getRoleKey());
+      default ->
+          throw new IllegalStateException(
+              "Unknown or unsupported entity type: '"
+                  + value.getEntityType()
+                  + "'. Please contact support for clarification.");
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -67,6 +67,18 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public void addRole(final long mappingKey, final long roleKey) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var fkKey = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(fkKey);
+      persistedMapping.addRoleKey(roleKey);
+      mappingColumnFamily.update(fkKey, persistedMapping);
+    }
+  }
+
+  @Override
   public Optional<PersistedMapping> get(final long key) {
     mappingKey.wrapLong(key);
     final var fk = claimByKeyColumnFamily.get(mappingKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -9,21 +9,29 @@ package io.camunda.zeebe.engine.state.authorization;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class PersistedMapping extends UnpackedObject implements DbValue {
 
   private final LongProperty mappingKeyProp = new LongProperty("mappingKey", -1L);
   private final StringProperty claimNameProp = new StringProperty("claimName", "");
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
+  private final ArrayProperty<LongValue> roleKeysProp =
+      new ArrayProperty<>("roleKeys", LongValue::new);
 
   public PersistedMapping() {
-    super(3);
+    super(4);
     declareProperty(mappingKeyProp);
     declareProperty(claimNameProp);
     declareProperty(claimValueProp);
+    declareProperty(roleKeysProp);
   }
 
   public long getMappingKey() {
@@ -50,6 +58,23 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
 
   public PersistedMapping setClaimValue(final String claimValue) {
     claimValueProp.setValue(claimValue);
+    return this;
+  }
+
+  public List<Long> getRoleKeysList() {
+    return StreamSupport.stream(roleKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
+  }
+
+  public PersistedMapping setRoleKeysList(final List<Long> roleKeys) {
+    roleKeysProp.reset();
+    roleKeys.forEach(roleKey -> roleKeysProp.add().setValue(roleKey));
+    return this;
+  }
+
+  public PersistedMapping addRoleKey(final long roleKey) {
+    roleKeysProp.add().setValue(roleKey);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -13,4 +13,6 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 public interface MutableMappingState extends MappingState {
 
   void create(final MappingRecord mappingRecord);
+
+  void addRole(final long mappingKey, final long roleKey);
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds `roleKeys` property into the `PersistedMapping` object and allow the `RoleEntityAddedApplier` to add the role key into the mapping state if the EntityType is MAPPING

## Related issues

closes #23843 
