### PR TITLE
fix: retry job on execution listener incident

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
@@ -108,6 +108,27 @@ public abstract class ZeebeRecordTestUtil {
   }
 
   @NotNull
+  public static Record<IncidentRecordValue> createIncidentZeebeRecord(
+      final Consumer<Builder> recordBuilderFunction,
+      final Consumer<ImmutableIncidentRecordValue.Builder> recordValueBuilderFunction) {
+    final Builder<IncidentRecordValue> builder = ImmutableRecord.builder();
+    final ImmutableIncidentRecordValue.Builder valueBuilder =
+        ImmutableIncidentRecordValue.builder();
+    if (recordValueBuilderFunction != null) {
+      recordValueBuilderFunction.accept(valueBuilder);
+    }
+    builder
+        .withPartitionId(1)
+        .withTimestamp(Instant.now().toEpochMilli())
+        .withValue(valueBuilder.build())
+        .withValueType(ValueType.PROCESS_INSTANCE);
+    if (recordBuilderFunction != null) {
+      recordBuilderFunction.accept(builder);
+    }
+    return builder.build();
+  }
+
+  @NotNull
   public static Record<ProcessInstanceRecordValue> createProcessInstanceZeebeRecord(
       final Consumer<Builder> recordBuilderFunction,
       final Consumer<ImmutableProcessInstanceRecordValue.Builder> recordValueBuilderFunction) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
@@ -8,7 +8,9 @@
 package io.camunda.operate.zeebeimport.processors;
 
 import static io.camunda.operate.util.TestUtil.createIncident;
+import static io.camunda.operate.util.ZeebeRecordTestUtil.createIncidentZeebeRecord;
 import static io.camunda.operate.util.ZeebeRecordTestUtil.createZeebeRecordFromIncident;
+import static io.camunda.zeebe.protocol.record.intent.IncidentIntent.CREATED;
 import static io.camunda.zeebe.protocol.record.intent.IncidentIntent.MIGRATED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -22,6 +24,7 @@ import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import java.io.IOException;
 import java.util.List;
@@ -150,6 +153,28 @@ public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
     assertThat(updatedInc.getProcessDefinitionKey()).isEqualTo(inc.getProcessDefinitionKey());
     assertThat(updatedInc.getFlowNodeId()).isEqualTo(inc.getFlowNodeId());
     assertThat(updatedInc.getPosition()).isEqualTo(oldPosition);
+  }
+
+  @Test
+  public void shouldImportExecutionListenerNoRetriesIncident()
+      throws PersistenceException, IOException {
+    // given
+    final long incidentKey = 1L;
+
+    final Record<IncidentRecordValue> zeebeRecord =
+        createIncidentZeebeRecord(
+            b -> b.withIntent(CREATED).withKey(incidentKey),
+            b -> b.withErrorType(ErrorType.EXECUTION_LISTENER_NO_RETRIES).withErrorMessage("foo"));
+
+    // when
+    importIncidentZeebeRecord(zeebeRecord);
+
+    // then
+    final IncidentEntity incidentEntity = findIncidentByKey(incidentKey);
+
+    // the error type was imported correctly
+    assertThat(incidentEntity.getErrorType())
+        .isEqualTo(io.camunda.operate.entities.ErrorType.EXECUTION_LISTENER_NO_RETRIES);
   }
 
   @NotNull

--- a/operate/qa/integration-tests/src/test/resources/execution-listener.bpmn
+++ b/operate/qa/integration-tests/src/test/resources/execution-listener.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_19r2v2w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="execution-listener-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0rxqr9x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0rxqr9x" sourceRef="StartEvent_1" targetRef="script-task" />
+    <bpmn:endEvent id="Event_0xmgw6o">
+      <bpmn:incoming>Flow_194mcv0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_194mcv0" sourceRef="script-task" targetRef="Event_0xmgw6o" />
+    <bpmn:scriptTask id="script-task" name="Script task">
+      <bpmn:extensionElements>
+        <zeebe:script expression="=true" resultVariable="result" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" retries="3" type="listener1" />
+        </zeebe:executionListeners>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0rxqr9x</bpmn:incoming>
+      <bpmn:outgoing>Flow_194mcv0</bpmn:outgoing>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="execution-listener-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0xmgw6o_di" bpmnElement="Event_0xmgw6o">
+        <dc:Bounds x="392" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m9zv33_di" bpmnElement="script-task">
+        <dc:Bounds x="250" y="77" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0rxqr9x_di" bpmnElement="Flow_0rxqr9x">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="250" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_194mcv0_di" bpmnElement="Flow_194mcv0">
+        <di:waypoint x="350" y="117" />
+        <di:waypoint x="392" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/schema/src/main/java/io/camunda/operate/entities/ErrorType.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/ErrorType.java
@@ -14,7 +14,8 @@ public enum ErrorType {
   UNSPECIFIED("Unspecified"),
   UNKNOWN("Unknown"),
   IO_MAPPING_ERROR("I/O mapping error"),
-  JOB_NO_RETRIES("No more retries left"),
+  JOB_NO_RETRIES("No more retries left", true),
+  EXECUTION_LISTENER_NO_RETRIES("Execution listener no more retries left", true),
   CONDITION_ERROR("Condition error"),
   EXTRACT_VALUE_ERROR("Extract value error"),
   CALLED_ELEMENT_ERROR("Called element error"),
@@ -27,10 +28,16 @@ public enum ErrorType {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ErrorType.class);
 
-  private String title;
+  private final String title;
+  private final boolean resolvedViaRetries;
 
-  ErrorType(String title) {
+  ErrorType(final String title) {
+    this(title, false);
+  }
+
+  ErrorType(final String title, boolean resolvedViaRetries) {
     this.title = title;
+    this.resolvedViaRetries = resolvedViaRetries;
   }
 
   public static ErrorType fromZeebeErrorType(String errorType) {
@@ -48,5 +55,9 @@ public enum ErrorType {
 
   public String getTitle() {
     return title;
+  }
+
+  public boolean isResolvedViaRetries() {
+    return resolvedViaRetries;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -7,9 +7,9 @@
  */
 package io.camunda.operate.webapp.zeebe.operation;
 
-import static io.camunda.operate.entities.ErrorType.JOB_NO_RETRIES;
 import static io.camunda.operate.entities.OperationType.RESOLVE_INCIDENT;
 
+import io.camunda.operate.entities.ErrorType;
 import io.camunda.operate.entities.IncidentEntity;
 import io.camunda.operate.entities.OperationEntity;
 import io.camunda.operate.entities.OperationType;
@@ -41,7 +41,8 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
       return;
     }
 
-    if (incident.getErrorType().equals(JOB_NO_RETRIES)) {
+    final ErrorType errorType = incident.getErrorType();
+    if (errorType != null && errorType.isResolvedViaRetries()) {
       zeebeClient.newUpdateRetriesCommand(incident.getJobKey()).retries(1).send().join();
     }
     zeebeClient.newResolveIncidentCommand(incident.getKey()).send().join();


### PR DESCRIPTION
- when Operate resolves an incident that was raised in an execution listener, it should update retries

related to #23383

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
