### PR TITLE
Operate's OperationHandlers propagate `operationreference` with zeebe commands

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -268,7 +268,10 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
   }
 
   private BatchOperationEntity createBatchOperationEntity(final OffsetDateTime endDate) {
-    return new BatchOperationEntity().setStartDate(endDate.minusMinutes(5)).setEndDate(endDate);
+    return new BatchOperationEntity()
+        .withGeneratedId()
+        .setStartDate(endDate.minusMinutes(5))
+        .setEndDate(endDate);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ArchiverZeebeIT.java
@@ -268,11 +268,7 @@ public class ArchiverZeebeIT extends OperateZeebeAbstractIT {
   }
 
   private BatchOperationEntity createBatchOperationEntity(final OffsetDateTime endDate) {
-    final BatchOperationEntity batchOperationEntity1 = new BatchOperationEntity();
-    batchOperationEntity1.generateId();
-    batchOperationEntity1.setStartDate(endDate.minus(5, ChronoUnit.MINUTES));
-    batchOperationEntity1.setEndDate(endDate);
-    return batchOperationEntity1;
+    return new BatchOperationEntity().setStartDate(endDate.minusMinutes(5)).setEndDate(endDate);
   }
 
   @Test

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ProcessInstanceReaderIT.java
@@ -66,7 +66,6 @@ public class ProcessInstanceReaderIT extends OperateSearchAbstractIT {
         indexName, String.valueOf(processInstanceKey), processInstanceData);
 
     operationData = new OperationEntity();
-    operationData.setId("operation-1");
     operationData.setProcessInstanceKey(processInstanceData.getProcessInstanceKey());
     operationData.setUsername(userService.getCurrentUser().getUsername());
     operationData.setState(OperationState.SCHEDULED);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
@@ -19,6 +19,7 @@ import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeType;
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -58,7 +59,8 @@ class ProcessInstanceMigrationIT extends OperateZeebeSearchAbstractIT {
                         .setSourceElementId("taskB")
                         .setTargetElementId("taskB")));
     migrateProcessInstanceHandler.setZeebeClient(zeebeContainerManager.getClient());
-    migrateProcessInstanceHandler.migrate(processFrom, migrationPlan);
+    migrateProcessInstanceHandler.migrate(
+        processFrom, migrationPlan, UUID.randomUUID().getMostSignificantBits());
 
     // then
     // subprocesses are migrated

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/operation/ProcessInstanceMigrationIT.java
@@ -60,7 +60,7 @@ class ProcessInstanceMigrationIT extends OperateZeebeSearchAbstractIT {
                         .setTargetElementId("taskB")));
     migrateProcessInstanceHandler.setZeebeClient(zeebeContainerManager.getClient());
     migrateProcessInstanceHandler.migrate(
-        processFrom, migrationPlan, UUID.randomUUID().getMostSignificantBits());
+        processFrom, migrationPlan, String.valueOf(UUID.randomUUID().getMostSignificantBits()));
 
     // then
     // subprocesses are migrated

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
@@ -176,49 +176,42 @@ public class BatchOperationRestServiceIT extends OperateSearchAbstractIT {
     final OperationEntity bo1op1 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[0])
-            .setId("11")
             .setState(OperationState.COMPLETED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo1op1.getId(), bo1op1);
     final OperationEntity bo1op2 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[0])
-            .setId("12")
             .setState(OperationState.COMPLETED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo1op2.getId(), bo1op2);
     final OperationEntity bo1op3 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[0])
-            .setId("13")
             .setState(OperationState.COMPLETED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo1op3.getId(), bo1op3);
     final OperationEntity bo1op4 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[0])
-            .setId("14")
             .setState(OperationState.FAILED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo1op4.getId(), bo1op4);
     final OperationEntity bo1op5 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[0])
-            .setId("15")
             .setState(OperationState.FAILED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo1op5.getId(), bo1op5);
     final OperationEntity bo2op1 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[1])
-            .setId("21")
             .setState(OperationState.COMPLETED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo2op1.getId(), bo2op1);
     final OperationEntity bo2op2 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[1])
-            .setId("22")
             .setState(OperationState.COMPLETED);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo2op2.getId(), bo2op2);
