### PR TITLE
ci: only 1 gateway + 1 ES node to save preview env resources

### DIFF
--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -187,227 +187,235 @@ global:
           name: identity-secret-for-components
 
 camunda-platform:
-    enabled: true
-    identity:
-      env:
-        - name: KEYCLOAK_USERS_0_ROLES_0
-          value: Identity
-        - name: KEYCLOAK_USERS_0_ROLES_1
-          value: Operate
-        - name: KEYCLOAK_USERS_0_ROLES_2
-          value: Tasklist
-        - name: KEYCLOAK_USERS_0_ROLES_3
-          value: Optimize
-        - name: KEYCLOAK_USERS_0_ROLES_4
-          value: Web Modeler
-        - name: KEYCLOAK_USERS_0_ROLES_5
-          value: Console
-        - name: KEYCLOAK_CLIENTS_2_ID
-          value: venom
-        - name: KEYCLOAK_CLIENTS_2_NAME
-          value: Venom
-        - name: KEYCLOAK_CLIENTS_2_SECRET
-        - name: KEYCLOAK_CLIENTS_2_ID
-          value: venom
-        - name: KEYCLOAK_CLIENTS_2_NAME
-          value: Venom
-        - name: KEYCLOAK_CLIENTS_2_SECRET
-          valueFrom:
-            secretKeyRef:
-              name: identity-secret-for-components
-              key: identity-secret
-        - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
-          value: /dummy
-        - name: KEYCLOAK_CLIENTS_2_ROOT_URL
-          value: http://dummy
-        - name: KEYCLOAK_CLIENTS_2_TYPE
-          value: CONFIDENTIAL
-        # Identity access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
-          value: read
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
-          value: write
-        # Operate access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
-          value: operate-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
-          value: "read:*"
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
-          value: operate-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
-          value: "write:*"
-        # Tasklist access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
-          value: tasklist-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
-          value: "read:*"
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
-          value: tasklist-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
-          value: "write:*"
-        # Optimize access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
-          value: optimize-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
-          value: "write:*"
-        # Zeebe access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
-          value: zeebe-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
-          value: "write:*"
-        # WebModeler access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
-          value: web-modeler-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
-          value: "write:*"
-        # Console access.
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
-          value: console-api
-        - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
-          value: "write:*"
-        - name: KEYCLOAK_CLIENTS_3_ID
-          value: test
-        - name: KEYCLOAK_CLIENTS_3_NAME
-          value: Test
-        - name: KEYCLOAK_CLIENTS_3_SECRET
-          value: ${DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET}
-        - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
-          value: /dummy
-        - name: KEYCLOAK_CLIENTS_3_ROOT_URL
-          value: http://dummy
-        - name: KEYCLOAK_CLIENTS_3_TYPE
-          value: CONFIDENTIAL
-        # Identity access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
-          value: read
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
-          value: camunda-identity-resource-server
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
-          value: write
-        # Operate access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
-          value: operate-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
-          value: "read:*"
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
-          value: operate-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
-          value: "write:*"
-        # Tasklist access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
-          value: tasklist-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
-          value: "read:*"
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
-          value: tasklist-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
-          value: "write:*"
-        # Optimize access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
-          value: optimize-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
-          value: "write:*"
-        # Zeebe access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
-          value: zeebe-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
-          value: "write:*"
-        # WebModeler access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
-          value: web-modeler-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
-          value: "write:*"
-        # Console access.
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
-          value: console-api
-        - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
-          value: "write:*"
-      contextPath: "/identity"
+  enabled: true
+
+  elasticsearch:
+    master:
+      replicaCount: 1
+      persistence:
+        size: 15Gi
+
+  identity:
+    env:
+      - name: KEYCLOAK_USERS_0_ROLES_0
+        value: Identity
+      - name: KEYCLOAK_USERS_0_ROLES_1
+        value: Operate
+      - name: KEYCLOAK_USERS_0_ROLES_2
+        value: Tasklist
+      - name: KEYCLOAK_USERS_0_ROLES_3
+        value: Optimize
+      - name: KEYCLOAK_USERS_0_ROLES_4
+        value: Web Modeler
+      - name: KEYCLOAK_USERS_0_ROLES_5
+        value: Console
+      - name: KEYCLOAK_CLIENTS_2_ID
+        value: venom
+      - name: KEYCLOAK_CLIENTS_2_NAME
+        value: Venom
+      - name: KEYCLOAK_CLIENTS_2_SECRET
+      - name: KEYCLOAK_CLIENTS_2_ID
+        value: venom
+      - name: KEYCLOAK_CLIENTS_2_NAME
+        value: Venom
+      - name: KEYCLOAK_CLIENTS_2_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: identity-secret-for-components
+            key: identity-secret
+      - name: KEYCLOAK_CLIENTS_2_REDIRECT_URIS_0
+        value: /dummy
+      - name: KEYCLOAK_CLIENTS_2_ROOT_URL
+        value: http://dummy
+      - name: KEYCLOAK_CLIENTS_2_TYPE
+        value: CONFIDENTIAL
+      # Identity access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_RESOURCE_SERVER_ID
+        value: camunda-identity-resource-server
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_0_DEFINITION
+        value: read
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_RESOURCE_SERVER_ID
+        value: camunda-identity-resource-server
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_1_DEFINITION
+        value: write
+      # Operate access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_RESOURCE_SERVER_ID
+        value: operate-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_2_DEFINITION
+        value: "read:*"
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_RESOURCE_SERVER_ID
+        value: operate-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_3_DEFINITION
+        value: "write:*"
+      # Tasklist access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_RESOURCE_SERVER_ID
+        value: tasklist-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_4_DEFINITION
+        value: "read:*"
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_RESOURCE_SERVER_ID
+        value: tasklist-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_5_DEFINITION
+        value: "write:*"
+      # Optimize access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_RESOURCE_SERVER_ID
+        value: optimize-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_6_DEFINITION
+        value: "write:*"
+      # Zeebe access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_RESOURCE_SERVER_ID
+        value: zeebe-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_7_DEFINITION
+        value: "write:*"
+      # WebModeler access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_RESOURCE_SERVER_ID
+        value: web-modeler-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_8_DEFINITION
+        value: "write:*"
+      # Console access.
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_RESOURCE_SERVER_ID
+        value: console-api
+      - name: KEYCLOAK_CLIENTS_2_PERMISSIONS_9_DEFINITION
+        value: "write:*"
+      - name: KEYCLOAK_CLIENTS_3_ID
+        value: test
+      - name: KEYCLOAK_CLIENTS_3_NAME
+        value: Test
+      - name: KEYCLOAK_CLIENTS_3_SECRET
+        value: ${DISTRO_QA_E2E_TESTS_KEYCLOAK_CLIENTS_SECRET}
+      - name: KEYCLOAK_CLIENTS_3_REDIRECT_URIS_0
+        value: /dummy
+      - name: KEYCLOAK_CLIENTS_3_ROOT_URL
+        value: http://dummy
+      - name: KEYCLOAK_CLIENTS_3_TYPE
+        value: CONFIDENTIAL
+      # Identity access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_RESOURCE_SERVER_ID
+        value: camunda-identity-resource-server
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_0_DEFINITION
+        value: read
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_RESOURCE_SERVER_ID
+        value: camunda-identity-resource-server
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_1_DEFINITION
+        value: write
+      # Operate access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_RESOURCE_SERVER_ID
+        value: operate-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_2_DEFINITION
+        value: "read:*"
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_RESOURCE_SERVER_ID
+        value: operate-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_3_DEFINITION
+        value: "write:*"
+      # Tasklist access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_RESOURCE_SERVER_ID
+        value: tasklist-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_4_DEFINITION
+        value: "read:*"
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_RESOURCE_SERVER_ID
+        value: tasklist-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_5_DEFINITION
+        value: "write:*"
+      # Optimize access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_RESOURCE_SERVER_ID
+        value: optimize-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_6_DEFINITION
+        value: "write:*"
+      # Zeebe access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_RESOURCE_SERVER_ID
+        value: zeebe-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_7_DEFINITION
+        value: "write:*"
+      # WebModeler access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_RESOURCE_SERVER_ID
+        value: web-modeler-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_8_DEFINITION
+        value: "write:*"
+      # Console access.
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_RESOURCE_SERVER_ID
+        value: console-api
+      - name: KEYCLOAK_CLIENTS_3_PERMISSIONS_9_DEFINITION
+        value: "write:*"
+    contextPath: "/identity"
+    # will be replaced by the preview-env-deploy workflow
+    fullURL: "https://test.camunda.camunda.cloud/identity"
+
+  operate:
+    env:
+      - name: SPRING_PROFILES_ACTIVE
+        value: dev-data
+    image:
+      registry: registry.camunda.cloud
+      repository: team-camunda/operate
       # will be replaced by the preview-env-deploy workflow
