### PR TITLE
[Backport stable/8.6] Add actor clock endpoint to test framework

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -72,7 +72,7 @@ public class ActorClockEndpoint {
    * To add a relative time offset:
    *
    * <pre>{@code
-   * curl -X POST -H 'Content-Type: application/json' -d '{"offsetMilli": 250}' "http://0.0.0.0:9600/actuator/clock/pin"
+   * curl -X POST -H 'Content-Type: application/json' -d '{"offsetMilli": 250}' "http://0.0.0.0:9600/actuator/clock/add"
    * "2021-10-31T09:36:04.783Z"%
    * }</pre>
    *

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 package io.camunda.zeebe.it.management;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
@@ -23,9 +23,9 @@ public class ActorClockEndpointIT {
         TestCluster.builder()
             .useRecordingExporter(true)
             .withEmbeddedGateway(true)
-            .withBrokersCount(2)
+            .withBrokersCount(1)
             .withPartitionsCount(1)
-            .withReplicationFactor(2)
+            .withReplicationFactor(1)
             .withBrokerConfig(
                 testStandaloneBroker ->
                     testStandaloneBroker.withProperty("zeebe.clock.controlled", true))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ActorClockEndpointIT.java
@@ -1,0 +1,51 @@
+package io.camunda.zeebe.it.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator;
+import io.camunda.zeebe.qa.util.actuator.ActorClockActuator.AddTimeRequest;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class ActorClockEndpointIT {
+
+  @TestZeebe(initMethod = "initTestCluster")
+  private static TestCluster cluster;
+
+  @SuppressWarnings("unused")
+  static void initTestCluster() {
+    cluster =
+        TestCluster.builder()
+            .useRecordingExporter(true)
+            .withEmbeddedGateway(true)
+            .withBrokersCount(2)
+            .withPartitionsCount(1)
+            .withReplicationFactor(2)
+            .withBrokerConfig(
+                testStandaloneBroker ->
+                    testStandaloneBroker.withProperty("zeebe.clock.controlled", true))
+            .build();
+  }
+
+  @Test
+  void shouldIncreaseActorClockTime() {
+    final var duration = Duration.ofMinutes(15);
+    final var actuator = actorClockActuator();
+
+    final var before = actuator.getCurrentClock().instant();
+    actuator.addTime(new AddTimeRequest(duration.toMillis()));
+    final var after = actuator.getCurrentClock().instant();
+
+    assertThat(Duration.between(before, after)).isGreaterThan(duration);
+  }
+
+  private ActorClockActuator actorClockActuator() {
+    final var broker = cluster.brokers().get(MemberId.from("0"));
+    return ActorClockActuator.of(broker);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ActorClockActuator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.zeebe.containers.ZeebeBrokerNode;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * Java interface for the broker's actor clock actuator (roughly mapping to the broker admin
+ * service). To instantiate this interface, you can use {@link Feign}; see {@link #of(String)} as an
+ * example.
+ *
+ * <p>You can use one of {@link #of(String)} or {@link #of(ZeebeBrokerNode)} to create a new client
+ * to use for yourself.
+ *
+ * <p>Adding a new method is simple: simply define the input/output here as you normally would, and
+ * make sure to add the correct JSON encoding headers (`Accept` for the response type,
+ * `Content-Type` if there's a body to send). See {@link LoggersActuator} for a more complete
+ * example.
+ *
+ * <p>This actuator should only be used for testing purposes. To use it in a test class, requires
+ * the controllable clock to be enabled through configuration as such:
+ * `testStandaloneBroker.withProperty("zeebe.clock.controlled", true)`
+ */
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public interface ActorClockActuator {
+
+  /**
+   * Returns a {@link ActorClockActuator} instance using the given node as upstream. This only
+   * accepts {@link ZeebeBrokerNode} at the moment, as only the broker has this actuator. It can be
+   * changed if we move these to the gateway.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link ActorClockActuator}
+   */
+  static ActorClockActuator of(final ZeebeBrokerNode<?> node) {
+    final var endpoint =
+        String.format("http://%s/actuator/clock", node.getExternalMonitoringAddress());
+    return of(endpoint);
+  }
+
+  /**
+   * Returns a {@link ActorClockActuator} instance using the given node as upstream. This only
+   * accepts {@link TestStandaloneBroker} at the moment, as only the broker has this actuator. It
+   * can be changed if we move these to the gateway.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link ActorClockActuator}
+   */
+  static ActorClockActuator of(final TestStandaloneBroker node) {
+    return of(node.actuatorUri("clock").toString());
+  }
+
+  /**
+   * Returns a {@link ActorClockActuator} instance using the given endpoint as upstream. The
+   * endpoint is expected to be a complete absolute URL, e.g.
+   * "http://localhost:9600/actuator/clock".
+   *
+   * @param endpoint the actuator URL to connect to
+   * @return a new instance of {@link ActorClockActuator}
+   */
+  @SuppressWarnings("JavadocLinkAsPlainText")
+  static ActorClockActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(ActorClockActuator.class, endpoint);
+    final var decoder = new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule()));
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(decoder)
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  @RequestLine("GET")
+  @Headers("Accept: application/json")
+  Response getCurrentClock();
+
+  @RequestLine("POST /add")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Response addTime(@RequestBody AddTimeRequest request);
+
+  record Response(long epochMilli, Instant instant) {}
+
+  record AddTimeRequest(Long offsetMilli) {}
+}


### PR DESCRIPTION
# Description
Backport of #24018 to `stable/8.6`.

relates to 
original author: @berkaycanbc