### PR TITLE
feat: backup only segment containing data not present in snapshots 

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/LogCompactor.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/LogCompactor.java
@@ -43,6 +43,23 @@ public final class LogCompactor {
     this.logger = logger;
   }
 
+  @VisibleForTesting
+  public long getCompactableIndex() {
+    return compactableIndex;
+  }
+
+  /**
+   * Sets the compactable index to the given index; this will cause a call to {@link #compact()} or
+   * {@link #compactIgnoringReplicationThreshold()} to compact the log up to the given index here.
+   *
+   * <p>NOTE: this method is thread safe
+   */
+  @VisibleForTesting
+  void setCompactableIndex(final long index) {
+    logger.trace("Updated compactable index to {}", index);
+    compactableIndex = index;
+  }
+
   /**
    * Assumes our snapshots are being taken asynchronously, and we regularly update the compactable
    * index. It can happen that nothing is compacted (e.g. there are no snapshots since the last
@@ -74,18 +91,6 @@ public final class LogCompactor {
   /** Compacts the log based on the snapshot store's lowest compaction bound. */
   public void compactFromSnapshots(final PersistedSnapshotStore snapshotStore) {
     snapshotStore.getCompactionBound().onComplete(this::onSnapshotCompactionBound, threadContext);
-  }
-
-  /**
-   * Sets the compactable index to the given index; this will cause a call to {@link #compact()} or
-   * {@link #compactIgnoringReplicationThreshold()} to compact the log up to the given index here.
-   *
-   * <p>NOTE: this method is thread safe
-   */
-  @VisibleForTesting
-  void setCompactableIndex(final long index) {
-    logger.trace("Updated compactable index to {}", index);
-    compactableIndex = index;
   }
 
   private boolean compact(final long index) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -80,8 +80,10 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
@@ -1254,6 +1256,16 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   public int getSnapshotChunkSize() {
     return snapshotChunkSize;
+  }
+
+  public CompletableFuture<Collection<Path>> getTailSegments(final long index) {
+    final var fut = new CompletableFuture<Collection<Path>>();
+    threadContext.execute(
+        () -> {
+          final var segments = raftLog.getTailSegments(index);
+          fut.complete(segments.values());
+        });
+    return fut;
   }
 
   /** Raft server state. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -48,6 +48,7 @@ import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Map;
@@ -327,5 +328,9 @@ public class RaftPartitionServer implements HealthMonitorable {
 
   public Collection<RaftMember> getMembers() {
     return server.cluster().getMembers();
+  }
+
+  public CompletableFuture<Collection<Path>> getTailSegments(final long index) {
+    return server.getContext().getTailSegments(index);
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -27,6 +27,8 @@ import io.atomix.raft.storage.serializer.RaftEntrySerializer;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalRecord;
 import java.io.Closeable;
+import java.nio.file.Path;
+import java.util.SortedMap;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -238,5 +240,9 @@ public final class RaftLog implements Closeable {
         + ", commitIndex="
         + commitIndex
         + '}';
+  }
+
+  public SortedMap<Long, Path> getTailSegments(final long index) {
+    return journal.getTailSegments(index);
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -196,7 +196,8 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
     return CompletableActorFuture.completed(reservation);
   }
 
-  boolean isReserved() {
+  @Override
+  public boolean isReserved() {
     return !reservations.isEmpty();
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/api/BackupManager.java
@@ -22,8 +22,9 @@ public interface BackupManager {
    *
    * @param checkpointId id of the backup
    * @param checkpointPosition position of the record until which must be included in the backup.
+   * @return an ActorFuture with the result of the backup
    */