-      fullURL: "https://test.camunda.camunda.cloud/identity"
+      tag: latest
+      pullSecrets:
+      - name: registry-camunda-cloud
+    contextPath: "/operate"
 
-    operate:
-      env:
-        - name: SPRING_PROFILES_ACTIVE
-          value: dev-data
-      image:
-        registry: registry.camunda.cloud
-        repository: team-camunda/operate
-        # will be replaced by the preview-env-deploy workflow
-        tag: latest
-        pullSecrets:
+  optimize:
+    image:
+      registry: registry.camunda.cloud
+      repository: team-camunda/optimize
+      # will be replaced by the preview-env-deploy workflow
+      tag: latest
+      pullSecrets:
         - name: registry-camunda-cloud
-      contextPath: "/operate"
+    contextPath: "/optimize"
 
-    optimize:
-      image:
-        registry: registry.camunda.cloud
-        repository: team-camunda/optimize
-        # will be replaced by the preview-env-deploy workflow
-        tag: latest
-        pullSecrets:
-          - name: registry-camunda-cloud
-      contextPath: "/optimize"
+  tasklist:
+    image:
+      registry: registry.camunda.cloud
+      repository: team-camunda/tasklist
+      # will be replaced by the preview-env-deploy workflow
+      tag: latest
+      pullSecrets:
+        - name: registry-camunda-cloud
+    contextPath: "/tasklist"
 
