### PR TITLE
Add ArchUnit test to ensure processors doing authorization checks

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ExcludeAuthorizationCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/ExcludeAuthorizationCheck.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing;
+
+public @interface ExcludeAuthorizationCheck {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
@@ -41,6 +42,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.slf4j.Logger;
 
+@ExcludeAuthorizationCheck
 public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessInstanceRecord> {
 
   private static final Logger LOGGER = Loggers.PROCESS_PROCESSOR_LOGGER;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributeProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.distribute;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
+@ExcludeAuthorizationCheck
 public final class DeploymentDistributeProcessor implements TypedRecordProcessor<DeploymentRecord> {
 
   private final StartEventSubscriptionManager startEventSubscriptionManager;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/distribute/DeploymentDistributionCompleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.distribute;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public class DeploymentDistributionCompleteProcessor
     implements TypedRecordProcessor<DeploymentDistributionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionAcknowledgeProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.distribution;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public class CommandDistributionAcknowledgeProcessor
     implements TypedRecordProcessor<CommandDistributionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionContinueProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.distribution;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedEventWriter;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistribut
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public class CommandDistributionContinueProcessor
     implements TypedRecordProcessor<CommandDistributionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionFinishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionFinishProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.distribution;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -15,6 +16,7 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.Optional;
 
+@ExcludeAuthorizationCheck
 public class CommandDistributionFinishProcessor
     implements TypedRecordProcessor<CommandDistributionRecord> {
   private final CommandDistributionBehavior commandDistributionBehavior;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -27,7 +27,7 @@ import java.util.List;
  * Default implementation to process JobCommands to reduce duplication in CommandProcessor
  * implementations.
  */
-final class DefaultJobCommandPreconditionGuard {
+public final class DefaultJobCommandPreconditionGuard {
 
   private final String intent;
   private final JobState state;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -36,6 +37,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
+@ExcludeAuthorizationCheck // TODO remove this when auth checks are implemented for this class
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
 
   private final StateWriter stateWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -16,6 +17,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
 
   public static final String NO_JOB_FOUND_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 
+@ExcludeAuthorizationCheck
 public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
 
   private static final String NOT_FAILED_JOB_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -22,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.time.InstantSource;
 
+@ExcludeAuthorizationCheck
 public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
       "Expected to time out activated job with key '%d', but %s";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobYieldProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
 
+@ExcludeAuthorizationCheck
 public final class JobYieldProcessor implements TypedRecordProcessor<JobRecord> {
   private final JobState jobState;
   private final BpmnJobActivationBehavior jobActivationBehavior;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageBatchExpireProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.protocol.record.intent.MessageIntent.*;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@ExcludeAuthorizationCheck
 public final class MessageBatchExpireProcessor implements TypedRecordProcessor<MessageBatchRecord> {
 
   private static final Logger LOG = LoggerFactory.getLogger(MessageBatchExpireProcessor.class);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageExpireProcessor.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public final class MessageExpireProcessor implements TypedRecordProcessor<MessageRecord> {
 
   private final StateWriter stateWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 
+@ExcludeAuthorizationCheck
 public final class MessageSubscriptionCorrelateProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.InstantSource;
 
+@ExcludeAuthorizationCheck
 public final class MessageSubscriptionCreateProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
@@ -20,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
+@ExcludeAuthorizationCheck
 public final class MessageSubscriptionDeleteProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionMigrateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public class MessageSubscriptionMigrateProcessor
     implements DistributedTypedRecordProcessor<MessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionRejectProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+@ExcludeAuthorizationCheck
 public final class MessageSubscriptionRejectProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import org.agrona.DirectBuffer;
 
+@ExcludeAuthorizationCheck
 public final class ProcessMessageSubscriptionCorrelateProcessor
     implements TypedRecordProcessor<ProcessMessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCreateProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
+@ExcludeAuthorizationCheck
 public final class ProcessMessageSubscriptionCreateProcessor
     implements TypedRecordProcessor<ProcessMessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionDeleteProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.message;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -18,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
+@ExcludeAuthorizationCheck
 public final class ProcessMessageSubscriptionDeleteProcessor
     implements TypedRecordProcessor<ProcessMessageSubscriptionRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchActivateProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
+@ExcludeAuthorizationCheck
 public final class ProcessInstanceBatchActivateProcessor
     implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
   private final TypedCommandWriter commandWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceBatchTerminateProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
+@ExcludeAuthorizationCheck
 public final class ProcessInstanceBatchTerminateProcessor
     implements TypedRecordProcessor<ProcessInstanceBatchRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithResultProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateWithResultProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public final class ProcessInstanceCreationCreateWithResultProcessor
     implements CommandProcessor<ProcessInstanceCreationRecord> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/CommandProcessorImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.streamprocessor;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
  *
  * @param <T> the record value type
  */
+@ExcludeAuthorizationCheck
 public final class CommandProcessorImpl<T extends UnifiedRecordValue>
     implements TypedRecordProcessor<T>, CommandControl<T> {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerCancelProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.timer;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -17,6 +18,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
+@ExcludeAuthorizationCheck
 public final class TimerCancelProcessor implements TypedRecordProcessor<TimerRecord> {
   public static final String NO_TIMER_FOUND_MESSAGE =
       "Expected to cancel timer with key '%d', but no such timer was found";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/TimerTriggerProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.timer;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -35,6 +36,7 @@ import java.time.Instant;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
+@ExcludeAuthorizationCheck
 public final class TimerTriggerProcessor implements TypedRecordProcessor<TimerRecord> {
 
   private static final String NO_TIMER_FOUND_MESSAGE =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserDeleteProcessor.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.user;
 
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.UNAUTHORIZED_ERROR_MESSAGE;
+
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -19,6 +23,8 @@ import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -29,18 +35,21 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior distributionBehavior;
+  private final AuthorizationCheckBehavior authCheckBehavior;
 
   public UserDeleteProcessor(
       final KeyGenerator keyGenerator,
       final ProcessingState state,
       final Writers writers,
-      final CommandDistributionBehavior distributionBehavior) {
+      final CommandDistributionBehavior distributionBehavior,
+      final AuthorizationCheckBehavior authCheckBehavior) {
     this.keyGenerator = keyGenerator;
     userState = state.getUserState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
     this.distributionBehavior = distributionBehavior;
+    this.authCheckBehavior = authCheckBehavior;
   }
 
   @Override
@@ -55,6 +64,18 @@ public class UserDeleteProcessor implements DistributedTypedRecordProcessor<User
 
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, rejectionMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, rejectionMessage);
+      return;
+    }
+
+    final var authRequest =
+        new AuthorizationRequest(command, AuthorizationResourceType.USER, PermissionType.DELETE)
+            .addResourceId(persistedUser.get().getUsername());
+    if (!authCheckBehavior.isAuthorized(authRequest)) {
+      final var message =
+          UNAUTHORIZED_ERROR_MESSAGE.formatted(
+              authRequest.getPermissionType(), authRequest.getResourceType());
+      rejectionWriter.appendRejection(command, RejectionType.UNAUTHORIZED, message);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.UNAUTHORIZED, message);
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserProcessors.java
@@ -40,7 +40,8 @@ public class UserProcessors {
         .onCommand(
             ValueType.USER,
             UserIntent.DELETE,
-            new UserDeleteProcessor(keyGenerator, processingState, writers, distributionBehavior))
+            new UserDeleteProcessor(
+                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
         .withListener(new DefaultUserCreator(processingState, config));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.usertask;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -38,6 +39,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.Optional;
 
+@ExcludeAuthorizationCheck
 public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private final UserTaskCommandProcessors commandProcessors;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -30,7 +30,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.Au
 import io.camunda.zeebe.engine.processing.job.DefaultJobCommandPreconditionGuard;
 import io.camunda.zeebe.engine.processing.job.JobBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.job.JobCancelProcessor;
-import io.camunda.zeebe.engine.processing.job.JobFailProcessor;
 import io.camunda.zeebe.engine.processing.job.JobRecurProcessor;
 import io.camunda.zeebe.engine.processing.job.JobTimeOutProcessor;
 import io.camunda.zeebe.engine.processing.job.JobYieldProcessor;
@@ -48,16 +47,12 @@ import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDele
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithResultProcessor;
-import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
 import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessorImpl;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.timer.TimerCancelProcessor;
 import io.camunda.zeebe.engine.processing.timer.TimerTriggerProcessor;
-import io.camunda.zeebe.engine.processing.user.UserCreateProcessor;
-import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
-import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
 import io.camunda.zeebe.engine.processing.usertask.UserTaskProcessor;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
 import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
@@ -124,7 +119,6 @@ public class AuthorizationArchTest {
     processors.add(CommandDistributionFinishProcessor.class);
     processors.add(JobBatchActivateProcessor.class); // TODO REMOVE THIS ONE
     processors.add(JobCancelProcessor.class);
-    processors.add(JobFailProcessor.class); // TODO REMOVE THIS ONE
     processors.add(JobRecurProcessor.class);
     processors.add(JobTimeOutProcessor.class);
     processors.add(JobYieldProcessor.class);
@@ -141,12 +135,8 @@ public class AuthorizationArchTest {
     processors.add(ProcessInstanceBatchActivateProcessor.class);
     processors.add(ProcessInstanceBatchTerminateProcessor.class);
     processors.add(ProcessInstanceCreationCreateWithResultProcessor.class);
-    processors.add(ResourceDeletionDeleteProcessor.class); // TODO REMOVE THIS ONE
     processors.add(TimerCancelProcessor.class);
     processors.add(TimerTriggerProcessor.class);
-    processors.add(UserCreateProcessor.class); // TODO REMOVE THIS ONE
-    processors.add(UserDeleteProcessor.class); // TODO REMOVE THIS ONE
-    processors.add(UserUpdateProcessor.class); // TODO REMOVE THIS ONE
     processors.add(UserTaskProcessor.class);
     return processors;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationArchTest.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClass.Predicates;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.conditions.ArchConditions;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnStreamProcessor;
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
+import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCompleteProcessor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionContinueProcessor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionFinishProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.job.DefaultJobCommandPreconditionGuard;
+import io.camunda.zeebe.engine.processing.job.JobBatchActivateProcessor;
+import io.camunda.zeebe.engine.processing.job.JobCancelProcessor;
+import io.camunda.zeebe.engine.processing.job.JobFailProcessor;
+import io.camunda.zeebe.engine.processing.job.JobRecurProcessor;
+import io.camunda.zeebe.engine.processing.job.JobTimeOutProcessor;
+import io.camunda.zeebe.engine.processing.job.JobYieldProcessor;
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
+import io.camunda.zeebe.engine.processing.message.MessageBatchExpireProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageExpireProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionCorrelateProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionCreateProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionDeleteProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionMigrateProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionRejectProcessor;
+import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCorrelateProcessor;
+import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionCreateProcessor;
+import io.camunda.zeebe.engine.processing.message.ProcessMessageSubscriptionDeleteProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchActivateProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceBatchTerminateProcessor;
+import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceCreationCreateWithResultProcessor;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor.CommandControl;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessorImpl;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.timer.TimerCancelProcessor;
+import io.camunda.zeebe.engine.processing.timer.TimerTriggerProcessor;
+import io.camunda.zeebe.engine.processing.user.UserCreateProcessor;
+import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
+import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
+import io.camunda.zeebe.engine.processing.usertask.UserTaskProcessor;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandPreconditionChecker;
+import io.camunda.zeebe.engine.processing.usertask.processors.UserTaskCommandProcessor;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayList;
+import java.util.List;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.engine.processing..",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class AuthorizationArchTest {
+
+  @ArchTest()
+  public static final ArchRule PROCESSOR_CHECKS_AUTHORIZATION =
+      classes()
+          .that(processCommands())
+          .and(areNotExcludedFromAuthorizationChecks())
+          .should(checkAuthorization());
+
+  /**
+   * We need to verify these classes explicitly as they are not a TypedRecordProcessor. These
+   * classes take care of authorization checks for job and user task processors. By making sure we
+   * call the isAuthorized method on these classes, in combination with the other rule we can ensure
+   * authorization checks are performed.
+   */
+  @ArchTest()
+  public static final ArchRule DELEGATED_CLASSES_CHECK_AUTHORIZATION =
+      classes().that(areDelegatedToCheckAuthorizations()).should(checkAuthorization());
+
+  private static DescribedPredicate<JavaClass> processCommands() {
+    return new DescribedPredicate<>("process commands") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        return Predicates.implement(TypedRecordProcessor.class)
+            // Not all processors use the TypedRecordProcessor interface. We also need to check
+            // the
+            // CommandProcessor and the UserTaskCommandProcessor interfaces.
+            .or(Predicates.implement(CommandProcessor.class))
+            .or(Predicates.implement(UserTaskCommandProcessor.class))
+            .test(javaClass);
+      }
+    };
+  }
+
+  private static DescribedPredicate<JavaClass> areNotExcludedFromAuthorizationChecks() {
+    return new DescribedPredicate<>("are not excluded from authorization checks") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        // Not all processors need to check authorization. We need to exclude those processors.
+        return !getProcessorsThatDoNotCheckAuthorization().contains(javaClass.reflect());
+      }
+    };
+  }
+
+  private static List<Class<?>> getProcessorsThatDoNotCheckAuthorization() {
+    final List<Class<?>> processors = new ArrayList<>();
+    processors.add(BpmnStreamProcessor.class);
+    processors.add(CommandProcessorImpl.class);
+    processors.add(DeploymentDistributeProcessor.class);
+    processors.add(DeploymentDistributionCompleteProcessor.class);
+    processors.add(CommandDistributionAcknowledgeProcessor.class);
+    processors.add(CommandDistributionContinueProcessor.class);
+    processors.add(CommandDistributionFinishProcessor.class);
+    processors.add(JobBatchActivateProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(JobCancelProcessor.class);
+    processors.add(JobFailProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(JobRecurProcessor.class);
+    processors.add(JobTimeOutProcessor.class);
+    processors.add(JobYieldProcessor.class);
+    processors.add(MessageBatchExpireProcessor.class);
+    processors.add(MessageExpireProcessor.class);
+    processors.add(MessageSubscriptionCorrelateProcessor.class);
+    processors.add(MessageSubscriptionDeleteProcessor.class);
+    processors.add(MessageSubscriptionMigrateProcessor.class);
+    processors.add(MessageSubscriptionCreateProcessor.class);
+    processors.add(MessageSubscriptionRejectProcessor.class);
+    processors.add(ProcessMessageSubscriptionCorrelateProcessor.class);
+    processors.add(ProcessMessageSubscriptionCreateProcessor.class);
+    processors.add(ProcessMessageSubscriptionDeleteProcessor.class);
+    processors.add(ProcessInstanceBatchActivateProcessor.class);
+    processors.add(ProcessInstanceBatchTerminateProcessor.class);
+    processors.add(ProcessInstanceCreationCreateWithResultProcessor.class);
+    processors.add(ResourceDeletionDeleteProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(TimerCancelProcessor.class);
+    processors.add(TimerTriggerProcessor.class);
+    processors.add(UserCreateProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(UserDeleteProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(UserUpdateProcessor.class); // TODO REMOVE THIS ONE
+    processors.add(UserTaskProcessor.class);
+    return processors;
+  }
+
+  private static ArchCondition<JavaClass> checkAuthorization() {
+    return new ArchCondition<>("check authorization") {
+      @Override
+      public void check(final JavaClass item, final ConditionEvents events) {
+        // The processor should directly check authorizations
+        ArchConditions.callMethod(
+                AuthorizationCheckBehavior.class, "isAuthorized", AuthorizationRequest.class)
+            // Or the processor should have delegated authorization to the JobUpdateBehaviour
+            .or(
+                ArchConditions.callMethod(
+                    JobUpdateBehaviour.class, "isAuthorized", TypedRecord.class, JobRecord.class))
+            // Or the processor should have delegated authorization to the
+            // DefaultJobCommandPreconditionGuard
+            .or(
+                ArchConditions.callMethod(
+                    DefaultJobCommandPreconditionGuard.class,
+                    "onCommand",
+                    TypedRecord.class,
+                    CommandControl.class))
+            // Or the processor should have delegated authorization to the
+            // UserTaskCommandPreconditionChecker
+            .or(
+                ArchConditions.callMethod(
+                    UserTaskCommandPreconditionChecker.class, "check", TypedRecord.class))
+            .check(item, events);
+      }
+    };
+  }
+
+  private static DescribedPredicate<JavaClass> areDelegatedToCheckAuthorizations() {
+    return new DescribedPredicate<>("process commands") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        return Predicates.assignableFrom(DefaultJobCommandPreconditionGuard.class)
+            .or(Predicates.assignableFrom(UserTaskCommandPreconditionChecker.class))
+            .test(javaClass);
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This test has 2 goals. The first is ensuring the authorization checks are not removed from a processor by accident. The second goal is ensuring devs are triggered to think about authorizations when they create a new processor. If they add a new processor and don't perform auth checks, this test will fail. To circumvent this the processors needs to be explicitly excluded from authorization checks.

I had to add he `UserDeleteProcessor` auth checks to make it succeed. This was missed and didn't have an issue. The ITs for it will be implemented in https://github.com/camunda/camunda/issues/21694

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22896
