### PR TITLE
feat: support keyset pagination in RDBMS #23997

### DIFF
--- a/db/rdbms/pom.xml
+++ b/db/rdbms/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.mybatis</groupId>
       <artifactId>mybatis</artifactId>
     </dependency>

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQueryPage.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.sort.SortOrder;
+import java.util.List;
+
+public record DbQueryPage(Integer size, Integer from, List<KeySetPagination> keySetPagination) {
+
+  public record KeySetPagination(List<KeySetPaginationFieldEntry> entries) {}
+
+  public record KeySetPaginationFieldEntry(String fieldName, Operator operator, Object fieldValue) {
+
+    public static Operator determineOperator(final SortOrder order, final boolean isSearchAfter) {
+      if (isSearchAfter) {
+        return order == SortOrder.ASC ? Operator.GREATER : Operator.LOWER;
+      }
+
+      return order == SortOrder.ASC ? Operator.LOWER : Operator.GREATER;
+    }
+  }
+
+  public enum Operator {
+    GREATER(">"),
+    LOWER("<"),
+    EQUALS("=");
+
+    private final String symbol;
+
+    Operator(final String symbol) {
+      this.symbol = symbol;
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.db.rdbms.sql.SearchColumn;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+public record DbQuerySorting<T>(List<SortingEntry<T>> orderings) {
+
+  public static <T> DbQuerySorting<T> of(
+      final Function<DbQuerySorting.Builder<T>, ObjectBuilder<DbQuerySorting<T>>> fn) {
+    return fn.apply(new DbQuerySorting.Builder<>()).build();
+  }
+
+  public static final class Builder<T> implements ObjectBuilder<DbQuerySorting<T>> {
+
+    private final List<SortingEntry<T>> entries;
+
+    public Builder() {
+      entries = new ArrayList<>();
+    }
+
+    public Builder<T> addEntry(final SearchColumn<T> column, final SortOrder order) {
+      entries.add(new SortingEntry<>(column, order));
+      return this;
+    }
+
+    @Override
+    public DbQuerySorting<T> build() {
+      return new DbQuerySorting<>(entries);
+    }
+  }
+
+  public record SortingEntry<T>(SearchColumn<T> column, SortOrder order) {}
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ProcessDefinitionDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ProcessDefinitionDbQuery.java
@@ -7,71 +7,68 @@
  */
 package io.camunda.db.rdbms.read.domain;
 
+import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessDefinitionFilter;
-import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.query.SearchQueryBase;
-import io.camunda.search.sort.ProcessDefinitionSort;
-import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 public record ProcessDefinitionDbQuery(
-    ProcessDefinitionFilter filter, ProcessDefinitionSort sort, SearchQueryPage page) {
-
-  public ProcessDefinitionDbQuery {
-    // There should be a default in the SearchQueryPage, so this should never happen
-    Objects.requireNonNull(page);
-  }
+    ProcessDefinitionFilter filter,
+    DbQuerySorting<ProcessDefinitionEntity> sort,
+    DbQueryPage page) {
 
   public static ProcessDefinitionDbQuery of(
       final Function<Builder, ObjectBuilder<ProcessDefinitionDbQuery>> fn) {
     return fn.apply(new Builder()).build();
   }
 
-  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
-      implements ObjectBuilder<ProcessDefinitionDbQuery> {
+  public static final class Builder implements ObjectBuilder<ProcessDefinitionDbQuery> {
 
     private static final ProcessDefinitionFilter EMPTY_FILTER =
         FilterBuilders.processDefinition().build();
-    private static final ProcessDefinitionSort EMPTY_SORT =
-        SortOptionBuilders.processDefinition().build();
 
     private ProcessDefinitionFilter filter;
-    private ProcessDefinitionSort sort;
+    private DbQuerySorting<ProcessDefinitionEntity> sort;
+    private DbQueryPage page;
 
-    public Builder filter(final ProcessDefinitionFilter value) {
+    public ProcessDefinitionDbQuery.Builder filter(final ProcessDefinitionFilter value) {
       filter = value;
       return this;
     }
 
-    public Builder sort(final ProcessDefinitionSort value) {
+    public ProcessDefinitionDbQuery.Builder sort(
+        final DbQuerySorting<ProcessDefinitionEntity> value) {
       sort = value;
       return this;
     }
 
-    public Builder filter(
+    public ProcessDefinitionDbQuery.Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public ProcessDefinitionDbQuery.Builder filter(
         final Function<ProcessDefinitionFilter.Builder, ObjectBuilder<ProcessDefinitionFilter>>
             fn) {
       return filter(FilterBuilders.processDefinition(fn));
     }
 
-    public Builder sort(
-        final Function<ProcessDefinitionSort.Builder, ObjectBuilder<ProcessDefinitionSort>> fn) {
-      return sort(SortOptionBuilders.processDefinition(fn));
-    }
-
-    @Override
-    protected Builder self() {
-      return this;
+    public ProcessDefinitionDbQuery.Builder sort(
+        final Function<
+                DbQuerySorting.Builder<ProcessDefinitionEntity>,
+                ObjectBuilder<DbQuerySorting<ProcessDefinitionEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
     }
 
     @Override
     public ProcessDefinitionDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
-      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
-      return new ProcessDefinitionDbQuery(filter, sort, page().sanitize());
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new ProcessDefinitionDbQuery(filter, sort, page);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ProcessInstanceDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/ProcessInstanceDbQuery.java
@@ -7,48 +7,43 @@
  */
 package io.camunda.db.rdbms.read.domain;
 
+import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.query.SearchQueryBase;
-import io.camunda.search.sort.ProcessInstanceSort;
-import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 public record ProcessInstanceDbQuery(
-    ProcessInstanceFilter filter, ProcessInstanceSort sort, SearchQueryPage page) {
-
-  public ProcessInstanceDbQuery {
-    // There should be a default in the SearchQueryPage, so this should never happen
-    Objects.requireNonNull(page);
-  }
+    ProcessInstanceFilter filter, DbQuerySorting<ProcessInstanceEntity> sort, DbQueryPage page) {
 
   public static ProcessInstanceDbQuery of(
       final Function<ProcessInstanceDbQuery.Builder, ObjectBuilder<ProcessInstanceDbQuery>> fn) {
     return fn.apply(new ProcessInstanceDbQuery.Builder()).build();
   }
 
-  public static final class Builder
-      extends SearchQueryBase.AbstractQueryBuilder<ProcessInstanceDbQuery.Builder>
-      implements ObjectBuilder<ProcessInstanceDbQuery> {
+  public static final class Builder implements ObjectBuilder<ProcessInstanceDbQuery> {
 
     private static final ProcessInstanceFilter EMPTY_FILTER =
         FilterBuilders.processInstance().build();
-    private static final ProcessInstanceSort EMPTY_SORT =
-        SortOptionBuilders.processInstance().build();
 
     private ProcessInstanceFilter filter;
-    private ProcessInstanceSort sort;
+    private DbQuerySorting<ProcessInstanceEntity> sort;
+    private DbQueryPage page;
 
     public Builder filter(final ProcessInstanceFilter value) {
       filter = value;
       return this;
     }
 
-    public Builder sort(final ProcessInstanceSort value) {
+    public Builder sort(final DbQuerySorting<ProcessInstanceEntity> value) {
       sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
       return this;
     }
 
@@ -58,20 +53,17 @@ public record ProcessInstanceDbQuery(
     }
 
     public Builder sort(
-        final Function<ProcessInstanceSort.Builder, ObjectBuilder<ProcessInstanceSort>> fn) {
-      return sort(SortOptionBuilders.processInstance(fn));
-    }
-
-    @Override
-    protected Builder self() {
-      return this;
+        final Function<
+                DbQuerySorting.Builder<ProcessInstanceEntity>,
+                ObjectBuilder<DbQuerySorting<ProcessInstanceEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
     }
 
     @Override
     public ProcessInstanceDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
-      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
-      final var page = page() != null ? page().sanitize() : SearchQueryPage.DEFAULT;
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
       return new ProcessInstanceDbQuery(filter, sort, page);
     }
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry.determineOperator;
+
+import io.camunda.db.rdbms.read.domain.DbQueryPage;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPagination;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
+import io.camunda.db.rdbms.read.domain.DbQuerySorting;
+import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
+import io.camunda.db.rdbms.sql.SearchColumn;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.SortOption;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+abstract class AbstractEntityReader<T> {
+
+  private final SearchColumnFinder<T> searchColumnFinder;
+
+  public AbstractEntityReader(final SearchColumnFinder<T> searchColumnFinder) {
+    this.searchColumnFinder = searchColumnFinder;
+  }
+
+  public DbQuerySorting<T> convertSort(
+      final SortOption sortOption, final SearchColumn<T> discriminatorColumn) {
+    final var builder = new DbQuerySorting.Builder<T>();
+
+    for (final FieldSorting fieldSorting : sortOption.getFieldSortings()) {
+      final var column = searchColumnFinder.findByProperty(fieldSorting.field());
+      if (column != null) {
+        builder.addEntry(column, fieldSorting.order());
+      }
+    }
+
+    builder.addEntry(discriminatorColumn, SortOrder.ASC);
+
+    return builder.build();
+  }
+
+  public static DbQueryPage convertPaging(
+      final DbQuerySorting<?> sort, final SearchQueryPage page) {
+    List<KeySetPagination> keySetPagination = new ArrayList<>();
+    if (page.searchAfter() != null || page.searchBefore() != null) {
+      keySetPagination = createKeySetPagination(sort, page);
+    }
+
+    return new DbQueryPage(page.size(), page.from(), keySetPagination);
+  }
+
+  /**
+   * To create key set pagination for rdbms, supporting mixed order (e.g. <code>ORDER BY name ASC,
+   * startDate DESC, key ASC</code>), a simple solution like
+   *
+   * <pre>WHERE (name, startDate, key) < ("Process A", "2024-10-10T08:00:00Z", 1234)</pre>
+   *
+   * <br>
+   * does not work anymore. <br>
+   * <br>
+   * Instead, we need to split up the query into multiple comparisons:
+   *
+   * <pre>
+   * WHERE (name > "Process A")
+   *    OR (name = "Process A" AND startDate < "2024-10-10T08:00:00Z")
+   *    OR (name = "Process A" AND startDate = "2024-10-10T08:00:00Z" AND key > 1234)
+   * </pre>
+   *
+   * This method takes the sortOrder and the sortValues (before or after) and creates a list grouped
+   * expressions. We do this in Java and not in MyBatis because it is easier to program and to test
+   */
+  private static List<KeySetPagination> createKeySetPagination(
+      final DbQuerySorting<?> sort, final SearchQueryPage page) {
+    final boolean isSearchAfter = page.searchAfter() != null;
+    final Object[] sortValues =
+        page.searchAfter() != null ? page.searchAfter() : page.searchBefore();
+    final List<KeySetPagination> keySetPagination = new ArrayList<>();
+
+    for (int i = 0; i < sort.orderings().size(); i++) {
+      final List<KeySetPaginationFieldEntry> fieldEntries = new ArrayList<>();
+      // add entries for equals sorting
+      for (int j = 0; j < i; j++) {
+        final SearchColumn<?> sortColumn = sort.orderings().get(j).column();
+        fieldEntries.add(
+            new KeySetPaginationFieldEntry(
+                sortColumn.name(), Operator.EQUALS, sortColumn.convertSortOption(sortValues[j])));
+      }
+
+      // add comparator entry
+      final var sorting = sort.orderings().get(i);
+      fieldEntries.add(
+          new KeySetPaginationFieldEntry(
+              sorting.column().name(),
+              determineOperator(sorting.order(), isSearchAfter),
+              sorting.column().convertSortOption(sortValues[i])));
+      keySetPagination.add(new KeySetPagination(fieldEntries));
+    }
+
+    return keySetPagination;
+  }
+
+  public Object[] extractSortValues(final List<T> hits, final DbQuerySorting<T> sort) {
+    if (hits.isEmpty() || sort.orderings().isEmpty()) {
+      return new Object[0];
+    }
+
+    final List<Object> sortOptions = new ArrayList<>();
+    for (final SortingEntry<T> fieldSorting : sort.orderings()) {
+      sortOptions.add(fieldSorting.column().getPropertyValue(hits.getLast()));
+    }
+
+    return sortOptions.toArray();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -37,9 +37,11 @@ abstract class AbstractEntityReader<T> {
 
     for (final FieldSorting fieldSorting : sortOption.getFieldSortings()) {
       final var column = searchColumnFinder.findByProperty(fieldSorting.field());
-      if (column != null) {
-        builder.addEntry(column, fieldSorting.order());
+      if (column == null) {
+        throw new IllegalArgumentException("Unknown sortField: " + fieldSorting.field());
       }
+
+      builder.addEntry(column, fieldSorting.order());
     }
 
     builder.addEntry(discriminatorColumn, SortOrder.ASC);

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SearchColumnFinder.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SearchColumnFinder.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.sql.SearchColumn;
+
+public interface SearchColumnFinder<T> {
+
+  SearchColumn<T> findByProperty(String property);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
@@ -11,6 +11,7 @@ import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import java.util.List;
+import java.util.function.Function;
 
 public interface ProcessDefinitionMapper {
 
@@ -19,4 +20,58 @@ public interface ProcessDefinitionMapper {
   Long count(ProcessDefinitionDbQuery filter);
 
   List<ProcessDefinitionEntity> search(ProcessDefinitionDbQuery filter);
+
+  enum ProcessDefinitionSearchColumn implements SearchColumn<ProcessDefinitionEntity> {
+    PROCESS_DEFINITION_KEY("key", ProcessDefinitionEntity::key),
+    PROCESS_DEFINITION_ID("bpmnProcessId", ProcessDefinitionEntity::bpmnProcessId),
+    NAME("name", ProcessDefinitionEntity::name),
+    VERSION("version", ProcessDefinitionEntity::version),
+    VERSION_TAG("versionTag", ProcessDefinitionEntity::versionTag),
+    TENANT_ID("tenantId", ProcessDefinitionEntity::tenantId),
+    FORM_ID("formId", ProcessDefinitionEntity::formId),
+    RESOURCE_NAME("resourceName", ProcessDefinitionEntity::resourceName),
+    BPMN_XML("bpmnXml", ProcessDefinitionEntity::bpmnXml);
+
+    private final String property;
+    private final Function<ProcessDefinitionEntity, Object> propertyReader;
+    private final Function<Object, Object> sortOptionConverter;
+
+    ProcessDefinitionSearchColumn(
+        final String property, final Function<ProcessDefinitionEntity, Object> propertyReader) {
+      this(property, propertyReader, Function.identity());
+    }
+
+    ProcessDefinitionSearchColumn(
+        final String property,
+        final Function<ProcessDefinitionEntity, Object> propertyReader,
+        final Function<Object, Object> sortOptionConverter) {
+      this.property = property;
+      this.propertyReader = propertyReader;
+      this.sortOptionConverter = sortOptionConverter;
+    }
+
+    @Override
+    public Object getPropertyValue(final ProcessDefinitionEntity entity) {
+      return propertyReader.apply(entity);
+    }
+
+    @Override
+    public Object convertSortOption(final Object object) {
+      if (object == null) {
+        return null;
+      }
+
+      return sortOptionConverter.apply(object);
+    }
+
+    public static ProcessDefinitionSearchColumn findByProperty(final String property) {
+      for (final ProcessDefinitionSearchColumn column : ProcessDefinitionSearchColumn.values()) {
+        if (column.property.equals(property)) {
+          return column;
+        }
+      }
+
+      return null;
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -10,7 +10,7 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.search.entities.ProcessInstanceEntity;
-import java.time.OffsetDateTime;
+import io.camunda.zeebe.util.DateUtil;
 import java.util.List;
 import java.util.function.Function;
 
@@ -31,9 +31,8 @@ public interface ProcessInstanceMapper {
     PROCESS_DEFINITION_NAME("processName", ProcessInstanceEntity::processName),
     PROCESS_DEFINITION_VERSION("processVersion", ProcessInstanceEntity::processVersion),
     PROCESS_DEFINITION_VERSION_TAG("processVersionTag", ProcessInstanceEntity::processVersionTag),
-    START_DATE(
-        "startDate", ProcessInstanceEntity::startDate, v -> OffsetDateTime.parse((String) v)),
-    END_DATE("endDate", ProcessInstanceEntity::endDate, v -> OffsetDateTime.parse((String) v)),
+    START_DATE("startDate", ProcessInstanceEntity::startDate, DateUtil::fuzzyToOffsetDateTime),
+    END_DATE("endDate", ProcessInstanceEntity::endDate, DateUtil::fuzzyToOffsetDateTime),
     STATE("state", ProcessInstanceEntity::state),
     TENANT_ID("tenantId", ProcessInstanceEntity::tenantId),
     PARENT_PROCESS_INSTANCE_KEY(

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -10,7 +10,9 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.function.Function;
 
 public interface ProcessInstanceMapper {
 
@@ -21,4 +23,66 @@ public interface ProcessInstanceMapper {
   Long count(ProcessInstanceDbQuery filter);
 
   List<ProcessInstanceEntity> search(ProcessInstanceDbQuery filter);
+
+  enum ProcessInstanceSearchColumn implements SearchColumn<ProcessInstanceEntity> {
+    PROCESS_INSTANCE_KEY("key", ProcessInstanceEntity::key),
+    PROCESS_DEFINITION_KEY("processDefinitionKey", ProcessInstanceEntity::processDefinitionKey),
+    PROCESS_DEFINITION_ID("bpmnProcessId", ProcessInstanceEntity::bpmnProcessId),
+    PROCESS_DEFINITION_NAME("processName", ProcessInstanceEntity::processName),
+    PROCESS_DEFINITION_VERSION("processVersion", ProcessInstanceEntity::processVersion),
+    PROCESS_DEFINITION_VERSION_TAG("processVersionTag", ProcessInstanceEntity::processVersionTag),
+    START_DATE(
+        "startDate", ProcessInstanceEntity::startDate, v -> OffsetDateTime.parse((String) v)),
+    END_DATE("endDate", ProcessInstanceEntity::endDate, v -> OffsetDateTime.parse((String) v)),
+    STATE("state", ProcessInstanceEntity::state),
+    TENANT_ID("tenantId", ProcessInstanceEntity::tenantId),
+    PARENT_PROCESS_INSTANCE_KEY(
+        "parentProcessInstanceKey", ProcessInstanceEntity::parentProcessInstanceKey),
+    PARENT_FLOW_NODE_INSTANCE_KEY(
+        "parentFlowNodeInstanceKey", ProcessInstanceEntity::parentFlowNodeInstanceKey),
+    TREE_PATH("treePath", ProcessInstanceEntity::treePath),
+    INCIDENT("incident", ProcessInstanceEntity::incident);
+
+    private final String property;
+    private final Function<ProcessInstanceEntity, Object> propertyReader;
+    private final Function<Object, Object> sortOptionConverter;
+
+    ProcessInstanceSearchColumn(
+        final String property, final Function<ProcessInstanceEntity, Object> propertyReader) {
+      this(property, propertyReader, Function.identity());
+    }
+
+    ProcessInstanceSearchColumn(
+        final String property,
+        final Function<ProcessInstanceEntity, Object> propertyReader,
+        final Function<Object, Object> sortOptionConverter) {
+      this.property = property;
+      this.propertyReader = propertyReader;
+      this.sortOptionConverter = sortOptionConverter;
+    }
+
+    @Override
+    public Object getPropertyValue(final ProcessInstanceEntity entity) {
+      return propertyReader.apply(entity);
+    }
+
+    @Override
+    public Object convertSortOption(final Object object) {
+      if (object == null) {
+        return null;
+      }
+
+      return sortOptionConverter.apply(object);
+    }
+
+    public static ProcessInstanceSearchColumn findByProperty(final String property) {
+      for (final ProcessInstanceSearchColumn column : ProcessInstanceSearchColumn.values()) {
+        if (column.property.equals(property)) {
+          return column;
+        }
+      }
+
+      return null;
+    }
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/SearchColumn.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+public interface SearchColumn<T> {
+
+  String name();
+
+  Object getPropertyValue(T entity);
+
+  Object convertSortOption(Object sortOption);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/VariableDbModel.java
@@ -23,6 +23,7 @@ public record VariableDbModel(
     boolean isPreview,
     Long scopeKey,
     Long processInstanceKey,
+    String processDefinitionId,
     String tenantId) {
 
   public static final int DEFAULT_VARIABLE_SIZE_THRESHOLD = 8191; // TODO make configurable
@@ -34,6 +35,7 @@ public record VariableDbModel(
     private String value;
     private Long scopeKey;
     private Long processInstanceKey;
+    private String processDefinitionId;
     private String tenantId;
 
     // Public constructor to initialize the builder
@@ -62,6 +64,11 @@ public record VariableDbModel(
 
     public VariableDbModelBuilder processInstanceKey(final Long processInstanceKey) {
       this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public VariableDbModelBuilder processDefinitionId(final String processDefinitionId) {
+      this.processDefinitionId = processDefinitionId;
       return this;
     }
 
@@ -96,6 +103,7 @@ public record VariableDbModel(
           false,
           scopeKey,
           processInstanceKey,
+          processDefinitionId,
           tenantId);
     }
 
@@ -111,6 +119,7 @@ public record VariableDbModel(
           true,
           scopeKey,
           processInstanceKey,
+          processDefinitionId,
           tenantId);
     }
 
@@ -126,6 +135,7 @@ public record VariableDbModel(
           false,
           scopeKey,
           processInstanceKey,
+          processDefinitionId,
           tenantId);
     }
 
@@ -141,6 +151,7 @@ public record VariableDbModel(
           false,
           scopeKey,
           processInstanceKey,
+          processDefinitionId,
           tenantId);
     }
   }

--- a/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
+++ b/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
@@ -61,6 +61,7 @@
         <constraints primaryKey="true"/>
       </column>
       <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)" />
       <column name="SCOPE_KEY" type="BIGINT" />
       <column name="TYPE" type="VARCHAR(255)"/>
       <column name="VAR_NAME" type="VARCHAR(255)" />

--- a/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/h2.properties
@@ -7,3 +7,4 @@
 #
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
+keysetPaging.limit=LIMIT #{page.size}

--- a/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/mariadb.properties
@@ -7,3 +7,4 @@
 #
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
+keysetPaging.limit=LIMIT #{page.size}

--- a/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/oracle.properties
@@ -7,3 +7,4 @@
 #
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=OFFSET #{page.from} ROWS FETCH NEXT #{page.size} ROWS ONLY
+keysetPaging.limit=FETCH NEXT #{page.size} ROWS ONLY

--- a/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
+++ b/db/rdbms/src/main/resources/db/vendor-properties/postgresql.properties
@@ -7,3 +7,4 @@
 #
 # filter object needs a 'paging' object of type io.camunda.db.rdbms.domain.Paging or similar signature
 paging.after=LIMIT #{page.size} OFFSET #{page.from}
+keysetPaging.limit=LIMIT #{page.size}

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -46,4 +46,36 @@
     </choose>
   </sql>
 
+  <sql id="keySetPageFilter">
+    <if test="page != null and page.keySetPagination != null and !page.keySetPagination.isEmpty()">
+      WHERE
+      <foreach collection="page.keySetPagination" item="keySet" open="(" separator=" OR "
+        close=")">
+        <foreach collection="keySet.entries" item="entry" open="(" separator=" AND "
+          close=")">
+            ${entry.fieldName} ${entry.operator.symbol} #{entry.fieldValue}
+        </foreach>
+      </foreach>
+    </if>
+  </sql>
+
+  <sql id="orderBy">
+    <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
+      <foreach collection="sort.orderings" open=" " separator=", " item="item">
+        ${item.column} ${item.order}
+      </foreach>
+    </if>
+  </sql>
+
+  <sql id="paging">
+    <if test="page != null">
+      <if test="page.keySetPagination == null or page.keySetPagination.isEmpty()">
+        ${paging.after}
+      </if>
+      <if test="page.keySetPagination != null and !page.keySetPagination.isEmpty()">
+        ${keysetPaging.limit}
+      </if>
+    </if>
+  </sql>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/Commons.xml
+++ b/db/rdbms/src/main/resources/mapper/Commons.xml
@@ -61,7 +61,7 @@
 
   <sql id="orderBy">
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
-      <foreach collection="sort.orderings" open=" " separator=", " item="item">
+      <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
         ${item.column} ${item.order}
       </foreach>
     </if>

--- a/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessDefinitionMapper.xml
@@ -18,6 +18,7 @@
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery"
     resultMap="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchResultMap">
+    SELECT * FROM (
     SELECT PROCESS_DEFINITION_KEY,
     PROCESS_DEFINITION_ID,
     RESOURCE_NAME,
@@ -29,14 +30,10 @@
     FORM_ID
     FROM PROCESS_DEFINITION
     <include refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.searchFilter"/>
-    <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
-      <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        <include
-          refid="io.camunda.db.rdbms.sql.ProcessDefinitionMapper.processDefinitionSortMapper"/>
-        ${item.order}
-      </foreach>
-    </if>
-    ${paging.after}
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
   <sql id="searchFilter">
@@ -83,32 +80,6 @@
         #{value}
       </foreach>
     </if>
-  </sql>
-
-  <sql id="processDefinitionSortMapper">
-    <choose>
-      <when test='item.field == "key"'>
-        PROCESS_DEFINITION_KEY
-      </when>
-      <when test='item.field == "resourceName"'>
-        RESOURCE_NAME
-      </when>
-      <when test='item.field == "name"'>
-        NAME
-      </when>
-      <when test='item.field == "version"'>
-        VERSION
-      </when>
-      <when test='item.field == "versionTag"'>
-        VERSION_TAG
-      </when>
-      <when test='item.field == "bpmnProcessId"'>
-        PROCESS_DEFINITION_ID
-      </when>
-      <when test='item.field == "tenantId"'>
-        TENANT_ID
-      </when>
-    </choose>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessDefinitionEntity">

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -23,7 +23,7 @@
            pi.PARENT_PROCESS_INSTANCE_KEY,
            pi.PARENT_ELEMENT_INSTANCE_KEY,
            pi.ELEMENT_ID,
-           pi.VERSION,
+           pi.VERSION AS PROCESS_DEFINITION_VERSION,
            pd.NAME        AS PROCESS_DEFINITION_NAME,
            pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM PROCESS_INSTANCE pi
@@ -41,32 +41,31 @@
 
   <!-- default search statement for databases supporting LIMIT/OFFSET-->
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery" resultMap="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchResultMap">
+    SELECT * FROM (
     SELECT
-      pi.PROCESS_INSTANCE_KEY,
-      pi.PROCESS_DEFINITION_ID,
-      pi.PROCESS_DEFINITION_KEY,
-      pi.STATE,
-      pi.START_DATE,
-      pi.END_DATE,
-      pi.TENANT_ID,
-      NULL as TREE_PATH,
-      NULL as INCIDENT,
-      pi.PARENT_PROCESS_INSTANCE_KEY,
-      pi.PARENT_ELEMENT_INSTANCE_KEY,
-      pi.ELEMENT_ID,
-      pi.VERSION,
-      pd.NAME AS PROCESS_DEFINITION_NAME,
-      pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
+    pi.PROCESS_INSTANCE_KEY,
+    pi.PROCESS_DEFINITION_ID,
+    pi.PROCESS_DEFINITION_KEY,
+    pi.STATE,
+    pi.START_DATE,
+    pi.END_DATE,
+    pi.TENANT_ID,
+    NULL as TREE_PATH,
+    NULL as INCIDENT,
+    pi.PARENT_PROCESS_INSTANCE_KEY,
+    pi.PARENT_ELEMENT_INSTANCE_KEY,
+    pi.ELEMENT_ID,
+    pi.VERSION PROCESS_DEFINITION_VERSION,
+    pd.NAME AS PROCESS_DEFINITION_NAME,
+    pd.VERSION_TAG AS PROCESS_DEFINITION_VERSION_TAG
     FROM PROCESS_INSTANCE pi
-        LEFT JOIN PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
+    LEFT JOIN PROCESS_DEFINITION pd ON (pi.PROCESS_DEFINITION_KEY = pd.PROCESS_DEFINITION_KEY)
     <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
-    <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
-      <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.processInstanceSortMapper"/>
-        ${item.order}
-      </foreach>
-    </if>
-    ${paging.after}
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    ORDER BY
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
   <sql id="searchFilter">
@@ -138,44 +137,12 @@
     </if>
   </sql>
 
-  <sql id="processInstanceSortMapper">
-    <choose>
-      <when test='item.field == "bpmnProcessId"'>
-        pi.PROCESS_DEFINITION_ID
-      </when>
-      <when test='item.field == "processName"'>
-        pd.NAME
-      </when>
-      <when test='item.field == "processVersion"'>
-        pi.VERSION
-      </when>
-      <when test='item.field == "processVersionTag"'>
-        pd.VERSION_TAG
-      </when>
-      <when test='item.field == "processDefinitionKey"'>
-        pi.PROCESS_DEFINITION_KEY
-      </when>
-      <when test='item.field == "parentProcessInstanceKey"'>
-        pi.PARENT_PROCESS_INSTANCE_KEY
-      </when>
-      <when test='item.field == "startDate"'>
-        pi.START_DATE
-      </when>
-      <when test='item.field == "endDate"'>
-        pi.END_DATE
-      </when>
-      <when test='item.field == "tenantId"'>
-        pi.TENANT_ID
-      </when>
-    </choose>
-  </sql>
-
   <resultMap id="searchResultMap" type="io.camunda.search.entities.ProcessInstanceEntity">
     <constructor>
       <idArg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
       <arg column="PROCESS_DEFINITION_NAME" javaType="java.lang.String"/>
-      <arg column="VERSION" javaType="java.lang.Integer"/>
+      <arg column="PROCESS_DEFINITION_VERSION" javaType="java.lang.Integer"/>
       <arg column="PROCESS_DEFINITION_VERSION_TAG" javaType="java.lang.String"/>
       <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
       <arg column="PARENT_PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>

--- a/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/ProcessInstanceMapper.xml
@@ -63,7 +63,6 @@
     <include refid="io.camunda.db.rdbms.sql.ProcessInstanceMapper.searchFilter"/>
     ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
-    ORDER BY
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>

--- a/db/rdbms/src/main/resources/mapper/VariableMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/VariableMapper.xml
@@ -26,7 +26,8 @@
       VAR_VALUE,
     VAR_FULL_VALUE,
       TENANT_ID,
-    IS_PREVIEW
+    IS_PREVIEW,
+    PROCESS_DEFINITION_ID
     FROM VARIABLE
     <include refid="io.camunda.db.rdbms.sql.VariableMapper.searchFilter"/>
     <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
@@ -198,6 +199,7 @@
       <arg column="IS_PREVIEW" javaType="java.lang.Boolean"/>
       <arg column="SCOPE_KEY" javaType="java.lang.Long"/>
       <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="PROCESS_DEFINITION_ID" javaType="java.lang.String"/>
       <arg column="TENANT_ID" javaType="java.lang.String"/>
     </constructor>
   </resultMap>
@@ -207,10 +209,10 @@
     statementType="PREPARED"
     parameterType="io.camunda.db.rdbms.write.domain.VariableDbModel"
     flushCache="true">
-    INSERT INTO VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
+    INSERT INTO VARIABLE (VAR_KEY, PROCESS_INSTANCE_KEY, PROCESS_DEFINITION_ID, SCOPE_KEY, TYPE, VAR_NAME, DOUBLE_VALUE,
                           LONG_VALUE,
                           VAR_VALUE, VAR_FULL_VALUE, TENANT_ID, IS_PREVIEW)
-    VALUES (#{key}, #{processInstanceKey}, #{scopeKey}, #{type}, #{name}, #{doubleValue},
+    VALUES (#{key}, #{processInstanceKey}, #{processDefinitionId}, #{scopeKey}, #{type}, #{name}, #{doubleValue},
             #{longValue},
             #{value}, #{fullValue}, #{tenantId}, #{isPreview})
   </insert>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.read.domain.DbQueryPage;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
+import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
+import io.camunda.db.rdbms.read.domain.DbQuerySorting;
+import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
+import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceSearchColumn;
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.ProcessInstanceSort;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class AbstractEntityReaderTest {
+
+  @Test
+  void shouldConvertSort() {
+    final var reader = new ProcessInstanceReader(null);
+
+    final var convertedSort =
+        reader.convertSort(
+            ProcessInstanceSort.of(b -> b.processDefinitionName().asc().startDate().desc()),
+            ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY);
+
+    assertThat(convertedSort.orderings()).hasSize(3);
+    assertThat(convertedSort.orderings())
+        .containsExactly(
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC),
+            new SortingEntry<>(ProcessInstanceSearchColumn.START_DATE, SortOrder.DESC),
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
+
+  @Test
+  void shouldSkipUnknownSortColumn() {
+    final var reader = new ProcessInstanceReader(null);
+
+    final var convertedSort =
+        reader.convertSort(
+            new ProcessInstanceSort(
+                List.of(
+                    new FieldSorting("processName", SortOrder.ASC),
+                    new FieldSorting("foo", SortOrder.ASC))),
+            ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY);
+
+    assertThat(convertedSort.orderings()).hasSize(2);
+    assertThat(convertedSort.orderings())
+        .containsExactly(
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC),
+            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+  }
+
+  @Test
+  void shouldExtractSortValues() {
+    final var reader = new ProcessInstanceReader(null);
+
+    final var hit1 = Mockito.mock(ProcessInstanceEntity.class);
+    when(hit1.key()).thenReturn(1L);
+    when(hit1.processName()).thenReturn("foo");
+    final var hit2 = Mockito.mock(ProcessInstanceEntity.class);
+    when(hit2.key()).thenReturn(2L);
+    when(hit2.processName()).thenReturn("bar");
+    final var hit3 = Mockito.mock(ProcessInstanceEntity.class);
+    when(hit3.key()).thenReturn(3L);
+    when(hit3.processName()).thenReturn("alice");
+    final var searchResult = List.of(hit1, hit2, hit3);
+
+    final DbQuerySorting<ProcessInstanceEntity> sorting =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+
+    final var sortValues = reader.extractSortValues(searchResult, sorting);
+
+    assertThat(sortValues).hasSize(2);
+    assertThat(sortValues).containsExactly("alice", 3L);
+  }
+
+  @Test
+  void convertWithValidSortAndPage() {
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    final SearchQueryPage page = new SearchQueryPage(0, 10, null, null);
+
+    final DbQueryPage result = AbstractEntityReader.convertPaging(sort, page);
+
+    assertThat(result.size()).isEqualTo(10);
+    assertThat(result.from()).isEqualTo(0);
+    assertThat(result.keySetPagination()).isEmpty();
+  }
+
+  @Test
+  void convertWithSearchAfter() {
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_ID, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    final SearchQueryPage page =
+        new SearchQueryPage(0, 10, new Object[] {"test-process-id", "Test Process", 42L}, null);
+
+    final DbQueryPage result = AbstractEntityReader.convertPaging(sort, page);
+
+    assertThat(result.size()).isEqualTo(10);
+    assertThat(result.from()).isEqualTo(0);
+    assertThat(result.keySetPagination()).hasSize(3);
+    final var sorting0 = result.keySetPagination().getFirst();
+    assertThat(sorting0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.GREATER, "test-process-id"));
+
+    final var sorting1 = result.keySetPagination().get(1);
+    assertThat(sorting1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.EQUALS, "test-process-id"),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.LOWER, "Test Process"));
+
+    final var sorting2 = result.keySetPagination().get(2);
+    assertThat(sorting2.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.EQUALS, "test-process-id"),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, "Test Process"),
+            new KeySetPaginationFieldEntry("PROCESS_INSTANCE_KEY", Operator.GREATER, 42L));
+  }
+
+  @Test
+  void convertWithSearchBefore() {
+    final DbQuerySorting<ProcessInstanceEntity> sort =
+        DbQuerySorting.of(
+            b ->
+                b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_ID, SortOrder.ASC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.DESC)
+                    .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    final SearchQueryPage page =
+        new SearchQueryPage(0, 10, null, new Object[] {"test-process-id", "Test Process", 42L});
+
+    final DbQueryPage result = AbstractEntityReader.convertPaging(sort, page);
+
+    assertThat(result.size()).isEqualTo(10);
+    assertThat(result.from()).isEqualTo(0);
+    assertThat(result.keySetPagination()).hasSize(3);
+    final var sorting0 = result.keySetPagination().getFirst();
+    assertThat(sorting0.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.LOWER, "test-process-id"));
+
+    final var sorting1 = result.keySetPagination().get(1);
+    assertThat(sorting1.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.EQUALS, "test-process-id"),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.GREATER, "Test Process"));
+
+    final var sorting2 = result.keySetPagination().get(2);
+    assertThat(sorting2.entries())
+        .containsExactly(
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_ID", Operator.EQUALS, "test-process-id"),
+            new KeySetPaginationFieldEntry(
+                "PROCESS_DEFINITION_NAME", Operator.EQUALS, "Test Process"),
+            new KeySetPaginationFieldEntry("PROCESS_INSTANCE_KEY", Operator.LOWER, 42L));
+  }
+}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.read.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.read.domain.DbQueryPage;
@@ -45,22 +46,19 @@ class AbstractEntityReaderTest {
   }
 
   @Test
-  void shouldSkipUnknownSortColumn() {
+  void shouldThrowOnUnknownSortColumn() {
     final var reader = new ProcessInstanceReader(null);
 
-    final var convertedSort =
-        reader.convertSort(
-            new ProcessInstanceSort(
-                List.of(
-                    new FieldSorting("processName", SortOrder.ASC),
-                    new FieldSorting("foo", SortOrder.ASC))),
-            ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY);
-
-    assertThat(convertedSort.orderings()).hasSize(2);
-    assertThat(convertedSort.orderings())
-        .containsExactly(
-            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC),
-            new SortingEntry<>(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
+    assertThatThrownBy(
+            () ->
+                reader.convertSort(
+                    new ProcessInstanceSort(
+                        List.of(
+                            new FieldSorting("processName", SortOrder.ASC),
+                            new FieldSorting("foo", SortOrder.ASC))),
+                    ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Unknown sortField: foo");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessDefinitionFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessDefinitionFixtures.java
@@ -52,6 +52,15 @@ public final class ProcessDefinitionFixtures extends CommonFixtures {
     rdbmsWriter.flush();
   }
 
+  public static ProcessDefinitionDbModel createAndSaveProcessDefinition(
+      final RdbmsWriter rdbmsWriter,
+      final Function<ProcessDefinitionDbModelBuilder, ProcessDefinitionDbModelBuilder>
+          builderFunction) {
+    final var definition = createRandomized(builderFunction);
+    createAndSaveProcessDefinitions(rdbmsWriter, List.of(definition));
+    return definition;
+  }
+
   public static void createAndSaveProcessDefinition(
       final RdbmsWriter rdbmsWriter, final ProcessDefinitionDbModel processDefinition) {
     createAndSaveProcessDefinitions(rdbmsWriter, List.of(processDefinition));

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/ProcessInstanceFixtures.java
@@ -24,13 +24,13 @@ public final class ProcessInstanceFixtures extends CommonFixtures {
         new ProcessInstanceDbModelBuilder()
             .processInstanceKey(nextKey())
             .processDefinitionKey(nextKey())
-            .processDefinitionId("process-" + RANDOM.nextInt(1000))
+            .processDefinitionId("process-" + RANDOM.nextInt(10000))
             .parentProcessInstanceKey(nextKey())
             .parentElementInstanceKey(nextKey())
             .startDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
             .endDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
-            .version(RANDOM.nextInt(20))
-            .tenantId("tenant-" + RANDOM.nextInt(1000));
+            .version(RANDOM.nextInt(10000))
+            .tenantId("tenant-" + RANDOM.nextInt(10000));
 
     return builderFunction.apply(builder).build();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSortIT.java
@@ -12,7 +12,6 @@ import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.nextStri
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
@@ -20,6 +19,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessDefinitionSort.Builder;
 import io.camunda.util.ObjectBuilder;
@@ -148,11 +148,11 @@ public class ProcessDefinitionSortIT {
     final var searchResult =
         reader
             .search(
-                new ProcessDefinitionDbQuery(
+                new ProcessDefinitionQuery(
                     new ProcessDefinitionFilter.Builder().versionTags(versionTag).build(),
                     ProcessDefinitionSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))
-            .hits();
+            .items();
 
     assertThat(searchResult).hasSize(20);
     assertThat(searchResult).isSortedAccordingTo(comparator);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processdefinition/ProcessDefinitionSpecificFilterIT.java
@@ -13,13 +13,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,14 +68,14 @@ public class ProcessDefinitionSpecificFilterIT {
 
     final var searchResult =
         processDefinitionReader.search(
-            new ProcessDefinitionDbQuery(
+            new ProcessDefinitionQuery(
                 filter,
                 ProcessDefinitionSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(1);
-    assertThat(searchResult.hits()).hasSize(1);
-    assertThat(searchResult.hits().getFirst().key()).isEqualTo(1337L);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().key()).isEqualTo(1337L);
   }
 
   static List<ProcessDefinitionFilter> shouldFindProcessDefinitionWithSpecificFilterParameters() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -5,15 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db;
+package io.camunda.it.rdbms.db.processinstance;
 
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
 import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstances;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
@@ -21,8 +19,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessInstanceEntity;
-import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
@@ -31,7 +28,6 @@ import java.util.List;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.jdbc.BadSqlGrammarException;
 
 @Tag("rdbms")
 @ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
@@ -79,13 +75,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder()
-                        .processDefinitionKeys(processDefinitionKey)
-                        .build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionId().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                            .sort(s -> s.processDefinitionId().asc())
+                            .page(p -> p.from(0).size(5))))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -132,11 +127,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionVersion().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.processDefinitionVersion().asc())
+                            .page(p -> p.from(0).size(5))))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -183,11 +179,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionKey().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.processDefinitionKey().asc())
+                            .page(p -> p.from(0).size(5))))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -262,11 +259,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionName().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.processDefinitionName().asc())
+                            .page(p -> p.from(0).size(5))))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -341,11 +339,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionVersionTag().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.processDefinitionVersionTag().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -392,11 +391,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.startDate().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.startDate().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -443,11 +443,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.endDate().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.endDate().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -494,11 +495,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.parentProcessInstanceKey().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.parentProcessInstanceKey().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -545,11 +547,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder().processDefinitionIds(bpmProcessId).build(),
-                    ProcessInstanceSort.of(b -> b.tenantId().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionIds(bpmProcessId))
+                            .sort(s -> s.tenantId().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -600,13 +603,12 @@ public class ProcessInstanceSortIT {
     final var searchResult =
         processInstanceReader
             .search(
-                new ProcessInstanceDbQuery(
-                    new ProcessInstanceFilter.Builder()
-                        .processDefinitionKeys(processDefinitionKey)
-                        .build(),
-                    ProcessInstanceSort.of(b -> b.processDefinitionId().asc().startDate().asc()),
-                    SearchQueryPage.of(b -> b)))
-            .hits();
+                ProcessInstanceQuery.of(
+                    b ->
+                        b.filter(f -> f.processDefinitionKeys(processDefinitionKey))
+                            .sort(s -> s.processDefinitionId().asc().startDate().asc())
+                            .page(p -> p)))
+            .items();
 
     assertThat(searchResult).hasSize(4);
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
@@ -615,20 +617,16 @@ public class ProcessInstanceSortIT {
   }
 
   @TestTemplate
-  public void shouldFailOnUnknownSortingOption(final CamundaRdbmsTestApplication testApplication) {
+  public void shouldNotFailOnUnknownSortingOption(
+      final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final ProcessInstanceReader processInstanceReader = rdbmsService.getProcessInstanceReader();
 
-    assertThatThrownBy(
-            () ->
-                processInstanceReader
-                    .search(
-                        new ProcessInstanceDbQuery(
-                            new ProcessInstanceFilter.Builder().build(),
-                            new ProcessInstanceSort(
-                                List.of(new FieldSorting("foo", SortOrder.ASC))),
-                            SearchQueryPage.of(b -> b)))
-                    .hits())
-        .isInstanceOf(BadSqlGrammarException.class);
+    processInstanceReader.search(
+        ProcessInstanceQuery.of(
+            b ->
+                b.filter(f -> f)
+                    .sort(new ProcessInstanceSort(List.of(new FieldSorting("foo", SortOrder.ASC))))
+                    .page(p -> p)));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSortIT.java
@@ -20,9 +20,6 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtensio
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.query.ProcessInstanceQuery;
-import io.camunda.search.sort.ProcessInstanceSort;
-import io.camunda.search.sort.SortOption.FieldSorting;
-import io.camunda.search.sort.SortOrder;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.Tag;
@@ -614,19 +611,5 @@ public class ProcessInstanceSortIT {
     assertThat(searchResult.stream().map(ProcessInstanceEntity::key).toList())
         .containsExactly(
             processInstanceKey2, processInstanceKey3, processInstanceKey, processInstanceKey4);
-  }
-
-  @TestTemplate
-  public void shouldNotFailOnUnknownSortingOption(
-      final CamundaRdbmsTestApplication testApplication) {
-    final RdbmsService rdbmsService = testApplication.getRdbmsService();
-    final ProcessInstanceReader processInstanceReader = rdbmsService.getProcessInstanceReader();
-
-    processInstanceReader.search(
-        ProcessInstanceQuery.of(
-            b ->
-                b.filter(f -> f)
-                    .sort(new ProcessInstanceSort(List.of(new FieldSorting("foo", SortOrder.ASC))))
-                    .page(p -> p)));
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.it.rdbms.db;
+package io.camunda.it.rdbms.db.processinstance;
 
 import static io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures.createAndSaveProcessDefinition;
 import static io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures.createAndSaveProcessInstance;
@@ -14,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.fixtures.ProcessDefinitionFixtures;
@@ -22,8 +21,7 @@ import io.camunda.it.rdbms.db.fixtures.ProcessInstanceFixtures;
 import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.filter.ProcessInstanceFilter;
-import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.sort.ProcessInstanceSort;
+import io.camunda.search.query.ProcessInstanceQuery;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -81,17 +79,14 @@ public class ProcessInstanceSpecificFilterIT {
                     .parentProcessInstanceKey(-1L)
                     .parentElementInstanceKey(-1L)
                     .version(1)));
-
     final var searchResult =
         processInstanceReader.search(
-            new ProcessInstanceDbQuery(
-                filter,
-                ProcessInstanceSort.of(b -> b),
-                SearchQueryPage.of(b -> b.from(0).size(5))));
+            ProcessInstanceQuery.of(
+                b -> b.filter(filter).sort(s -> s).page(p -> p.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(1);
-    assertThat(searchResult.hits()).hasSize(1);
-    assertThat(searchResult.hits().getFirst().key()).isEqualTo(42L);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().key()).isEqualTo(42L);
   }
 
   static List<ProcessInstanceFilter> shouldFindProcessInstanceWithSpecificFilterParameters() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceSpecificFilterIT.java
@@ -61,9 +61,9 @@ public class ProcessInstanceSpecificFilterIT {
         rdbmsWriter,
         ProcessDefinitionFixtures.createRandomized(
             b ->
-                b.processDefinitionKey(1337L)
-                    .processDefinitionId("test-process")
-                    .name("Test Process")
+                b.processDefinitionKey(987654321L)
+                    .processDefinitionId("test-process-987654321")
+                    .name("Test Process 987654321")
                     .versionTag("Version 1")));
     createAndSaveRandomProcessInstances(rdbmsWriter);
     createAndSaveProcessInstance(
@@ -71,8 +71,8 @@ public class ProcessInstanceSpecificFilterIT {
         ProcessInstanceFixtures.createRandomized(
             b ->
                 b.processInstanceKey(42L)
-                    .processDefinitionId("test-process")
-                    .processDefinitionKey(1337L)
+                    .processDefinitionId("test-process-987654321")
+                    .processDefinitionKey(987654321L)
                     .state(ProcessInstanceState.ACTIVE)
                     .startDate(NOW)
                     .endDate(NOW)
@@ -92,12 +92,14 @@ public class ProcessInstanceSpecificFilterIT {
   static List<ProcessInstanceFilter> shouldFindProcessInstanceWithSpecificFilterParameters() {
     return List.of(
         new ProcessInstanceFilter.Builder().processInstanceKeys(42L).build(),
-        new ProcessInstanceFilter.Builder().processDefinitionIds("test-process").build(),
-        new ProcessInstanceFilter.Builder().processDefinitionKeys(1337L).build(),
+        new ProcessInstanceFilter.Builder().processDefinitionIds("test-process-987654321").build(),
+        new ProcessInstanceFilter.Builder().processDefinitionKeys(987654321L).build(),
         new ProcessInstanceFilter.Builder().states(ProcessInstanceState.ACTIVE.name()).build(),
         new ProcessInstanceFilter.Builder().parentProcessInstanceKeys(-1L).build(),
         new ProcessInstanceFilter.Builder().parentFlowNodeInstanceKeys(-1L).build(),
-        new ProcessInstanceFilter.Builder().processDefinitionNames("Test Process").build(),
+        new ProcessInstanceFilter.Builder()
+            .processDefinitionNames("Test Process 987654321")
+            .build(),
         new ProcessInstanceFilter.Builder().processDefinitionVersionTags("Version 1").build());
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/variables/VariableIT.java
@@ -19,6 +19,7 @@ import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.it.rdbms.db.fixtures.VariableFixtures;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.VariableQuery;
@@ -39,7 +40,7 @@ public class VariableIT {
         testApplication.getRdbmsService().getVariableReader().findOne(randomizedVariable.key());
 
     assertThat(instance).isNotNull();
-    assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedVariable);
+    assertVariableDbModelEqualToEntity(randomizedVariable, instance);
     assertThat(instance.fullValue()).isNull();
     assertThat(instance.isPreview()).isFalse();
   }
@@ -56,7 +57,7 @@ public class VariableIT {
     final var instance = rdbmsService.getVariableReader().findOne(randomizedVariable.key());
 
     assertThat(instance).isNotNull();
-    assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedVariable);
+    assertVariableDbModelEqualToEntity(randomizedVariable, instance);
     assertThat(instance.fullValue()).isEqualTo(bigValue);
     assertThat(instance.isPreview()).isTrue();
   }
@@ -87,7 +88,7 @@ public class VariableIT {
     final var instance = searchResult.hits().getFirst();
 
     assertThat(instance).isNotNull();
-    assertThat(instance).usingRecursiveComparison().isEqualTo(randomizedVariable);
+    assertVariableDbModelEqualToEntity(randomizedVariable, instance);
   }
 
   @TestTemplate
@@ -159,5 +160,13 @@ public class VariableIT {
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.hits()).hasSize(1);
     assertThat(searchResult.hits().getFirst().key()).isEqualTo(randomizedVariable.key());
+  }
+
+  private void assertVariableDbModelEqualToEntity(VariableDbModel dbModel, VariableEntity entity) {
+    assertThat(entity)
+        .usingRecursiveComparison()
+        .ignoringFields("bpmnProcessId", "processDefinitionId")
+        .isEqualTo(dbModel);
+    assertThat(entity.bpmnProcessId()).isEqualTo(dbModel.processDefinitionId());
   }
 }

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -10,7 +10,6 @@ package io.camunda.search.rdbms;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
-import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.clients.DecisionInstanceSearchClient;
@@ -88,14 +87,7 @@ public class RdbmsSearchClient
       final ProcessInstanceQuery query) {
     LOG.debug("[RDBMS Search Client] Search for processInstance: {}", query);
 
-    final var searchResult =
-        rdbmsService
-            .getProcessInstanceReader()
-            .search(
-                ProcessInstanceDbQuery.of(
-                    b -> b.filter(query.filter()).sort(query.sort()).page(query.page())));
-
-    return new SearchQueryResult<>(searchResult.total(), searchResult.hits(), null);
+    return rdbmsService.getProcessInstanceReader().search(query);
   }
 
   @Override

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -9,7 +9,6 @@ package io.camunda.search.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
-import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.clients.DecisionInstanceSearchClient;
@@ -181,13 +180,6 @@ public class RdbmsSearchClient
       final ProcessDefinitionQuery query) {
     LOG.debug("[RDBMS Search Client] Search for processDefinition: {}", query);
 
-    final var searchResult =
-        rdbmsService
-            .getProcessDefinitionReader()
-            .search(
-                ProcessDefinitionDbQuery.of(
-                    b -> b.filter(query.filter()).sort(query.sort()).page(query.page())));
-
-    return new SearchQueryResult<>(searchResult.total(), searchResult.hits(), null);
+    return rdbmsService.getProcessDefinitionReader().search(query);
   }
 }

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -45,6 +45,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>webapps-schema</artifactId>
     </dependency>
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/FlowNodeExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/FlowNodeExportHandler.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.util.DateUtil;
 import java.time.Instant;
 import java.util.Set;
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/ProcessInstanceExportHandler.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.util.DateUtil;
 import java.time.Instant;
 
 public class ProcessInstanceExportHandler

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/VariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/VariableExportHandler.java
@@ -46,6 +46,7 @@ public class VariableExportHandler implements RdbmsExportHandler<VariableRecordV
         .value(value.getValue())
         .scopeKey(value.getScopeKey())
         .processInstanceKey(value.getProcessInstanceKey())
+        .processDefinitionId(value.getBpmnProcessId())
         .tenantId(value.getTenantId())
         .build();
   }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/DateUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/DateUtil.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.zeebe.util;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -17,5 +17,18 @@ public final class DateUtil {
 
   public static OffsetDateTime toOffsetDateTime(final Instant timestamp) {
     return OffsetDateTime.ofInstant(timestamp, ZoneOffset.UTC);
+  }
+
+  public static OffsetDateTime fuzzyToOffsetDateTime(final Object object) {
+    return switch (object) {
+      case null -> null;
+      case final OffsetDateTime offsetDateTime -> offsetDateTime;
+      case final Instant instant -> toOffsetDateTime(instant);
+      case final Long l -> toOffsetDateTime(Instant.ofEpochMilli(l));
+      case final String s -> OffsetDateTime.parse(s);
+      default ->
+          throw new IllegalArgumentException(
+              "Could not convert " + object.getClass() + " to OffsetDateTime");
+    };
   }
 }


### PR DESCRIPTION
## Description

With this PR rdbms supports keyset based paging for processInstance

The solution is mainly based on https://www.cybertec-postgresql.com/en/keyset-pagination-with-descending-order/ Chapter "Keyset Pagination by splitting up the query".

To support keyset paging with searchAfter and mixed search orders (ASC, DESC), I needed to use a more complex WHERE clause. E.g. when we have a query with orderBy: "processName, startDate DESC, key" and sortValues ["Process A", "2024-10-10T08:00:00Z", 1234L], we deflate this expression to:

```sql
WHERE (name > "Process A")
   OR (name = "Process A" AND startDate < "2024-10-10T08:00:00Z")
   OR (name = "Process A" AND startDate = "2024-10-10T08:00:00Z" AND key > 1234)
```

closes #23997
