### PR TITLE
feat: allow for listener requests that filter by flowNodeInstanceId

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
@@ -15,6 +15,7 @@ import io.camunda.operate.qa.util.DependencyInjectionTestExecutionListener;
 import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.j5templates.MockMvcManager;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
+import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -92,5 +93,18 @@ public class ProcessInstanceRestServiceIT {
     final MvcResult mvcResult =
         mockMvcManager.postRequestShouldFailWithException(url, ConstraintViolationException.class);
     assertThat(mvcResult.getResolvedException().getMessage()).contains("Specified ID is not valid");
+  }
+
+  @Test
+  public void testListenersRequestWithFlowNodeIdAndFlowNodeInstanceIdInvalid() throws Exception {
+    final String url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
+    final ListenerRequestDto request =
+        new ListenerRequestDto()
+            .setPageSize(20)
+            .setFlowNodeId("testid")
+            .setFlowNodeInstanceId(123L);
+    final MvcResult mvcResult = mockMvcManager.postRequest(url, request, 400);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains("Only one of 'flowNodeId' or 'flowNodeInstanceId'");
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -57,7 +57,7 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
     final Query query =
         and(
             term(JobTemplate.PROCESS_INSTANCE_KEY, processInstanceId),
-            term(JobTemplate.FLOW_NODE_ID, request.getFlowNodeId()),
+            getFlowNodeQuery(request),
             or(
                 term(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER.name()),
                 term(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER.name())));
@@ -83,6 +83,13 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
       Collections.reverse(listeners);
     }
     return new ListenerResponseDto(listeners, totalHitCount);
+  }
+
+  private Query getFlowNodeQuery(final ListenerRequestDto request) {
+    if (request.getFlowNodeInstanceId() != null) {
+      return term(JobTemplate.FLOW_NODE_INSTANCE_ID, request.getFlowNodeInstanceId());
+    }
+    return term(JobTemplate.FLOW_NODE_ID, request.getFlowNodeId());
   }
 
   private void applySorting(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
   private String flowNodeId;
+  private Long flowNodeInstanceId;
 
   public ListenerRequestDto() {}
 
@@ -24,6 +25,15 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
 
   public ListenerRequestDto setFlowNodeId(final String flowNodeId) {
     this.flowNodeId = flowNodeId;
+    return this;
+  }
+
+  public Long getFlowNodeInstanceId() {
+    return flowNodeInstanceId;
+  }
+
+  public ListenerRequestDto setFlowNodeInstanceId(final Long flowNodeInstanceId) {
+    this.flowNodeInstanceId = flowNodeInstanceId;
     return this;
   }
 
@@ -50,7 +60,7 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), flowNodeId);
+    return Objects.hash(super.hashCode(), flowNodeId, flowNodeInstanceId);
   }
 
   @Override
@@ -65,7 +75,8 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
       return false;
     }
     final ListenerRequestDto that = (ListenerRequestDto) o;
-    return Objects.equals(flowNodeId, that.flowNodeId);
+    return Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId);
   }
 
   @Override
@@ -74,8 +85,8 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
         + "flowNodeId='"
         + flowNodeId
         + '\''
-        + ", pageSize="
-        + pageSize
+        + ", flowNodeInstanceId="
+        + flowNodeInstanceId
         + '}';
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
@@ -62,9 +62,14 @@ public class ProcessInstanceRequestValidator {
   }
 
   public void validateListenerRequest(final ListenerRequestDto request) {
-    if (request.getPageSize() == null || request.getFlowNodeId() == null) {
+    if (request.getPageSize() == null
+        || (request.getFlowNodeId() == null && request.getFlowNodeInstanceId() == null)) {
       throw new InvalidRequestException(
-          "'pageSize' and 'flowNodeId' must be specified in the request.");
+          "'pageSize' and either 'flowNodeId' or 'flowNodeInstanceId' must be specified in the request.");
+    }
+    if (request.getFlowNodeId() != null && request.getFlowNodeInstanceId() != null) {
+      throw new InvalidRequestException(
+          "Only one of 'flowNodeId' or 'flowNodeInstanceId' must be specified in the request.");
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds `flowNodeInstanceId` as possible parameter to filter Listener executions to allow for displaying listeners for flow node instances in the UI.
Added checks to the request validation to ensure either `flowNodeInstanceId` or `flowNodeId` is set, but not both.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/23942
