### PR TITLE
feat: Reject task listener job completion with variables

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.function.BiFunction;
 
 /**
  * Default implementation to process JobCommands to reduce duplication in CommandProcessor
@@ -29,7 +30,6 @@ import java.util.List;
  */
 public final class DefaultJobCommandPreconditionGuard {
 
-  private final String intent;
   private final JobState state;
   private final JobAcceptFunction acceptCommand;
   private final JobCommandPreconditionChecker preconditionChecker;
@@ -40,12 +40,21 @@ public final class DefaultJobCommandPreconditionGuard {
       final JobState state,
       final JobAcceptFunction acceptCommand,
       final AuthorizationCheckBehavior authCheckBehavior) {
-    this.intent = intent;
+    this(intent, state, acceptCommand, authCheckBehavior, List.of());
+  }
+
+  public DefaultJobCommandPreconditionGuard(
+      final String intent,
+      final JobState state,
+      final JobAcceptFunction acceptCommand,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final List<BiFunction<TypedRecord<JobRecord>, JobRecord, Either<Rejection, JobRecord>>>
+          customChecks) {
     this.state = state;
     this.acceptCommand = acceptCommand;
     preconditionChecker =
         new JobCommandPreconditionChecker(
-            state, intent, List.of(State.ACTIVATABLE, State.ACTIVATED));
+            state, intent, List.of(State.ACTIVATABLE, State.ACTIVATED), customChecks);
     this.authCheckBehavior = authCheckBehavior;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.function.BiFunction;
 
 /**
  * Default implementation to process JobCommands to reduce duplication in CommandProcessor
@@ -48,8 +47,7 @@ public final class DefaultJobCommandPreconditionGuard {
       final JobState state,
       final JobAcceptFunction acceptCommand,
       final AuthorizationCheckBehavior authCheckBehavior,
-      final List<BiFunction<TypedRecord<JobRecord>, JobRecord, Either<Rejection, JobRecord>>>
-          customChecks) {
+      final List<JobCommandCheck> customChecks) {
     this.state = state;
     this.acceptCommand = acceptCommand;
     preconditionChecker =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandCheck.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.Rejection;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+
+/** Represents a validation check for a job command to be applied before command execution. */
+@FunctionalInterface
+public interface JobCommandCheck {
+
+  Either<Rejection, JobRecord> check(
+      final TypedRecord<JobRecord> command, final JobRecord jobRecord);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCommandPreconditionChecker.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.function.BiFunction;
 
 public class JobCommandPreconditionChecker {
 
@@ -27,8 +26,7 @@ public class JobCommandPreconditionChecker {
   private final List<JobState.State> validStates;
   private final JobState jobState;
   private final String intent;
-  private final List<BiFunction<TypedRecord<JobRecord>, JobRecord, Either<Rejection, JobRecord>>>
-      customChecks;
+  private final List<JobCommandCheck> customChecks;
 
   public JobCommandPreconditionChecker(
       final JobState jobState, final String intent, final List<State> validStates) {
@@ -39,8 +37,7 @@ public class JobCommandPreconditionChecker {
       final JobState jobState,
       final String intent,
       final List<State> validStates,
-      final List<BiFunction<TypedRecord<JobRecord>, JobRecord, Either<Rejection, JobRecord>>>
-          customChecks) {
+      final List<JobCommandCheck> customChecks) {
     this.jobState = jobState;
     this.intent = intent;
     this.validStates = validStates;
@@ -66,7 +63,7 @@ public class JobCommandPreconditionChecker {
     }
 
     return customChecks.stream()
-        .map(check -> check.apply(command, persistedJob))
+        .map(check -> check.check(command, persistedJob))
         .filter(Either::isLeft)
         .findFirst()
         .orElse(Either.right(persistedJob));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -95,9 +95,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
         }
       case TASK_LISTENER:
         {
-          // to store the variable for merge, to handle concurrent commands
-          eventHandle.triggeringProcessEvent(value);
-
           /*
            We retrieve the intermediate user task state rather than the regular user task record
            because the intermediate state captures the exact data provided during the original

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -33,7 +33,8 @@ import java.util.List;
 public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
   public static final String TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE =
-      "Task Listener job completion with variables payload provided is not supported (job key '%d', type '%s', processInstanceKey '%d')";
+      "Task Listener job completion with variables payload provided is not yet supported (job key '%d', type '%s', processInstanceKey '%d'). "
+          + "Support will be enabled with the resolution of issue #23702";
 
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -33,7 +33,7 @@ import java.util.List;
 public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
   public static final String TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE =
-      "Task Listener job completion with variables is not supported (job key '%d', type '%s', processInstanceKey '%d')";
+      "Task Listener job completion with variables payload provided is not supported (job key '%d', type '%s', processInstanceKey '%d')";
 
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -54,7 +54,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
             state.getJobState(),
             this::acceptCommand,
             authCheckBehavior,
-            List.of(this::checkTaskListenerVariablesNotSet));
+            List.of(this::checkVariablesNotProvidedForTaskListenerJob));
     this.jobMetrics = jobMetrics;
     this.eventHandle = eventHandle;
   }
@@ -130,7 +130,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     }
   }
 
-  private Either<Rejection, JobRecord> checkTaskListenerVariablesNotSet(
+  private Either<Rejection, JobRecord> checkVariablesNotProvidedForTaskListenerJob(
       final TypedRecord<JobRecord> command, final JobRecord job) {
 
     if (job.getJobKind() == JobKind.TASK_LISTENER && hasVariables(command)) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -424,6 +424,10 @@ public class TaskListenerTest {
         .hasRejectionReason(
             TL_JOB_COMPLETION_WITH_VARS_NOT_SUPPORTED_MESSAGE.formatted(
                 result.getKey(), LISTENER_TYPE, processInstanceKey));
+
+    // complete the listener job without variables to have a completed process
+    // and prevent flakiness in other tests
+    ENGINE.job().ofInstance(processInstanceKey).withType(LISTENER_TYPE).complete();
   }
 
   private void assertThatProcessInstanceCompleted(final long processInstanceKey) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -139,7 +139,7 @@ public class UserTaskListenersTest {
 
     // assert that an incident was created due to the rejection of TL job completion with variables
     final var expectedErrorMessageWithRejectionReason =
-        "Command 'COMPLETE' rejected with code 'INVALID_ARGUMENT': Task Listener job completion with variables is not supported";
+        "Command 'COMPLETE' rejected with code 'INVALID_ARGUMENT': Task Listener job completion with variables payload provided is not supported";
     ZeebeAssertHelper.assertIncidentCreated(
         incident ->
             assertThat(incident)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -82,6 +82,26 @@ public class UserTaskListenersTest {
         });
   }
 
+  /**
+   * This test verifies the behavior when attempting to complete a Task Listener job with variables
+   * while awaiting the result of the completion command.
+   *
+   * <p>TL job completion with variables is currently not supported but is planned to be enabled
+   * with the resolution of issue https://github.com/camunda/camunda/issues/23702.
+   *
+   * <p>The current behavior is as follows:
+   *
+   * <ul>
+   *   <li>The TL job completion request is rejected due to the presence of variables. Since the
+   *       request is awaiting a result (using the `.join()` method), it throws a
+   *       `ClientStatusException` if the command is rejected.
+   *   <li>The job is treated as failed and retried until all retries are exhausted.
+   *   <li>Upon exhausting retries, a `JOB_NO_RETRIES` incident is created with a message explaining
+   *       that the rejection is due to the unsupported use of variables during TL job completion.
+   *   <li>The original `COMPLETE` user task command request fails with a timeout exception, as the
+   *       User Task remains in the `COMPLETING` state without a response being written.
+   * </ul>
+   */
   @Test
   void shouldRejectCompleteTaskListenerJobCompletionWhenVariablesAreSetAndCreateIncident() {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -7,15 +7,22 @@
  */
 package io.camunda.zeebe.it.client.command;
 
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.as;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.it.util.RecordingJobHandler;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -24,6 +31,7 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -102,5 +110,65 @@ public class UserTaskListenersTest {
           assertThat(userTask.getVariables()).isEmpty();
           assertThat(userTask.getAction()).isEqualTo("complete");
         });
+  }
+
+  @Test
+  void shouldRejectCompleteTaskListenerJobCompletionWhenVariablesAreSetAndCreateIncident() {
+    // given
+    final int jobRetries = 2;
+    final var listenerType = "complete_with_variables";
+    final var userTaskKey =
+        resourcesHelper.createSingleUserTask(
+            task ->
+                task.zeebeTaskListener(
+                    listener ->
+                        listener
+                            .complete()
+                            .type(listenerType)
+                            .retries(String.valueOf(jobRetries))));
+
+    final JobHandler completeJobWithVariableHandler =
+        (jobClient, job) ->
+            jobClient.newCompleteCommand(job.getKey()).variable("my_variable", 123).send().join();
+
+    final var recordingHandler = new RecordingJobHandler(completeJobWithVariableHandler);
+    workers.add(client.newWorker().jobType(listenerType).handler(recordingHandler).open());
+
+    // when
+    client.newUserTaskCompleteCommand(userTaskKey).send();
+    await("until all retries are exhausted")
+        .untilAsserted(
+            () ->
+                assertThat(recordingHandler.getHandledJobs())
+                    .describedAs(
+                        "TL job should retry until reaching the final attempt with retries set to 1")
+                    .last()
+                    .extracting(ActivatedJob::getRetries)
+                    .isEqualTo(1));
+
+    // then
+    final var handledJobs = recordingHandler.getHandledJobs();
+    assertThat(handledJobs)
+        .hasSize(jobRetries)
+        .allSatisfy(job -> assertThat(job.getType()).isEqualTo(listenerType));
+
+    assertThat(handledJobs.getFirst())
+        .describedAs("Job attempts should have same field values except 'retries' and 'deadline'")
+        .usingRecursiveComparison()
+        .ignoringFields("retries", "deadline")
+        .isEqualTo(handledJobs.getLast());
+
+    // assert that an incident was created due to the rejection of TL job completion with variables
+    final var expectedErrorMessageWithRejectionReason =
+        "Command 'COMPLETE' rejected with code 'INVALID_ARGUMENT': Task Listener job completion with variables is not supported";
+    ZeebeAssertHelper.assertIncidentCreated(
+        incident ->
+            assertThat(incident)
+                .hasJobKey(handledJobs.getLast().getKey())
+                .hasErrorType(ErrorType.JOB_NO_RETRIES)
+                .extracting(
+                    IncidentRecordValue::getErrorMessage, as(InstanceOfAssertFactories.STRING))
+                .startsWith("io.camunda.zeebe.client.api.command.ClientStatusException:")
+                .contains(expectedErrorMessageWithRejectionReason));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/RecordingJobHandler.java
@@ -20,7 +20,7 @@ public final class RecordingJobHandler implements JobHandler {
 
   public RecordingJobHandler() {
     this(
-        (controller, job) -> {
+        (client, job) -> {
           // do nothing
         });
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -70,13 +70,14 @@ public final class ZeebeAssertHelper {
     assertIncidentCreated(ignore -> {});
   }
 
-  public static void assertIncidentCreated(final Consumer<IncidentRecordValue> requirement) {
-    assertThat(
-            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-                .findFirst()
-                .map(Record::getValue))
+  public static long assertIncidentCreated(final Consumer<IncidentRecordValue> requirement) {
+    final var incidentRecord =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED).findFirst();
+    assertThat(incidentRecord)
         .describedAs("Expect incident to be created")
-        .hasValueSatisfying(requirement);
+        .hasValueSatisfying(incident -> requirement.accept(incident.getValue()));
+
+    return incidentRecord.map(Record::getKey).orElseThrow();
   }
 
   public static void assertProcessInstanceCompleted(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
@@ -66,7 +67,16 @@ public final class ZeebeAssertHelper {
   }
 
   public static void assertIncidentCreated() {
-    assertThat(RecordingExporter.incidentRecords(IncidentIntent.CREATED).exists()).isTrue();
+    assertIncidentCreated(ignore -> {});
+  }
+
+  public static void assertIncidentCreated(final Consumer<IncidentRecordValue> requirement) {
+    assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .findFirst()
+                .map(Record::getValue))
+        .describedAs("Expect incident to be created")
+        .hasValueSatisfying(requirement);
   }
 
   public static void assertProcessInstanceCompleted(


### PR DESCRIPTION
## Description

This PR implements a validation check to reject Task Listener job completions when variable payloads are provided, in alignment with [PDP decision](https://github.com/camunda/product-hub/issues/1822#issuecomment-2441116402). By enforcing this restriction, we prevent unintended modifications to the variable state through task listener job completions.
> [!NOTE]
> Management of Task Listener variables will be handled as part of a separate [issue](https://github.com/camunda/camunda/issues/23702).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24056 
