### PR TITLE
Move BatchOperationTemplate to webapps

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
@@ -9,10 +9,8 @@ package io.camunda.webapps.schema.descriptors.operate.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
-import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
-public class BatchOperationTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+public class BatchOperationTemplate extends OperateTemplateDescriptor implements Prio3Backup {
 
   public static final String INDEX_NAME = "batch-operation";
 
@@ -39,7 +37,6 @@ public class BatchOperationTemplate extends OperateTemplateDescriptor
 
   @Override
   public String getVersion() {
-    // TODO: Determine what is the correct version
-    return "8.3.0";
+    return "8.1.0";
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/BatchOperationTemplate.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.operate.template;
+
+import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+
+public class BatchOperationTemplate extends OperateTemplateDescriptor
+    implements ProcessInstanceDependant, Prio3Backup {
+
+  public static final String INDEX_NAME = "batch-operation";
+
+  public static final String ID = "id";
+  public static final String TYPE = "type";
+  public static final String NAME = "name";
+  public static final String USERNAME = "username";
+  public static final String START_DATE = "startDate";
+  public static final String END_DATE = "endDate";
+  public static final String INSTANCES_COUNT = "instancesCount";
+  public static final String OPERATIONS_TOTAL_COUNT = "operationsTotalCount";
+  public static final String OPERATIONS_FINISHED_COUNT = "operationsFinishedCount";
+  public static final String FAILED_OPERATIONS_COUNT = "failedOperationsCount";
+  public static final String COMPLETED_OPERATIONS_COUNT = "completedOperationsCount";
+
+  public BatchOperationTemplate(final String indexPrefix, final boolean isElasticsearch) {
+    super(indexPrefix, isElasticsearch);
+  }
+
+  @Override
+  public String getIndexName() {
+    return INDEX_NAME;
+  }
+
+  @Override
+  public String getVersion() {
+    // TODO: Determine what is the correct version
+    return "8.3.0";
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -46,6 +46,7 @@ import io.camunda.webapps.schema.descriptors.operate.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
@@ -102,7 +103,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             EventTemplate.class,
             new EventTemplate(globalPrefix, isElasticsearch),
             TaskTemplate.class,
-            new TaskTemplate(globalPrefix, isElasticsearch));
+            new TaskTemplate(globalPrefix, isElasticsearch),
+            BatchOperationTemplate.class,
+            new BatchOperationTemplate(globalPrefix, isElasticsearch));
 
     indexDescriptorsMap =
         Map.of(


### PR DESCRIPTION
## Description

This PR moves the to the schema webapps since we need to use this template in the future to migrate `BatchOperationArchiverJob` to the camunda exporter.

The version returned in this migrated template is the same as in the original one in operate one since this was an extension of [AbstractIndexDescriptor](https://github.com/camunda/camunda/blob/b88820c5cec26171efc9a93e761705c15dab1dec/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java).

relates to https://github.com/camunda/camunda/issues/24093

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