@@ -227,7 +220,6 @@ public class BatchOperationRestServiceIT extends OperateSearchAbstractIT {
     final OperationEntity bo3op1 =
         new OperationEntity()
             .setBatchOperationId(TEST_BATCH_OP_IDS[2])
-            .setId("31")
             .setState(OperationState.SENT);
     testSearchRepository.createOrUpdateDocumentFromObject(
         operationIndexName, bo3op1.getId(), bo3op1);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
@@ -548,14 +548,14 @@ public abstract class TestUtil {
       final OperationState state,
       final String username,
       final boolean lockExpired) {
-    final OperationEntity oe = new OperationEntity();
-    oe.generateId();
-    oe.setProcessInstanceKey(processInstanceKey);
-    oe.setScopeKey(processInstanceKey);
-    oe.setProcessDefinitionKey(processDefinitionKey);
-    oe.setBpmnProcessId(bpmnProcessId);
-    oe.setIncidentKey(incidentKey);
-    oe.setVariableName(varName);
+    final OperationEntity oe =
+        new OperationEntity()
+            .setProcessInstanceKey(processInstanceKey)
+            .setScopeKey(processInstanceKey)
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setBpmnProcessId(bpmnProcessId)
+            .setIncidentKey(incidentKey)
+            .setVariableName(varName);
     if (varName != null) {
       oe.setType(OperationType.UPDATE_VARIABLE);
       oe.setVariableValue(varName);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
@@ -550,6 +550,7 @@ public abstract class TestUtil {
       final boolean lockExpired) {
     final OperationEntity oe =
         new OperationEntity()
+            .withGeneratedId()
             .setProcessInstanceKey(processInstanceKey)
             .setScopeKey(processInstanceKey)
             .setProcessDefinitionKey(processDefinitionKey)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestUtil.java
@@ -593,7 +593,7 @@ public abstract class TestUtil {
   public static BatchOperationEntity createBatchOperationEntity(
       final OffsetDateTime startDate, final OffsetDateTime endDate, final String username) {
     return new BatchOperationEntity()
-        .setId(UUID.randomUUID().toString())
+        .withGeneratedId()
         .setStartDate(startDate)
         .setEndDate(endDate)
         .setUsername(username)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
@@ -308,6 +308,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
       throws IOException {
     final OperationEntity operation =
         new OperationEntity()
+            .withGeneratedId()
             .setProcessInstanceKey(MOCK_PROCESS_INSTANCE_KEY)
             .setProcessDefinitionKey(MOCK_PROCESS_DEFINITION_KEY)
             .setBpmnProcessId("demoProcess")

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/ModifyProcessInstanceOperationIT.java
@@ -65,7 +65,6 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
     createBatchCommandDocument(batchOperationId);
 
     // Create operation entity to process
-    final String operationId = UUID.randomUUID().toString();
     final ModifyProcessInstanceRequestDto modifyInstructions =
         new ModifyProcessInstanceRequestDto()
             .setProcessInstanceKey(String.valueOf(MOCK_PROCESS_INSTANCE_KEY))
@@ -74,7 +73,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
                     new Modification().setModification(Type.ADD_TOKEN).setToFlowNodeId("taskB")));
 
     final OperationEntity operation =
-        createOperationEntityDocument(batchOperationId, operationId, modifyInstructions);
+        createOperationEntityDocument(batchOperationId, modifyInstructions);
     searchContainerManager.refreshIndices("*operation*");
 
     // Test execution of the operation entity
@@ -112,7 +111,6 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
     createBatchCommandDocument(batchOperationId);
 
     // Create operation entity to process
-    final String operationId = UUID.randomUUID().toString();
     final ModifyProcessInstanceRequestDto modifyInstructions =
         new ModifyProcessInstanceRequestDto()
             .setProcessInstanceKey(String.valueOf(MOCK_PROCESS_INSTANCE_KEY))
@@ -124,7 +122,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
                         .setVariables(Map.of("taskB", List.of(Map.of("c", "d"))))));
 
     final OperationEntity operation =
-        createOperationEntityDocument(batchOperationId, operationId, modifyInstructions);
+        createOperationEntityDocument(batchOperationId, modifyInstructions);
     searchContainerManager.refreshIndices("*operation*");
 
     // Test execution of the operation entity
@@ -178,7 +176,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
                         .setFromFlowNodeId("taskA")));
 
     final OperationEntity operation =
-        createOperationEntityDocument(batchOperationId, operationId, modifyInstructions);
+        createOperationEntityDocument(batchOperationId, modifyInstructions);
     searchContainerManager.refreshIndices("*operation*");
 
     // Test execution of the operation entity
@@ -224,7 +222,6 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
     createBatchCommandDocument(batchOperationId);
 
     // Create operation entity to process
-    final String operationId = UUID.randomUUID().toString();
     final ModifyProcessInstanceRequestDto modifyInstructions =
         new ModifyProcessInstanceRequestDto()
             .setProcessInstanceKey(String.valueOf(MOCK_PROCESS_INSTANCE_KEY))
@@ -236,7 +233,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
                         .setToFlowNodeId("taskB")));
 
     final OperationEntity operation =
-        createOperationEntityDocument(batchOperationId, operationId, modifyInstructions);
+        createOperationEntityDocument(batchOperationId, modifyInstructions);
     searchContainerManager.refreshIndices("*operation*");
 
     // Test execution of the operation entity
