### PR TITLE
Fix Daily QA workflow

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -99,14 +99,22 @@ jobs:
       - name: Start Test
         shell: bash
         run: |
-          variables=$(echo "${{ inputs.variables }}" | envsubst)
-          curl -L -X POST '${{ steps.secrets.outputs.TESTBENCH_PROD_REST_ADDRESS }}/v2/process-instances' \
-          -H "Authorization: Bearer ${{ env.access_token }}" \
-          -H 'Content-Type: application/json' \
-          -H 'Accept: application/json' \
-          --data-raw '{
-            "processDefinitionId": "${{ inputs.processId }}",
-            "variables": '"$variables"'
-          }'
+          # Substitute environment variables in the JSON payload
+          substituted_variables=$(echo '${{ inputs.variables }}' | envsubst)
+
+          # Format the JSON to ensure it’s correct
+          variables=$(echo "$substituted_variables" | jq -c .)
+
+          # Run the curl command with expanded variables
+          curl -L -X POST "${{ steps.secrets.outputs.TESTBENCH_PROD_REST_ADDRESS }}/v2/process-instances" \
+            -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/json" \
+            --data-raw "{
+              \"processDefinitionId\": \"${{ inputs.processId }}\",
+              \"variables\": $variables
+            }"
         env:
           IMAGE: ${{ steps.build-zeebe-docker.outputs.image }}
+          access_token: ${{ env.access_token }}
+


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Due to the deprecation of zbctl in favour of REST the daily QA workflow on main is not running since last week, due to an issue parsing the variables.

related to: #22536 
