### PR TITLE
Prevent duplicate sequence numbers in records exported to Elasticsearch and OpenSearch

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -49,11 +49,11 @@ final class BulkIndexRequest implements ContentProducer {
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
    */
-  void index(
+  boolean index(
       final BulkIndexAction action, final Record<?> record, final RecordSequence recordSequence) {
     // exit early in case we're retrying the last indexed record again
     if (lastIndexedMetadata != null && lastIndexedMetadata.equals(action)) {
-      return;
+      return false;
     }
 
     final byte[] source;
@@ -69,6 +69,7 @@ final class BulkIndexRequest implements ContentProducer {
     memoryUsageBytes += command.source().length;
     lastIndexedMetadata = action;
     operations.add(command);
+    return true;
   }
 
   private static byte[] serializeRecord(final Record<?> record, final RecordSequence recordSequence)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -48,6 +48,7 @@ final class BulkIndexRequest implements ContentProducer {
    * @param action the bulk action to take
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
+   * @return true if the record was appended to the batch, false otherwise
    */
   boolean index(
       final BulkIndexAction action, final Record<?> record, final RecordSequence recordSequence) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/BulkIndexRequest.java
@@ -48,7 +48,8 @@ final class BulkIndexRequest implements ContentProducer {
    * @param action the bulk action to take
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
-   * @return true if the record was appended to the batch, false otherwise
+   * @return true if the record was appended to the batch, false if the record is already indexed in
+   *     the batch because only one copy of the record is allowed in the batch
    */
   boolean index(
       final BulkIndexAction action, final Record<?> record, final RecordSequence recordSequence) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -99,6 +99,13 @@ class ElasticsearchClient implements AutoCloseable {
     client.close();
   }
 
+  /**
+   * Indexes a record to the batch of records that will be sent to Elasticsearch
+   *
+   * @param record the record that will be the source of the document
+   * @param recordSequence the sequence number of the record
+   * @return true if the record was appended to the batch, false otherwise
+   */
   public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     if (bulkIndexRequest.isEmpty()) {
       flushLatencyMeasurement = metrics.startFlushLatencyMeasurement();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -99,7 +99,7 @@ class ElasticsearchClient implements AutoCloseable {
     client.close();
   }
 
-  public void index(final Record<?> record, final RecordSequence recordSequence) {
+  public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     if (bulkIndexRequest.isEmpty()) {
       flushLatencyMeasurement = metrics.startFlushLatencyMeasurement();
     }
@@ -109,7 +109,7 @@ class ElasticsearchClient implements AutoCloseable {
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             indexRouter.routingFor(record));
-    bulkIndexRequest.index(action, record, recordSequence);
+    return bulkIndexRequest.index(action, record, recordSequence);
   }
 
   /**

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -104,7 +104,8 @@ class ElasticsearchClient implements AutoCloseable {
    *
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
-   * @return true if the record was appended to the batch, false otherwise
+   * @return true if the record was appended to the batch, false if the record is already indexed in
+   *     the batch because only one copy of the record is allowed in the batch
    */
   public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     if (bulkIndexRequest.isEmpty()) {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -380,6 +380,7 @@ final class ElasticsearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
+    private final int position = 1;
 
     @BeforeEach
     void initExporter() {
@@ -454,6 +455,7 @@ final class ElasticsearchExporterTest {
               newRecord(PARTITION_ID, ValueType.JOB),
               newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
               newRecord(PARTITION_ID, ValueType.JOB));
+      when(client.index(any(), any())).thenReturn(true);
 
       // when
       records.forEach(exporter::export);
@@ -481,34 +483,8 @@ final class ElasticsearchExporterTest {
           .isInstanceOf(ElasticsearchExporterException.class);
 
       // retry index successfully
-      doNothing().when(client).index(any(), any());
-      exporter.export(record);
-
-      // then
-      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
-      verify(client, times(2)).index(any(), recordSequenceCaptor.capture());
-
-      assertThat(recordSequenceCaptor.getAllValues())
-          .extracting(RecordSequence::counter)
-          .describedAs("Expect that the record counter is the same on retry")
-          .containsExactly(1L, 1L);
-    }
-
-    @Test
-    void shouldNotIncrementCounterOnFlushErrors() {
-      // given
-      when(client.shouldFlush()).thenReturn(true);
-
-      final var record = newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE);
-
-      // when
-      doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
-
-      assertThatCode(() -> exporter.export(record))
-          .isInstanceOf(ElasticsearchExporterException.class);
-
-      // retry flush successfully
-      doNothing().when(client).flush();
+      doReturn(true).when(client).index(any(), any());
+      when(client.index(any(), any())).thenReturn(true);
       exporter.export(record);
 
       // then
@@ -525,6 +501,7 @@ final class ElasticsearchExporterTest {
     void shouldStoreRecordCountersOnFlush() {
       // given
       when(client.shouldFlush()).thenReturn(true);
+      when(client.index(any(), any())).thenReturn(true);
 
       final var records =
           List.of(
@@ -559,6 +536,7 @@ final class ElasticsearchExporterTest {
               newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
               newRecord(PARTITION_ID, ValueType.VARIABLE),
               newRecord(PARTITION_ID, ValueType.JOB));
+      when(client.index(any(), any())).thenReturn(true);
 
       // when
       records.forEach(exporter::export);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -106,6 +106,7 @@ public class RecordCounterTest {
     when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be 1
@@ -130,6 +131,7 @@ public class RecordCounterTest {
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
     doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be empty
@@ -155,6 +157,7 @@ public class RecordCounterTest {
 
     // and the exported record is flushed asynchronously
     doNothing().when(client).flush();
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be 1
@@ -183,6 +186,8 @@ public class RecordCounterTest {
         .isInstanceOf(ElasticsearchExporterException.class);
 
     // and the record export is retried
+    // when the exporter tries to index the same record multiple times in the same batch,
+    // the method returns false as it only keeps a single copy of the record in the batch.
     when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(false);
     doNothing().when(client).flush();
     exporter.export(mockRecord);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -14,6 +14,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,6 +30,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class RecordCounterTest {
   private final ElasticsearchExporterConfiguration config =
@@ -226,6 +229,28 @@ public class RecordCounterTest {
     assertThat(counters.get(valueType))
         .describedAs("The record counter should be 2, as we have exported the two records")
         .isEqualTo(2);
+  }
+
+  @Test
+  void shouldIncrementCounterOnFlushErrors() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    when(client.shouldFlush()).thenReturn(true);
+
+    // when
+    doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(ElasticsearchExporterException.class);
+
+    // then
+    final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
+    verify(client, times(1)).index(any(), recordSequenceCaptor.capture());
+    assertThat(recordSequenceCaptor.getAllValues())
+        .extracting(RecordSequence::counter)
+        .describedAs("Expect that the record counter is incremented")
+        .containsExactly(1L);
   }
 
   private Map<ValueType, Long> readMetadata() {

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -59,6 +60,7 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(true);
     exporter.export(mockRecord);
 
@@ -80,6 +82,7 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(true);
     doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
     assertThatThrownBy(() -> exporter.export(mockRecord))
@@ -100,6 +103,7 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
     exporter.close();
@@ -122,6 +126,7 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
     doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
@@ -142,6 +147,7 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported, but the synchronous flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(true);
     doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
     assertThatThrownBy(() -> exporter.export(mockRecord))
@@ -170,12 +176,14 @@ public class RecordCounterTest {
     when(mockRecord.getValueType()).thenReturn(valueType);
 
     // when a new record is exported, but the synchronous flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(true);
     doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
     assertThatThrownBy(() -> exporter.export(mockRecord))
         .isInstanceOf(ElasticsearchExporterException.class);
 
     // and the record export is retried
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(false);
     doNothing().when(client).flush();
     exporter.export(mockRecord);
 
@@ -199,10 +207,12 @@ public class RecordCounterTest {
     when(mockRecord2.getValueType()).thenReturn(valueType);
 
     // when a new record is exported
+    when(client.index(eq(mockRecord1), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(true);
     exporter.export(mockRecord1);
 
     // and another new record export is exported
+    when(client.index(eq(mockRecord2), any(RecordSequence.class))).thenReturn(true);
     exporter.export(mockRecord2);
 
     // then the record counter should be 2

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordCounterTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RecordCounterTest {
+  private final ElasticsearchExporterConfiguration config =
+      new ElasticsearchExporterConfiguration();
+  private final ExporterTestContext context =
+      new ExporterTestContext().setConfiguration(new ExporterTestConfiguration<>("test", config));
+  private final ExporterTestController controller = new ExporterTestController();
+  private final ElasticsearchClient client = mock(ElasticsearchClient.class);
+  private final ElasticsearchExporter exporter =
+      new ElasticsearchExporter() {
+        @Override
+        protected ElasticsearchClient createClient() {
+          return client;
+        }
+      };
+
+  @BeforeEach
+  void beforeEach() {
+    when(client.putIndexTemplate(any())).thenReturn(true);
+    when(client.putComponentTemplate()).thenReturn(true);
+  }
+
+  @Test
+  void shouldIncrementCounterOnSynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported
+    when(client.shouldFlush()).thenReturn(true);
+    exporter.export(mockRecord);
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1 as only exported 1 record")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementCounterOnFailedSynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(ElasticsearchExporterException.class);
+
+    // then the record counter should be empty
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is not stored in the metadata").isEmpty();
+  }
+
+  @Test
+  void shouldIncrementCounterOnAsynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.shouldFlush()).thenReturn(false);
+    exporter.export(mockRecord);
+    exporter.close();
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1 as only exported 1 record")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementCounterOnFailedAsynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.shouldFlush()).thenReturn(false);
+    exporter.export(mockRecord);
+    doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    exporter.close();
+
+    // then the record counter should be empty
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is not stored in the metadata").isEmpty();
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/24192")
+  void shouldIncrementCounterOnSynchronousFlushFailure() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the synchronous flush fails
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(ElasticsearchExporterException.class);
+
+    // and the exported record is flushed asynchronously
+    doNothing().when(client).flush();
+    exporter.close();
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs(
+            "The record counter should be 1, as we have exported the record asynchronously")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementSequenceOnDuplicateExportedRecord() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the synchronous flush fails
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new ElasticsearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(ElasticsearchExporterException.class);
+
+    // and the record export is retried
+    doNothing().when(client).flush();
+    exporter.export(mockRecord);
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1, as we have exported the same record twice")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldIncrementSequenceOnDifferentExportedRecords() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord1 = mock(Record.class);
+    final Record mockRecord2 = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord1.getValueType()).thenReturn(valueType);
+    when(mockRecord2.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported
+    when(client.shouldFlush()).thenReturn(true);
+    exporter.export(mockRecord1);
+
+    // and another new record export is exported
+    exporter.export(mockRecord2);
+
+    // then the record counter should be 2
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 2, as we have exported the two records")
+        .isEqualTo(2);
+  }
+
+  private Map<ValueType, Long> readMetadata() {
+    return controller
+        .readMetadata()
+        .map(
+            bytes -> {
+              try {
+                return new ObjectMapper().readValue(bytes, ElasticsearchExporterMetadata.class);
+              } catch (final IOException exception) {
+                System.out.println("Failed to map metadata: " + exception);
+                return null;
+              }
+            })
+        .map(ElasticsearchExporterMetadata::getRecordCountersByValueType)
+        .orElse(Collections.emptyMap());
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -47,12 +47,13 @@ final class BulkIndexRequest implements ContentProducer {
    * @param action the bulk action to take
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
+   * @return true if the record was appended to the batch, false otherwise
    */
-  void index(
+  boolean index(
       final BulkIndexAction action, final Record<?> record, final RecordSequence recordSequence) {
     // exit early in case we're retrying the last indexed record again
     if (lastIndexedMetadata != null && lastIndexedMetadata.equals(action)) {
-      return;
+      return false;
     }
 
     final byte[] source;
@@ -68,6 +69,7 @@ final class BulkIndexRequest implements ContentProducer {
     memoryUsageBytes += command.source().length;
     lastIndexedMetadata = action;
     operations.add(command);
+    return true;
   }
 
   private static byte[] serializeRecord(final Record<?> record, final RecordSequence recordSequence)

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/BulkIndexRequest.java
@@ -47,7 +47,8 @@ final class BulkIndexRequest implements ContentProducer {
    * @param action the bulk action to take
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
-   * @return true if the record was appended to the batch, false otherwise
+   * @return true if the record was appended to the batch, false if the record is already indexed in
+   *     the batch because only one copy of the record is allowed in the batch
    */
   boolean index(
       final BulkIndexAction action, final Record<?> record, final RecordSequence recordSequence) {

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -96,13 +96,20 @@ public class OpensearchClient implements AutoCloseable {
     client.close();
   }
 
-  public void index(final Record<?> record, final RecordSequence recordSequence) {
+  /**
+   * Indexes a record to the batch of records that will be sent to Elasticsearch
+   *
+   * @param record the record that will be the source of the document
+   * @param recordSequence the sequence number of the record
+   * @return true if the record was appended to the batch, false otherwise
+   */
+  public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     final BulkIndexAction action =
         new BulkIndexAction(
             indexRouter.indexFor(record),
             indexRouter.idFor(record),
             indexRouter.routingFor(record));
-    bulkIndexRequest.index(action, record, recordSequence);
+    return bulkIndexRequest.index(action, record, recordSequence);
   }
 
   /**

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -101,7 +101,8 @@ public class OpensearchClient implements AutoCloseable {
    *
    * @param record the record that will be the source of the document
    * @param recordSequence the sequence number of the record
-   * @return true if the record was appended to the batch, false otherwise
+   * @return true if the record was appended to the batch, false if the record is already indexed in
+   *     the batch because only one copy of the record is allowed in the batch
    */
   public boolean index(final Record<?> record, final RecordSequence recordSequence) {
     final BulkIndexAction action =

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -109,20 +109,15 @@ public class OpensearchExporter implements Exporter {
     }
 
     final var recordSequence = recordCounters.getNextRecordSequence(record);
-    client.index(record, recordSequence);
+    final var isRecordIndexedToBatch = client.index(record, recordSequence);
+    if (isRecordIndexedToBatch) {
+      recordCounters.updateRecordCounters(record, recordSequence);
+    }
     lastPosition = record.getPosition();
 
     if (client.shouldFlush()) {
       flush();
-      // Update the record counters only after the flush was successful. If the synchronous flush
-      // fails then the exporter will be invoked with the same record again.
-      recordCounters.updateRecordCounters(record, recordSequence);
       updateLastExportedPosition();
-    } else {
-      // If the exporter doesn't flush synchronously then it can update the record counters
-      // immediately. If the asynchronous flush fails then it will retry only the flush operation
-      // with the records in the pending bulk request.
-      recordCounters.updateRecordCounters(record, recordSequence);
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -406,6 +406,7 @@ final class OpensearchExporterTest {
   final class RecordSequenceTest {
 
     private static final int PARTITION_ID = 123;
+    private final int position = 1;
 
     @BeforeEach
     void initExporter() {
@@ -480,6 +481,7 @@ final class OpensearchExporterTest {
               newRecord(PARTITION_ID, ValueType.JOB),
               newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
               newRecord(PARTITION_ID, ValueType.JOB));
+      when(client.index(any(), any())).thenReturn(true);
 
       // when
       records.forEach(exporter::export);
@@ -504,33 +506,8 @@ final class OpensearchExporterTest {
       assertThatCode(() -> exporter.export(record)).isInstanceOf(OpensearchExporterException.class);
 
       // retry index successfully
-      doNothing().when(client).index(any(), any());
-      exporter.export(record);
-
-      // then
-      final var recordSequenceCaptor = ArgumentCaptor.forClass(RecordSequence.class);
-      verify(client, times(2)).index(any(), recordSequenceCaptor.capture());
-
-      assertThat(recordSequenceCaptor.getAllValues())
-          .extracting(RecordSequence::counter)
-          .describedAs("Expect that the record counter is the same on retry")
-          .containsExactly(1L, 1L);
-    }
-
-    @Test
-    void shouldNotIncrementCounterOnFlushErrors() {
-      // given
-      when(client.shouldFlush()).thenReturn(true);
-
-      final var record = newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE);
-
-      // when
-      doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
-
-      assertThatCode(() -> exporter.export(record)).isInstanceOf(OpensearchExporterException.class);
-
-      // retry flush successfully
-      doNothing().when(client).flush();
+      doReturn(true).when(client).index(any(), any());
+      when(client.index(any(), any())).thenReturn(true);
       exporter.export(record);
 
       // then
@@ -547,6 +524,7 @@ final class OpensearchExporterTest {
     void shouldStoreRecordCountersOnFlush() {
       // given
       when(client.shouldFlush()).thenReturn(true);
+      when(client.index(any(), any())).thenReturn(true);
 
       final var records =
           List.of(
@@ -581,6 +559,7 @@ final class OpensearchExporterTest {
               newRecord(PARTITION_ID, ValueType.PROCESS_INSTANCE),
               newRecord(PARTITION_ID, ValueType.VARIABLE),
               newRecord(PARTITION_ID, ValueType.JOB));
+      when(client.index(any(), any())).thenReturn(true);
 
       // when
       records.forEach(exporter::export);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RecordCounterTest {
+  private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
+  private final ExporterTestContext context =
+      new ExporterTestContext().setConfiguration(new ExporterTestConfiguration<>("test", config));
+  private final ExporterTestController controller = new ExporterTestController();
+  private final OpensearchClient client = mock(OpensearchClient.class);
+  private final OpensearchExporter exporter =
+      new OpensearchExporter() {
+        @Override
+        protected OpensearchClient createClient() {
+          return client;
+        }
+      };
+
+  @BeforeEach
+  void beforeEach() {
+    when(client.putIndexTemplate(any())).thenReturn(true);
+    when(client.putComponentTemplate()).thenReturn(true);
+  }
+
+  @Test
+  void shouldIncrementCounterOnSynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(true);
+    exporter.export(mockRecord);
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1 as only exported 1 record")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementCounterOnFailedSynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(OpensearchExporterException.class);
+
+    // then the record counter should be empty
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is not stored in the metadata").isEmpty();
+  }
+
+  @Test
+  void shouldIncrementCounterOnAsynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(false);
+    exporter.export(mockRecord);
+    exporter.close();
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1 as only exported 1 record")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementCounterOnFailedAsynchronousFlush() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(false);
+    exporter.export(mockRecord);
+    doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
+    exporter.close();
+
+    // then the record counter should be empty
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is not stored in the metadata").isEmpty();
+  }
+
+  @RegressionTest("https://github.com/camunda/camunda/issues/24192")
+  void shouldIncrementCounterOnSynchronousFlushFailure() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the synchronous flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(OpensearchExporterException.class);
+
+    // and the exported record is flushed asynchronously
+    doNothing().when(client).flush();
+    exporter.close();
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs(
+            "The record counter should be 1, as we have exported the record asynchronously")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldNotIncrementSequenceOnDuplicateExportedRecord() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported, but the synchronous flush fails
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(true);
+    doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
+    assertThatThrownBy(() -> exporter.export(mockRecord))
+        .isInstanceOf(OpensearchExporterException.class);
+
+    // and the record export is retried
+    when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(false);
+    doNothing().when(client).flush();
+    exporter.export(mockRecord);
+
+    // then the record counter should be 1
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 1, as we have exported the same record twice")
+        .isEqualTo(1);
+  }
+
+  @Test
+  void shouldIncrementSequenceOnDifferentExportedRecords() {
+    // given
+    exporter.configure(context);
+    exporter.open(controller);
+    final Record mockRecord1 = mock(Record.class);
+    final Record mockRecord2 = mock(Record.class);
+    final var valueType = ValueType.PROCESS_INSTANCE;
+    when(mockRecord1.getValueType()).thenReturn(valueType);
+    when(mockRecord2.getValueType()).thenReturn(valueType);
+
+    // when a new record is exported
+    when(client.index(eq(mockRecord1), any(RecordSequence.class))).thenReturn(true);
+    when(client.shouldFlush()).thenReturn(true);
+    exporter.export(mockRecord1);
+
+    // and another new record export is exported
+    when(client.index(eq(mockRecord2), any(RecordSequence.class))).thenReturn(true);
+    exporter.export(mockRecord2);
+
+    // then the record counter should be 2
+    final var counters = readMetadata();
+    assertThat(counters).describedAs("The counter is stored in the metadata").isNotEmpty();
+    assertThat(counters.get(valueType))
+        .describedAs("The record counter should be 2, as we have exported the two records")
+        .isEqualTo(2);
+  }
+
+  private Map<ValueType, Long> readMetadata() {
+    return controller
+        .readMetadata()
+        .map(
+            bytes -> {
+              try {
+                return new ObjectMapper().readValue(bytes, OpensearchExporterMetadata.class);
+              } catch (final IOException exception) {
+                System.out.println("Failed to map metadata: " + exception);
+                return null;
+              }
+            })
+        .map(OpensearchExporterMetadata::getRecordCountersByValueType)
+        .orElse(Collections.emptyMap());
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordCounterTest.java
@@ -105,6 +105,7 @@ public class RecordCounterTest {
     when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(true);
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be 1
@@ -129,6 +130,7 @@ public class RecordCounterTest {
     when(client.shouldFlush()).thenReturn(false);
     exporter.export(mockRecord);
     doThrow(new OpensearchExporterException("failed to flush")).when(client).flush();
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be empty
@@ -154,6 +156,7 @@ public class RecordCounterTest {
 
     // and the exported record is flushed asynchronously
     doNothing().when(client).flush();
+    // the close() method is used to simulate the asynchronous flush
     exporter.close();
 
     // then the record counter should be 1
@@ -182,6 +185,8 @@ public class RecordCounterTest {
         .isInstanceOf(OpensearchExporterException.class);
 
     // and the record export is retried
+    // when the exporter tries to index the same record multiple times in the same batch,
+    // the method returns false as it only keeps a single copy of the record in the batch.
     when(client.index(eq(mockRecord), any(RecordSequence.class))).thenReturn(false);
     doNothing().when(client).flush();
     exporter.export(mockRecord);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Before this change we would only update the record counters on a successful flush. As a result there is a risk of a
reused sequence number when the flush fails. This happens when:

1. A record is exported
2. The client detects a flush is required immediately (synchronous flush)
3. The synchronous flush fails
4. The next flush is triggered by an asynchronous flush (because of the configurable delay)

If all this is true we were in a scenario where the record counters never got updated, but we did flush a record with a
sequence number to Elasticsearch. A next record will receive the same sequence number in this case.

We can solve this by updating the sequence number as soon as we have written the record to the batch. Regardless of a
successful flush, the counter will be updated. If the flush still fails and the record is re-exported, the record is not
appended to the batch a second time. By using a boolean to keep track whether the exported record was appended to the
batch, we can determine if we need to update the record counters.

By using a boolean, we can easily write a unit test for this as well. If we updated the counters inside the
index method of the client, this becomes nearly impossible.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24192 