@@ -307,13 +304,10 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
   }
 
   private OperationEntity createOperationEntityDocument(
-      final String batchOperationId,
-      final String operationId,
-      final ModifyProcessInstanceRequestDto modifyInstructions)
+      final String batchOperationId, final ModifyProcessInstanceRequestDto modifyInstructions)
       throws IOException {
     final OperationEntity operation =
         new OperationEntity()
-            .setId(operationId)
             .setProcessInstanceKey(MOCK_PROCESS_INSTANCE_KEY)
             .setProcessDefinitionKey(MOCK_PROCESS_DEFINITION_KEY)
             .setBpmnProcessId("demoProcess")
@@ -324,7 +318,7 @@ public class ModifyProcessInstanceOperationIT extends OperateSearchAbstractIT {
             .setModifyInstructions(objectMapper.writeValueAsString(modifyInstructions));
 
     testSearchRepository.createOrUpdateDocumentFromObject(
-        operationTemplate.getFullQualifiedName(), operationId, operation);
+        operationTemplate.getFullQualifiedName(), operation.getId(), operation);
 
     return operation;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -378,6 +378,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
     // Create operation
     final OperationEntity operationEntity =
         new OperationEntity()
+            .withGeneratedId()
             .setDecisionDefinitionKey(decisionDefinitionKey)
             .setType(operationType)
             .setState(OperationState.SCHEDULED)
@@ -427,6 +428,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
     // Create operation
     final OperationEntity operationEntity =
         new OperationEntity()
+            .withGeneratedId()
             .setProcessDefinitionKey(processDefinitionKey)
             .setType(operationType)
             .setState(OperationState.SCHEDULED)
@@ -557,6 +559,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
       final String batchOperationId) {
 
     return new OperationEntity()
+        .withGeneratedId()
         .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
         .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
         .setBpmnProcessId(processInstanceSource.getBpmnProcessId())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -527,6 +527,7 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
   private BatchOperationEntity createBatchOperationEntity(
       final OperationType operationType, final String name) {
     return new BatchOperationEntity()
+        .withGeneratedId()
         .setType(operationType)
         .setName(name)
         .setStartDate(OffsetDateTime.now())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -376,13 +376,13 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
             .setInstancesCount(0);
 
     // Create operation
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setDecisionDefinitionKey(decisionDefinitionKey);
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperation.getId());
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setDecisionDefinitionKey(decisionDefinitionKey)
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperation.getId())
+            .setUsername(userService.getCurrentUser().getUsername());
 
     // Create request
     try {
@@ -425,13 +425,13 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
             .setInstancesCount(0);
 
     // Create operation
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setProcessDefinitionKey(processDefinitionKey);
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperation.getId());
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperation.getId())
+            .setUsername(userService.getCurrentUser().getUsername());
 
     // Create request
     try {
@@ -526,13 +526,11 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
 
   private BatchOperationEntity createBatchOperationEntity(
       final OperationType operationType, final String name) {
-    final BatchOperationEntity batchOperationEntity = new BatchOperationEntity();
-    batchOperationEntity.generateId();
-    batchOperationEntity.setType(operationType);
-    batchOperationEntity.setName(name);
-    batchOperationEntity.setStartDate(OffsetDateTime.now());
-    batchOperationEntity.setUsername(userService.getCurrentUser().getUsername());
-    return batchOperationEntity;
+    return new BatchOperationEntity()
+        .setType(operationType)
+        .setName(name)
+        .setStartDate(OffsetDateTime.now())
+        .setUsername(userService.getCurrentUser().getUsername());
   }
 
   private OperationEntity createOperationEntity(
@@ -557,17 +555,14 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
       final OperationType operationType,
       final String batchOperationId) {
 
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setProcessInstanceKey(processInstanceSource.getProcessInstanceKey());
-    operationEntity.setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey());
-    operationEntity.setBpmnProcessId(processInstanceSource.getBpmnProcessId());
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperationId);
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
-
-    return operationEntity;
+    return new OperationEntity()
+        .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
+        .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
+        .setBpmnProcessId(processInstanceSource.getBpmnProcessId())
+        .setType(operationType)
+        .setState(OperationState.SCHEDULED)
+        .setBatchOperationId(batchOperationId)
+        .setUsername(userService.getCurrentUser().getUsername());
   }
 
   private void validateTotalHits(final SearchHits hits) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -533,17 +533,14 @@ public class OpensearchBatchOperationWriter
       final OperationType operationType,
       final String batchOperationId) {
 
-    final OperationEntity operationEntity =
-        new OperationEntity()
-            .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
-            .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
-            .setBpmnProcessId(processInstanceSource.getBpmnProcessId())
-            .setType(operationType)
-            .setState(OperationState.SCHEDULED)
-            .setBatchOperationId(batchOperationId)
-            .setUsername(userService.getCurrentUser().getUsername());
-
-    return operationEntity;
+    return new OperationEntity()
+        .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
+        .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
+        .setBpmnProcessId(processInstanceSource.getBpmnProcessId())
+        .setType(operationType)
+        .setState(OperationState.SCHEDULED)
+        .setBatchOperationId(batchOperationId)
+        .setUsername(userService.getCurrentUser().getUsername());
   }
 
   private Optional<ProcessInstanceForListViewEntity> tryGetProcessInstance(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -505,6 +505,7 @@ public class OpensearchBatchOperationWriter
   private BatchOperationEntity createBatchOperationEntity(
       final OperationType operationType, final String name) {
     return new BatchOperationEntity()
+        .withGeneratedId()
         .setType(operationType)
         .setName(name)
         .setStartDate(OffsetDateTime.now())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -358,13 +358,13 @@ public class OpensearchBatchOperationWriter
             .setInstancesCount(0);
 
     // Create operation
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setDecisionDefinitionKey(decisionDefinitionKey);
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperation.getId());
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setDecisionDefinitionKey(decisionDefinitionKey)
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperation.getId())
+            .setUsername(userService.getCurrentUser().getUsername());
 
     // Create request
     try {
@@ -398,13 +398,13 @@ public class OpensearchBatchOperationWriter
             .setInstancesCount(0);
 
     // Create operation
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setProcessDefinitionKey(processDefinitionKey);
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperation.getId());
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setProcessDefinitionKey(processDefinitionKey)
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperation.getId())
+            .setUsername(userService.getCurrentUser().getUsername());
 
     // Create request
     try {
@@ -504,13 +504,11 @@ public class OpensearchBatchOperationWriter
 
   private BatchOperationEntity createBatchOperationEntity(
       final OperationType operationType, final String name) {
-    final BatchOperationEntity batchOperationEntity = new BatchOperationEntity();
-    batchOperationEntity.generateId();
-    batchOperationEntity.setType(operationType);
-    batchOperationEntity.setName(name);
-    batchOperationEntity.setStartDate(OffsetDateTime.now());
-    batchOperationEntity.setUsername(userService.getCurrentUser().getUsername());
-    return batchOperationEntity;
+    return new BatchOperationEntity()
+        .setType(operationType)
+        .setName(name)
+        .setStartDate(OffsetDateTime.now())
+        .setUsername(userService.getCurrentUser().getUsername());
   }
 
   private OperationEntity createOperationEntity(
@@ -535,15 +533,15 @@ public class OpensearchBatchOperationWriter
       final OperationType operationType,
       final String batchOperationId) {
 
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setProcessInstanceKey(processInstanceSource.getProcessInstanceKey());
-    operationEntity.setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey());
-    operationEntity.setBpmnProcessId(processInstanceSource.getBpmnProcessId());
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperationId);
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
+            .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
+            .setBpmnProcessId(processInstanceSource.getBpmnProcessId())
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperationId)
+            .setUsername(userService.getCurrentUser().getUsername());
 
     return operationEntity;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -360,6 +360,7 @@ public class OpensearchBatchOperationWriter
     // Create operation
     final OperationEntity operationEntity =
         new OperationEntity()
