### PR TITLE
fix: enable configuration processor

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -26,6 +26,12 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -240,6 +240,7 @@
             <dependency>io.camunda:zeebe-stream-platform</dependency>
             <dependency>io.camunda:zeebe-protocol-impl</dependency>
             <dependency>io.camunda:zeebe-protocol-jackson</dependency>
+            <dependency>org.springframework.boot:spring-boot-configuration-processor</dependency>
           </usedDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR enables the configuration processor so that IDEs can prompt developers with properties coming from the sdk.

Spring docs link: https://docs.spring.io/spring-boot/specification/configuration-metadata/annotation-processor.html

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
