### PR TITLE
feat: Implement basic document upload

### DIFF
--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "dependencies": {
     "@bpmn-io/element-template-icon-renderer": "0.5.2",
-    "@bpmn-io/form-js-carbon-styles": "1.10.1",
-    "@bpmn-io/form-js-viewer": "1.10.1",
+    "@bpmn-io/form-js-carbon-styles": "1.11.0-alpha.0",
+    "@bpmn-io/form-js-viewer": "1.11.0-alpha.0",
     "@camunda/camunda-composite-components": "0.9.0",
     "@carbon/elements": "11.54.0",
     "@carbon/react": "1.67.1",

--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "dependencies": {
     "@bpmn-io/element-template-icon-renderer": "0.5.2",
-    "@bpmn-io/form-js-carbon-styles": "1.11.0-alpha.0",
-    "@bpmn-io/form-js-viewer": "1.11.0-alpha.0",
+    "@bpmn-io/form-js-carbon-styles": "1.11.1",
+    "@bpmn-io/form-js-viewer": "1.11.1",
     "@camunda/camunda-composite-components": "0.9.0",
     "@carbon/elements": "11.54.0",
     "@carbon/react": "1.67.1",

--- a/tasklist/client/public/mockServiceWorker.js
+++ b/tasklist/client/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.9'
+const PACKAGE_VERSION = '2.4.11'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/tasklist/client/src/Processes/ProcessTile/FormModal/index.test.tsx
+++ b/tasklist/client/src/Processes/ProcessTile/FormModal/index.test.tsx
@@ -56,6 +56,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -113,6 +114,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={mockOnClose}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -154,6 +156,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -190,6 +193,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -231,6 +235,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -292,6 +297,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockFailOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled
         tenantId={undefined}
       />,
@@ -337,6 +343,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockSuccessOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled
         tenantId="tenantA"
       />,
@@ -394,6 +401,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {
@@ -442,6 +450,7 @@ describe('<FormModal />', () => {
         isOpen={false}
         onClose={() => Promise.resolve()}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
     );
@@ -455,6 +464,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
     );
@@ -480,6 +490,7 @@ describe('<FormModal />', () => {
         isOpen
         onClose={() => Promise.resolve()}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         isMultiTenancyEnabled={false}
       />,
       {

--- a/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
+++ b/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
@@ -8,9 +8,9 @@
 
 import {FormManager} from 'modules/formManager';
 import {useForm} from 'modules/queries/useForm';
-import type {Process, Variable} from 'modules/types';
+import type {Process} from 'modules/types';
 import {getProcessDisplayName} from 'modules/utils/getProcessDisplayName';
-import {useRef, useState} from 'react';
+import React, {useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {
   TextInputSkeleton,
@@ -30,10 +30,8 @@ type Props = {
   process: Process;
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (
-    variables: Pick<Variable, 'name' | 'value'>[],
-    files?: Map<string, File[]>,
-  ) => Promise<void>;
+  onSubmit: React.ComponentProps<typeof FormJSRenderer>['handleSubmit'];
+  onFileUpload: React.ComponentProps<typeof FormJSRenderer>['handleFileUpload'];
   isMultiTenancyEnabled: boolean;
   tenantId?: string;
 };
@@ -43,6 +41,7 @@ const FormModal: React.FC<Props> = ({
   onClose,
   process,
   onSubmit,
+  onFileUpload,
   isMultiTenancyEnabled,
   tenantId,
 }) => {
@@ -152,6 +151,7 @@ const FormModal: React.FC<Props> = ({
                       <FormJSRenderer
                         schema={schema!}
                         handleSubmit={onSubmit}
+                        handleFileUpload={onFileUpload}
                         onMount={(formManager) => {
                           formManagerRef.current = formManager;
                         }}

--- a/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
+++ b/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
@@ -30,7 +30,10 @@ type Props = {
   process: Process;
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (variables: Variable[]) => Promise<void>;
+  onSubmit: (
+    variables: Pick<Variable, 'name' | 'value'>[],
+    files?: Map<string, File[]>,
+  ) => Promise<void>;
   isMultiTenancyEnabled: boolean;
   tenantId?: string;
 };

--- a/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
+++ b/tasklist/client/src/Processes/ProcessTile/FormModal/index.tsx
@@ -10,7 +10,7 @@ import {FormManager} from 'modules/formManager';
 import {useForm} from 'modules/queries/useForm';
 import type {Process} from 'modules/types';
 import {getProcessDisplayName} from 'modules/utils/getProcessDisplayName';
-import React, {useRef, useState} from 'react';
+import {useRef, useState} from 'react';
 import {useTranslation} from 'react-i18next';
 import {
   TextInputSkeleton,

--- a/tasklist/client/src/Processes/ProcessTile/index.tsx
+++ b/tasklist/client/src/Processes/ProcessTile/index.tsx
@@ -224,35 +224,24 @@ const ProcessTile: React.FC<Props> = ({
               pathname: '/processes',
             });
           }}
-          onSubmit={async (variables, files) => {
-            let fileUploadResponses: Awaited<
-              ReturnType<typeof uploadDocuments>
-            > = new Map();
-
-            if (files !== undefined) {
-              fileUploadResponses = await uploadDocuments({
-                files,
-              });
-            }
+          onSubmit={async (variables) => {
             await startProcess({
               bpmnProcessId,
-              variables:
-                fileUploadResponses.size === 0
-                  ? variables
-                  : [
-                      ...variables,
-                      {
-                        name: 'documentMetadata',
-                        value: JSON.stringify(
-                          Object.fromEntries(fileUploadResponses.entries()),
-                        ),
-                      },
-                    ],
+              variables,
               tenantId,
             });
             navigate({
               ...location,
               pathname: '/processes',
+            });
+          }}
+          onFileUpload={async (files: Map<string, File[]>) => {
+            if (files.size === 0) {
+              return new Map();
+            }
+
+            return uploadDocuments({
+              files,
             });
           }}
           isMultiTenancyEnabled={isMultiTenancyEnabled}

--- a/tasklist/client/src/Tasks/Task/FormJS/index.test.tsx
+++ b/tasklist/client/src/Tasks/Task/FormJS/index.test.tsx
@@ -120,6 +120,7 @@ describe('<FormJS />', () => {
         task={unassignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -176,6 +177,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -231,6 +233,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -284,6 +287,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -354,6 +358,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={mockOnSubmit}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -432,6 +437,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -465,6 +471,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,
@@ -508,6 +515,7 @@ describe('<FormJS />', () => {
         task={assignedTaskWithForm(MOCK_TASK_ID)}
         user={userMocks.currentUser}
         onSubmit={() => Promise.resolve()}
+        onFileUpload={() => Promise.resolve(new Map())}
         onSubmitFailure={noop}
         onSubmitSuccess={noop}
       />,

--- a/tasklist/client/src/Tasks/Task/FormJS/index.tsx
+++ b/tasklist/client/src/Tasks/Task/FormJS/index.tsx
@@ -56,7 +56,7 @@ type Props = {
   id: Form['id'];
   processDefinitionKey: Form['processDefinitionKey'];
   task: Task;
-  onSubmit: (variables: Variable[]) => Promise<void>;
+  onSubmit: (variables: Variable[], files?: File[]) => Promise<void>;
   onSubmitSuccess: () => void;
   onSubmitFailure: (error: Error) => void;
   user: CurrentUser;

--- a/tasklist/client/src/Tasks/Task/FormJS/index.tsx
+++ b/tasklist/client/src/Tasks/Task/FormJS/index.tsx
@@ -56,7 +56,10 @@ type Props = {
   id: Form['id'];
   processDefinitionKey: Form['processDefinitionKey'];
   task: Task;
-  onSubmit: (variables: Variable[], files?: File[]) => Promise<void>;
+  onSubmit: (
+    variables: Variable[],
+    files?: Map<string, File[]>,
+  ) => Promise<void>;
   onSubmitSuccess: () => void;
   onSubmitFailure: (error: Error) => void;
   user: CurrentUser;

--- a/tasklist/client/src/Tasks/Task/FormJS/index.tsx
+++ b/tasklist/client/src/Tasks/Task/FormJS/index.tsx
@@ -56,10 +56,8 @@ type Props = {
   id: Form['id'];
   processDefinitionKey: Form['processDefinitionKey'];
   task: Task;
-  onSubmit: (
-    variables: Variable[],
-    files?: Map<string, File[]>,
-  ) => Promise<void>;
+  onSubmit: React.ComponentProps<typeof FormJSRenderer>['handleSubmit'];
+  onFileUpload: React.ComponentProps<typeof FormJSRenderer>['handleFileUpload'];
   onSubmitSuccess: () => void;
   onSubmitFailure: (error: Error) => void;
   user: CurrentUser;
@@ -71,6 +69,7 @@ const FormJS: React.FC<Props> = ({
   task,
   onSubmit,
   onSubmitSuccess,
+  onFileUpload,
   onSubmitFailure,
   user,
 }) => {
@@ -148,6 +147,7 @@ const FormJS: React.FC<Props> = ({
                     formManagerRef.current = formManager;
                   }}
                   handleSubmit={onSubmit}
+                  handleFileUpload={onFileUpload}
                   onImportError={() => {
                     removeFormReference();
                     notificationsStore.displayNotification({

--- a/tasklist/client/src/Tasks/Task/index.tsx
+++ b/tasklist/client/src/Tasks/Task/index.tsx
@@ -86,16 +86,31 @@ const Task: React.FC = observer(() => {
 
   async function handleSubmission(
     variables: Pick<Variable, 'name' | 'value'>[],
-    files?: File[],
+    files?: Map<string, File[]>,
   ) {
+    let fileUploadResponses: Awaited<ReturnType<typeof uploadDocuments>> =
+      new Map();
+
     if (files !== undefined) {
-      await uploadDocuments({
+      fileUploadResponses = await uploadDocuments({
         files,
       });
     }
+
     await completeTask({
       taskId,
-      variables,
+      variables:
+        fileUploadResponses.size === 0
+          ? variables
+          : [
+              ...variables,
+              {
+                name: 'documentMetadata',
+                value: JSON.stringify(
+                  Object.fromEntries(fileUploadResponses.entries()),
+                ),
+              },
+            ],
     });
 
     const filter = new URLSearchParams(window.location.search).get('filter');

--- a/tasklist/client/src/Tasks/Task/index.tsx
+++ b/tasklist/client/src/Tasks/Task/index.tsx
@@ -86,31 +86,10 @@ const Task: React.FC = observer(() => {
 
   async function handleSubmission(
     variables: Pick<Variable, 'name' | 'value'>[],
-    files?: Map<string, File[]>,
   ) {
-    let fileUploadResponses: Awaited<ReturnType<typeof uploadDocuments>> =
-      new Map();
-
-    if (files !== undefined) {
-      fileUploadResponses = await uploadDocuments({
-        files,
-      });
-    }
-
     await completeTask({
       taskId,
-      variables:
-        fileUploadResponses.size === 0
-          ? variables
-          : [
-              ...variables,
-              {
-                name: 'documentMetadata',
-                value: JSON.stringify(
-                  Object.fromEntries(fileUploadResponses.entries()),
-                ),
-              },
-            ],
+      variables,
     });
 
     const filter = new URLSearchParams(window.location.search).get('filter');
@@ -130,6 +109,16 @@ const Task: React.FC = observer(() => {
       kind: 'success',
       title: t('taskCompletedNotification'),
       isDismissable: true,
+    });
+  }
+
+  async function handleFileUpload(files: Map<string, File[]>) {
+    if (files.size === 0) {
+      return new Map();
+    }
+
+    return uploadDocuments({
+      files,
     });
   }
 
@@ -188,6 +177,7 @@ const Task: React.FC = observer(() => {
         id={isEmbeddedForm ? getFormId(formKey) : formId!}
         user={currentUser}
         onSubmit={handleSubmission}
+        onFileUpload={handleFileUpload}
         onSubmitSuccess={handleSubmissionSuccess}
         onSubmitFailure={handleSubmissionFailure}
         processDefinitionKey={processDefinitionKey!}

--- a/tasklist/client/src/Tasks/Task/index.tsx
+++ b/tasklist/client/src/Tasks/Task/index.tsx
@@ -32,6 +32,7 @@ import {getCompleteTaskErrorMessage} from './getCompleteTaskErrorMessage';
 import {shouldFetchMore} from './shouldFetchMore';
 import {Variables} from './Variables';
 import {FormJS} from './FormJS';
+import {useUploadDocuments} from 'modules/mutations/useUploadDocuments';
 
 const CAMUNDA_FORMS_PREFIX = 'camunda-forms:bpmn:';
 
@@ -62,6 +63,7 @@ const Task: React.FC = observer(() => {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const {mutateAsync: completeTask} = useCompleteTask();
+  const {mutateAsync: uploadDocuments} = useUploadDocuments();
   const {formKey, processDefinitionKey, formId, id: taskId} = task;
 
   const {enabled: autoSelectNextTaskEnabled} = autoSelectNextTaskStore;
@@ -84,7 +86,13 @@ const Task: React.FC = observer(() => {
 
   async function handleSubmission(
     variables: Pick<Variable, 'name' | 'value'>[],
+    files?: File[],
   ) {
+    if (files !== undefined) {
+      await uploadDocuments({
+        files,
+      });
+    }
     await completeTask({
       taskId,
       variables,

--- a/tasklist/client/src/modules/api.ts
+++ b/tasklist/client/src/modules/api.ts
@@ -319,6 +319,20 @@ const api = {
       });
     },
   },
+  uploadDocuments: ({file}: {file: File}) => {
+    const body = new FormData();
+
+    body.append('file', file);
+
+    return new Request(getFullURL('/v2/documents'), {
+      ...BASE_REQUEST_OPTIONS,
+      method: 'POST',
+      body,
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  },
 } as const;
 
 export {api};

--- a/tasklist/client/src/modules/api.ts
+++ b/tasklist/client/src/modules/api.ts
@@ -45,7 +45,7 @@ const api = {
       }),
     startProcess: (payload: {
       bpmnProcessId: string;
-      variables: Variable[];
+      variables: Pick<Variable, 'name' | 'value'>[];
       tenantId?: Task['tenantId'];
     }) => {
       const {bpmnProcessId, variables, tenantId} = payload;
@@ -318,20 +318,17 @@ const api = {
         },
       });
     },
-  },
-  uploadDocuments: ({file}: {file: File}) => {
-    const body = new FormData();
+    uploadDocuments: ({file}: {file: File}) => {
+      const body = new FormData();
 
-    body.append('file', file);
+      body.append('file', file);
 
-    return new Request(getFullURL('/v2/documents'), {
-      ...BASE_REQUEST_OPTIONS,
-      method: 'POST',
-      body,
-      headers: {
-        'Content-Type': 'multipart/form-data',
-      },
-    });
+      return new Request(getFullURL('/v2/documents'), {
+        ...BASE_REQUEST_OPTIONS,
+        method: 'POST',
+        body,
+      });
+    },
   },
 } as const;
 

--- a/tasklist/client/src/modules/components/FormJSRenderer/getFieldLabels.test.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/getFieldLabels.test.tsx
@@ -60,6 +60,7 @@ const schemaWithNoLabels = JSON.stringify({
       key: 'fromExpression',
       id: 'field2',
       type: 'textfield',
+      label: '',
     },
     {
       key: 'button1',
@@ -135,6 +136,7 @@ const schemaWithNestedFieldsNoGroupLabels = JSON.stringify({
       type: 'group',
       id: 'group1',
       path: 'root',
+      label: '',
     },
   ],
   type: 'default',

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
@@ -18,7 +18,10 @@ import '@bpmn-io/form-js-viewer/dist/assets/form-js-base.css';
 import '@bpmn-io/form-js-carbon-styles/src/carbon-styles.scss';
 
 type Props = {
-  handleSubmit: (variables: Variable[], files?: File[]) => Promise<void>;
+  handleSubmit: (
+    variables: Variable[],
+    files?: Map<string, File[]>,
+  ) => Promise<void>;
   schema: string;
   data?: Record<string, unknown>;
   readOnly?: boolean;
@@ -141,10 +144,7 @@ const FormJSRenderer: React.FC<Props> = ({
               );
 
               try {
-                await handleSubmit(
-                  variables,
-                  Array.from(files.values()).flat(),
-                );
+                await handleSubmit(variables, files);
                 onSubmitSuccess?.();
               } catch (error) {
                 onSubmitError?.(error);

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
@@ -18,7 +18,7 @@ import '@bpmn-io/form-js-viewer/dist/assets/form-js-base.css';
 import '@bpmn-io/form-js-carbon-styles/src/carbon-styles.scss';
 
 type Props = {
-  handleSubmit: (variables: Variable[]) => Promise<void>;
+  handleSubmit: (variables: Variable[], files?: File[]) => Promise<void>;
   schema: string;
   data?: Record<string, unknown>;
   readOnly?: boolean;
@@ -126,7 +126,7 @@ const FormJSRenderer: React.FC<Props> = ({
           schema,
           data,
           onImportError,
-          onSubmit: async ({data: newData, errors}) => {
+          onSubmit: async ({data: newData, errors, files}) => {
             onSubmitStart?.();
             setInvalidFields(undefined);
             if (Object.keys(errors).length === 0) {
@@ -141,7 +141,10 @@ const FormJSRenderer: React.FC<Props> = ({
               );
 
               try {
-                await handleSubmit(variables);
+                await handleSubmit(
+                  variables,
+                  Array.from(files.values()).flat(),
+                );
                 onSubmitSuccess?.();
               } catch (error) {
                 onSubmitError?.(error);

--- a/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
+++ b/tasklist/client/src/modules/components/FormJSRenderer/index.tsx
@@ -200,25 +200,25 @@ const FormJSRenderer: React.FC<Props> = ({
             onSubmitStart?.();
             setInvalidFields(undefined);
             if (Object.keys(errors).length === 0) {
-              const enrichedData =
-                files.size === 0
-                  ? newData
-                  : injectFileMetadataIntoData({
-                      data: newData,
-                      fileMetadata: await handleFileUpload(files),
-                      pathsToInject: extractFilePath(newData),
-                    });
-              const variables = Object.entries(
-                mergeVariables(data, enrichedData),
-              ).map(
-                ([name, value]) =>
-                  ({
-                    name,
-                    value: JSON.stringify(value),
-                  }) as Variable,
-              );
-
               try {
+                const enrichedData =
+                  files.size === 0
+                    ? newData
+                    : injectFileMetadataIntoData({
+                        data: newData,
+                        fileMetadata: await handleFileUpload(files),
+                        pathsToInject: extractFilePath(newData),
+                      });
+                const variables = Object.entries(
+                  mergeVariables(data, enrichedData),
+                ).map(
+                  ([name, value]) =>
+                    ({
+                      name,
+                      value: JSON.stringify(value),
+                    }) as Variable,
+                );
+
                 await handleSubmit(variables);
                 onSubmitSuccess?.();
               } catch (error) {

--- a/tasklist/client/src/modules/mutations/useStartProcess.tsx
+++ b/tasklist/client/src/modules/mutations/useStartProcess.tsx
@@ -18,7 +18,7 @@ function useStartProcess(
       RequestError | Error,
       {
         bpmnProcessId: Process['bpmnProcessId'];
-        variables?: Variable[];
+        variables?: Pick<Variable, 'name' | 'value'>[];
         tenantId?: Task['tenantId'];
       }
     >,
@@ -28,7 +28,9 @@ function useStartProcess(
   return useMutation<
     ProcessInstance,
     RequestError | Error,
-    Pick<Process, 'bpmnProcessId'> & {variables?: Variable[]} & {
+    Pick<Process, 'bpmnProcessId'> & {
+      variables?: Pick<Variable, 'name' | 'value'>[];
+    } & {
       tenantId?: Task['tenantId'];
     }
   >({

--- a/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
+++ b/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {useMutation} from '@tanstack/react-query';
+import {api} from 'modules/api';
+import {type RequestError, request} from 'modules/request';
+
+type Payload = {
+  files: File[];
+};
+
+function useUploadDocuments() {
+  return useMutation<null, RequestError | Error, Payload>({
+    mutationFn: async ({files}) => {
+      const responses = await Promise.all(
+        files.map((file) => request(api.uploadDocuments({file}))),
+      );
+
+      if (responses.every(({response}) => response !== null)) {
+        return null;
+      }
+
+      throw new Error('Failed to upload all files');
+    },
+  });
+}
+
+export {useUploadDocuments};

--- a/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
+++ b/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
@@ -46,7 +46,7 @@ function useUploadDocuments() {
       });
       const responses = await Promise.all(requests);
 
-      if (responses.every(({response}) => response !== null)) {
+      if (responses.every(({response}) => response !== null && response.ok)) {
         const metadataMapping: [string, FileUploadMetadata[]][] = [];
 
         for (const [key, responses] of fileRequestMapping) {

--- a/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
+++ b/tasklist/client/src/modules/mutations/useUploadDocuments.tsx
@@ -14,7 +14,7 @@ type Payload = {
   files: Map<string, File[]>;
 };
 
-type FileUploadResponse = {
+type FileUploadMetadata = {
   documentType: string;
   storeId: string;
   documentId: string;
@@ -27,7 +27,7 @@ type FileUploadResponse = {
 
 function useUploadDocuments() {
   return useMutation<
-    Map<string, FileUploadResponse[]>,
+    Map<string, FileUploadMetadata[]>,
     RequestError | Error,
     Payload
   >({
@@ -47,7 +47,7 @@ function useUploadDocuments() {
       const responses = await Promise.all(requests);
 
       if (responses.every(({response}) => response !== null)) {
-        const metadataMapping: [string, FileUploadResponse[]][] = [];
+        const metadataMapping: [string, FileUploadMetadata[]][] = [];
 
         for (const [key, responses] of fileRequestMapping) {
           const metadata = await responses;
@@ -67,3 +67,4 @@ function useUploadDocuments() {
 }
 
 export {useUploadDocuments};
+export type {FileUploadMetadata};

--- a/tasklist/client/yarn.lock
+++ b/tasklist/client/yarn.lock
@@ -237,29 +237,29 @@
     "@codemirror/language" "^6.10.0"
     lezer-feel "^1.2.3"
 
-"@bpmn-io/form-js-carbon-styles@1.11.0-alpha.0":
-  version "1.11.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.11.0-alpha.0.tgz#5800b6ecdb7ae0412beccd463819ec6cb286015b"
-  integrity sha512-EO8kQAxQdyYGNLdnmPnTJAlQXtPUGawIHckt85aEr+xWLjx/glEkSwpyyUicV57My2KfW4ik/V2xkqxKPQ+FfA==
+"@bpmn-io/form-js-carbon-styles@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.11.1.tgz#be97a1ecfef209cc241e11d93469e14a8aca88b8"
+  integrity sha512-ljDttTrrtJzJ6RCT4kaZftDN5Ew7g3TJ5MViwMFDYjK39nTNKELbdOyubSxOPJOX1n23xyk3xdd9zSqhi1ex7A==
 
-"@bpmn-io/form-js-viewer@1.11.0-alpha.0":
-  version "1.11.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-viewer/-/form-js-viewer-1.11.0-alpha.0.tgz#83e5bbc508d3c4cbf4eceb0c6fb2508af3a53834"
-  integrity sha512-S07rLJ740qGcVJ6zLnaZaKEEs7Ed4jcRsezh5O6u0r9Q55rHVpkm1xIPu7XPxNdEdQPgcDA6fzG7xg7rbt5pxQ==
+"@bpmn-io/form-js-viewer@1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-viewer/-/form-js-viewer-1.11.1.tgz#9122d613409dd36b4bdc2d5cb3ffc14c3444488b"
+  integrity sha512-mU2pqF/J8YIMMMyBSaIB9Zv0mOo856nNi8Zyr5QS3LmrRAWRsVbwVuXMbdFzuv61tWLYC3srZ1J8IgvrqcJk7Q==
   dependencies:
-    "@carbon/grid" "^11.22.0"
-    big.js "^6.2.1"
+    "@carbon/grid" "^11.27.0"
+    big.js "^6.2.2"
     classnames "^2.5.1"
     didi "^10.2.2"
-    dompurify "^3.1.2"
-    feelers "^1.3.1"
+    dompurify "^3.1.6"
+    feelers "^1.4.0"
     feelin "^3.1.2"
     flatpickr "^4.6.13"
     ids "^1.0.5"
     lodash "^4.17.21"
     luxon "^3.5.0"
-    marked "^14.0.0"
-    min-dash "^4.2.1"
+    marked "^14.1.2"
+    min-dash "^4.2.2"
     preact "^10.5.14"
 
 "@bundled-es-modules/cookie@^2.0.0":
@@ -328,7 +328,7 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
-"@carbon/grid@^11.22.0", "@carbon/grid@^11.28.0", "@carbon/grid@^11.29.0":
+"@carbon/grid@^11.27.0", "@carbon/grid@^11.28.0", "@carbon/grid@^11.29.0":
   version "11.29.0"
   resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.29.0.tgz#783bec6503f8a0812d4951a49d93677558969226"
   integrity sha512-SAJhTexN6TjbItcUczOqhzgHBGXLhvUhlTdyqj+wzUH0tqEN8g6gLp+1sn9+rL+kV4obSb/7bdSESZtwQr/tQg==
@@ -2191,7 +2191,7 @@ base64-arraybuffer@^1.0.1:
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz#1c37589a7c4b0746e34bd1feb951da2df01c1bdc"
   integrity sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==
 
-big.js@^6.2.1:
+big.js@^6.2.2:
   version "6.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.2.tgz#be3bb9ac834558b53b099deef2a1d06ac6368e1a"
   integrity sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==
@@ -2884,7 +2884,7 @@ domify@^2.0.0:
   resolved "https://registry.yarnpkg.com/domify/-/domify-2.0.0.tgz#951f0c36ff960b1cc527444f41819c765336dca8"
   integrity sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==
 
-dompurify@^3.1.2:
+dompurify@^3.1.6:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
   integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
@@ -3277,7 +3277,7 @@ fdir@^6.4.2:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
   integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
 
-feelers@^1.3.1:
+feelers@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/feelers/-/feelers-1.4.0.tgz#b0fc2c5e387f27ba171f044d229d4755771bb8a5"
   integrity sha512-CGa/7ILuqoqTaeYeoKsg/4tzu2es9sEEJTmSjdu0lousZBw4V9gcYhHYFNmbrSrKmbAVfOzj6/DsymGJWFIOeg==
@@ -4284,7 +4284,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-marked@^14.0.0:
+marked@^14.1.2:
   version "14.1.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-14.1.3.tgz#42372cffd22e76e0f1d7f3627ebc116d291abbed"
   integrity sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==
@@ -4613,7 +4613,7 @@ mimic-response@^3.1.0:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-3.1.0.tgz#2d1d59af9c1b129815accc2c46a022a5ce1fa3c9"
   integrity sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==
 
-min-dash@^4.0.0, min-dash@^4.1.0, min-dash@^4.1.1, min-dash@^4.2.1:
+min-dash@^4.0.0, min-dash@^4.1.0, min-dash@^4.1.1, min-dash@^4.2.1, min-dash@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/min-dash/-/min-dash-4.2.2.tgz#f9d3b6d5901e3a627f926013bcfd9efb2cad93a3"
   integrity sha512-qbhSYUxk6mBaF096B3JOQSumXbKWHenmT97cSpdNzgkWwGjhjhE/KZODCoDNhI2I4C9Cb6R/Q13S4BYkUSXoXQ==

--- a/tasklist/client/yarn.lock
+++ b/tasklist/client/yarn.lock
@@ -237,28 +237,28 @@
     "@codemirror/language" "^6.10.0"
     lezer-feel "^1.2.3"
 
-"@bpmn-io/form-js-carbon-styles@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.10.1.tgz#d0af4ab33e6ca2b5d42dc44b47648766317ec985"
-  integrity sha512-UopfGHhfvmdK8p9PPRs/LezSVTUA6UoYmE2h6kRAHAMud2C1V9YjLRinWC5XTR3U5/MGI6Q4KPX9dT30Dr0E7A==
+"@bpmn-io/form-js-carbon-styles@1.11.0-alpha.0":
+  version "1.11.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-carbon-styles/-/form-js-carbon-styles-1.11.0-alpha.0.tgz#5800b6ecdb7ae0412beccd463819ec6cb286015b"
+  integrity sha512-EO8kQAxQdyYGNLdnmPnTJAlQXtPUGawIHckt85aEr+xWLjx/glEkSwpyyUicV57My2KfW4ik/V2xkqxKPQ+FfA==
 
-"@bpmn-io/form-js-viewer@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-viewer/-/form-js-viewer-1.10.1.tgz#d15f5465dd575c17e92ba3e872ec841aee2fbf3e"
-  integrity sha512-gy5D+pyM9vvwfIWac4+dcEeUuyy+M44YlB9yOYfbsuM1uXWgOXMxsYCxwyPkNL0+J1dPqHCDm6w/RIvfGeFedw==
+"@bpmn-io/form-js-viewer@1.11.0-alpha.0":
+  version "1.11.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@bpmn-io/form-js-viewer/-/form-js-viewer-1.11.0-alpha.0.tgz#83e5bbc508d3c4cbf4eceb0c6fb2508af3a53834"
+  integrity sha512-S07rLJ740qGcVJ6zLnaZaKEEs7Ed4jcRsezh5O6u0r9Q55rHVpkm1xIPu7XPxNdEdQPgcDA6fzG7xg7rbt5pxQ==
   dependencies:
-    "@carbon/grid" "^11.26.0"
+    "@carbon/grid" "^11.22.0"
     big.js "^6.2.1"
     classnames "^2.5.1"
     didi "^10.2.2"
-    dompurify "^3.1.6"
-    feelers "^1.4.0"
+    dompurify "^3.1.2"
+    feelers "^1.3.1"
     feelin "^3.1.2"
     flatpickr "^4.6.13"
     ids "^1.0.5"
     lodash "^4.17.21"
     luxon "^3.5.0"
-    marked "^14.1.2"
+    marked "^14.0.0"
     min-dash "^4.2.1"
     preact "^10.5.14"
 
@@ -328,7 +328,7 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
-"@carbon/grid@^11.26.0", "@carbon/grid@^11.28.0", "@carbon/grid@^11.29.0":
+"@carbon/grid@^11.22.0", "@carbon/grid@^11.28.0", "@carbon/grid@^11.29.0":
   version "11.29.0"
   resolved "https://registry.yarnpkg.com/@carbon/grid/-/grid-11.29.0.tgz#783bec6503f8a0812d4951a49d93677558969226"
   integrity sha512-SAJhTexN6TjbItcUczOqhzgHBGXLhvUhlTdyqj+wzUH0tqEN8g6gLp+1sn9+rL+kV4obSb/7bdSESZtwQr/tQg==
@@ -2884,7 +2884,7 @@ domify@^2.0.0:
   resolved "https://registry.yarnpkg.com/domify/-/domify-2.0.0.tgz#951f0c36ff960b1cc527444f41819c765336dca8"
   integrity sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==
 
-dompurify@^3.1.6:
+dompurify@^3.1.2:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.1.7.tgz#711a8c96479fb6ced93453732c160c3c72418a6a"
   integrity sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ==
@@ -3277,7 +3277,7 @@ fdir@^6.4.2:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.2.tgz#ddaa7ce1831b161bc3657bb99cb36e1622702689"
   integrity sha512-KnhMXsKSPZlAhp7+IjUkRZKPb4fUyccpDrdFXbi4QL1qkmFh9kVY09Yox+n4MaOb3lHZ1Tv829C3oaaXoMYPDQ==
 
-feelers@^1.4.0:
+feelers@^1.3.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/feelers/-/feelers-1.4.0.tgz#b0fc2c5e387f27ba171f044d229d4755771bb8a5"
   integrity sha512-CGa/7ILuqoqTaeYeoKsg/4tzu2es9sEEJTmSjdu0lousZBw4V9gcYhHYFNmbrSrKmbAVfOzj6/DsymGJWFIOeg==
@@ -4284,7 +4284,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-marked@^14.1.2:
+marked@^14.0.0:
   version "14.1.3"
   resolved "https://registry.yarnpkg.com/marked/-/marked-14.1.3.tgz#42372cffd22e76e0f1d7f3627ebc116d291abbed"
   integrity sha512-ZibJqTULGlt9g5k4VMARAktMAjXoVnnr+Y3aCqW1oDftcV4BA3UmrBifzXoZyenHRk75csiPu9iwsTj4VNBT0g==


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR implements document uploads on Tasklist using the new `filepicker` component from `form-js`

I couldn't add a test because `DataTransfer` is not mocked on `jsdom`. I'll try to add an E2E tests Monday.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/team-hto/issues/662