+            .withGeneratedId()
             .setDecisionDefinitionKey(decisionDefinitionKey)
             .setType(operationType)
             .setState(OperationState.SCHEDULED)
@@ -400,6 +401,7 @@ public class OpensearchBatchOperationWriter
     // Create operation
     final OperationEntity operationEntity =
         new OperationEntity()
+            .withGeneratedId()
             .setProcessDefinitionKey(processDefinitionKey)
             .setType(operationType)
             .setState(OperationState.SCHEDULED)
@@ -535,6 +537,7 @@ public class OpensearchBatchOperationWriter
       final String batchOperationId) {
 
     return new OperationEntity()
+        .withGeneratedId()
         .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
         .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
         .setBpmnProcessId(processInstanceSource.getBpmnProcessId())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
@@ -158,15 +158,15 @@ public class PersistOperationHelper {
       final OperationType operationType,
       final String batchOperationId) {
 
-    final OperationEntity operationEntity = new OperationEntity();
-    operationEntity.generateId();
-    operationEntity.setProcessInstanceKey(processInstanceSource.getProcessInstanceKey());
-    operationEntity.setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey());
-    operationEntity.setBpmnProcessId(processInstanceSource.getBpmnProcessId());
-    operationEntity.setType(operationType);
-    operationEntity.setState(OperationState.SCHEDULED);
-    operationEntity.setBatchOperationId(batchOperationId);
-    operationEntity.setUsername(userService.getCurrentUser().getUsername());
+    final OperationEntity operationEntity =
+        new OperationEntity()
+            .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
+            .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
+            .setBpmnProcessId(processInstanceSource.getBpmnProcessId())
+            .setType(operationType)
+            .setState(OperationState.SCHEDULED)
+            .setBatchOperationId(batchOperationId)
+            .setUsername(userService.getCurrentUser().getUsername());
 
     return operationEntity;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
@@ -160,6 +160,7 @@ public class PersistOperationHelper {
 
     final OperationEntity operationEntity =
         new OperationEntity()
+            .withGeneratedId()
             .setProcessInstanceKey(processInstanceSource.getProcessInstanceKey())
             .setProcessDefinitionKey(processInstanceSource.getProcessDefinitionKey())
             .setBpmnProcessId(processInstanceSource.getBpmnProcessId())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
@@ -150,7 +150,9 @@ public abstract class AbstractOperationHandler implements OperationHandler {
       final long operationReference = Long.parseLong(id);
       command.operationReference(operationReference);
     } catch (final NumberFormatException e) {
-      // ignore
+      LOGGER.debug(
+          "The operation reference provided is not a number: {}. Ignoring propagating it to zeebe commands.",
+          id);
     }
     return command;
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/AbstractOperationHandler.java
@@ -15,6 +15,7 @@ import io.camunda.operate.webapp.writer.BatchOperationWriter;
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.CommandWithOperationReferenceStep;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.Arrays;
@@ -141,5 +142,16 @@ public abstract class AbstractOperationHandler implements OperationHandler {
       LOGGER.debug("Operation {} was sent to Zeebe", operation.getId());
     }
     recordCommandMetric(operation);
+  }
+
+  protected static <T extends CommandWithOperationReferenceStep<T>> T withOperationReference(
+      final T command, final String id) {
+    try {
+      final long operationReference = Long.parseLong(id);
+      command.operationReference(operationReference);
+    } catch (final NumberFormatException e) {
+      // ignore
+    }
+    return command;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
@@ -43,7 +43,11 @@ public class CancelProcessInstanceHandler extends AbstractOperationHandler
               processInstance.getState()));
       return;
     }
