### PR TITLE
Fix flakiness of Role and Tenant tests

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -63,7 +63,8 @@ public class UpdateTenantMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limit(record -> record.getIntent().equals(CommandDistributionIntent.FINISHED)))
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
         .extracting(
             Record::getIntent,
             Record::getRecordType,
@@ -124,12 +125,12 @@ public class UpdateTenantMultiPartitionTest {
   @Test
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // when
-    final var tenantId = UUID.randomUUID().toString();
-    final var tenantKey =
-        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
       interceptTenantCreateForPartition(partitionId);
     }
+    final var tenantId = UUID.randomUUID().toString();
+    final var tenantKey =
+        engine.tenant().newTenant().withTenantId(tenantId).create().getValue().getTenantKey();
     engine.tenant().updateTenant(tenantKey).withTenantId(tenantId + "-updated").update();
 
     // Increase time to trigger a redistribution


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Remove direct access to the state from `RoleTest` class. Improved Tenant multi partition tests

## Related issues

closes #24024 
