### PR TITLE
feat: added Task Listener no retries error type

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ErrorType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ErrorType.java
@@ -15,6 +15,7 @@ public enum ErrorType {
   UNKNOWN("Unknown"),
   IO_MAPPING_ERROR("I/O mapping error"),
   JOB_NO_RETRIES("No more retries left"),
+  TASK_LISTENER_NO_RETRIES("Task Listener no more retries left"),
   CONDITION_ERROR("Condition error"),
   EXTRACT_VALUE_ERROR("Extract value error"),
   CALLED_ELEMENT_ERROR("Called element error"),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added error types described for task listeners in the specification.
`EXTRACT_VALUE_ERROR` already existed beforehand, so it didn't need to be added.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/23945