-    zeebeClient.newCancelInstanceCommand(processInstance.getKey()).send().join();
+    zeebeClient
+        .newCancelInstanceCommand(processInstance.getKey())
+        .operationReference(Long.parseLong(operation.getId()))
+        .send()
+        .join();
     // mark operation as sent
     markAsSent(operation);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/CancelProcessInstanceHandler.java
@@ -43,11 +43,12 @@ public class CancelProcessInstanceHandler extends AbstractOperationHandler
               processInstance.getState()));
       return;
     }
-    zeebeClient
-        .newCancelInstanceCommand(processInstance.getKey())
-        .operationReference(Long.parseLong(operation.getId()))
-        .send()
-        .join();
+
+    final String id = operation.getId();
+    final var cancelInstanceCommand =
+        withOperationReference(zeebeClient.newCancelInstanceCommand(processInstance.getKey()), id);
+    cancelInstanceCommand.send().join();
+
     // mark operation as sent
     markAsSent(operation);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
@@ -51,7 +51,11 @@ public class DeleteDecisionDefinitionHandler extends AbstractOperationHandler
         String.format(
             "Operation [%s]: Sending Zeebe delete command for decisionRequirementsKey [%s]...",
             operation.getId(), decisionRequirementsKey));
-    zeebeClient.newDeleteResourceCommand(decisionRequirementsKey).send().join();
+    zeebeClient
+        .newDeleteResourceCommand(decisionRequirementsKey)
+        .operationReference(Long.parseLong(operation.getId()))
+        .send()
+        .join();
     markAsSent(operation);
     LOGGER.info(
         String.format(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteDecisionDefinitionHandler.java
@@ -51,11 +51,10 @@ public class DeleteDecisionDefinitionHandler extends AbstractOperationHandler
         String.format(
             "Operation [%s]: Sending Zeebe delete command for decisionRequirementsKey [%s]...",
             operation.getId(), decisionRequirementsKey));
-    zeebeClient
-        .newDeleteResourceCommand(decisionRequirementsKey)
-        .operationReference(Long.parseLong(operation.getId()))
-        .send()
-        .join();
+    final var deleteResourceCommand =
+        withOperationReference(
+            zeebeClient.newDeleteResourceCommand(decisionRequirementsKey), operation.getId());
+    deleteResourceCommand.send().join();
     markAsSent(operation);
     LOGGER.info(
         String.format(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
@@ -70,11 +70,10 @@ public class DeleteProcessDefinitionHandler extends AbstractOperationHandler
         String.format(
             "Operation [%s]: Sending Zeebe delete command for processDefinitionKey [%s]...",
             operation.getId(), processDefinitionKey));
-    zeebeClient
-        .newDeleteResourceCommand(processDefinitionKey)
-        .operationReference(Long.parseLong(operation.getId()))
-        .send()
-        .join();
+    final var deleteResourceCommand =
+        withOperationReference(
+            zeebeClient.newDeleteResourceCommand(processDefinitionKey), operation.getId());
+    deleteResourceCommand.send().join();
     markAsSent(operation);
     LOGGER.info(
         String.format(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/DeleteProcessDefinitionHandler.java
@@ -70,7 +70,11 @@ public class DeleteProcessDefinitionHandler extends AbstractOperationHandler
         String.format(
             "Operation [%s]: Sending Zeebe delete command for processDefinitionKey [%s]...",
             operation.getId(), processDefinitionKey));
-    zeebeClient.newDeleteResourceCommand(processDefinitionKey).send().join();
+    zeebeClient
+        .newDeleteResourceCommand(processDefinitionKey)
+        .operationReference(Long.parseLong(operation.getId()))
+        .send()
+        .join();
     markAsSent(operation);
     LOGGER.info(
         String.format(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
@@ -50,7 +50,7 @@ public class MigrateProcessInstanceHandler extends AbstractOperationHandler
         "Operation [{}]: Sending Zeebe migrate command for processInstanceKey [{}]...",
         operation.getId(),
         processInstanceKey);
-    migrate(processInstanceKey, migrationPlanDto);
+    migrate(processInstanceKey, migrationPlanDto, Long.parseLong(operation.getId()));
     markAsSent(operation);
     LOGGER.info(
         "Operation [{}]: Migrate command sent to Zeebe for processInstanceKey [{}]",
@@ -63,7 +63,10 @@ public class MigrateProcessInstanceHandler extends AbstractOperationHandler
     return Set.of(OperationType.MIGRATE_PROCESS_INSTANCE);
   }
 
-  public void migrate(final Long processInstanceKey, final MigrationPlanDto migrationPlanDto) {
+  public void migrate(
+      final Long processInstanceKey,
+      final MigrationPlanDto migrationPlanDto,
+      final long operationReference) {
     final long targetProcessDefinitionKey =
         Long.parseLong(migrationPlanDto.getTargetProcessDefinitionKey());
 
@@ -82,6 +85,7 @@ public class MigrateProcessInstanceHandler extends AbstractOperationHandler
     zeebeClient
         .newMigrateProcessInstanceCommand(processInstanceKey)
         .migrationPlan(migrationPlan)
+        .operationReference(operationReference)
         .send()
         .join();
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ModifyProcessZeebeWrapper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ModifyProcessZeebeWrapper.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.zeebe.operation;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
+import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
@@ -38,14 +39,21 @@ public class ModifyProcessZeebeWrapper {
     return zeebeClient.newModifyProcessInstanceCommand(processInstanceKey);
   }
 
-  public void setVariablesInZeebe(final Long scopeKey, final Map<String, Object> variables) {
-    zeebeClient.newSetVariablesCommand(scopeKey).variables(variables).local(true).send().join();
+  public void setVariablesInZeebe(
+      final Long scopeKey, final Map<String, Object> variables, final long operationReference) {
+    zeebeClient
+        .newSetVariablesCommand(scopeKey)
+        .variables(variables)
+        .local(true)
+        .operationReference(operationReference)
+        .send()
+        .join();
   }
 
   public void sendModificationsToZeebe(
-      final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 stepCommand) {
+      final ModifyProcessInstanceCommandStep2 stepCommand, final long operationReference) {
     if (stepCommand != null) {
-      stepCommand.send().join();
+      stepCommand.operationReference(operationReference).send().join();
     }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ModifyProcessZeebeWrapper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ModifyProcessZeebeWrapper.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.webapp.zeebe.operation;
 
+import static io.camunda.operate.webapp.zeebe.operation.AbstractOperationHandler.withOperationReference;
+
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2;
@@ -40,20 +42,19 @@ public class ModifyProcessZeebeWrapper {
   }
 
   public void setVariablesInZeebe(
-      final Long scopeKey, final Map<String, Object> variables, final long operationReference) {
-    zeebeClient
-        .newSetVariablesCommand(scopeKey)
-        .variables(variables)
-        .local(true)
-        .operationReference(operationReference)
-        .send()
-        .join();
+      final Long scopeKey, final Map<String, Object> variables, final String operationId) {
+    final var setVariablesCommand =
+        withOperationReference(
+            zeebeClient.newSetVariablesCommand(scopeKey).variables(variables).local(true),
+            operationId);
+
+    setVariablesCommand.send().join();
   }
 
   public void sendModificationsToZeebe(
-      final ModifyProcessInstanceCommandStep2 stepCommand, final long operationReference) {
+      final ModifyProcessInstanceCommandStep2 stepCommand, final String operationId) {
     if (stepCommand != null) {
-      stepCommand.operationReference(operationReference).send().join();
+      withOperationReference(stepCommand, operationId).send().join();
     }
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -42,9 +42,18 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
     }
 
     if (incident.getErrorType().equals(JOB_NO_RETRIES)) {
-      zeebeClient.newUpdateRetriesCommand(incident.getJobKey()).retries(1).send().join();
+      zeebeClient
+          .newUpdateRetriesCommand(incident.getJobKey())
+          .retries(1)
+          .operationReference(Long.parseLong(operation.getId()))
+          .send()
+          .join();
     }
-    zeebeClient.newResolveIncidentCommand(incident.getKey()).send().join();
+    zeebeClient
+        .newResolveIncidentCommand(incident.getKey())
+        .operationReference(Long.parseLong(operation.getId()))
+        .send()
+        .join();
     // mark operation as sent
     markAsSent(operation);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/ResolveIncidentHandler.java
@@ -42,18 +42,16 @@ public class ResolveIncidentHandler extends AbstractOperationHandler implements 
     }
 
     if (incident.getErrorType().equals(JOB_NO_RETRIES)) {
-      zeebeClient
-          .newUpdateRetriesCommand(incident.getJobKey())
-          .retries(1)
-          .operationReference(Long.parseLong(operation.getId()))
-          .send()
-          .join();
+      final var updateRetriesJobCommand =
+          withOperationReference(
+              zeebeClient.newUpdateRetriesCommand(incident.getJobKey()).retries(1),
+              operation.getId());
+      updateRetriesJobCommand.send().join();
     }
-    zeebeClient
-        .newResolveIncidentCommand(incident.getKey())
-        .operationReference(Long.parseLong(operation.getId()))
-        .send()
-        .join();
+    final var resolveIncidentCommand =
+        withOperationReference(
+            zeebeClient.newResolveIncidentCommand(incident.getKey()), operation.getId());
+    resolveIncidentCommand.send().join();
     // mark operation as sent
     markAsSent(operation);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
@@ -12,7 +12,6 @@ import static io.camunda.webapps.schema.entities.operation.OperationType.UPDATE_
 
 import io.camunda.webapps.schema.entities.operation.OperationEntity;
 import io.camunda.webapps.schema.entities.operation.OperationType;
-import io.camunda.zeebe.client.api.response.SetVariablesResponse;
 import java.util.Set;
 import org.springframework.stereotype.Component;
 
@@ -24,14 +23,14 @@ public class UpdateVariableHandler extends AbstractOperationHandler implements O
   public void handleWithException(final OperationEntity operation) throws Exception {
     final String updateVariableJson =
         mergeVariableJson(operation.getVariableName(), operation.getVariableValue());
-    final SetVariablesResponse response =
-        zeebeClient
-            .newSetVariablesCommand(operation.getScopeKey())
-            .variables(updateVariableJson)
-            .local(true)
-            .operationReference(Long.parseLong(operation.getId()))
-            .send()
-            .join();
+    final var setVariablesCommand =
+        withOperationReference(
+            zeebeClient
+                .newSetVariablesCommand(operation.getScopeKey())
+                .variables(updateVariableJson)
+                .local(true),
+            operation.getId());
+    final var response = setVariablesCommand.send().join();
     markAsSent(operation, response.getKey());
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/UpdateVariableHandler.java
@@ -29,6 +29,7 @@ public class UpdateVariableHandler extends AbstractOperationHandler implements O
             .newSetVariablesCommand(operation.getScopeKey())
             .variables(updateVariableJson)
             .local(true)
+            .operationReference(Long.parseLong(operation.getId()))
             .send()
             .join();
     markAsSent(operation, response.getKey());

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
@@ -63,7 +63,7 @@ public class SingleStepModifyProcessInstanceHandler extends AbstractOperationHan
     final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 lastStep =
         processTokenModifications(modifyProcessInstanceRequest, operation);
 
-    modifyProcessZeebeWrapper.sendModificationsToZeebe(lastStep, Long.parseLong(operation.getId()));
+    modifyProcessZeebeWrapper.sendModificationsToZeebe(lastStep, operation.getId());
     markAsSent(operation);
     operationsManager.completeOperation(operation, false);
   }
@@ -146,7 +146,7 @@ public class SingleStepModifyProcessInstanceHandler extends AbstractOperationHan
       final Long scopeKey =
           modification.getScopeKey() == null ? processInstanceKey : modification.getScopeKey();
       modifyProcessZeebeWrapper.setVariablesInZeebe(
-          scopeKey, modification.getVariables(), Long.parseLong(operation.getId()));
+          scopeKey, modification.getVariables(), operation.getId());
       updateFinishedInBatchOperation(operation);
     }
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
@@ -63,7 +63,7 @@ public class SingleStepModifyProcessInstanceHandler extends AbstractOperationHan
     final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 lastStep =
         processTokenModifications(modifyProcessInstanceRequest, operation);
 
-    modifyProcessZeebeWrapper.sendModificationsToZeebe(lastStep);
+    modifyProcessZeebeWrapper.sendModificationsToZeebe(lastStep, Long.parseLong(operation.getId()));
     markAsSent(operation);
     operationsManager.completeOperation(operation, false);
   }
@@ -145,7 +145,8 @@ public class SingleStepModifyProcessInstanceHandler extends AbstractOperationHan
     for (final Modification modification : modifications) {
       final Long scopeKey =
           modification.getScopeKey() == null ? processInstanceKey : modification.getScopeKey();
-      modifyProcessZeebeWrapper.setVariablesInZeebe(scopeKey, modification.getVariables());
+      modifyProcessZeebeWrapper.setVariablesInZeebe(
+          scopeKey, modification.getVariables(), Long.parseLong(operation.getId()));
       updateFinishedInBatchOperation(operation);
     }
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -112,7 +112,9 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   }
 
   public void generateId() {
-    final long operationReference = UUID.randomUUID().getMostSignificantBits();
+    // Operation reference has to be positive and `UUID.randomUUID().getMostSignificantBits()` can
+    // generate negative values
+    final long operationReference = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
     setId(String.valueOf(operationReference));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -26,6 +26,10 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
 
   @JsonIgnore private Object[] sortValues;
 
+  public BatchOperationEntity() {
+    generateId();
+  }
+
   public String getName() {
     return name;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -112,10 +112,7 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   }
 
   public void generateId() {
-    // Operation reference has to be positive and `UUID.randomUUID().getMostSignificantBits()` can
-    // generate negative values
-    final long operationReference = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
-    setId(String.valueOf(operationReference));
+    setId(UUID.randomUUID().toString());
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -108,7 +108,8 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
   }
 
   public void generateId() {
-    setId(UUID.randomUUID().toString());
+    final long operationReference = UUID.randomUUID().getMostSignificantBits();
+    setId(String.valueOf(operationReference));
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/BatchOperationEntity.java
@@ -26,10 +26,6 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
 
   @JsonIgnore private Object[] sortValues;
 
-  public BatchOperationEntity() {
-    generateId();
-  }
-
   public String getName() {
     return name;
   }
@@ -111,8 +107,9 @@ public class BatchOperationEntity extends AbstractExporterEntity<BatchOperationE
     return this;
   }
 
-  public void generateId() {
+  public BatchOperationEntity withGeneratedId() {
     setId(UUID.randomUUID().toString());
+    return this;
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -218,7 +218,9 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   }
 
   public void generateId() {
-    final long operationReference = UUID.randomUUID().getMostSignificantBits();
+    // Operation reference has to be positive and `UUID.randomUUID().getMostSignificantBits()` can
+    // generate negative values
+    final long operationReference = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
     setId(String.valueOf(operationReference));
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -42,6 +42,10 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
 
   private OffsetDateTime completedDate;
 
+  public OperationEntity() {
+    generateId();
+  }
+
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -73,8 +73,9 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
     return decisionDefinitionKey;
   }
 
-  public void setDecisionDefinitionKey(final Long decisionDefinitionKey) {
+  public OperationEntity setDecisionDefinitionKey(final Long decisionDefinitionKey) {
     this.decisionDefinitionKey = decisionDefinitionKey;
+    return this;
   }
 
   public Long getIncidentKey() {
@@ -213,7 +214,8 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
   }
 
   public void generateId() {
-    setId(UUID.randomUUID().toString());
+    final long operationReference = UUID.randomUUID().getMostSignificantBits();
+    setId(String.valueOf(operationReference));
   }
 
   @Override

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operation/OperationEntity.java
@@ -42,10 +42,6 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
 
   private OffsetDateTime completedDate;
 
-  public OperationEntity() {
-    generateId();
-  }
-
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
@@ -217,11 +213,12 @@ public class OperationEntity extends AbstractExporterEntity<OperationEntity> {
     return this;
   }
 
-  public void generateId() {
+  public OperationEntity withGeneratedId() {
     // Operation reference has to be positive and `UUID.randomUUID().getMostSignificantBits()` can
     // generate negative values
     final long operationReference = UUID.randomUUID().getMostSignificantBits() & Long.MAX_VALUE;
     setId(String.valueOf(operationReference));
+    return this;
   }
 
   @Override


### PR DESCRIPTION
## Description
Updated all operate's [OperationHandlers](https://github.com/camunda/camunda/tree/main/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation) to send the `operationReference` along with the underlying zeebe commands

- Set `OperationEntity` and `BatchOperationEntity` Ids to `UUID.mostSignificantBits`
- Refactor: call `generateId()` in `OperationEntity` and `BatchOperationEntity` constructors. Instead of generating the Id as a separate expression after each instantiation
- Propagate `OperationReference` with all Zeebe client calls
- Handles parsing `operation.id` to `operationReference` gracefully, and ignores setting it if `Invalid Format`

## Related issues

closes #24028
