### PR TITLE
fix: exclude task-template from being populated and created by tasklist when CamundaExporter is enabled

### DIFF
--- a/dist/src/main/resources/application-tasklist.properties
+++ b/dist/src/main/resources/application-tasklist.properties
@@ -14,6 +14,9 @@ graphql.schema-strategy=annotations
 graphql.annotations.base-package=io.camunda.tasklist
 graphql.annotations.always-prettify=false
 graphql.annotations.input-prefix=
+
+# Temporary workaround for CamundaExporter
+camunda.tasklist.exporterClassName=${zeebe.broker.exporters.camunda.className:${zeebe.broker.exporters.camundaExporter.className:${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:${ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME}:}}}
 #---
 spring.config.activate.on-profile=identity-auth
 spring.security.oauth2.resourceserver.jwt.issuer-uri=${camunda.identity.issuer:${camunda.tasklist.identity.issuerUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL:}}}

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistProperties.java
@@ -46,6 +46,7 @@ public class TasklistProperties {
   private String readerPassword = "view";
   private String readerDisplayName = "view";
   private String database = ELASTIC_SEARCH;
+  private String exporterClassName = "";
 
   private List<String> roles = List.of("OWNER");
 
@@ -427,5 +428,13 @@ public class TasklistProperties {
       return openSearch.getIndexPrefix();
     }
     return null;
+  }
+
+  public String getExporterClassName() {
+    return exporterClassName;
+  }
+
+  public void setExporterClassName(final String exporterClassName) {
+    this.exporterClassName = exporterClassName;
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -53,7 +53,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -77,9 +76,6 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Autowired protected TasklistProperties tasklistProperties;
 
-  @Value("${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:}")
-  private String camundaExporterClassName;
-
   private boolean isCamundaExporterEnabled;
 
   @Autowired
@@ -93,7 +89,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @PostConstruct
   public void init() {
     isCamundaExporterEnabled =
-        "io.camunda.exporter.CamundaExporter".equals(camundaExporterClassName);
+        "io.camunda.exporter.CamundaExporter".equals(tasklistProperties.getExporterClassName());
   }
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -58,7 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -94,15 +93,12 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Value("${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:}")
-  private String camundaExporterClassName;
-
   private boolean isCamundaExporterEnabled;
 
   @PostConstruct
   public void init() {
     isCamundaExporterEnabled =
-        "io.camunda.exporter.CamundaExporter".equals(camundaExporterClassName);
+        "io.camunda.exporter.CamundaExporter".equals(tasklistProperties.getExporterClassName());
   }
 
   @Override

--- a/tasklist/importer-870/pom.xml
+++ b/tasklist/importer-870/pom.xml
@@ -95,6 +95,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/BulkProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/BulkProcessorElasticSearch.java
@@ -26,6 +26,7 @@ import io.camunda.tasklist.zeebeimport.v870.record.value.deployment.DeployedProc
 import io.camunda.tasklist.zeebeimport.v870.record.value.deployment.FormRecordImpl;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import jakarta.annotation.PostConstruct;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -34,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -61,6 +63,17 @@ public class BulkProcessorElasticSearch extends AbstractImportBatchProcessorElas
   private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
+
+  @Value("${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:}")
+  private String camundaExporterClassName;
+
+  private boolean isCamundaExporterEnabled;
+
+  @PostConstruct
+  public void init() {
+    isCamundaExporterEnabled =
+        "io.camunda.exporter.CamundaExporter".equals(camundaExporterClassName);
+  }
 
   @Override
   protected void processZeebeRecords(
@@ -97,10 +110,16 @@ public class BulkProcessorElasticSearch extends AbstractImportBatchProcessorElas
           processZeebeRecordProcessor.processDeploymentRecord(record, bulkRequest);
           break;
         case FORM:
-          formZeebeRecordProcessor.processFormRecord(record, bulkRequest);
+          // TODO: skip form record importing when Camunda exporter is enabled
+          if (!isCamundaExporterEnabled) {
+            formZeebeRecordProcessor.processFormRecord(record, bulkRequest);
+          }
           break;
         case USER_TASK:
-          userTaskZeebeRecordProcessor.processUserTaskRecord(record, bulkRequest);
+          // TODO: skip user task record importing when Camunda exporter is enabled
+          if (!isCamundaExporterEnabled) {
+            userTaskZeebeRecordProcessor.processUserTaskRecord(record, bulkRequest);
+          }
           break;
         default:
           LOGGER.debug("Default case triggered for type {}", importValueType);

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/BulkProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/BulkProcessorElasticSearch.java
@@ -13,6 +13,7 @@ import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.PersistenceException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.ElasticsearchUtil;
 import io.camunda.tasklist.zeebe.ImportValueType;
 import io.camunda.tasklist.zeebeimport.ImportBatch;
@@ -35,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -58,21 +58,20 @@ public class BulkProcessorElasticSearch extends AbstractImportBatchProcessorElas
 
   @Autowired private UserTaskZeebeRecordProcessorElasticSearch userTaskZeebeRecordProcessor;
 
+  @Autowired private TasklistProperties tasklistProperties;
+
   @Autowired
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 
-  @Value("${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:}")
-  private String camundaExporterClassName;
-
   private boolean isCamundaExporterEnabled;
 
   @PostConstruct
   public void init() {
     isCamundaExporterEnabled =
-        "io.camunda.exporter.CamundaExporter".equals(camundaExporterClassName);
+        "io.camunda.exporter.CamundaExporter".equals(tasklistProperties.getExporterClassName());
   }
 
   @Override

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/OpenSearchBulkProcessor.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/OpenSearchBulkProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.tasklist.Metrics;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.exceptions.PersistenceException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.OpenSearchUtil;
 import io.camunda.tasklist.zeebe.ImportValueType;
 import io.camunda.tasklist.zeebeimport.ImportBatch;
@@ -35,7 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -58,21 +58,20 @@ public class OpenSearchBulkProcessor extends AbstractImportBatchProcessorOpenSea
 
   @Autowired private UserTaskZeebeRecordProcessorOpenSearch userTaskZeebeRecordProcessor;
 
+  @Autowired private TasklistProperties tasklistProperties;
+
   @Autowired
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 
-  @Value("${ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME:}")
-  private String camundaExporterClassName;
-
   private boolean isCamundaExporterEnabled;
 
   @PostConstruct
   public void init() {
     isCamundaExporterEnabled =
-        "io.camunda.exporter.CamundaExporter".equals(camundaExporterClassName);
+        "io.camunda.exporter.CamundaExporter".equals(tasklistProperties.getExporterClassName());
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -13,7 +13,7 @@ import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor
 public class TaskTemplate extends TasklistTemplateDescriptor implements Prio3Backup {
 
   public static final String INDEX_NAME = "task";
-  public static final String INDEX_VERSION = "8.7.0";
+  public static final String INDEX_VERSION = "8.5.0";
 
   /* User Task Fields*/
   public static final String ID = "id";


### PR DESCRIPTION
## Description
- Change `tasklist-task` version to 8.5.0
- When `ZEEBE_BROKER_EXPORTERS_CAMUNDA_CLASSNAME=io.camunda.exporter.CamundaExporter`
- - Exclude `tasklist-task` from Tasklist's SchemaManager
- - Exclude UserTask and Form record from being handled by Tasklist's 8.7 Importer

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
