### PR TITLE
Opensearch IndexMappingProperty bug fix

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/IndexMappingProperty.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.json.stream.JsonParser;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import org.apache.commons.io.IOUtils;
@@ -64,7 +64,7 @@ public record IndexMappingProperty(String name, Object typeDefinition) {
   @Override
   public String toString() {
     final var typeDefinitionStr =
-        ((HashMap<String, Object>) typeDefinition)
+        ((Map<String, Object>) typeDefinition)
             .entrySet().stream()
                 .collect(
                     Collectors.toMap(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -121,7 +121,8 @@ public class ElasticsearchEngineClientIT {
   @Test
   void shouldRetrieveAllIndexMappingsWithImplementationAgnosticReturnType() {
     final var index =
-        SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
+        SchemaTestUtil.mockIndex(
+            "index_qualified_name", "alias", "index_name", "/mappings-complex-property.json");
 
     elsEngineClient.createIndex(index, new IndexSettings());
 
@@ -134,7 +135,8 @@ public class ElasticsearchEngineClientIT {
         .containsExactlyInAnyOrder(
             new IndexMappingProperty.Builder()
                 .name("hello")
-                .typeDefinition(Map.of("type", "text"))
+                .typeDefinition(
+                    Map.of("type", "text", "index", false, "eager_global_ordinals", true))
                 .build(),
             new IndexMappingProperty.Builder()
                 .name("world")
@@ -146,7 +148,12 @@ public class ElasticsearchEngineClientIT {
   void shouldRetrieveAllIndexTemplateMappingsWithImplementationAgnosticReturnType() {
     final var template =
         SchemaTestUtil.mockIndexTemplate(
-            "index_name", "index_pattern.*", "alias", List.of(), "template_name", "/mappings.json");
+            "index_name",
+            "index_pattern.*",
+            "alias",
+            List.of(),
+            "template_name",
+            "/mappings-complex-property.json");
 
     elsEngineClient.createIndexTemplate(template, new IndexSettings(), true);
 
@@ -158,7 +165,8 @@ public class ElasticsearchEngineClientIT {
         .containsExactlyInAnyOrder(
             new IndexMappingProperty.Builder()
                 .name("hello")
-                .typeDefinition(Map.of("type", "text"))
+                .typeDefinition(
+                    Map.of("type", "text", "index", false, "eager_global_ordinals", true))
                 .build(),
             new IndexMappingProperty.Builder()
                 .name("world")

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
@@ -172,7 +172,8 @@ public class OpensearchEngineClientIT {
   void shouldRetrieveAllIndexMappingsWithImplementationAgnosticReturnType() {
     // given
     final var index =
-        SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
+        SchemaTestUtil.mockIndex(
+            "index_qualified_name", "alias", "index_name", "/mappings-complex-property.json");
 
     opensearchEngineClient.createIndex(index, new IndexSettings());
 
@@ -187,7 +188,8 @@ public class OpensearchEngineClientIT {
         .containsExactlyInAnyOrder(
             new IndexMappingProperty.Builder()
                 .name("hello")
-                .typeDefinition(Map.of("type", "text"))
+                .typeDefinition(
+                    Map.of("type", "text", "index", false, "eager_global_ordinals", true))
                 .build(),
             new IndexMappingProperty.Builder()
                 .name("world")
@@ -200,7 +202,12 @@ public class OpensearchEngineClientIT {
     // given
     final var template =
         SchemaTestUtil.mockIndexTemplate(
-            "index_name", "index_pattern.*", "alias", List.of(), "template_name", "/mappings.json");
+            "index_name",
+            "index_pattern.*",
+            "alias",
+            List.of(),
+            "template_name",
+            "/mappings-complex-property.json");
 
     opensearchEngineClient.createIndexTemplate(template, new IndexSettings(), true);
 
@@ -214,7 +221,8 @@ public class OpensearchEngineClientIT {
         .containsExactlyInAnyOrder(
             new IndexMappingProperty.Builder()
                 .name("hello")
-                .typeDefinition(Map.of("type", "text"))
+                .typeDefinition(
+                    Map.of("type", "text", "index", false, "eager_global_ordinals", true))
                 .build(),
             new IndexMappingProperty.Builder()
                 .name("world")


### PR DESCRIPTION
## Description

The type definition of a property must contain all fields of that property such as as `index` or any other defined, the `ElasticsearchEngineClient` fixed this by implementing the `propertyToMap` to serialize a `Property` into a `Map`.
However this was forgotten to be done for Opensearch(OS) this would cause schema validation errors for OS.

- [x] OS supports full index mapping property serialization of all fields.
- [x] Modify tests which build `IndexMappingProperty` instances to catch this error case. 