-    tasklist:
-      image:
-        registry: registry.camunda.cloud
-        repository: team-camunda/tasklist
-        # will be replaced by the preview-env-deploy workflow
-        tag: latest
-        pullSecrets:
-          - name: registry-camunda-cloud
-      contextPath: "/tasklist"
+  zeebe:
+    image:
+      registry: registry.camunda.cloud
+      repository: team-camunda/zeebe
+      # will be replaced by the preview-env-deploy workflow
+      tag: latest
+      pullSecrets:
+        - name: registry-camunda-cloud
 
-    zeebe:
-      image:
-        registry: registry.camunda.cloud
-        repository: team-camunda/zeebe
-        # will be replaced by the preview-env-deploy workflow
-        tag: latest
-        pullSecrets:
-          - name: registry-camunda-cloud
+  webModeler:
+    contextPath: "/modeler"
 
-    webModeler:
-      contextPath: "/modeler"
+  console:
+    contextPath: "/console"
 
-    console:
-      contextPath: "/console"
+  connectors:
+    contextPath: "/connectors"
 
-    connectors:
-      contextPath: "/connectors"
-
-    zeebeGateway:
-      contextPath: "/zeebe"
-      ingress:
-        grpc:
-          enabled: true
-          className: nginx
-          host: "test.camunda.camunda.cloud"
-          annotations:
-            ingress.kubernetes.io/rewrite-target: "/"
-            nginx.ingress.kubernetes.io/ssl-redirect: "true"
-            nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
-            nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
-          tls:
-            enabled: true
-            secretName: camunda-tls
-
-    identityKeycloak:
-      auth:
-        existingSecret: keycloak-admin-secret
-        passwordSecretKey: admin-password
-        adminUser: admin
-
-      postgresql:
+  zeebeGateway:
+    contextPath: "/zeebe"
+    replicas: 1
+    ingress:
+      grpc:
         enabled: true