-  void takeBackup(long checkpointId, long checkpointPosition);
+  ActorFuture<Void> takeBackup(long checkpointId, long checkpointPosition);
 
   /**
    * Get the status of the backup

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/BackupService.java
@@ -21,7 +21,6 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.function.Predicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,13 +28,13 @@ import org.slf4j.LoggerFactory;
 public final class BackupService extends Actor implements BackupManager {
   private static final Logger LOG = LoggerFactory.getLogger(BackupService.class);
   private final String actorName;
+  private final JournalInfoProvider journalInfoProvider;
   private final int nodeId;
   private final int partitionId;
   private final int numberOfPartitions;
   private final BackupServiceImpl internalBackupManager;
   private final PersistedSnapshotStore snapshotStore;
   private final Path segmentsDirectory;
-  private final Predicate<Path> isSegmentsFile;
   private final BackupManagerMetrics metrics;
 
   public BackupService(
@@ -45,16 +44,16 @@ public final class BackupService extends Actor implements BackupManager {
       final BackupStore backupStore,
       final PersistedSnapshotStore snapshotStore,
       final Path segmentsDirectory,
-      final Predicate<Path> isSegmentsFile) {
+      final JournalInfoProvider raftMetadataProvider) {
     this.nodeId = nodeId;
     this.partitionId = partitionId;
     this.numberOfPartitions = numberOfPartitions;
     this.snapshotStore = snapshotStore;
     this.segmentsDirectory = segmentsDirectory;
-    this.isSegmentsFile = isSegmentsFile;
     metrics = new BackupManagerMetrics(partitionId);
     internalBackupManager = new BackupServiceImpl(backupStore);
     actorName = buildActorName("BackupService", partitionId);
+    journalInfoProvider = raftMetadataProvider;
   }
 
   @Override
@@ -69,7 +68,8 @@ public final class BackupService extends Actor implements BackupManager {
   }
 
   @Override
-  public void takeBackup(final long checkpointId, final long checkpointPosition) {
+  public ActorFuture<Void> takeBackup(final long checkpointId, final long checkpointPosition) {
+    final ActorFuture<Void> result = createFuture();
     actor.run(
         () -> {
           final InProgressBackupImpl inProgressBackup =
@@ -80,7 +80,7 @@ public final class BackupService extends Actor implements BackupManager {
                   numberOfPartitions,
                   actor,
                   segmentsDirectory,
-                  isSegmentsFile);
+                  journalInfoProvider);
 
           final var opMetrics = metrics.startTakingBackup();
           final var backupResult = internalBackupManager.takeBackup(inProgressBackup, actor);
@@ -101,7 +101,9 @@ public final class BackupService extends Actor implements BackupManager {
                       inProgressBackup.checkpointPosition());
                 }
               });
+          backupResult.onComplete(result);
         });
+    return result;
   }
 
   @Override

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/InProgressBackupImpl.java
@@ -24,13 +24,14 @@ import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,7 @@ final class InProgressBackupImpl implements InProgressBackup {
 
   private final Path segmentsDirectory;
 
-  private final Predicate<Path> isSegmentsFile;
+  private final JournalInfoProvider journalInfoProvider;
 
   // Snapshot related data
   private boolean hasSnapshot = true;
@@ -67,14 +68,14 @@ final class InProgressBackupImpl implements InProgressBackup {
       final int numberOfPartitions,
       final ConcurrencyControl concurrencyControl,
       final Path segmentsDirectory,
-      final Predicate<Path> isSegmentsFile) {
+      final JournalInfoProvider journalInfoProvider) {
     this.snapshotStore = snapshotStore;
     this.backupId = backupId;
     this.checkpointPosition = checkpointPosition;
     this.numberOfPartitions = numberOfPartitions;
     this.concurrencyControl = concurrencyControl;
     this.segmentsDirectory = segmentsDirectory;
-    this.isSegmentsFile = isSegmentsFile;
+    this.journalInfoProvider = journalInfoProvider;
   }
 
   @Override
@@ -104,6 +105,7 @@ final class InProgressBackupImpl implements InProgressBackup {
               } else if (snapshots.isEmpty()) {
                 // no snapshot is taken until now, so return successfully
                 hasSnapshot = false;
+                availableValidSnapshots = Collections.emptySet();
                 result.complete(null);
               } else {
                 final var eitherSnapshots = findValidSnapshot(snapshots);
@@ -176,26 +178,37 @@ final class InProgressBackupImpl implements InProgressBackup {
   @Override
   public ActorFuture<Void> findSegmentFiles() {
     final ActorFuture<Void> filesCollected = concurrencyControl.createFuture();
-    try (final var stream = Files.list(segmentsDirectory)) {
-      final var fileSet =
-          stream
-              .filter(isSegmentsFile)
-              .collect(
-                  Collectors.toMap(
-                      path -> segmentsDirectory.relativize(path).toString(), path -> path));
-
-      if (fileSet.isEmpty()) {
-        filesCollected.completeExceptionally(
-            new IllegalStateException("Segments must not be empty"));
-        return filesCollected;
+    try {
+      long maxIndex = 0L;
+      if (availableValidSnapshots != null) {
+        maxIndex =
+            availableValidSnapshots.stream()
+                .mapToLong(PersistedSnapshot::getIndex)
+                .max()
+                .orElse(0L);
       }
-
-      segmentsFileSet = new NamedFileSetImpl(fileSet);
-      filesCollected.complete(null);
-    } catch (final IOException e) {
+      final var segments = journalInfoProvider.getTailSegments(maxIndex);
+      segments.whenComplete(
+          (journalMetadata, throwable) -> {
+            if (throwable != null) {
+              filesCollected.completeExceptionally(throwable);
+            } else if (journalMetadata.isEmpty()) {
+              filesCollected.completeExceptionally(
+                  new IllegalStateException("Segments must not be empty"));
+            } else {
+              final Map<String, Path> map =
+                  journalMetadata.stream()
+                      .collect(
+                          Collectors.toMap(
+                              path -> segmentsDirectory.relativize(path).toString(),
+                              Function.identity()));
+              segmentsFileSet = new NamedFileSetImpl(map);
+              filesCollected.complete(null);
+            }
+          });
+    } catch (final Exception e) {
       filesCollected.completeExceptionally(e);
     }
-
     return filesCollected;
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/JournalInfoProvider.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/JournalInfoProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.backup.management;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Get the some information from the journal from an outside thread. All APIs are thread safe and
+ * can be safely used from a different thread then the one used by Raft.
+ */
+public interface JournalInfoProvider {
+
+  /**
+   * Get the segment files that are after or equal to an index.
+   *
+   * <p>As an example, it can Useful for getting all the segment files >= commit_index or
+   * checkpoint_index.
+   *
+   * @param index the index in the log to select the segments
+   * @return a future containing a collection of segment files
+   */
+  CompletableFuture<Collection<Path>> getTailSegments(long index);
+}

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/management/NoopBackupManager.java
@@ -30,8 +30,9 @@ public class NoopBackupManager implements BackupManager {
   }
 
   @Override
