### PR TITLE
fix: use older index version

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -102,7 +102,7 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
   @Override
   public List<String> toIndices(final UserTaskFilter filter) {
     if (isCamundaExporterEnabled) {
-      return List.of("tasklist-task-8.7.0_");
+      return List.of("tasklist-task-8.5.0_");
     }
     return List.of("tasklist-list-view-8.6.0_");
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -13,7 +13,7 @@ import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor
 public class TaskTemplate extends TasklistTemplateDescriptor implements Prio3Backup {
 
   public static final String INDEX_NAME = "task";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.5.0";
 
   /* User Task Fields*/
   public static final String ID = "id";


### PR DESCRIPTION
## Description

Using a newer version causes conflicts with previous created index, we do not want to do any migration so we just using the old index name and extending it with more properties.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