-        auth:
-          existingSecret: postgres-secret
-          secretKeys:
-            userPasswordKey: password
+        className: nginx
+        host: "test.camunda.camunda.cloud"
+        annotations:
+          ingress.kubernetes.io/rewrite-target: "/"
+          nginx.ingress.kubernetes.io/ssl-redirect: "true"
+          nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
+          nginx.ingress.kubernetes.io/proxy-buffer-size: "128k"
+        tls:
+          enabled: true
+          secretName: camunda-tls
+
+  identityKeycloak:
+    auth:
+      existingSecret: keycloak-admin-secret
+      passwordSecretKey: admin-password
+      adminUser: admin
+
+    postgresql:
+      enabled: true
+      auth:
+        existingSecret: postgres-secret
+        secretKeys:
+          userPasswordKey: password

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -194,6 +194,12 @@ camunda-platform:
       replicaCount: 1
       persistence:
         size: 15Gi
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+        - key: "previews"
+          operator: "Exists"
+          effect: "NoSchedule"
 
   identity:
     env:
@@ -338,6 +344,19 @@ camunda-platform:
     contextPath: "/identity"
     # will be replaced by the preview-env-deploy workflow
     fullURL: "https://test.camunda.camunda.cloud/identity"
+    keycloak:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+        - key: "previews"
+          operator: "Exists"
+          effect: "NoSchedule"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   operate:
     env:
@@ -351,6 +370,12 @@ camunda-platform:
       pullSecrets:
       - name: registry-camunda-cloud
     contextPath: "/operate"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   optimize:
     image:
@@ -361,6 +386,12 @@ camunda-platform:
       pullSecrets:
         - name: registry-camunda-cloud
     contextPath: "/optimize"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   tasklist:
     image:
@@ -371,6 +402,12 @@ camunda-platform:
       pullSecrets:
         - name: registry-camunda-cloud
     contextPath: "/tasklist"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   zeebe:
     image:
@@ -380,15 +417,47 @@ camunda-platform:
       tag: latest
       pullSecrets:
         - name: registry-camunda-cloud
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   webModeler:
     contextPath: "/modeler"
+    restapi:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+        - key: "previews"
+          operator: "Exists"
+          effect: "NoSchedule"
+    webapp:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: previews
+      tolerations:
+        - key: "previews"
+          operator: "Exists"
+          effect: "NoSchedule"
 
   console:
     contextPath: "/console"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   connectors:
     contextPath: "/connectors"
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   zeebeGateway:
     contextPath: "/zeebe"
@@ -406,6 +475,12 @@ camunda-platform:
         tls:
           enabled: true
           secretName: camunda-tls
+    nodeSelector:
+      cloud.google.com/gke-nodepool: previews
+    tolerations:
+      - key: "previews"
+        operator: "Exists"
+        effect: "NoSchedule"
 
   identityKeycloak:
     auth:
@@ -419,3 +494,10 @@ camunda-platform:
         existingSecret: postgres-secret
         secretKeys:
           userPasswordKey: password
+      primary:
+        nodeSelector:
+          cloud.google.com/gke-nodepool: previews
+        tolerations:
+          - key: "previews"
+            operator: "Exists"
+            effect: "NoSchedule"

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -451,6 +451,8 @@ camunda-platform:
         effect: "NoSchedule"
 
   connectors:
+    # temporarily disabled until solution for problem from https://github.com/camunda/camunda/pull/24253 is found
+    enabled: false
     contextPath: "/connectors"
     nodeSelector:
       cloud.google.com/gke-nodepool: previews


### PR DESCRIPTION
## Description

This PR configures new preview environments in this monorepo to only use 1 ElasticSearch node (instead of 3) and only 1 ZeebeGateway node (instead of 2) to save on CPU+memory resources. One node of each should still be enough to have all functionality available and working without spending idle resources - this is how Infra team does it also for other team's preview environment setups.

Indentation was inconsistent in `values.yaml` so please diff ignoring whitespace since I fixed it!

**Note**: I temporarily enabled Connectors as part of this PR to allow creating preview environments again. This will be addressed in a subsequent PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
