### PR TITLE
fix: retry job on execution listener incident

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
@@ -108,6 +108,27 @@ public abstract class ZeebeRecordTestUtil {
   }
 
   @NotNull
+  public static Record<IncidentRecordValue> createIncidentZeebeRecord(
+      final Consumer<Builder> recordBuilderFunction,
+      final Consumer<ImmutableIncidentRecordValue.Builder> recordValueBuilderFunction) {
+    final Builder<IncidentRecordValue> builder = ImmutableRecord.builder();
+    final ImmutableIncidentRecordValue.Builder valueBuilder =
+        ImmutableIncidentRecordValue.builder();
+    if (recordValueBuilderFunction != null) {
+      recordValueBuilderFunction.accept(valueBuilder);
+    }
+    builder
+        .withPartitionId(1)
+        .withTimestamp(Instant.now().toEpochMilli())
+        .withValue(valueBuilder.build())
+        .withValueType(ValueType.PROCESS_INSTANCE);
+    if (recordBuilderFunction != null) {
+      recordBuilderFunction.accept(builder);
+    }
+    return builder.build();
+  }
+
+  @NotNull
   public static Record<ProcessInstanceRecordValue> createProcessInstanceZeebeRecord(
       final Consumer<Builder> recordBuilderFunction,
       final Consumer<ImmutableProcessInstanceRecordValue.Builder> recordValueBuilderFunction) {

--- a/operate/qa/integration-tests/src/test/resources/execution-listener.bpmn
+++ b/operate/qa/integration-tests/src/test/resources/execution-listener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19r2v2w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="execution-listener-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0rxqr9x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0rxqr9x" sourceRef="StartEvent_1" targetRef="script-task" />
+    <bpmn:endEvent id="Event_0xmgw6o">
+      <bpmn:incoming>Flow_194mcv0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_194mcv0" sourceRef="script-task" targetRef="Event_0xmgw6o" />
+    <bpmn:scriptTask id="script-task" name="Script task">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=true" resultVariable="result" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="listener1" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0rxqr9x</bpmn:incoming>
+      <bpmn:outgoing>Flow_194mcv0</bpmn:outgoing>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="execution-listener-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xmgw6o_di" bpmnElement="Event_0xmgw6o">
+        <dc:Bounds x="392" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m9zv33_di" bpmnElement="script-task">
+        <dc:Bounds x="250" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0rxqr9x_di" bpmnElement="Flow_0rxqr9x">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="250" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_194mcv0_di" bpmnElement="Flow_194mcv0">
+        <di:waypoint x="350" y="117" />
+        <di:waypoint x="392" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.operate.webapp.zeebe.operation;
 
-import static io.camunda.webapps.schema.entities.operate.ErrorType.JOB_NO_RETRIES;
 import static io.camunda.webapps.schema.entities.operation.OperationType.RESOLVE_INCIDENT;
 
 import io.camunda.operate.webapp.reader.IncidentReader;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
+import io.camunda.webapps.schema.entities.operate.ErrorType;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
@@ -41,7 +41,8 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
       return;
     }
 
-    if (incident.getErrorType().equals(JOB_NO_RETRIES)) {
+    final ErrorType errorType = incident.getErrorType();
+    if (errorType != null && errorType.isResolvedViaRetries()) {
       final var updateRetriesJobCommand =
           withOperationReference(
               zeebeClient.newUpdateRetriesCommand(incident.getJobKey()).retries(1),

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ErrorType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ErrorType.java
@@ -14,7 +14,8 @@ public enum ErrorType {
   UNSPECIFIED("Unspecified"),
   UNKNOWN("Unknown"),
   IO_MAPPING_ERROR("I/O mapping error"),
-  JOB_NO_RETRIES("No more retries left"),
+  JOB_NO_RETRIES("No more retries left", true),
+  EXECUTION_LISTENER_NO_RETRIES("Execution Listener no more retries left", true),
   CONDITION_ERROR("Condition error"),
   EXTRACT_VALUE_ERROR("Extract value error"),
   CALLED_ELEMENT_ERROR("Called element error"),
@@ -28,9 +29,15 @@ public enum ErrorType {
   private static final Logger LOGGER = LoggerFactory.getLogger(ErrorType.class);
 
   private final String title;
+  private final boolean resolvedViaRetries;
 
   ErrorType(final String title) {
+    this(title, false);
+  }
+
+  ErrorType(final String title, boolean resolvedViaRetries) {
     this.title = title;
+    this.resolvedViaRetries = resolvedViaRetries;
   }
 
   public static ErrorType fromZeebeErrorType(final String errorType) {
@@ -48,5 +55,9 @@ public enum ErrorType {
 
   public String getTitle() {
     return title;
+  }
+
+  public boolean isResolvedViaRetries() {
+    return resolvedViaRetries;
   }
 }


### PR DESCRIPTION
- when Operate resolves an incident that was raised in an execution listener, it should update retries

related to #23383

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
