### PR TITLE
Add a process cache available to the exporter

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -149,6 +149,7 @@
     <version.jakarta-annotation>3.0.0</version.jakarta-annotation>
     <version.jna-platform>5.15.0</version.jna-platform>
     <version.liquibase>4.29.2</version.liquibase>
+    <version.caffeine>3.1.8</version.caffeine>
 
     <version.commons-io>2.17.0</version.commons-io>
     <version.thymeleaf>3.1.2.RELEASE</version.thymeleaf>
@@ -2242,6 +2243,12 @@
         <artifactId>xmlunit-core</artifactId>
         <version>${version.xmlunit-core}</version>
         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>${version.caffeine}</version>
       </dependency>
 
     </dependencies>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -19,6 +19,12 @@
 
   <name>Camunda Exporter</name>
   <dependencies>
+
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-exporter-api</artifactId>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/CachedProcessEntity.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/CachedProcessEntity.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+public record CachedProcessEntity(String name, String versionTag) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ElasticSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ElasticSearchProcessCacheLoader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.entities.operate.ProcessEntity;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticSearchProcessCacheLoader implements CacheLoader<Long, CachedProcessEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchProcessCacheLoader.class);
+
+  private final ElasticsearchClient client;
+  private final String processIndexName;
+
+  public ElasticSearchProcessCacheLoader(
+      final ElasticsearchClient client, final String processIndexName) {
+    this.client = client;
+    this.processIndexName = processIndexName;
+  }
+
+  @Override
+  public CachedProcessEntity load(final Long processDefinitionKey) throws IOException {
+    final var response =
+        client.get(
+            request -> request.index(processIndexName).id(String.valueOf(processDefinitionKey)),
+            ProcessEntity.class);
+    if (response.found()) {
+      final var processEntity = response.source();
+      return new CachedProcessEntity(processEntity.getName(), processEntity.getVersionTag());
+    } else {
+      // This should only happen if the process was deleted from ElasticSearch which should never
+      // happen. Normally, the process is exported before the process instance is exporter. So the
+      // process should be found in ElasticSearch index.
+      LOG.debug("Process '{}' not found in Elasticsearch", processDefinitionKey);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/OpenSearchProcessCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/OpenSearchProcessCacheLoader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.entities.operate.ProcessEntity;
+import java.io.IOException;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OpenSearchProcessCacheLoader implements CacheLoader<Long, CachedProcessEntity> {
+  private static final Logger LOG = LoggerFactory.getLogger(OpenSearchProcessCacheLoader.class);
+
+  private final OpenSearchClient client;
+  private final String processIndexName;
+
+  public OpenSearchProcessCacheLoader(
+      final OpenSearchClient client, final String processIndexName) {
+    this.client = client;
+    this.processIndexName = processIndexName;
+  }
+
+  @Override
+  public CachedProcessEntity load(final Long processDefinitionKey) throws IOException {
+    final var response =
+        client.get(
+            request -> request.index(processIndexName).id(String.valueOf(processDefinitionKey)),
+            ProcessEntity.class);
+    if (response.found()) {
+      final var processEntity = response.source();
+      return new CachedProcessEntity(processEntity.getName(), processEntity.getVersionTag());
+    } else {
+      // This should only happen if the process was deleted from OpenSearch which should never
+      // happen. Normally, the process is exported before the process instance is exporter. So the
+      // process should be found in OpenSearch index.
+      LOG.debug("Process '{}' not found in OpenSearch", processDefinitionKey);
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCache.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCache.java
@@ -36,7 +36,7 @@ public interface ProcessCache {
    *
    * @param processDefinitionKey the key of the process definition to delete
    */
-  void delete(long processDefinitionKey);
+  void remove(long processDefinitionKey);
 
   /** Clear the cache. */
   void clear();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCache.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCache.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import java.util.Optional;
+
+public interface ProcessCache {
+
+  /**
+   * Get cached process entity for the given processDefinitionKey. If the process is not cached, it
+   * will be loaded from the configured backed. If no processDefinition is found then the returned
+   * optional will be empty. If the query to backend fails otherwise, the method will throw an
+   * exception.
+   *
+   * @param processDefinitionKey key of the process definition
+   * @return an optional with the cached process entity
+   * @throws {@link CacheLoaderFailedException}
+   */
+  Optional<CachedProcessEntity> get(long processDefinitionKey);
+
+  /**
+   * Put a processEntity entity into the cache.
+   *
+   * @param processDefinitionKey key of the process definition
+   * @param processEntity the process entity to cache
+   */
+  void put(long processDefinitionKey, CachedProcessEntity processEntity);
+
+  /**
+   * Delete a process entity from the cache.
+   *
+   * @param processDefinitionKey the key of the process definition to delete
+   */
+  void delete(long processDefinitionKey);
+
+  /** Clear the cache. */
+  void clear();
+
+  class CacheLoaderFailedException extends RuntimeException {
+    public CacheLoaderFailedException(final Throwable cause) {
+      super(cause);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheImpl.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheImpl.java
@@ -42,7 +42,7 @@ public class ProcessCacheImpl implements ProcessCache {
   }
 
   @Override
-  public void delete(final long processDefinitionKey) {
+  public void remove(final long processDefinitionKey) {
     cache.invalidate(processDefinitionKey);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheImpl.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.util.Optional;
+
+public class ProcessCacheImpl implements ProcessCache {
+
+  private final LoadingCache<Long, CachedProcessEntity> cache;
+
+  public ProcessCacheImpl(
+      final long maxSize, final CacheLoader<Long, CachedProcessEntity> cacheLoader) {
+    cache =
+        Caffeine.newBuilder()
+            .maximumSize(maxSize)
+            .build(
+                k -> {
+                  try {
+                    return cacheLoader.load(k);
+                  } catch (final Exception e) {
+                    throw new CacheLoaderFailedException(e);
+                  }
+                });
+  }
+
+  @Override
+  public Optional<CachedProcessEntity> get(final long processDefinitionKey) {
+    return Optional.ofNullable(cache.get(processDefinitionKey));
+  }
+
+  @Override
+  public void put(final long processDefinitionKey, final CachedProcessEntity processEntity) {
+    cache.put(processDefinitionKey, processEntity);
+  }
+
+  @Override
+  public void delete(final long processDefinitionKey) {
+    cache.invalidate(processDefinitionKey);
+  }
+
+  @Override
+  public void clear() {
+    cache.invalidateAll();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import io.camunda.exporter.cache.ProcessCache.CacheLoaderFailedException;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
+import io.camunda.exporter.utils.TestSupport;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
+import io.camunda.webapps.schema.entities.operate.ProcessEntity;
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+class ProcessCacheImplIT {
+
+  @Container
+  private static final ElasticsearchContainer ELASTICSEARCH_CONTAINER =
+      TestSupport.createDefeaultElasticsearchContainer();
+
+  @Container
+  private static final OpensearchContainer OPENSEARCH_CONTAINER =
+      TestSupport.createDefaultOpensearchContainer();
+
+  private static ElasticsearchClient elsClient;
+  private static OpenSearchClient osClient;
+  private static final ProcessIndex PROCESS_INDEX = new ProcessIndex("test", true);
+
+  @BeforeAll
+  static void init() {
+    final var config = new ExporterConfiguration();
+    config.getConnect().setUrl(ELASTICSEARCH_CONTAINER.getHttpHostAddress());
+    elsClient = new ElasticsearchConnector(config.getConnect()).createClient();
+
+    final var osConfig = new ExporterConfiguration();
+    osConfig.getConnect().setType("opensearch");
+    osConfig.getConnect().setUrl(OPENSEARCH_CONTAINER.getHttpHostAddress());
+    osClient = new OpensearchConnector(osConfig.getConnect()).createClient();
+  }
+
+  @BeforeEach
+  void setup() {
+    new ElasticsearchEngineClient(elsClient).createIndex(PROCESS_INDEX, new IndexSettings());
+    new OpensearchEngineClient(osClient).createIndex(PROCESS_INDEX, new IndexSettings());
+  }
+
+  @AfterEach
+  void cleanup() throws IOException {
+    elsClient.indices().delete(req -> req.index(PROCESS_INDEX.getFullQualifiedName()));
+    osClient.indices().delete(req -> req.index(PROCESS_INDEX.getFullQualifiedName()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideProcessCache")
+  void shouldReturnEmptyOptionalIfProcessDoesNotExist(
+      final ProcessCacheArgument processCacheArgument) {
+    // when
+    final var process = processCacheArgument.processCache().get(1L);
+
+    // then
+    assertThat(process).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideProcessCache")
+  void shouldLoadProcessEntityFromBackend(final ProcessCacheArgument processCacheArgument)
+      throws IOException {
+    // given
+    final var processEntity = new ProcessEntity().setId("3").setName("test").setVersionTag("v1");
+    processCacheArgument.indexer().accept(processEntity);
+
+    // when
+    final var process = processCacheArgument.processCache().get(3L);
+
+    // then
+    final var expectedCachedProcessEntity = new CachedProcessEntity("test", "v1");
+    assertThat(process).isPresent().get().isEqualTo(expectedCachedProcessEntity);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideFailingProcessCache")
+  void shouldThrowExceptionIfQueryToElasticFailed(final ProcessCacheArgument processCacheArgument) {
+    // given
+    final var failingProcessCache = processCacheArgument.processCache();
+
+    // when - then
+    assertThatException()
+        .isThrownBy(() -> failingProcessCache.get(1L))
+        .isInstanceOf(CacheLoaderFailedException.class);
+  }
+
+  static Stream<Arguments> provideProcessCache() {
+    return Stream.of(
+        Arguments.of(
+            Named.of("ElasticSearch", getESProcessCache(PROCESS_INDEX.getFullQualifiedName()))),
+        Arguments.of(
+            Named.of("OpenSearch", getOSProcessCache(PROCESS_INDEX.getFullQualifiedName()))));
+  }
+
+  static Stream<Arguments> provideFailingProcessCache() {
+    return Stream.of(
+        Arguments.of(Named.of("ElasticSearch", getESProcessCache("invalid-index-name"))),
+        Arguments.of(Named.of("OpenSearch", getOSProcessCache("invalid-index-name"))));
+  }
+
+  static ProcessCacheArgument getESProcessCache(final String indexName) {
+    return new ProcessCacheArgument(
+        new ProcessCacheImpl(10, new ElasticSearchProcessCacheLoader(elsClient, indexName)),
+        ProcessCacheImplIT::indexInElasticSearch);
+  }
+
+  static ProcessCacheArgument getOSProcessCache(final String indexName) {
+    return new ProcessCacheArgument(
+        new ProcessCacheImpl(10, new OpenSearchProcessCacheLoader(osClient, indexName)),
+        ProcessCacheImplIT::indexInOpenSearch);
+  }
+
+  private static void indexInElasticSearch(final ProcessEntity processEntity) {
+    try {
+      elsClient.index(
+          request ->
+              request
+                  .index(PROCESS_INDEX.getFullQualifiedName())
+                  .id(processEntity.getId())
+                  .document(processEntity));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void indexInOpenSearch(final ProcessEntity processEntity) {
+    try {
+      osClient.index(
+          request ->
+              request
+                  .index(PROCESS_INDEX.getFullQualifiedName())
+                  .id(processEntity.getId())
+                  .document(processEntity));
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  record ProcessCacheArgument(ProcessCache processCache, Consumer<ProcessEntity> indexer) {}
+}


### PR DESCRIPTION
## Description

This PR adds a Caffeine based cache for caching selected properties of a Process. The cache entries will be loaded automatically on demand using the provided loaders. Caffeine cache is thread-safe, however initially we expect the cache to be instantiated per exporter (per partition). 

The current implementation only caches process name and versionTag. If more data needs to be cached, this can be easily extended. 

An integration test is provided that verifies the cache loads entries as expected from Elasticsearch and Opensearch. The test starts both Elasticsearch and Opensearch container and runs parameterized tests for both backends.

## Related issues

closes #24154
