### PR TITLE
Adds archiver skeleton

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -106,6 +106,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -111,6 +111,16 @@
     </dependency>
 
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
@@ -163,6 +173,7 @@
       <artifactId>zeebe-exporter-test</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-protocol-test-util</artifactId>
@@ -178,6 +189,12 @@
     <dependency>
       <groupId>org.opensearch</groupId>
       <artifactId>opensearch-testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-test-util</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import javax.annotation.WillCloseWhenClosed;
+import org.agrona.CloseHelper;
+import org.slf4j.Logger;
+
+@SuppressWarnings({"unused", "FieldCanBeLocal"}) // can be removed in the future
+public final class Archiver implements CloseableSilently {
+  private final int partitionId;
+  private final ArchiverRepository repository;
+  private final ArchiverConfiguration config;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+  private final ScheduledExecutorService executor;
+
+  @VisibleForTesting
+  Archiver(
+      final int partitionId,
+      final @WillCloseWhenClosed ArchiverRepository repository,
+      final ArchiverConfiguration config,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final @WillCloseWhenClosed ScheduledExecutorService executor) {
+    this.partitionId = partitionId;
+    this.repository = Objects.requireNonNull(repository, "must specify a repository");
+    this.config = Objects.requireNonNull(config, "must specify configuration");
+    this.metrics = Objects.requireNonNull(metrics, "must specify metrics");
+    this.logger = Objects.requireNonNull(logger, "must specify a logger");
+    this.executor = Objects.requireNonNull(executor, "must specify an executor");
+  }
+
+  @Override
+  public void close() {
+    // avoid calling executor.close, which will await 1d (!) until termination
+    // we also don't need to wait for the jobs to fully finish, as we should be able to handle
+    // partial jobs (e.g. node crash/restart)
+    executor.shutdownNow();
+    // TODO: any closed resources used in the jobs should handle cases where it's been closed
+    CloseHelper.close(
+        error ->
+            logger.warn("Failed to close archiver repository for partition {}", partitionId, error),
+        repository);
+  }
+
+  public static Archiver create(
+      final int partitionId,
+      final @WillCloseWhenClosed ArchiverRepository repository,
+      final ArchiverConfiguration config,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("exporter-" + partitionId + "-background-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(logger))
+            .factory();
+    final var executor = defaultExecutor(threadFactory);
+
+    return new Archiver(partitionId, repository, config, metrics, logger, executor);
+  }
+
+  private static ScheduledThreadPoolExecutor defaultExecutor(final ThreadFactory threadFactory) {
+    // TODO: set size to 2 in case we need to do batch operations
+    final var executor = new ScheduledThreadPoolExecutor(1, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+
+    return executor;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+/** Placeholder interface for future abstracted access to the underlying storage (e.g. ES/OS). */
+public interface ArchiverRepository extends AutoCloseable {
+  static final class NoopArchiverRepository implements ArchiverRepository {
+
+    @Override
+    public void close() throws Exception {}
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ArchiverTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ArchiverTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+@AutoCloseResources
+final class ArchiverTest {
+  @AutoCloseResource // ensures we always reap the thread no matter what
+  private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+
+  @Nested
+  final class CloseTest {
+    private final CloseableRepository repository = new CloseableRepository();
+    private final Archiver archiver =
+        new Archiver(
+            1,
+            repository,
+            new ArchiverConfiguration(),
+            new CamundaExporterMetrics(new SimpleMeterRegistry()),
+            LoggerFactory.getLogger(ArchiverTest.class),
+            executor);
+
+    @Test
+    void shouldCloseExecutorOnClose() {
+      // when
+      archiver.close();
+
+      // then
+      assertThat(executor.isTerminated()).isTrue();
+    }
+
+    @Test
+    void shouldCloseRepositoryOnClose() {
+      // when
+      archiver.close();
+
+      // then
+      assertThat(repository.isClosed).isTrue();
+    }
+
+    @Test
+    void shouldNotThrowOnRepositoryCloseError() {
+      // given
+      repository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(archiver::close).doesNotThrowAnyException();
+    }
+
+    private static final class CloseableRepository implements ArchiverRepository {
+      private boolean isClosed;
+      private Exception exception;
+
+      @Override
+      public void close() throws Exception {
+        if (exception != null) {
+          throw exception;
+        }
+
+        isClosed = true;
+      }
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/resources/log4j2-test.xml
+++ b/zeebe/exporters/camunda-exporter/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="debug"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Description

This PR adds a basic `Archiver` component which starts a new background thread pool. It accepts several new properties that will definitely be required and will later be fleshed out.

There were some dummy types added that will be added in #24078, but until that's available, we can make do with the dummy types (which will then be removed).

The tests mainly focus on resource management, specifically that everything is closed on shutdown without throwing any exception (even though we still handle possible ones in the exporter close phase anyway).

## Related issues

closes #24079 
