### PR TITLE
Add GroupState for group management

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbFormState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.group.DbGroupState;
+import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.instance.DbElementInstanceState;
@@ -47,6 +49,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
@@ -112,6 +115,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableRoutingState routingState;
   private final MutableTenantState tenantState;
   private final MutableRoleState roleState;
+  private final MutableGroupState groupState;
   private final MutableMappingState mappingState;
 
   private final int partitionId;
@@ -162,6 +166,7 @@ public class ProcessingDbState implements MutableProcessingState {
     authorizationState = new DbAuthorizationState(zeebeDb, transactionContext);
     routingState = new DbRoutingState(zeebeDb, transactionContext);
     roleState = new DbRoleState(zeebeDb, transactionContext);
+    groupState = new DbGroupState(zeebeDb, transactionContext);
     tenantState = new DbTenantState(zeebeDb, transactionContext);
     mappingState = new DbMappingState(zeebeDb, transactionContext);
   }
@@ -302,6 +307,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableRoleState getRoleState() {
     return roleState;
+  }
+
+  @Override
+  public GroupState getGroupState() {
+    return groupState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.state.deployment.DbFormState;
 import io.camunda.zeebe.engine.state.deployment.DbProcessState;
 import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
 import io.camunda.zeebe.engine.state.group.DbGroupState;
-import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.instance.DbElementInstanceState;
@@ -310,7 +309,7 @@ public class ProcessingDbState implements MutableProcessingState {
   }
 
   @Override
-  public GroupState getGroupState() {
+  public MutableGroupState getGroupState() {
     return groupState;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedRole extends UnpackedObject implements DbValue {
 
-  private final LongProperty roleKeyProp = new LongProperty("roleKey", -1L);
-  private final StringProperty nameProp = new StringProperty("name", "");
+  private final LongProperty roleKeyProp = new LongProperty("roleKey");
+  private final StringProperty nameProp = new StringProperty("name");
 
   public PersistedRole() {
     super(2);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.state.authorization.EntityTypeValue;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -27,8 +28,11 @@ public class DbGroupState implements MutableGroupState {
   private final DbLong entityKey;
   private final DbCompositeKey<DbForeignKey<DbLong>, DbLong> fkGroupKeyAndEntityKey;
   private final EntityTypeValue entityTypeValue = new EntityTypeValue();
-  private ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbLong>, EntityTypeValue>
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbLong>, EntityTypeValue>
       entityTypeByGroupColumnFamily;
+
+  private final DbString groupName;
+  private final ColumnFamily<DbString, DbForeignKey<DbLong>> groupByNameColumnFamily;
 
   public DbGroupState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -47,5 +51,10 @@ public class DbGroupState implements MutableGroupState {
             transactionContext,
             fkGroupKeyAndEntityKey,
             entityTypeValue);
+
+    groupName = new DbString();
+    groupByNameColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.GROUP_BY_NAME, transactionContext, groupName, fkGroupKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.group;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+
+public class DbGroupState implements MutableGroupState {
+
+  public DbGroupState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -7,13 +7,25 @@
  */
 package io.camunda.zeebe.engine.state.group;
 
+import io.camunda.zeebe.db.ColumnFamily;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 
 public class DbGroupState implements MutableGroupState {
 
+  private final DbLong groupKey;
+  private final PersistedGroup persistedGroup = new PersistedGroup();
+  private final ColumnFamily<DbLong, PersistedGroup> groupColumnFamily;
+
   public DbGroupState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {}
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+
+    groupKey = new DbLong();
+    groupColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.GROUPS, transactionContext, groupKey, persistedGroup);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.group;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public class PersistedGroup extends UnpackedObject implements DbValue {
+
+  private final LongProperty groupKeyProp = new LongProperty("groupKey", -1L);
+  private final StringProperty nameProp = new StringProperty("name", "");
+
+  public PersistedGroup() {
+    super(2);
+    declareProperty(groupKeyProp);
+    declareProperty(nameProp);
+  }
+
+  public long getGroupKey() {
+    return groupKeyProp.getValue();
+  }
+
+  public PersistedGroup setGroupKey(final long groupKey) {
+    groupKeyProp.setValue(groupKey);
+    return this;
+  }
+
+  public String getName() {
+    return BufferUtil.bufferAsString(nameProp.getValue());
+  }
+
+  public PersistedGroup setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  public PersistedGroup copy() {
+    return new PersistedGroup();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -15,8 +15,8 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedGroup extends UnpackedObject implements DbValue {
 
-  private final LongProperty groupKeyProp = new LongProperty("groupKey", -1L);
-  private final StringProperty nameProp = new StringProperty("name", "");
+  private final LongProperty groupKeyProp = new LongProperty("groupKey");
+  private final StringProperty nameProp = new StringProperty("name");
 
   public PersistedGroup() {
     super(2);
@@ -40,9 +40,5 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
   public PersistedGroup setName(final String name) {
     nameProp.setValue(name);
     return this;
-  }
-
-  public PersistedGroup copy() {
-    return new PersistedGroup();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+public interface GroupState {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -72,6 +72,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   RoleState getRoleState();
 
+  GroupState getGroupState();
+
   TenantState getTenantState();
 
   MappingState getMappingState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.GroupState;
+
+public interface MutableGroupState extends GroupState {}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
-import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -92,7 +91,7 @@ public interface MutableProcessingState extends ProcessingState {
   MutableRoleState getRoleState();
 
   @Override
-  GroupState getGroupState();
+  MutableGroupState getGroupState();
 
   @Override
   MutableTenantState getTenantState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
+import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -89,6 +90,9 @@ public interface MutableProcessingState extends ProcessingState {
 
   @Override
   MutableRoleState getRoleState();
+
+  @Override
+  GroupState getGroupState();
 
   @Override
   MutableTenantState getTenantState();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedTenant extends UnpackedObject implements DbValue {
 
-  private final LongProperty tenantKeyProp = new LongProperty("tenantKey", -1L);
-  private final StringProperty tenantIdProp = new StringProperty("tenantId", "");
+  private final LongProperty tenantKeyProp = new LongProperty("tenantKey");
+  private final StringProperty tenantIdProp = new StringProperty("tenantId");
   private final StringProperty nameProp = new StringProperty("name", "");
 
   public PersistedTenant() {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -214,7 +214,8 @@ public enum ZbColumnFamilies implements EnumValue {
   USER_TASK_RECORD_REQUEST_METADATA(109),
 
   GROUPS(110),
-  ENTITY_BY_GROUP(111);
+  ENTITY_BY_GROUP(111),
+  GROUP_BY_NAME(112);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -211,7 +211,9 @@ public enum ZbColumnFamilies implements EnumValue {
   MAPPINGS(107),
   CLAIM_BY_KEY(108),
 
-  USER_TASK_RECORD_REQUEST_METADATA(109);
+  USER_TASK_RECORD_REQUEST_METADATA(109),
+
+  GROUPS(110);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -213,7 +213,8 @@ public enum ZbColumnFamilies implements EnumValue {
 
   USER_TASK_RECORD_REQUEST_METADATA(109),
 
-  GROUPS(110);
+  GROUPS(110),
+  ENTITY_BY_GROUP(111);
 
   private final int value;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Define basic Zeebe state interfaces and classes for Group management and link them to the `ProcessingState` classes. Basic `DbGroupState` properties and column families are also defined.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23477 
