### PR TITLE
fix: use onChange instead of downshift props

### DIFF
--- a/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.test.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.test.tsx
@@ -97,7 +97,7 @@ it('should format user list information correctly', async () => {
   expect(item3Content.find('.subText')).not.toExist();
 });
 
-it('should invoke onAdd & onRemove when selecting/deselecting an identity', async () => {
+it('should invoke onAdd when selecting an identity', async () => {
   const testUser = {
     name: 'test',
     type: 'user',
@@ -117,7 +117,7 @@ it('should invoke onAdd & onRemove when selecting/deselecting an identity', asyn
 
   const items = node.find(FilterableMultiSelect).prop('items');
 
-  node.find(FilterableMultiSelect).prop('downshiftProps')?.onSelect(items[0]);
+  node.find(FilterableMultiSelect).simulate('change', {selectedItems: items});
   expect(spy).toHaveBeenCalledWith(testUser);
 });
 
@@ -128,32 +128,33 @@ it('should invoke onRemove when deselecting an identity', async () => {
     email: 'test@test.com',
     id: 'test',
   };
+
+  const selectedUsers = [
+    {
+      id: 'USER:test',
+      identity: testUser,
+    },
+    {
+      id: 'USER:userToRemove',
+      identity: {...testUser, id: 'userToRemove'},
+    },
+  ];
+
   (searchIdentities as jest.Mock).mockReturnValue({
     result: [testUser],
     total: 0,
   });
 
   const spy = jest.fn();
-  const node = shallow(
-    <MultiUserInput
-      {...props}
-      onRemove={spy}
-      users={[
-        {
-          id: 'USER:test',
-          identity: testUser,
-        },
-      ]}
-    />
-  );
+  const node = shallow(<MultiUserInput {...props} onRemove={spy} users={selectedUsers} />);
 
   runAllEffects();
   await flushPromises();
 
-  const items = node.find(FilterableMultiSelect).prop('items');
-
-  node.find(FilterableMultiSelect).prop('downshiftProps')?.onSelect(items[0]);
-  expect(spy).toHaveBeenCalledWith('USER:test');
+  node.find(FilterableMultiSelect).simulate('change', {
+    selectedItems: [selectedUsers[0]],
+  });
+  expect(spy).toHaveBeenCalledWith('USER:userToRemove');
 });
 
 it('should invoke onAdd when selecting an identity even if it is not in loaded identities', async () => {
@@ -163,6 +164,9 @@ it('should invoke onAdd when selecting an identity even if it is not in loaded i
   runAllEffects();
   await flushPromises();
 
-  node.find(FilterableMultiSelect).prop('downshiftProps')?.onSelect({id: 'test', label: 'test'});
-  expect(spy).toHaveBeenCalledWith({id: 'test'});
+  node.find(FilterableMultiSelect).simulate('change', {
+    selectedItems: [{id: 'testUserID'}],
+  });
+
+  expect(spy).toHaveBeenCalledWith({id: 'testUserID'});
 });

--- a/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.tsx
@@ -150,28 +150,34 @@ export default function MultiUserInput({
       // disable the internal sorting since we have the data sorted by default
       sortItems={(items) => items}
       initialSelectedItems={selectedUsers}
-      downshiftProps={{
-        onSelect: (item) => {
-          if (!item) {
-            return;
-          }
-
-          const userToRemove = users.find((user) => user.id === item.id);
-
-          if (userToRemove) {
-            onRemove(userToRemove.id);
-          } else {
-            addIdentity(item.id);
-          }
-        },
-      }}
       onChange={({selectedItems}) => {
+        // If no items are selected, clear the selection
         if (selectedItems.length === 0) {
           onClear();
+          return;
+        }
+
+        const removedUser = selectedUsers.find(
+          (user) => !selectedItems.some((item) => item.id === user.id)
+        );
+
+        if (removedUser) {
+          onRemove(removedUser.id);
+        }
+
+        const addedUser = selectedItems.find(
+          (item) => !selectedUsers.some((user) => user.id === item.id)
+        );
+
+        if (addedUser) {
+          addIdentity(addedUser.id);
         }
       }}
       items={getItems()}
       itemToString={(item) => {
+        if (!item) {
+          return '';
+        }
         const {label, subText, id} = item;
         return label + subText + (id || '');
       }}


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
It seems that carbon remove the `downshiftProps` property from the `filterableMultiSelect` component.
This is broke our user selection and the e2e tests. I created a fix that uses the onChange instead of the downshiftProps.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