-  public void takeBackup(final long checkpointId, final long checkpointPosition) {
+  public ActorFuture<Void> takeBackup(final long checkpointId, final long checkpointPosition) {
     LOG.warn("Attempted to take backup, but cannot take backup. {}", errorMessage);
+    return CompletableActorFuture.completedExceptionally(new Exception(errorMessage));
   }
 
   @Override

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/management/BackupServiceImplTest.java
@@ -155,7 +155,10 @@ class BackupServiceImplTest {
     final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
 
     // then
-    assertThat(result).failsWithin(Duration.ofMillis(100));
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Expected");
     verifyInProgressBackupIsCleanedUpAfterFailure(inProgressBackup);
   }
 
@@ -169,7 +172,10 @@ class BackupServiceImplTest {
     final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
 
     // then
-    assertThat(result).failsWithin(Duration.ofMillis(100));
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Expected");
     verifyInProgressBackupIsCleanedUpAfterFailure(inProgressBackup);
   }
 
@@ -184,7 +190,10 @@ class BackupServiceImplTest {
     final var result = backupService.takeBackup(inProgressBackup, concurrencyControl);
 
     // then
-    assertThat(result).failsWithin(Duration.ofMillis(100));
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("Expected");
     verifyInProgressBackupIsCleanedUpAfterFailure(inProgressBackup);
   }
 
@@ -273,7 +282,8 @@ class BackupServiceImplTest {
         .thenReturn(
             CompletableFuture.completedFuture(
                 List.of(inProgressStatus, notExistingStatus, completedStatus)));
-
+    when(backupStore.markFailed(any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(BackupStatusCode.FAILED));
     // when
     backupService.failInProgressBackups(1, 10, concurrencyControl);
 

--- a/zeebe/backup/src/test/resources/log4j2-test.xml
+++ b/zeebe/backup/src/test/resources/log4j2-test.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="debug"/>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -401,6 +401,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>io.camunda:zeebe-journal</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
           <usedDependencies>
             <dependency>net.jqwik:jqwik</dependency>
           </usedDependencies>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/BackupServiceTransitionStep.java
@@ -14,11 +14,8 @@ import io.camunda.zeebe.backup.management.NoopBackupManager;
 import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
-import io.camunda.zeebe.journal.file.SegmentFile;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import java.nio.file.Path;
-import java.util.function.Predicate;
 
 public final class BackupServiceTransitionStep implements PartitionTransitionStep {
 
@@ -102,9 +99,6 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
     // now because SegmentedJournal requires some information from RaftContext in its builder. Until
     // we can refactor SegmentedJournal and build it outside of raft, we have to do this in this
     // hacky way.
-    final Predicate<Path> isSegmentsFile =
-        path ->
-            SegmentFile.isSegmentFile(context.getRaftPartition().name(), path.toFile().getName());
     final BackupService backupManager =
         new BackupService(
             context.getNodeId(),
@@ -113,7 +107,7 @@ public final class BackupServiceTransitionStep implements PartitionTransitionSte
             context.getBackupStore(),
             context.getPersistedSnapshotStore(),
             context.getRaftPartition().dataDirectory().toPath(),
-            isSegmentsFile);
+            index -> context.getRaftPartition().getServer().getTailSegments(index));
 
     final ActorFuture<Void> installed = context.getConcurrencyControl().createFuture();
     context

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/ConcurrentBackupCompactionTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.backup;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import io.atomix.primitive.partition.PartitionMetadata;
+import io.atomix.raft.impl.LogCompactor;
+import io.atomix.raft.metrics.RaftServiceMetrics;
+import io.atomix.raft.partition.RaftPartition;
+import io.atomix.raft.storage.log.RaftLog;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.zeebe.backup.management.BackupService;
+import io.camunda.zeebe.broker.utils.InlineThreadContext;
+import io.camunda.zeebe.journal.JournalMetaStore;
+import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.scheduler.SchedulingHints;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.test.util.AutoCloseableRule;
+import io.camunda.zeebe.util.FileUtil;
+import io.camunda.zeebe.util.buffer.DirectBufferWriter;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+public class ConcurrentBackupCompactionTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ConcurrentBackupCompactionTest.class);
+  private static final String SNAPSHOT_FILE_NAME = "file1";
+  @TempDir Path dataDirectory;
+  private final AutoCloseableRule closeRule = new AutoCloseableRule();
+  private ActorScheduler actorScheduler;
+  private SegmentedJournal journal;
+  private FileBasedSnapshotStore snapshotStore;
+  private InMemoryMockBackupStore backupStore;
+  private BackupService backupService;
+  private final int nodeId = 1;
+  private final int partitionId = 1;
+  private LogCompactor logCompactor;
+  private final ThreadContext threadContext = new InlineThreadContext();
+  @Mock private RaftLog raftLog;
+  private final RaftServiceMetrics raftMetrics = new RaftServiceMetrics("1");
+
+  @BeforeEach
+  void setUp() {
+    actorScheduler = closeRule.manage(ActorScheduler.newActorScheduler().build());
+    actorScheduler.start();
+    backupStore = closeRule.manage(new InMemoryMockBackupStore());
+    snapshotStore =
+        closeRule.manage(
+            new FileBasedSnapshotStore(0, partitionId, dataDirectory, snapshotPath -> Map.of()));
+    actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
+
+    final var partitionMetadata =
+        new PartitionMetadata(
+            PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
+    final var raftPartition = new RaftPartition(partitionMetadata, null, dataDirectory.toFile());
+
+    journal =
+        closeRule.manage(
+            SegmentedJournal.builder()
+                .withDirectory(dataDirectory.toFile())
+                .withName(raftPartition.name())
+                .withMetaStore(mock(JournalMetaStore.class))
+                .withMaxSegmentSize(128)
+                .build());
+    logCompactor = new LogCompactor(threadContext, raftLog, 3, raftMetrics, LOG);
+
+    // raftLog just calls journal in the real implementation
+    when(raftLog.deleteUntil(anyLong()))
+        .thenAnswer(
+            (Answer<Boolean>)
+                invocation -> {
+                  final Long index = invocation.getArgument(0);
+                  return journal.deleteUntil(index);
+                });
+
+    backupService =
+        closeRule.manage(
+            new BackupService(
+                nodeId,
+                partitionId,
+                1,
+                backupStore,
+                snapshotStore,
+                dataDirectory,
+                // RaftPartitions implements this interface, but the RaftServer is not started
+                index ->
+                    CompletableFuture.completedFuture(journal.getTailSegments(index).values())));
+    actorScheduler.submitActor(backupService);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    closeRule.after();
+  }
+
+  @Test
+  public void shouldNotFailWhenCompactionTriggers() throws Exception {
+    // given
+    appendRecord(1L, "1");
+    appendRecord(2L, "2");
+    final var snapshot = takeSnapshot(2L, 2L);
+    final var backupIdx = 3L;
+    logCompactor.compactFromSnapshots(snapshotStore);
+    Awaitility.await("compaction is done")
+        .until(() -> logCompactor.getCompactableIndex() == snapshot.getIndex());
+    appendRecord(3L, "3");
+
+    // when
+    // a backup is taken (but the snapshot store does not complete it,
+    // because the BackupStore it's blocked)
+    final var backupResultFut = backupService.takeBackup(backupIdx, backupIdx);
+
+    Awaitility.await("snapshot is reserved")
+        .until(
+            () ->
+                snapshotStore.getLatestSnapshot().map(PersistedSnapshot::isReserved).orElse(false));
+
+    // backup service is blocked
+
+    appendRecord(4L, "4");
+    appendRecord(5L, "5");
+
+    takeSnapshot(4L, 5L);
+    logCompactor.compactFromSnapshots(snapshotStore);
+    Awaitility.await("no compaction is done")
+        .until(() -> logCompactor.getCompactableIndex() == snapshot.getIndex());
+
+    // then
+    // snapshot files are not deleted
+    try (final var files =
+        Files.list(dataDirectory.resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY))) {
+      // 2 file per snapshot: snapshot + checksum
+      assertThat(files.toList().size()).isEqualTo(4L);
+    }
+    // all segments needed are still in the file system
+    final var activeSegmentPaths = journal.getTailSegments(backupIdx);
+    activeSegmentPaths.values().forEach(p -> assertThat(p).exists());
+
+    assertThat(backupResultFut.isDone()).isFalse();
+
+    // given
+    Awaitility.await("BackStore.save is called")
+        .atMost(Duration.ofSeconds(5))
+        .until(() -> !backupStore.backupInProgress().isEmpty());
+
+    // when
+    // unlock futures from the backupStore
+    backupStore.completeSaveFutures();
+
+    // then
+    Awaitility.await("backup is completed successfully")
+        .atMost(Duration.ofSeconds(5))
+        .until(backupResultFut::isDone);
+  }
+
+  private void appendRecord(final long asqn, final String data) {
+    journal.append(asqn, new DirectBufferWriter().wrap(new UnsafeBuffer(data.getBytes())));
+  }
+
+  private PersistedSnapshot takeSnapshot(final long index, final long lastWrittenPosition) {
+    final var transientSnapshot = snapshotStore.newTransientSnapshot(index, 1, 1, 1).get();
+    transientSnapshot.take(
+        path -> {
+          try {
+            FileUtil.ensureDirectoryExists(path);
+
+            Files.write(
+                path.resolve(SNAPSHOT_FILE_NAME),
+                "This is the content".getBytes(),
+                CREATE_NEW,
+                StandardOpenOption.WRITE);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+        });
+
+    return transientSnapshot.withLastFollowupEventPosition(lastWrittenPosition).persist().join();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/backup/InMemoryMockBackupStore.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.backup;
+
+import io.camunda.zeebe.backup.api.Backup;
+import io.camunda.zeebe.backup.api.BackupIdentifier;
+import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
+import io.camunda.zeebe.backup.api.BackupStatus;
+import io.camunda.zeebe.backup.api.BackupStatusCode;
+import io.camunda.zeebe.backup.api.BackupStore;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class InMemoryMockBackupStore implements BackupStore, AutoCloseable {
+
+  private final ConcurrentHashMap<BackupIdentifier, CompletableFuture<Void>> saveFutures =
+      new ConcurrentHashMap<>();
+
+  private final ConcurrentHashMap<BackupIdentifier, BackupStatus> backupStatusMap =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<BackupIdentifier, Backup> backupMap = new ConcurrentHashMap<>();
+
+  public Set<BackupIdentifier> backupInProgress() {
+    return backupMap.keySet();
+  }
+
+  @Override
+  public CompletableFuture<Void> save(final Backup backup) {
+    backupMap.put(backup.id(), backup);
+    final var fut = new CompletableFuture<Void>();
+    saveFutures.put(backup.id(), fut);
+    return fut;
+  }
+
+  @Override
+  public CompletableFuture<BackupStatus> getStatus(final BackupIdentifier id) {
+    return CompletableFuture.completedFuture(backupStatusMap.get(id));
+  }
+
+  @Override
+  public CompletableFuture<Collection<BackupStatus>> list(final BackupIdentifierWildcard wildcard) {
+    return CompletableFuture.completedFuture(
+        backupStatusMap.entrySet().stream()
+            .filter(e -> wildcard.matches(e.getKey()))
+            .map(Entry::getValue)
+            .toList());
+  }
+
+  @Override
+  public CompletableFuture<Void> delete(final BackupIdentifier id) {
+    backupStatusMap.remove(id);
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
+    return CompletableFuture.completedFuture(backupMap.get(id));
+  }
+
+  @Override
+  public CompletableFuture<BackupStatusCode> markFailed(
+      final BackupIdentifier id, final String failureReason) {
+    throw new UnsupportedOperationException("Not yet implemented; implemented it when required");
+  }
+
+  @Override
+  public CompletableFuture<Void> closeAsync() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  public void completeSaveFutures() {
+    for (final var entry : saveFutures.entrySet()) {
+      final var future = entry.getValue();
+      final var id = entry.getKey();
+      // complete the future if all files exist
+      final var backup = backupMap.get(id);
+      completeFuture(backup, future);
+    }
+    saveFutures.clear();
+  }
+
+  private void completeFuture(final Backup backup, final CompletableFuture<Void> future) {
+    final var allFiles = new ArrayList<Path>();
+    allFiles.addAll(backup.snapshot().files());
+    allFiles.addAll(backup.segments().files());
+    for (final var path : allFiles) {
+      if (!Files.exists(path)) {
+        future.completeExceptionally(
+            new FileNotFoundException("File not found %s".formatted(path)));
+        break;
+      }
+    }
+    if (!future.isCompletedExceptionally()) {
+      future.complete(null);
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    completeSaveFutures();
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/utils/InlineThreadContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/utils/InlineThreadContext.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.utils;
+
+import io.atomix.utils.concurrent.Scheduled;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.time.Duration;
+
+public class InlineThreadContext implements ThreadContext {
+
+  @Override
+  public void checkThread() {}
+
+  @Override
+  public Scheduled schedule(
+      final Duration initialDelay, final Duration interval, final Runnable callback) {
+    throw new UnsupportedOperationException("schedule");
+  }
+
+  @Override
+  public void execute(final Runnable runnable) {
+    runnable.run();
+  }
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -18,6 +18,8 @@ package io.camunda.zeebe.journal;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.file.Path;
+import java.util.SortedMap;
 
 public interface Journal extends AutoCloseable {
 
@@ -134,4 +136,6 @@ public interface Journal extends AutoCloseable {
    * @return true if open, false otherwise
    */
   boolean isOpen();
+
+  SortedMap<Long, Path> getTailSegments(long index);
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -24,9 +24,15 @@ import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.nio.file.Path;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
 import java.util.concurrent.locks.StampedLock;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -185,6 +191,21 @@ public final class SegmentedJournal implements Journal {
   @Override
   public boolean isOpen() {
     return open;
+  }
+
+  @Override
+  public SortedMap<Long, Path> getTailSegments(final long index) {
+    final var tailSegments = segments.getTailSegments(index);
+    final var treeMap =
+        tailSegments.entrySet().stream()
+            .collect(
+                Collectors.toMap(
+                    Entry::getKey,
+                    e -> e.getValue().file().file().toPath(),
+                    (a, b) -> b,
+                    TreeMap::new));
+
+    return Collections.unmodifiableSortedMap(treeMap);
   }
 
   @Override

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -122,7 +122,7 @@ final class SegmentedJournalWriter {
     // even if the next flush index has not been written, this will always flush at least the last
     // segment if only to cover cases such as truncating the log, where the next flush index may not
     // have been written yet but we still want to flush that segment after modifying it
-    flusher.flush(segments.getTailSegments(flusher.nextFlushIndex()));
+    flusher.flush(segments.getTailSegments(flusher.nextFlushIndex()).values());
   }
 
   private void createNewSegment() {

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -326,13 +326,13 @@ final class SegmentsManager implements AutoCloseable {
     nextSegment = CompletableFuture.supplyAsync(() -> createUninitializedSegment(descriptor));
   }
 
-  Collection<Segment> getTailSegments(final long index) {
+  SortedMap<Long, Segment> getTailSegments(final long index) {
     final var segment = getSegment(index);
     if (segment == null) {
-      return Collections.emptySet();
+      return Collections.emptySortedMap();
     }
 
-    return Collections.unmodifiableSortedMap(segments.tailMap(segment.index(), true)).values();
+    return Collections.unmodifiableSortedMap(segments.tailMap(segment.index(), true)); // inclusive
   }
 
   private UninitializedSegment createUninitializedSegment(final SegmentDescriptor descriptor) {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -278,7 +278,7 @@ class SegmentsManagerTest {
     segments = journalFactory.segmentsManager(directory, loader, metaStore);
     try (final var journal = journalFactory.journal(segments)) {
       // grab all segments and copy them to avoid the map getting cleared
-      final var loadedSegments = new ArrayList<>(segments.getTailSegments(0));
+      final var loadedSegments = new ArrayList<>(segments.getTailSegments(0).values());
       journal.reset(10);
 
       // then - assert we reset first, then delete the segments in reversed order

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -38,6 +38,7 @@ import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -84,17 +85,6 @@ class PartitionRestoreServiceTest {
         new FileBasedSnapshotStore(0, partitionId, dataDirectory, snapshotPath -> Map.of());
     actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
 
-    backupService =
-        new BackupService(
-            nodeId,
-            partitionId,
-            1,
-            backupStore,
-            snapshotStore,
-            dataDirectory,
-            path -> path.toString().endsWith(".log"));
-    actorScheduler.submitActor(backupService);
-
     final var partitionMetadata =
         new PartitionMetadata(
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
@@ -109,6 +99,18 @@ class PartitionRestoreServiceTest {
             .withName(raftPartition.name())
             .withMetaStore(mock(JournalMetaStore.class))
             .build();
+
+    backupService =
+        new BackupService(
+            nodeId,
+            partitionId,
+            1,
+            backupStore,
+            snapshotStore,
+            dataDirectory,
+            // RaftPartitions implements this interface, but the RaftServer is not started
+            index -> CompletableFuture.completedFuture(journal.getTailSegments(index).values()));
+    actorScheduler.submitActor(backupService);
   }
 
   @AfterEach

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/TestRestorableBackupStore.java
@@ -117,7 +117,7 @@ final class TestRestorableBackupStore implements BackupStore {
             waiter ->
                 waiter.completeExceptionally(
                     new RuntimeException("Backup failed: %s".formatted(failureReason))));
-    return null;
+    return CompletableFuture.completedFuture(BackupStatusCode.FAILED);
   }
 
   @Override
@@ -125,7 +125,7 @@ final class TestRestorableBackupStore implements BackupStore {
     waiters
         .values()
         .forEach(waiter -> waiter.completeExceptionally(new RuntimeException("Store was closed")));
-    return null;
+    return CompletableFuture.completedFuture(null);
   }
 
   private NamedFileSet copyNamedFileSet(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.snapshots;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.nio.file.Path;
 
 /** Represents a snapshot, which was persisted at the {@link PersistedSnapshotStore}. */
@@ -98,4 +99,7 @@ public interface PersistedSnapshot {
    * @return future with SnapshotReservation
    */
   ActorFuture<SnapshotReservation> reserve();
+
+  @VisibleForTesting
+  boolean isReserved();
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/TransientSnapshot.java
@@ -16,12 +16,12 @@ public interface TransientSnapshot extends PersistableSnapshot {
 
   /**
    * Takes a snapshot on the given path. This can be persisted later via calling {@link
-   * PersistableSnapshot#persist()}. Based on the implementation this could mean that this is writen
-   * before on a temporary folder and then moved to the valid snapshot directory.
+   * PersistableSnapshot#persist()}. Based on the implementation this could mean that this is
+   * written before on a temporary folder and then moved to the valid snapshot directory.
    *
    * @param takeSnapshot the predicate which should take the snapshot and should return true on
    *     success
-   * @return true on success, false otherwise
+   * @return a future reflecting the result of the operation
    */
   ActorFuture<Void> take(Consumer<Path> takeSnapshot);
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -143,6 +143,11 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
     return snapshotLocked;
   }
 
+  @Override
+  public boolean isReserved() {
+    return !reservations.isEmpty();
+  }
+
   void delete() {
     // the checksum, as a mark file, should be deleted first
     try {
@@ -204,10 +209,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
         + ", metadata="
         + metadata
         + '}';
-  }
-
-  boolean isReserved() {
-    return !reservations.isEmpty();
   }
 
   ActorFuture<Void> removeReservation(final FileBasedSnapshotReservation reservation) {

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/DynamicAutoCloseable.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/DynamicAutoCloseable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Class that can managed AutoCloseable added dynamically. AutoCloseable are closed in the opposite
+ * order they were added.
+ */
+public class DynamicAutoCloseable implements AutoCloseable {
+
+  final List<AutoCloseable> thingsToClose = new ArrayList<>();
+
+  public <A extends AutoCloseable> A manage(final A closeable) {
+    thingsToClose.add(closeable);
+    return closeable;
+  }
+
+  @Override
+  public void close() {
+    RuntimeException firstException = null;
+    final int size = thingsToClose.size();
+    for (int i = size - 1; i >= 0; i--) {
+      try {
+        thingsToClose.remove(i).close();
+      } catch (final Exception e) {
+        if (firstException == null) {
+          firstException = new RuntimeException(e);
+        }
+      }
+    }
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/AutoCloseableRule.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/AutoCloseableRule.java
@@ -22,8 +22,9 @@ public final class AutoCloseableRule extends ExternalResource {
 
   final List<AutoCloseable> thingsToClose = new ArrayList<>();
 
-  public void manage(final AutoCloseable closeable) {
+  public <A extends AutoCloseable> A manage(final A closeable) {
     thingsToClose.add(closeable);
+    return closeable;
   }
 
   @Override

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/AutoCloseableRule.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/AutoCloseableRule.java
@@ -7,8 +7,7 @@
  */
 package io.camunda.zeebe.test.util;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.camunda.zeebe.test.DynamicAutoCloseable;
 import org.junit.After;
 import org.junit.rules.ExternalResource;
 
@@ -20,22 +19,15 @@ import org.junit.rules.ExternalResource;
  */
 public final class AutoCloseableRule extends ExternalResource {
 
-  final List<AutoCloseable> thingsToClose = new ArrayList<>();
+  private final DynamicAutoCloseable dynAutoCloseable = new DynamicAutoCloseable();
 
   public <A extends AutoCloseable> A manage(final A closeable) {
-    thingsToClose.add(closeable);
+    dynAutoCloseable.manage(closeable);
     return closeable;
   }
 
   @Override
   public void after() {
-    final int size = thingsToClose.size();
-    for (int i = size - 1; i >= 0; i--) {
-      try {
-        thingsToClose.remove(i).close();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
+    dynAutoCloseable.close();
   }
 }


### PR DESCRIPTION
## Description
Previously, all segments present in the directory would be marked
eligible for backup without coordinator with the LogCompaction.

With this change, the BackupManager will check with the Journal which
segments contain data that is not present in the selected snapshot,
limiting the possibility that these files will be canceled while a
backup is in place.

However, nothing stops the LogCompaction to delete these files if the
backup is particularly slow. To avoid such issue another synchronization
mechanism should be added to the LogCompaction.

## Related issues

closes #23082
