### PR TITLE
Access user task completion variables in task listener jobs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -137,7 +137,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     jobActivationBehavior =
         new BpmnJobActivationBehavior(
             jobStreamer,
-            processingState.getVariableState(),
+            processingState,
             writers,
             processingState.getKeyGenerator(),
             jobMetrics,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobActivationBehavior.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer.JobStream;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJobImpl;
@@ -48,7 +48,7 @@ public class BpmnJobActivationBehavior {
 
   public BpmnJobActivationBehavior(
       final JobStreamer jobStreamer,
-      final VariableState variableState,
+      final ProcessingState state,
       final Writers writers,
       final KeyGenerator keyGenerator,
       final JobMetrics jobMetrics,
@@ -56,7 +56,7 @@ public class BpmnJobActivationBehavior {
     this.jobStreamer = jobStreamer;
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
-    jobVariablesCollector = new JobVariablesCollector(variableState);
+    jobVariablesCollector = new JobVariablesCollector(state);
     stateWriter = writers.state();
     sideEffectWriter = writers.sideEffect();
     this.clock = clock;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -56,9 +56,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    jobBatchCollector =
-        new JobBatchCollector(
-            state.getJobState(), state.getVariableState(), stateWriter::canWriteEventOfLength);
+    jobBatchCollector = new JobBatchCollector(state, stateWriter::canWriteEventOfLength);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -43,20 +44,15 @@ final class JobBatchCollector {
   private final Predicate<Integer> canWriteEventOfLength;
 
   /**
-   * @param jobState the state from which jobs are collected
-   * @param variableState the state from which variables are resolved and collected
    * @param canWriteEventOfLength a predicate which should return whether the resulting {@link
    *     TypedRecord} containing the {@link JobBatchRecord} will be writable or not. The predicate
    *     takes in the size of the record, and should return true if it can write such a record, and
    *     false otherwise
    */
-  JobBatchCollector(
-      final JobState jobState,
-      final VariableState variableState,
-      final Predicate<Integer> canWriteEventOfLength) {
-    this.jobState = jobState;
+  JobBatchCollector(final ProcessingState state, final Predicate<Integer> canWriteEventOfLength) {
+    jobState = state.getJobState();
     this.canWriteEventOfLength = canWriteEventOfLength;
-    jobVariablesCollector = new JobVariablesCollector(variableState);
+    jobVariablesCollector = new JobVariablesCollector(state);
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -69,57 +69,57 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     if (elementInstance == null) {
       return;
-    } else {
-      switch (value.getJobKind()) {
-        case EXECUTION_LISTENER:
-          {
-            // to store the variable for merge, to handle concurrent commands
-            eventHandle.triggeringProcessEvent(value);
+    }
 
+    switch (value.getJobKind()) {
+      case EXECUTION_LISTENER:
+        {
+          // to store the variable for merge, to handle concurrent commands
+          eventHandle.triggeringProcessEvent(value);
+
+          commandWriter.appendFollowUpCommand(
+              elementInstanceKey,
+              ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER,
+              elementInstance.getValue());
+          return;
+        }
+      case TASK_LISTENER:
+        {
+          // to store the variable for merge, to handle concurrent commands
+          eventHandle.triggeringProcessEvent(value);
+
+          /*
+           We retrieve the intermediate user task state rather than the regular user task record
+           because the intermediate state captures the exact data provided during the original
+           user task command (e.g., COMPLETE, ASSIGN). This data includes variables, actions,
+           and other command-related details that may not yet be reflected in the persisted user
+           task record, that can be accessed via `userTaskState.getUserTask`.
+
+           When task listeners are involved, it's essential to preserve this original state
+           until all task listeners have been executed. Retrieving the intermediate state here
+           ensures that the finalization of the user task command uses the correct, unmodified
+           data as originally intended by the user. Once all task listeners have been processed
+           and the original user task command is finalized, the intermediate state is cleared.
+          */
+          final var userTask =
+              userTaskState.getIntermediateState(elementInstance.getUserTaskKey()).getRecord();
+          commandWriter.appendFollowUpCommand(
+              userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
+          return;
+        }
+      default:
+        {
+          final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+          final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+          if (scopeInstance != null && scopeInstance.isActive()) {
+            eventHandle.triggeringProcessEvent(value);
             commandWriter.appendFollowUpCommand(
                 elementInstanceKey,
-                ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER,
+                ProcessInstanceIntent.COMPLETE_ELEMENT,
                 elementInstance.getValue());
-            return;
           }
-        case TASK_LISTENER:
-          {
-            // to store the variable for merge, to handle concurrent commands
-            eventHandle.triggeringProcessEvent(value);
-
-            /*
-             We retrieve the intermediate user task state rather than the regular user task record
-             because the intermediate state captures the exact data provided during the original
-             user task command (e.g., COMPLETE, ASSIGN). This data includes variables, actions,
-             and other command-related details that may not yet be reflected in the persisted user
-             task record, that can be accessed via `userTaskState.getUserTask`.
-
-             When task listeners are involved, it's essential to preserve this original state
-             until all task listeners have been executed. Retrieving the intermediate state here
-             ensures that the finalization of the user task command uses the correct, unmodified
-             data as originally intended by the user. Once all task listeners have been processed
-             and the original user task command is finalized, the intermediate state is cleared.
-            */
-            final var userTask =
-                userTaskState.getIntermediateState(elementInstance.getUserTaskKey()).getRecord();
-            commandWriter.appendFollowUpCommand(
-                userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
-            return;
-          }
-        default:
-          {
-            final long scopeKey = elementInstance.getValue().getFlowScopeKey();
-            final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
-
-            if (scopeInstance != null && scopeInstance.isActive()) {
-              eventHandle.triggeringProcessEvent(value);
-              commandWriter.appendFollowUpCommand(
-                  elementInstanceKey,
-                  ProcessInstanceIntent.COMPLETE_ELEMENT,
-                  elementInstance.getValue());
-            }
-          }
-      }
+        }
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -67,7 +67,9 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
     final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
-    if (elementInstance != null) {
+    if (elementInstance == null) {
+      return;
+    } else {
       switch (value.getJobKind()) {
         case EXECUTION_LISTENER:
           {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -27,12 +27,10 @@ public class JobVariablesCollector {
     final DirectBuffer variables;
     if (elementInstanceKey < 0) {
       variables = DocumentValue.EMPTY_DOCUMENT;
+    } else if (requestedVariables.isEmpty()) {
+      variables = variableState.getVariablesAsDocument(elementInstanceKey);
     } else {
-      if (requestedVariables.isEmpty()) {
-        variables = variableState.getVariablesAsDocument(elementInstanceKey);
-      } else {
-        variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
-      }
+      variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
     }
     jobRecord.setVariables(variables);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -7,18 +7,29 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import org.agrona.DirectBuffer;
 
 public class JobVariablesCollector {
 
   private final VariableState variableState;
+  private final UserTaskState userTaskState;
+  private final ElementInstanceState elementInstanceState;
 
-  public JobVariablesCollector(final VariableState variableState) {
-    this.variableState = variableState;
+  public JobVariablesCollector(final ProcessingState processingState) {
+    variableState = processingState.getVariableState();
+    userTaskState = processingState.getUserTaskState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   public void setJobVariables(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -25,14 +25,14 @@ public class JobVariablesCollector {
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
     final long elementInstanceKey = jobRecord.getElementInstanceKey();
     final DirectBuffer variables;
-    if (elementInstanceKey >= 0) {
+    if (elementInstanceKey < 0) {
+      variables = DocumentValue.EMPTY_DOCUMENT;
+    } else {
       if (requestedVariables.isEmpty()) {
         variables = variableState.getVariablesAsDocument(elementInstanceKey);
       } else {
         variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
       }
-    } else {
-      variables = DocumentValue.EMPTY_DOCUMENT;
     }
     jobRecord.setVariables(variables);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -31,10 +31,9 @@ public class JobVariablesCollector {
       } else {
         variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
       }
-      jobRecord.setVariables(variables);
     } else {
       variables = DocumentValue.EMPTY_DOCUMENT;
-      jobRecord.setVariables(variables);
     }
+    jobRecord.setVariables(variables);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public class JobVariablesCollector {
@@ -81,13 +81,8 @@ public class JobVariablesCollector {
     if (requestedVariables.isEmpty()) {
       return taskVariablesMap;
     }
-    final Map<String, Object> filteredTaskVariablesMap = new HashMap<>();
-    taskVariablesMap.forEach(
-        (key, value) -> {
-          if (requestedVariables.contains(BufferUtil.wrapString(key))) {
-            filteredTaskVariablesMap.put(key, value);
-          }
-        });
-    return filteredTaskVariablesMap;
+    return taskVariablesMap.entrySet().stream()
+        .filter(e -> requestedVariables.contains(BufferUtil.wrapString(e.getKey())))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -24,8 +24,8 @@ public class JobVariablesCollector {
   public void setJobVariables(
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
     final long elementInstanceKey = jobRecord.getElementInstanceKey();
+    final DirectBuffer variables;
     if (elementInstanceKey >= 0) {
-      final DirectBuffer variables;
       if (requestedVariables.isEmpty()) {
         variables = variableState.getVariablesAsDocument(elementInstanceKey);
       } else {
@@ -33,7 +33,8 @@ public class JobVariablesCollector {
       }
       jobRecord.setVariables(variables);
     } else {
-      jobRecord.setVariables(DocumentValue.EMPTY_DOCUMENT);
+      variables = DocumentValue.EMPTY_DOCUMENT;
+      jobRecord.setVariables(variables);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -24,14 +24,15 @@ public class JobVariablesCollector {
   public void setJobVariables(
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
     final long elementInstanceKey = jobRecord.getElementInstanceKey();
-    final DirectBuffer variables;
+    final DirectBuffer processVariables;
     if (elementInstanceKey < 0) {
-      variables = DocumentValue.EMPTY_DOCUMENT;
+      processVariables = DocumentValue.EMPTY_DOCUMENT;
     } else if (requestedVariables.isEmpty()) {
-      variables = variableState.getVariablesAsDocument(elementInstanceKey);
+      processVariables = variableState.getVariablesAsDocument(elementInstanceKey);
     } else {
-      variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
+      processVariables =
+          variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
     }
-    jobRecord.setVariables(variables);
+    jobRecord.setVariables(processVariables);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobVariablesCollector.java
@@ -25,23 +25,15 @@ public class JobVariablesCollector {
       final Collection<DirectBuffer> requestedVariables, final JobRecord jobRecord) {
     final long elementInstanceKey = jobRecord.getElementInstanceKey();
     if (elementInstanceKey >= 0) {
-      final DirectBuffer variables = collectVariables(requestedVariables, elementInstanceKey);
+      final DirectBuffer variables;
+      if (requestedVariables.isEmpty()) {
+        variables = variableState.getVariablesAsDocument(elementInstanceKey);
+      } else {
+        variables = variableState.getVariablesAsDocument(elementInstanceKey, requestedVariables);
+      }
       jobRecord.setVariables(variables);
     } else {
       jobRecord.setVariables(DocumentValue.EMPTY_DOCUMENT);
     }
-  }
-
-  private DirectBuffer collectVariables(
-      final Collection<DirectBuffer> variableNames, final long elementInstanceKey) {
-    final DirectBuffer variables;
-
-    if (variableNames.isEmpty()) {
-      variables = variableState.getVariablesAsDocument(elementInstanceKey);
-    } else {
-      variables = variableState.getVariablesAsDocument(elementInstanceKey, variableNames);
-    }
-
-    return variables;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -61,21 +61,21 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    this.commandProcessors =
+    commandProcessors =
         new UserTaskCommandProcessors(
             state, keyGenerator, bpmnBehaviors, writers, authCheckBehavior);
-    this.processState = state.getProcessState();
+    processState = state.getProcessState();
     this.userTaskState = userTaskState;
-    this.elementInstanceState = state.getElementInstanceState();
-    this.eventScopeInstanceState = state.getEventScopeInstanceState();
+    elementInstanceState = state.getElementInstanceState();
+    eventScopeInstanceState = state.getEventScopeInstanceState();
 
-    this.jobBehavior = bpmnBehaviors.jobBehavior();
-    this.incidentBehavior = bpmnBehaviors.incidentBehavior();
-    this.variableBehavior = bpmnBehaviors.variableBehavior();
-    this.eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();
+    jobBehavior = bpmnBehaviors.jobBehavior();
+    incidentBehavior = bpmnBehaviors.incidentBehavior();
+    variableBehavior = bpmnBehaviors.variableBehavior();
+    eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();
 
-    this.rejectionWriter = writers.rejection();
-    this.responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
   }
 
   @Override
@@ -106,7 +106,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   }
 
   private void processOperationCommand(
-      final TypedRecord<UserTaskRecord> command, UserTaskIntent intent) {
+      final TypedRecord<UserTaskRecord> command, final UserTaskIntent intent) {
     final var commandProcessor = commandProcessors.getCommandProcessor(intent);
     commandProcessor
         .validateCommand(command)
@@ -200,7 +200,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
         ExecutableUserTask.class);
   }
 
-  private ZeebeTaskListenerEventType mapIntentToEventType(UserTaskIntent intent) {
+  private ZeebeTaskListenerEventType mapIntentToEventType(final UserTaskIntent intent) {
     return switch (intent) {
       case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assignment;
       case UPDATE -> ZeebeTaskListenerEventType.update;
@@ -210,7 +210,8 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     };
   }
 
-  private ZeebeTaskListenerEventType mapLifecycleStateToEventType(LifecycleState lifecycleState) {
+  private ZeebeTaskListenerEventType mapLifecycleStateToEventType(
+      final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
       case CREATING -> ZeebeTaskListenerEventType.create;
       case ASSIGNING -> ZeebeTaskListenerEventType.assignment;
@@ -223,7 +224,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     };
   }
 
-  private UserTaskIntent mapLifecycleStateToIntent(LifecycleState lifecycleState) {
+  private UserTaskIntent mapLifecycleStateToIntent(final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
       case ASSIGNING -> UserTaskIntent.ASSIGN;
       case UPDATING -> UserTaskIntent.UPDATE;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -81,10 +81,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   @Override
   public void processRecord(final TypedRecord<UserTaskRecord> command) {
     final UserTaskIntent intent = (UserTaskIntent) command.getIntent();
-    if (intent == UserTaskIntent.COMPLETE_TASK_LISTENER) {
-      processCompleteTaskListener(command);
-    } else {
-      processOperationCommand(command, intent);
+    switch (intent) {
+      case ASSIGN, CLAIM, COMPLETE, UPDATE -> processOperationCommand(command, intent);
+      case COMPLETE_TASK_LISTENER -> processCompleteTaskListener(command);
+      default -> throw new UnsupportedOperationException("Unexpected user task intent: " + intent);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -417,6 +417,48 @@ public class TaskListenerTest {
     completeJobs(processInstanceKey, LISTENER_TYPE);
   }
 
+  @Test
+  public void shouldProvideVariablesOfTaskCompletionToCompleteTaskListener() {
+    // given
+    final var processInstanceKey =
+        createProcessInstanceWithVariables(
+            createProcessWithCompleteTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
+
+    // when
+    ENGINE.userTask().ofInstance(processInstanceKey).withVariables(Map.of("baz", 123)).complete();
+
+    // then
+    assertThat(ENGINE.jobs().withType(LISTENER_TYPE).activate().getValue().getJobs())
+        .describedAs(
+            "Expect that both the process variables and the completion variables are provided to the job")
+        .allSatisfy(
+            job ->
+                assertThat(job.getVariables())
+                    .containsExactly(Map.entry("foo", "bar"), Map.entry("baz", 123)));
+  }
+
+  @Test
+  public void shouldProvideVariablesOfTaskCompletionShadowingProcessVariables() {
+    // given
+    final var processInstanceKey =
+        createProcessInstanceWithVariables(
+            createProcessWithCompleteTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
+
+    // when
+    ENGINE
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withVariables(Map.of("foo", "overwritten"))
+        .complete();
+
+    // then
+    assertThat(ENGINE.jobs().withType(LISTENER_TYPE).activate().getValue().getJobs())
+        .describedAs(
+            "Expect that both the process variables and the completion variables are provided to the job")
+        .allSatisfy(
+            job -> assertThat(job.getVariables()).containsExactly(Map.entry("foo", "overwritten")));
+  }
+
   private void assertThatProcessInstanceCompleted(final long processInstanceKey) {
     assertThat(
             RecordingExporter.processInstanceRecords()
@@ -468,13 +510,13 @@ public class TaskListenerTest {
         .create();
   }
 
-  private void completeJobs(long processInstanceKey, String... jobTypes) {
-    for (String jobType : jobTypes) {
+  private void completeJobs(final long processInstanceKey, final String... jobTypes) {
+    for (final String jobType : jobTypes) {
       ENGINE.job().ofInstance(processInstanceKey).withType(jobType).complete();
     }
   }
 
-  private JobRecordValue activateJob(long processInstanceKey, String jobType) {
+  private JobRecordValue activateJob(final long processInstanceKey, final String jobType) {
     return ENGINE.jobs().withType(jobType).activate().getValue().getJobs().stream()
         .filter(job -> job.getProcessInstanceKey() == processInstanceKey)
         .findFirst()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -57,8 +57,7 @@ final class JobBatchCollectorTest {
 
   @BeforeEach
   void beforeEach() {
-    collector =
-        new JobBatchCollector(state.getJobState(), state.getVariableState(), lengthEvaluator);
+    collector = new JobBatchCollector(state, lengthEvaluator);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR provides access to the variables with which a user task is completed in the task listener for this operation. For example when a user completes a task with variables, these variables are now available for the listener to validate.

The variables are provided as regular `variables` on the task listener `job`. This means they are merged together with the process variables. Task operation variables hide process variables of the same name.

This PR takes the liberty to clean up some code I encountered along the way.

## Related issues

closes #24101
