### PR TITLE
fix: log message refers to Opensearch in Elasticsearch Code

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -163,7 +163,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
       return retryElasticsearchClient.isHealthy();
     } else {
-      LOGGER.warn("OpenSearch cluster health check is disabled.");
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
       return true;
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixed log message referring to Opensearch instead of Elasticsearch, see https://github.com/camunda/camunda/issues/22918#issuecomment-2440214556

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
