### PR TITLE
feat: support findAll search with scrolling

### DIFF
--- a/search/search-client-elasticsearch/pom.xml
+++ b/search/search-client-elasticsearch/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -63,6 +68,11 @@
     <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
@@ -9,18 +9,29 @@ package io.camunda.search.es.clients;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.search.clients.DocumentBasedSearchClient;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.transformers.SearchTransfomer;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.es.transformers.search.SearchRequestTransformer;
 import io.camunda.search.es.transformers.search.SearchResponseTransformer;
 import io.camunda.search.exception.SearchQueryExecutionException;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ElasticsearchSearchClient implements DocumentBasedSearchClient, AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSearchClient.class);
+  private static final String SCROLL_KEEP_ALIVE_TIME = "1m";
 
   private final ElasticsearchClient client;
   private final ElasticsearchTransformers transformers;
@@ -49,12 +60,60 @@ public class ElasticsearchSearchClient implements DocumentBasedSearchClient, Aut
     }
   }
 
-  protected SearchTransfomer<SearchQueryRequest, SearchRequest> getSearchRequestTransformer() {
-    return transformers.getTransformer(SearchQueryRequest.class);
+  @Override
+  public <T> List<T> findAll(final SearchQueryRequest searchRequest, final Class<T> documentClass) {
+    final List<T> result = new ArrayList<>();
+    String scrollId = null;
+    try {
+      final var request =
+          getSearchRequestTransformer()
+              .toSearchRequestBuilder(searchRequest)
+              .scroll(s -> s.time(SCROLL_KEEP_ALIVE_TIME))
+              .build();
+      final SearchResponse<T> rawSearchResponse = client.search(request, documentClass);
+      scrollId = rawSearchResponse.scrollId();
+      var items = rawSearchResponse.hits().hits().stream().map(Hit::source).toList();
+      result.addAll(items);
+      final int pageSize = Optional.ofNullable(searchRequest.size()).orElse(items.size());
+      while (!items.isEmpty() && items.size() == pageSize) {
+        final ScrollResponse<T> scrollResponse = scroll(scrollId, documentClass);
+        scrollId = scrollResponse.scrollId();
+        items = scrollResponse.hits().hits().stream().map(Hit::source).toList();
+        result.addAll(items);
+      }
+    } catch (final IOException | ElasticsearchException e) {
+      throw new SearchQueryExecutionException("Failed to execute findAll query", e);
+    } finally {
+      clearScroll(scrollId);
+    }
+    return result;
+  }
+
+  private <T> ScrollResponse<T> scroll(final String scrollId, final Class<T> documentClass)
+      throws IOException {
+    return client.scroll(r -> r.scrollId(scrollId), documentClass);
+  }
+
+  private void clearScroll(final String scrollId) {
+    if (scrollId != null) {
+      try {
+        client.clearScroll(r -> r.scrollId(scrollId));
+      } catch (final IOException | ElasticsearchException e) {
+        LOGGER.error("Failed to clear scroll.", e);
+      }
+    }
+  }
+
+  private SearchRequestTransformer getSearchRequestTransformer() {
+    final SearchTransfomer<SearchQueryRequest, SearchRequest> transformer =
+        transformers.getTransformer(SearchQueryRequest.class);
+    return (SearchRequestTransformer) transformer;
   }
 
   private <T> SearchResponseTransformer<T> getSearchResponseTransformer() {
-    return new SearchResponseTransformer<>(transformers);
+    final SearchTransfomer<SearchResponse<T>, SearchQueryResponse<T>> transformer =
+        transformers.getTransformer(SearchQueryResponse.class);
+    return (SearchResponseTransformer<T>) transformer;
   }
 
   @Override

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchRequestTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchRequestTransformer.java
@@ -30,6 +30,10 @@ public final class SearchRequestTransformer
 
   @Override
   public SearchRequest apply(final SearchQueryRequest value) {
+    return toSearchRequestBuilder(value).build();
+  }
+
+  public SearchRequest.Builder toSearchRequestBuilder(final SearchQueryRequest value) {
     final var sort = value.sort();
     final var searchAfter = value.searchAfter();
     final var searchQuery = value.query();
@@ -54,8 +58,7 @@ public final class SearchRequestTransformer
     if (value.source() != null) {
       builder.source(of(value.source()));
     }
-
-    return builder.build();
+    return builder;
   }
 
   private List<SortOptions> of(final List<SearchSortOptions> values) {

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchSearchClientTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.os.clients;
+package io.camunda.search.es.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -15,26 +15,26 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.exception.SearchQueryExecutionException;
-import io.camunda.search.os.transformers.OpensearchTransformers;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch.core.ScrollResponse;
-import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.core.search.Hit;
 
-public class OpensearchSearchClientTest {
+class ElasticsearchSearchClientTest {
 
   private static final String SCROLL_ID = "scrollId123";
-  private OpenSearchClient client;
-  private OpensearchSearchClient searchClient;
+  private ElasticsearchClient client;
+  private ElasticsearchSearchClient searchClient;
   private SearchQueryRequest searchRequest;
   private SearchResponse<Object> searchResponse;
   private ScrollResponse<Object> scrollResponse;
@@ -42,12 +42,12 @@ public class OpensearchSearchClientTest {
 
   @BeforeEach
   void setUp() {
-    client = mock(OpenSearchClient.class);
-    searchClient = new OpensearchSearchClient(client, new OpensearchTransformers());
+    client = mock(ElasticsearchClient.class);
+    searchClient = new ElasticsearchSearchClient(client, new ElasticsearchTransformers());
     searchRequest = mock(SearchQueryRequest.class);
     when(searchRequest.size()).thenReturn(null);
     searchResponse =
-        SearchResponse.searchResponseOf(
+        SearchResponse.of(
             f ->
                 f.scrollId(SCROLL_ID)
                     .hits(

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -30,6 +30,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>
@@ -67,7 +72,11 @@
       <artifactId>jakarta.json-api</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
@@ -13,14 +13,25 @@ import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.transformers.SearchTransfomer;
 import io.camunda.search.exception.SearchQueryExecutionException;
 import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.transformers.search.SearchRequestTransformer;
 import io.camunda.search.os.transformers.search.SearchResponseTransformer;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 import org.opensearch.client.opensearch.OpenSearchClient;
 import org.opensearch.client.opensearch._types.OpenSearchException;
+import org.opensearch.client.opensearch.core.ScrollResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OpensearchSearchClient implements DocumentBasedSearchClient, AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchSearchClient.class);
+  private static final String SCROLL_KEEP_ALIVE_TIME = "1m";
 
   private final OpenSearchClient client;
   private final OpensearchTransformers transformers;
@@ -49,8 +60,54 @@ public class OpensearchSearchClient implements DocumentBasedSearchClient, AutoCl
     }
   }
 
-  private SearchTransfomer<SearchQueryRequest, SearchRequest> getSearchRequestTransformer() {
-    return transformers.getTransformer(SearchQueryRequest.class);
+  @Override
+  public <T> List<T> findAll(final SearchQueryRequest searchRequest, final Class<T> documentClass) {
+    final List<T> result = new ArrayList<>();
+    String scrollId = null;
+    try {
+      final var request =
+          getSearchRequestTransformer()
+              .toSearchRequestBuilder(searchRequest)
+              .scroll(s -> s.time(SCROLL_KEEP_ALIVE_TIME))
+              .build();
+      final SearchResponse<T> rawSearchResponse = client.search(request, documentClass);
+      scrollId = rawSearchResponse.scrollId();
+      var items = rawSearchResponse.hits().hits().stream().map(Hit::source).toList();
+      result.addAll(items);
+      final int pageSize = Optional.ofNullable(searchRequest.size()).orElse(items.size());
+      while (!items.isEmpty() && pageSize == items.size()) {
+        final ScrollResponse<T> scrollResponse = scroll(scrollId, documentClass);
+        scrollId = scrollResponse.scrollId();
+        items = scrollResponse.hits().hits().stream().map(Hit::source).toList();
+        result.addAll(items);
+      }
+    } catch (final IOException | OpenSearchException e) {
+      throw new SearchQueryExecutionException("Failed to execute findAll query", e);
+    } finally {
+      clearScroll(scrollId);
+    }
+    return result;
+  }
+
+  private <T> ScrollResponse<T> scroll(final String scrollId, final Class<T> documentClass)
+      throws IOException {
+    return client.scroll(r -> r.scrollId(scrollId), documentClass);
+  }
+
+  private void clearScroll(final String scrollId) {
+    if (scrollId != null) {
+      try {
+        client.clearScroll(r -> r.scrollId(scrollId));
+      } catch (final IOException | OpenSearchException e) {
+        LOGGER.error("Failed to clear scroll.", e);
+      }
+    }
+  }
+
+  private SearchRequestTransformer getSearchRequestTransformer() {
+    final SearchTransfomer<SearchQueryRequest, SearchRequest> transformer =
+        transformers.getTransformer(SearchQueryRequest.class);
+    return (SearchRequestTransformer) transformer;
   }
 
   private <T> SearchResponseTransformer<T> getSearchResponseTransformer() {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/search/SearchRequestTransformer.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchRequest.Builder;
 import org.opensearch.client.opensearch.core.search.SourceConfig;
 
 public final class SearchRequestTransformer
@@ -28,12 +29,15 @@ public final class SearchRequestTransformer
 
   @Override
   public SearchRequest apply(final SearchQueryRequest value) {
+    return toSearchRequestBuilder(value).build();
+  }
+
+  public Builder toSearchRequestBuilder(final SearchQueryRequest value) {
     final var sort = value.sort();
     final var searchAfter = value.searchAfter();
     final var searchQuery = value.query();
 
-    final var builder =
-        new SearchRequest.Builder().index(value.index()).from(value.from()).size(value.size());
+    final var builder = new Builder().index(value.index()).from(value.from()).size(value.size());
 
     if (searchQuery != null) {
       final var queryTransformer = getQueryTransformer();
@@ -52,8 +56,7 @@ public final class SearchRequestTransformer
     if (value.source() != null) {
       builder.source(of(value.source()));
     }
-
-    return builder.build();
+    return builder;
   }
 
   private List<SortOptions> of(final List<SearchSortOptions> values) {

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchDataStoreClientTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.os.util.StubbedOpensearchClient;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+
+public class OpensearchDataStoreClientTest {
+
+  private OpensearchSearchClient client;
+  private StubbedOpensearchClient stubbedOpensearchClient;
+
+  @BeforeEach
+  public void before() {
+    stubbedOpensearchClient = new StubbedOpensearchClient();
+    stubbedOpensearchClient.registerHandler(
+        (h) -> {
+          return SearchResponse.searchResponseOf(
+              (f) ->
+                  f.took(122)
+                      .hits(
+                          HitsMetadata.of(
+                              (m) ->
+                                  m.hits(new ArrayList<>())
+                                      .total((t) -> t.value(789).relation(TotalHitsRelation.Eq))))
+                      .shards((s) -> s.failed(0).successful(100).total(100))
+                      .timedOut(false));
+        });
+
+    client = new OpensearchSearchClient(stubbedOpensearchClient);
+  }
+
+  @Test
+  public void shouldTransformSearchRequest() {
+    // given
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
+
+    // when
+    client.search(request, Object.class);
+
+    // then
+    final var searchRequest = stubbedOpensearchClient.getSingleSearchRequest();
+    assertThat(searchRequest.index()).hasSize(1).contains("operate-list-view-8.3.0_");
+  }
+
+  @Test
+  public void shouldTransformSearchResponse() {
+    // given
+    final SearchQueryRequest request =
+        SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
+
+    // when
+    final var response = client.search(request, Object.class);
+
+    // then
+    assertThat(response).isNotNull();
+    assertThat(response.totalHits()).isEqualTo(789);
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClient.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/DocumentBasedSearchClient.java
@@ -13,6 +13,7 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryRequest.Builder;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.function.Function;
 
 public interface DocumentBasedSearchClient {
@@ -24,4 +25,6 @@ public interface DocumentBasedSearchClient {
       final Function<Builder, ObjectBuilder<SearchQueryRequest>> fn, final Class<T> documentClass) {
     return search(searchRequest(fn), documentClass);
   }
+
+  <T> List<T> findAll(final SearchQueryRequest searchRequest, final Class<T> documentClass);
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
@@ -95,9 +95,9 @@ class DocumentAuthorizationQueryStrategyTest {
                 s.withAuthentication(a -> a.user(123L))
                     .withAuthorization(
                         a -> a.permissionType(READ).resourceType(PROCESS_DEFINITION)));
-    when(searchClient.search(any(SearchQueryRequest.class), eq(AuthorizationEntity.class)))
+    when(searchClient.findAll(any(SearchQueryRequest.class), eq(AuthorizationEntity.class)))
         .thenReturn(
-            buildSearchQueryResponse(
+            List.of(
                 new AuthorizationEntity(
                     null,
                     null,
@@ -125,8 +125,8 @@ class DocumentAuthorizationQueryStrategyTest {
                 s.withAuthentication(a -> a.user(123L))
                     .withAuthorization(
                         a -> a.permissionType(READ).resourceType(PROCESS_DEFINITION)));
-    when(searchClient.search(any(SearchQueryRequest.class), eq(AuthorizationEntity.class)))
-        .thenReturn(SearchQueryResponse.of(r -> r));
+    when(searchClient.findAll(any(SearchQueryRequest.class), eq(AuthorizationEntity.class)))
+        .thenReturn(List.of());
 
     // when
     final SearchQueryRequest result =
@@ -149,10 +149,10 @@ class DocumentAuthorizationQueryStrategyTest {
                     .withAuthorization(
                         a -> a.permissionType(READ).resourceType(PROCESS_DEFINITION)));
     final var authorizationsSearchQueryCaptor = ArgumentCaptor.forClass(SearchQueryRequest.class);
-    when(searchClient.search(
+    when(searchClient.findAll(
             authorizationsSearchQueryCaptor.capture(), eq(AuthorizationEntity.class)))
         .thenReturn(
-            buildSearchQueryResponse(
+            List.of(
                 new AuthorizationEntity(
                     null,
                     null,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add `findAll` methods in DocumentBasedSearchClient to fetch all the documents matching a given search query using ES/OS scrolling mechanism

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #23174 
