### PR TITLE
[Backport stable/operate-8.5] fix: log message refers to Opensearch in Elasticsearch Code

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -168,7 +168,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
     if (operateProperties.getElasticsearch().isHealthCheckEnabled()) {
       return retryElasticsearchClient.isHealthy();
     } else {
-      LOGGER.warn("OpenSearch cluster health check is disabled.");
+      LOGGER.warn("Elasticsearch cluster health check is disabled.");
       return true;
     }
   }


### PR DESCRIPTION
# Description
Backport of #24100 to `stable/operate-8.5`.

relates to 
original author: @kristinkomschow