### PR TITLE
feat: enable log4j2 AsyncLogger globally

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -346,7 +346,12 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>
-
+    <!-- Needed by log4j2 with async appenders -->
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>3.4.4</version>
+    </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>

--- a/dist/src/main/resources/log4j2.component.properties
+++ b/dist/src/main/resources/log4j2.component.properties
@@ -9,3 +9,6 @@
 log4j2.enableThreadlocals=true
 log4j2.enableDirectEncoders=true
 log4j2.garbagefreeThreadContextMap=true
+log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+log4j2.initialReusableMsgSize=1024
+log4j2.asyncQueueFullPolicy=Discard


### PR DESCRIPTION
# Description

Enable the AsyncLogger everywhere.
When the ringbuffer is full, all messages with LOG_LEVEL <= Info will be discarded, to avoid blocking the caller.



closes #24222 
