### PR TITLE
[Backport stable/8.4] fix: set the correct elementId in Incident record when Job throw with no catch event

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.Optional;
+import org.agrona.DirectBuffer;
 
 public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
 
@@ -92,9 +93,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final JobRecord job) {
     jobMetrics.jobErrorThrown(job.getType());
 
-    final var serviceTaskInstanceKey = job.getElementId();
-
-    if (NO_CATCH_EVENT_FOUND.equals(serviceTaskInstanceKey)) {
+    if (NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
       raiseIncident(jobKey, job, stateWriter, foundCatchEvent.getLeft());
       return;
     }
@@ -160,12 +159,22 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
         .setBpmnProcessId(job.getBpmnProcessIdBuffer())
         .setProcessDefinitionKey(job.getProcessDefinitionKey())
         .setProcessInstanceKey(job.getProcessInstanceKey())
-        .setElementId(job.getElementIdBuffer())
+        .setElementId(getElementId(job))
         .setElementInstanceKey(job.getElementInstanceKey())
         .setTenantId(job.getTenantId())
         .setJobKey(key)
         .setVariableScopeKey(job.getElementInstanceKey());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
+  }
+
+  private DirectBuffer getElementId(final JobRecord job) {
+    if (NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
+      final var elementInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
+      if (elementInstance != null) {
+        return elementInstance.getValue().getElementIdBuffer();
+      }
+    }
+    return job.getElementIdBuffer();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -258,7 +258,13 @@ public final class EventAppliers implements EventApplier {
         new IncidentCreatedApplier(state.getIncidentState(), state.getJobState()));
     register(
         IncidentIntent.RESOLVED,
-        new IncidentResolvedApplier(
+        1,
+        new IncidentResolvedV1Applier(
+            state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
+    register(
+        IncidentIntent.RESOLVED,
+        2,
+        new IncidentResolvedV2Applier(
             state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -264,8 +264,7 @@ public final class EventAppliers implements EventApplier {
     register(
         IncidentIntent.RESOLVED,
         2,
-        new IncidentResolvedV2Applier(
-            state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
+        new IncidentResolvedV2Applier(state.getIncidentState(), state.getJobState()));
   }
 
   private void registerProcessMessageSubscriptionEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
@@ -45,7 +45,7 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
       final var stateOfJob = jobState.getState(jobKey);
       if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
         final var job = jobState.getJob(jobKey);
-        resetElementId(job);
+        resetElementId(job, value.getElementId());
         jobState.resolve(jobKey, job);
       }
     }
@@ -56,13 +56,10 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
    * {@link JobThrowErrorProcessor} sets the job's elementId to NO_CATCH_EVENT_FOUND for unhandled
    * error incidents. In order to completely resolve the issue, the elementId must be reset.
    */
-  private void resetElementId(final JobRecord job) {
+  private void resetElementId(final JobRecord job, final String incidentElementId) {
     if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
-      final var elementInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
-      if (elementInstance != null) {
-        // change the job object here, it will be persisted with the jobState.resolve call
-        job.setElementId(elementInstance.getValue().getElementId());
-      }
+      // change the job object here, it will be persisted with the jobState.resolve call
+      job.setElementId(incidentElementId);
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV1Applier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV1Applier.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import java.util.EnumSet;
 import java.util.Set;
 
-final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+final class IncidentResolvedV1Applier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
 
   private static final Set<State> RESOLVABLE_JOB_STATES =
       EnumSet.of(State.FAILED, State.ERROR_THROWN);
@@ -28,7 +28,7 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
   private final MutableJobState jobState;
   private final ElementInstanceState elementInstanceState;
 
-  public IncidentResolvedApplier(
+  public IncidentResolvedV1Applier(
       final MutableIncidentState incidentState,
       final MutableJobState jobState,
       final ElementInstanceState elementInstanceState) {
@@ -45,7 +45,7 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
       final var stateOfJob = jobState.getState(jobKey);
       if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
         final var job = jobState.getJob(jobKey);
-        resetElementId(job, value.getElementId());
+        resetElementId(job);
         jobState.resolve(jobKey, job);
       }
     }
@@ -56,10 +56,13 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
    * {@link JobThrowErrorProcessor} sets the job's elementId to NO_CATCH_EVENT_FOUND for unhandled
    * error incidents. In order to completely resolve the issue, the elementId must be reset.
    */
-  private void resetElementId(final JobRecord job, final String incidentElementId) {
+  private void resetElementId(final JobRecord job) {
     if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
-      // change the job object here, it will be persisted with the jobState.resolve call
-      job.setElementId(incidentElementId);
+      final var elementInstance = elementInstanceState.getInstance(job.getElementInstanceKey());
+      if (elementInstance != null) {
+        // change the job object here, it will be persisted with the jobState.resolve call
+        job.setElementId(elementInstance.getValue().getElementId());
+      }
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.engine.state.appliers;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import java.util.EnumSet;
+import java.util.Set;
+
+final class IncidentResolvedV2Applier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+
+  private static final Set<State> RESOLVABLE_JOB_STATES =
+      EnumSet.of(State.FAILED, State.ERROR_THROWN);
+
+  private final MutableIncidentState incidentState;
+  private final MutableJobState jobState;
+  private final MutableElementInstanceState elementInstanceState;
+
+  public IncidentResolvedV2Applier(
+      final MutableIncidentState incidentState,
+      final MutableJobState jobState,
+      final MutableElementInstanceState elementInstanceState) {
+    this.incidentState = incidentState;
+    this.jobState = jobState;
+    this.elementInstanceState = elementInstanceState;
+  }
+
+  @Override
+  public void applyState(final long incidentKey, final IncidentRecord value) {
+    if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
+      resetExecutionListenerIndex(value);
+    }
+
+    final var jobKey = value.getJobKey();
+    final boolean isJobRelatedIncident = jobKey > 0;
+
+    if (isJobRelatedIncident) {
+      final var stateOfJob = jobState.getState(jobKey);
+      if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
+        final var job = jobState.getJob(jobKey);
+        resetElementId(job, value.getElementId());
+        jobState.resolve(jobKey, job);
+      }
+    }
+    incidentState.deleteIncident(incidentKey);
+  }
+
+  private void resetExecutionListenerIndex(final IncidentRecord value) {
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.resetExecutionListenerIndex();
+      elementInstanceState.updateInstance(elementInstance);
+    }
+  }
+
+  /**
+   * {@link JobThrowErrorProcessor} sets the job's elementId to NO_CATCH_EVENT_FOUND for unhandled
+   * error incidents. In order to completely resolve the issue, the elementId must be reset.
+   */
+  private void resetElementId(final JobRecord job, final String incidentRecordElementId) {
+    if (JobThrowErrorProcessor.NO_CATCH_EVENT_FOUND.equals(job.getElementId())) {
+      // change the job object here, it will be persisted with the jobState.resolve call
+      job.setElementId(incidentRecordElementId);
+    }
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
@@ -10,13 +10,11 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
-import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.value.ErrorType;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -27,23 +25,15 @@ final class IncidentResolvedV2Applier implements TypedEventApplier<IncidentInten
 
   private final MutableIncidentState incidentState;
   private final MutableJobState jobState;
-  private final MutableElementInstanceState elementInstanceState;
 
   public IncidentResolvedV2Applier(
-      final MutableIncidentState incidentState,
-      final MutableJobState jobState,
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableIncidentState incidentState, final MutableJobState jobState) {
     this.incidentState = incidentState;
     this.jobState = jobState;
-    this.elementInstanceState = elementInstanceState;
   }
 
   @Override
   public void applyState(final long incidentKey, final IncidentRecord value) {
-    if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
-      resetExecutionListenerIndex(value);
-    }
-
     final var jobKey = value.getJobKey();
     final boolean isJobRelatedIncident = jobKey > 0;
 
@@ -56,14 +46,6 @@ final class IncidentResolvedV2Applier implements TypedEventApplier<IncidentInten
       }
     }
     incidentState.deleteIncident(incidentKey);
-  }
-
-  private void resetExecutionListenerIndex(final IncidentRecord value) {
-    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
-    if (elementInstance != null) {
-      elementInstance.resetExecutionListenerIndex();
-      elementInstanceState.updateInstance(elementInstance);
-    }
   }
 
   /**

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/ErrorEventIncidentTest.java
@@ -120,7 +120,6 @@ public final class ErrorEventIncidentTest {
         .hasBpmnProcessId(jobEvent.getValue().getBpmnProcessId())
         .hasProcessDefinitionKey(jobEvent.getValue().getProcessDefinitionKey())
         .hasProcessInstanceKey(jobEvent.getValue().getProcessInstanceKey())
-        .hasElementId(jobEvent.getValue().getElementId())
         .hasElementInstanceKey(jobEvent.getValue().getElementInstanceKey())
         .hasVariableScopeKey(jobEvent.getValue().getElementInstanceKey())
         .hasJobKey(jobEvent.getKey());
@@ -202,10 +201,11 @@ public final class ErrorEventIncidentTest {
         .withErrorCode(ERROR_CODE)
         .throwError();
 
+    final String elementIdThrowingIncident = "task-in-subprocess";
     final var jobKey =
         RecordingExporter.jobRecords(JobIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
-            .withElementId("task-in-subprocess")
+            .withElementId(elementIdThrowingIncident)
             .getFirst()
             .getKey();
 
@@ -223,7 +223,7 @@ public final class ErrorEventIncidentTest {
             String.format(
                 "Expected to throw an error event with the code '%s', but it was not caught. No error events are available in the scope.",
                 ERROR_CODE))
-        .hasElementId("NO_CATCH_EVENT_FOUND");
+        .hasElementId(elementIdThrowingIncident);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #24206 to `stable/8.4`.

### Changes compared to original PR were mainly:
- Probably different folder structure, so I had just to accept the additions as is.
- Then the changes in the commit https://github.com/camunda/camunda/pull/24225/commits/70b37a057c204c0f9ba286650ff83859a0d2e9b8: since in this version we didn't have the `resetExecutionListenerIndex` yet. I removed this code to match with V1, and removed the `elementInstanceState` field, since it was not used anymore.
- Updated licence

relates to #21567
original author: @mustafadagher