### PR TITLE
Add process cache metrics

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -22,6 +22,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 
 import co.elastic.clients.util.VisibleForTesting;
 import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.cache.ExporterCacheMetrics;
 import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -56,6 +57,7 @@ public class CamundaExporter implements Exporter {
   private CamundaExporterMetrics metrics;
   private Logger logger;
   private BackgroundTaskManager taskManager;
+  private ExporterCacheMetrics exporterCacheMetrics;
 
   public CamundaExporter() {
     this(new DefaultExporterResourceProvider());
@@ -74,7 +76,8 @@ public class CamundaExporter implements Exporter {
     context.setFilter(new CamundaExporterRecordFilter());
     metrics = new CamundaExporterMetrics(context.getMeterRegistry());
     clientAdapter = ClientAdapter.of(configuration);
-    provider.init(configuration, clientAdapter.getExporterEntityCacheProvider());
+    provider.init(
+        configuration, clientAdapter.getExporterEntityCacheProvider(), context.getMeterRegistry());
 
     taskManager =
         BackgroundTaskManager.create(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -12,6 +12,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Set;
 
@@ -19,7 +20,8 @@ public interface ExporterResourceProvider {
 
   void init(
       final ExporterConfiguration configuration,
-      final ExporterEntityCacheProvider entityCacheProvider);
+      final ExporterEntityCacheProvider entityCacheProvider,
+      final MeterRegistry meterRegistry);
 
   /**
    * This should return descriptors describing the desired state of all indices provided.

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterCacheMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterCacheMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.benmanes.caffeine.cache.stats.StatsCounter;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+
+public class ExporterCacheMetrics implements StatsCounter {
+
+  private static final String NAMESPACE = "zeebe.camunda.exporter.processcache";
+
+  private final Counter hitCount;
+  private final Counter missCount;
+  private final Timer loadSuccessDuration;
+  private final Timer loadFailureDuration;
+  private final Counter evictionCount;
+  private final String cacheName;
+
+  public ExporterCacheMetrics(final String cacheName, final MeterRegistry meterRegistry) {
+    this.cacheName = cacheName;
+    hitCount =
+        Counter.builder(meterName("hits"))
+            .description("Number of cache hits")
+            .register(meterRegistry);
+
+    missCount =
+        Counter.builder(meterName("misses"))
+            .description("Number of cache misses")
+            .register(meterRegistry);
+
+    evictionCount =
+        Counter.builder(meterName("evictions"))
+            .description("Number of cache evictions")
+            .register(meterRegistry);
+
+    loadSuccessDuration =
+        Timer.builder(meterName("load.duration.success"))
+            .description("The time the cache spent computing or retrieving the new value")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+
+    loadFailureDuration =
+        Timer.builder(meterName("load.duration.failure"))
+            .description(
+                "The time the cache spent computing or retrieving the new value prior to discovering the value doesn't exist or an exception being thrown")
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+  }
+
+  @Override
+  public void recordHits(final int count) {
+    hitCount.increment(count);
+  }
+
+  @Override
+  public void recordMisses(final int count) {
+    missCount.increment(count);
+  }
+
+  @Override
+  public void recordLoadSuccess(final long loadTime) {
+    loadSuccessDuration.record(loadTime, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public void recordLoadFailure(final long loadTime) {
+    loadFailureDuration.record(loadTime, TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public void recordEviction(final int weight, final RemovalCause cause) {
+    evictionCount.increment();
+  }
+
+  @Override
+  public CacheStats snapshot() {
+    // not implemented, as we don't need it
+    return null;
+  }
+
+  private String meterName(final String name) {
+    return NAMESPACE + "." + cacheName + "." + name;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheImpl.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheImpl.java
@@ -16,10 +16,14 @@ public class ExporterEntityCacheImpl<K, T> implements ExporterEntityCache<K, T> 
 
   private final LoadingCache<K, T> cache;
 
-  public ExporterEntityCacheImpl(final long maxSize, final CacheLoader<K, T> cacheLoader) {
+  public ExporterEntityCacheImpl(
+      final long maxSize,
+      final CacheLoader<K, T> cacheLoader,
+      final ExporterCacheMetrics exporterCacheMetrics) {
     cache =
         Caffeine.newBuilder()
             .maximumSize(maxSize)
+            .recordStats(() -> exporterCacheMetrics)
             .build(
                 k -> {
                   try {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
@@ -85,6 +85,8 @@ import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
@@ -439,7 +441,10 @@ public class CamundaExporterHandlerIT {
   private <S extends ExporterEntity<S>, T extends RecordValue> ExportHandler<S, T> getHandler(
       final ExporterConfiguration config, final Class<?> handlerClass) {
     final var provider = new DefaultExporterResourceProvider();
-    provider.init(config, ClientAdapter.of(config).getExporterEntityCacheProvider());
+    provider.init(
+        config,
+        ClientAdapter.of(config).getExporterEntityCacheProvider(),
+        new SimpleMeterRegistry());
 
     return provider.getExportHandlers().stream()
         .filter(handler -> handler.getClass().equals(handlerClass))
@@ -456,7 +461,8 @@ public class CamundaExporterHandlerIT {
   private CamundaExporter getExporter(
       final ExporterConfiguration config, final ExportHandler<?, ?> handler) {
     final var provider = spy(new DefaultExporterResourceProvider());
-    provider.init(config, ClientAdapter.of(config).getExporterEntityCacheProvider());
+    provider.init(
+        config, ClientAdapter.of(config).getExporterEntityCacheProvider(), Metrics.globalRegistry);
 
     doReturn(Set.of(handler)).when(provider).getExportHandlers();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -301,7 +302,7 @@ final class CamundaExporterIT {
       final Set<IndexTemplateDescriptor> templateDescriptors,
       final ExporterConfiguration config) {
     final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
-    provider.init(config, mock(ExporterEntityCacheProvider.class));
+    provider.init(config, mock(ExporterEntityCacheProvider.class), mock(MeterRegistry.class));
 
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -40,7 +40,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
@@ -302,7 +302,7 @@ final class CamundaExporterIT {
       final Set<IndexTemplateDescriptor> templateDescriptors,
       final ExporterConfiguration config) {
     final var provider = mock(DefaultExporterResourceProvider.class, CALLS_REAL_METHODS);
-    provider.init(config, mock(ExporterEntityCacheProvider.class), mock(MeterRegistry.class));
+    provider.init(config, mock(ExporterEntityCacheProvider.class), new SimpleMeterRegistry());
 
     when(provider.getIndexDescriptors()).thenReturn(indexDescriptors);
     when(provider.getIndexTemplateDescriptors()).thenReturn(templateDescriptors);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -15,6 +15,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
@@ -28,7 +29,7 @@ public class DefaultExporterResourceProviderTest {
   void shouldHaveCorrectFullQualifiedNamesForIndexAndTemplates(final ExporterConfiguration config) {
     final var provider = new DefaultExporterResourceProvider();
 
-    provider.init(config, mock(ExporterEntityCacheProvider.class));
+    provider.init(config, mock(ExporterEntityCacheProvider.class), mock(MeterRegistry.class));
 
     provider
         .getIndexDescriptors()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/DefaultExporterResourceProviderTest.java
@@ -15,7 +15,7 @@ import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
@@ -29,7 +29,7 @@ public class DefaultExporterResourceProviderTest {
   void shouldHaveCorrectFullQualifiedNamesForIndexAndTemplates(final ExporterConfiguration config) {
     final var provider = new DefaultExporterResourceProvider();
 
-    provider.init(config, mock(ExporterEntityCacheProvider.class), mock(MeterRegistry.class));
+    provider.init(config, mock(ExporterEntityCacheProvider.class), new SimpleMeterRegistry());
 
     provider
         .getIndexDescriptors()

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/FormCacheIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/FormCacheIT.java
@@ -24,6 +24,7 @@ import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -132,15 +133,19 @@ class FormCacheIT {
 
   static FormCacheArgument getESFormCache(final String indexName) {
     return new FormCacheArgument(
-        new ExporterEntityCacheImpl<String, CachedFormEntity>(
-            10, new ElasticSearchFormCacheLoader(elsClient, indexName)),
+        new ExporterEntityCacheImpl<>(
+            10,
+            new ElasticSearchFormCacheLoader(elsClient, indexName),
+            new ExporterCacheMetrics("ES", new SimpleMeterRegistry())),
         FormCacheIT::indexInElasticSearch);
   }
 
   static FormCacheArgument getOSFormCache(final String indexName) {
     return new FormCacheArgument(
-        new ExporterEntityCacheImpl<String, CachedFormEntity>(
-            10, new OpenSearchFormCacheLoader(osClient, indexName)),
+        new ExporterEntityCacheImpl<>(
+            10,
+            new OpenSearchFormCacheLoader(osClient, indexName),
+            new ExporterCacheMetrics("ES", new SimpleMeterRegistry())),
         FormCacheIT::indexInOpenSearch);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -28,6 +28,7 @@ import io.camunda.webapps.schema.entities.operate.ProcessEntity;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
@@ -154,14 +155,18 @@ class ProcessCacheImplIT {
   static ProcessCacheArgument getESProcessCache(final String indexName) {
     return new ProcessCacheArgument(
         new ExporterEntityCacheImpl(
-            10, new ElasticSearchProcessCacheLoader(elsClient, indexName, new XMLUtil())),
+            10,
+            new ElasticSearchProcessCacheLoader(elsClient, indexName, new XMLUtil()),
+            new ExporterCacheMetrics(new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInElasticSearch);
   }
 
   static ProcessCacheArgument getOSProcessCache(final String indexName) {
     return new ProcessCacheArgument(
         new ExporterEntityCacheImpl(
-            10, new OpenSearchProcessCacheLoader(osClient, indexName, new XMLUtil())),
+            10,
+            new OpenSearchProcessCacheLoader(osClient, indexName, new XMLUtil()),
+            new ExporterCacheMetrics(new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInOpenSearch);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/ProcessCacheImplIT.java
@@ -157,7 +157,7 @@ class ProcessCacheImplIT {
         new ExporterEntityCacheImpl(
             10,
             new ElasticSearchProcessCacheLoader(elsClient, indexName, new XMLUtil()),
-            new ExporterCacheMetrics(new SimpleMeterRegistry())),
+            new ExporterCacheMetrics("ES", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInElasticSearch);
   }
 
@@ -166,7 +166,7 @@ class ProcessCacheImplIT {
         new ExporterEntityCacheImpl(
             10,
             new OpenSearchProcessCacheLoader(osClient, indexName, new XMLUtil()),
-            new ExporterCacheMetrics(new SimpleMeterRegistry())),
+            new ExporterCacheMetrics("OS", new SimpleMeterRegistry())),
         ProcessCacheImplIT::indexInOpenSearch);
   }
 


### PR DESCRIPTION
## Description

Adds metrics for ProcessCache in CamundaExporter. Following metrics has been added:

* Cache hit count
* Cache misses count
* Cache eviction count
* Duration for loading cache entry from the backend
* Time spent trying to load cache entry but failed

The metrics is added via a concrete implementation of `StatsCounter` which will be used by the Caffeine implementation to directly record the statistics. This provides a clean way to record the metrics. Alternative is to use the default implementation for statistics and periodically query it and update micrometer metrics.

## Related issues

closes #24208
