### PR TITLE
Update process instance entity with properties from ProcessCache

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -84,7 +84,7 @@ public class CamundaExporter implements Exporter {
     this.controller = controller;
     clientAdapter = ClientAdapter.of(configuration);
 
-    provider.init(configuration, clientAdapter);
+    provider.init(configuration, clientAdapter::getProcessCacheLoader);
 
     final var searchEngineClient = clientAdapter.getSearchEngineClient();
     final var schemaManager =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -74,7 +74,6 @@ public class CamundaExporter implements Exporter {
     logger = context.getLogger();
     configuration = context.getConfiguration().instantiate(ExporterConfiguration.class);
     ConfigValidator.validate(configuration);
-    provider.init(configuration);
     context.setFilter(new CamundaExporterRecordFilter());
     metrics = new CamundaExporterMetrics(context.getMeterRegistry());
     LOG.debug("Exporter configured with {}", configuration);
@@ -84,6 +83,9 @@ public class CamundaExporter implements Exporter {
   public void open(final Controller controller) {
     this.controller = controller;
     clientAdapter = ClientAdapter.of(configuration);
+
+    provider.init(configuration, clientAdapter);
+
     final var searchEngineClient = clientAdapter.getSearchEngineClient();
     final var schemaManager =
         new SchemaManager(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -9,8 +9,8 @@ package io.camunda.exporter;
 
 import static java.util.Map.entry;
 
-import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ProcessCacheImpl;
+import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.AuthorizationHandler;
@@ -83,7 +83,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   private Set<ExportHandler> exportHandlers;
 
   @Override
-  public void init(final ExporterConfiguration configuration, final ClientAdapter clientAdapter) {
+  public void init(
+      final ExporterConfiguration configuration,
+      final ProcessCacheLoaderFactory processCacheLoaderFactory) {
     final var globalPrefix = configuration.getIndex().getPrefix();
     final var isElasticsearch =
         ConnectionTypes.from(configuration.getConnect().getType())
@@ -135,7 +137,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
     final var processCache =
         new ProcessCacheImpl(
             10000,
-            clientAdapter.getProcessCacheLoader(
+            processCacheLoaderFactory.create(
                 indexDescriptorsMap.get(ProcessIndex.class).getFullQualifiedName()));
 
     exportHandlers =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -146,7 +146,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new DecisionHandler(
                 indexDescriptorsMap.get(DecisionIndex.class).getFullQualifiedName()),
             new ListViewProcessInstanceFromProcessInstanceHandler(
-                templateDescriptorsMap.get(ListViewTemplate.class).getFullQualifiedName(), false),
+                templateDescriptorsMap.get(ListViewTemplate.class).getFullQualifiedName(),
+                false,
+                processCache),
             new ListViewFlowNodeFromIncidentHandler(
                 templateDescriptorsMap.get(ListViewTemplate.class).getFullQualifiedName(), false),
             new ListViewFlowNodeFromJobHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter;
 
-import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -17,7 +17,9 @@ import java.util.Set;
 
 public interface ExporterResourceProvider {
 
-  void init(ExporterConfiguration configuration, final ClientAdapter clientAdapter);
+  void init(
+      ExporterConfiguration configuration,
+      final ProcessCacheLoaderFactory processCacheLoaderFactory);
 
   /**
    * This should return descriptors describing the desired state of all indices provided.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -16,7 +17,7 @@ import java.util.Set;
 
 public interface ExporterResourceProvider {
 
-  void init(ExporterConfiguration configuration);
+  void init(ExporterConfiguration configuration, final ClientAdapter clientAdapter);
 
   /**
    * This should return descriptors describing the desired state of all indices provided.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ClientAdapter.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.adapters;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.exporter.cache.CachedProcessEntity;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
@@ -25,6 +27,8 @@ public interface ClientAdapter {
   SearchEngineClient getSearchEngineClient();
 
   BatchRequest createBatchRequest();
+
+  CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(String processIndexName);
 
   void close() throws IOException;
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -9,6 +9,9 @@ package io.camunda.exporter.adapters;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.exporter.cache.CachedProcessEntity;
+import io.camunda.exporter.cache.ElasticSearchProcessCacheLoader;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
@@ -42,5 +45,11 @@ class ElasticsearchAdapter implements ClientAdapter {
   @Override
   public void close() throws IOException {
     client._transport().close();
+  }
+
+  @Override
+  public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
+      final String processIndexName) {
+    return new ElasticSearchProcessCacheLoader(client, processIndexName);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.exporter.adapters;
 
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.exporter.cache.CachedProcessEntity;
+import io.camunda.exporter.cache.OpenSearchProcessCacheLoader;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
@@ -37,6 +40,12 @@ class OpensearchAdapter implements ClientAdapter {
   public BatchRequest createBatchRequest() {
     return new OpensearchBatchRequest(
         client, new BulkRequest.Builder(), new OpensearchScriptBuilder());
+  }
+
+  @Override
+  public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
+      final String processIndexName) {
+    return new OpenSearchProcessCacheLoader(client, processIndexName);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheLoaderFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ProcessCacheLoaderFactory.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+
+@FunctionalInterface
+public interface ProcessCacheLoaderFactory {
+  CacheLoader<Long, CachedProcessEntity> create(String processIndexName);
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -326,20 +326,17 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
   }
 
   private String getProcessName(final Long processDefinitionKey, final String bpmnProcessId) {
-    final var processName =
-        processCache
-            .get(processDefinitionKey)
-            .map(CachedProcessEntity::name)
-            // If the cache does not contain the process definition then the process has been
-            // deleted from the backend. This is a special case which can happen only if there was a
-            // data loss in the backend. In that case, inorder to not block the exporter, we can
-            // return the bpmnProcessId as the process name.
-            .orElse(null);
-    if (processName == null || processName.isEmpty()) {
-      return bpmnProcessId;
-    }
-
-    return processName;
+    return processCache
+        .get(processDefinitionKey)
+        .map(CachedProcessEntity::name)
+        .map(
+            processName ->
+                processName == null || processName.isBlank() ? bpmnProcessId : processName)
+        // If the cache does not contain the process definition then the process has been
+        // deleted from the backend. This is a special case which can happen only if there was a
+        // data loss in the backend. In that case, inorder to not block the exporter, we can
+        // return the bpmnProcessId as the process name.
+        .orElse(bpmnProcessId);
   }
 
   private String getVersionTag(final long processDefinitionJey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -11,6 +11,8 @@ import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 import static io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate.*;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.*;
 
+import io.camunda.exporter.cache.CachedProcessEntity;
+import io.camunda.exporter.cache.ProcessCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
@@ -42,12 +44,14 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
       Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
 
   private final boolean concurrencyMode;
+  private final ProcessCache processCache;
   private final String indexName;
 
   public ListViewProcessInstanceFromProcessInstanceHandler(
-      final String indexName, final boolean concurrencyMode) {
+      final String indexName, final boolean concurrencyMode, final ProcessCache processCache) {
     this.indexName = indexName;
     this.concurrencyMode = concurrencyMode;
+    this.processCache = processCache;
   }
 
   @Override
@@ -101,7 +105,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         .setBpmnProcessId(recordValue.getBpmnProcessId())
         .setProcessVersion(recordValue.getVersion())
         .setProcessName(
-            getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()));
+            getProcessName(piEntity.getProcessDefinitionKey(), recordValue.getBpmnProcessId()))
+        .setProcessVersionTag(getVersionTag(piEntity.getProcessDefinitionKey()));
 
     final OffsetDateTime timestamp =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);
@@ -320,16 +325,24 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     //    }
   }
 
-  /// TODO - because it depends on processCache
   private String getProcessName(final Long processDefinitionKey, final String bpmnProcessId) {
-    return bpmnProcessId;
+    final var processName =
+        processCache
+            .get(processDefinitionKey)
+            .map(CachedProcessEntity::name)
+            // If the cache does not contain the process definition then the process has been
+            // deleted from the backend. This is a special case which can happen only if there was a
+            // data loss in the backend. In that case, inorder to not block the exporter, we can
+            // return the bpmnProcessId as the process name.
+            .orElse(null);
+    if (processName == null || processName.isEmpty()) {
+      return bpmnProcessId;
+    }
 
-    // TODO https://github.com/camunda/camunda/issues/18364
-    //    final ProcessCache processCache = null;
-    //    if (processCache == null) {
-    //      return bpmnProcessId;
-    //    }
-    //
-    //    return processCache.getProcessNameOrDefaultValue(processDefinitionKey, bpmnProcessId);
+    return processName;
+  }
+
+  private String getVersionTag(final long processDefinitionJey) {
+    return processCache.get(processDefinitionJey).map(CachedProcessEntity::versionTag).orElse(null);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.cache.CachedProcessEntity;
+import io.camunda.exporter.cache.ProcessCache;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.exporter.utils.XMLUtil;
@@ -23,10 +25,13 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
 
   private final String indexName;
   private final XMLUtil xmlUtil;
+  private final ProcessCache processCache;
 
-  public ProcessHandler(final String indexName, final XMLUtil xmlUtil) {
+  public ProcessHandler(
+      final String indexName, final XMLUtil xmlUtil, final ProcessCache processCache) {
     this.indexName = indexName;
     this.xmlUtil = xmlUtil;
+    this.processCache = processCache;
   }
 
   @Override
@@ -85,6 +90,12 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
                 .setVersionTag(processEntity.getVersionTag())
                 .setFormId(processEntity.getFormId())
                 .setIsPublic(processEntity.getIsPublic()));
+
+    // update local cache so that the process info is available immediately to the process instance
+    // record handler
+    final var cachedProcessEntity =
+        new CachedProcessEntity(entity.getName(), entity.getVersionTag());
+    processCache.put(process.getProcessDefinitionKey(), cachedProcessEntity);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SchemaTestUtil;
@@ -375,7 +376,7 @@ final class CamundaExporterIT {
       final Set<IndexTemplateDescriptor> templateDescriptors,
       final ExporterConfiguration config) {
     final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
-    provider.init(config);
+    provider.init(config, mock(ClientAdapter.class));
 
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SchemaTestUtil;
@@ -376,7 +376,7 @@ final class CamundaExporterIT {
       final Set<IndexTemplateDescriptor> templateDescriptors,
       final ExporterConfiguration config) {
     final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
-    provider.init(config, mock(ClientAdapter.class));
+    provider.init(config, mock(ProcessCacheLoaderFactory.class));
 
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -8,7 +8,9 @@
 package io.camunda.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
+import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -26,7 +28,7 @@ public class DefaultExporterResourceProviderTest {
   void shouldHaveCorrectFullQualifiedNamesForIndexAndTemplates(final ExporterConfiguration config) {
     final var provider = new DefaultExporterResourceProvider();
 
-    provider.init(config);
+    provider.init(config, mock(ClientAdapter.class));
 
     provider
         .getIndexDescriptors()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -10,7 +10,7 @@ package io.camunda.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -28,7 +28,7 @@ public class DefaultExporterResourceProviderTest {
   void shouldHaveCorrectFullQualifiedNamesForIndexAndTemplates(final ExporterConfiguration config) {
     final var provider = new DefaultExporterResourceProvider();
 
-    provider.init(config, mock(ClientAdapter.class));
+    provider.init(config, mock(ProcessCacheLoaderFactory.class));
 
     provider
         .getIndexDescriptors()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestProcessCache.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestProcessCache.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import java.util.HashMap;
+import java.util.Optional;
+
+public class TestProcessCache implements ProcessCache {
+
+  private final HashMap<Long, CachedProcessEntity> cache = new HashMap<>();
+
+  @Override
+  public Optional<CachedProcessEntity> get(final long processDefinitionKey) {
+    return Optional.ofNullable(cache.get(processDefinitionKey));
+  }
+
+  @Override
+  public void put(final long processDefinitionKey, final CachedProcessEntity processEntity) {
+    cache.put(processDefinitionKey, processEntity);
+  }
+
+  @Override
+  public void remove(final long processDefinitionKey) {
+    cache.remove(processDefinitionKey);
+  }
+
+  @Override
+  public void clear() {
+    cache.clear();
+  }
+}


### PR DESCRIPTION
## Description

* `ProcessCache` is instantiated per exporter (per partition)
* Process cache is updated when exporting PROCESS record
* Process name and versionTag in the process instance entitity is updated from the values from the cache. One special case here is what if process do not exist in the backend and thus there is no entry in the cache for that process. This should not happen normally. The only case when this happens is the process was explicitly deleted from the backend or the backend suffered a data loss. In this case, we do not want to block exporting. So instead of throwing an exception, we can deliberately choose a behavior. In this PR, we chose the `bpmnProcessId` if the name is not found. This is similar to what was done in the Operate Importer. Alternative is to not set the `processName`. However, this might have impact on other components, especially search api. 

## Related issues

closes #24179 
