### PR TITLE
Add support for filtering listener per flow node instance

### DIFF
--- a/operate/client/e2e-playwright/pages/ProcessInstance.ts
+++ b/operate/client/e2e-playwright/pages/ProcessInstance.ts
@@ -30,6 +30,7 @@ export class ProcessInstance {
   readonly executionCountToggleOff: Locator;
   readonly listenersTabButton: Locator;
   readonly metadataModal: Locator;
+  readonly modifyInstanceButton: Locator;
 
   constructor(page: Page) {
     this.page = page;
@@ -57,6 +58,7 @@ export class ProcessInstance {
     );
     this.listenersTabButton = page.getByTestId('listeners-tab-button');
     this.metadataModal = this.page.getByRole('dialog', {name: /metadata/i});
+    this.modifyInstanceButton = page.getByTestId('enter-modification-mode');
   }
 
   getEditVariableFieldSelector(variableName: string) {

--- a/operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts
@@ -32,8 +32,8 @@ test.beforeAll(async ({request}) => {
     .toBe(200);
 });
 
+// @TODO: remove .skip when tests are fixed
 test.describe.skip('Process Instance Listeners', () => {
-  // TODO: remove .skip when we can use Zeebe SNAPSHOT or 8.6 version for E2E tests
   test('Listeners tab button show/hide', async ({
     page,
     processInstancePage,
@@ -58,5 +58,61 @@ test.describe.skip('Process Instance Listeners', () => {
     await processInstancePage.listenersTabButton.click();
 
     await expect(page.getByText('Execution listener')).toBeVisible();
+  });
+
+  // @TODO: remove skip flag when BE ticket is merged - https://github.com/camunda/camunda/issues/23942
+  test.skip('Listeners list filtered by flow node instance', async ({
+    page,
+    processInstancePage,
+  }) => {
+    const processInstanceKey = initialData.instance.processInstanceKey;
+    processInstancePage.navigateToProcessInstance({id: processInstanceKey});
+
+    // select flow node in diagram, check amount of listeners and add a token to it
+    await processInstancePage.diagram.clickFlowNode('Service Task B');
+    await processInstancePage.listenersTabButton.click();
+    expect(
+      await page
+        .getByRole('row')
+        .filter({hasText: /execution listener/i})
+        .count(),
+    ).toBe(1);
+    await processInstancePage.modifyInstanceButton.click();
+    await page.getByRole('button', {name: 'Continue'}).click();
+    await processInstancePage.diagram.clickFlowNode('Service Task B');
+    await page
+      .getByRole('button', {name: 'Add single flow node instance'})
+      .click();
+    await page.getByRole('button', {name: 'Apply Modifications'}).click();
+    //confirm modal
+    await page.getByRole('button', {name: 'Apply', exact: true}).click();
+
+    // wait for new instance to appear on instance history
+    const instanceHistoryPanel = page.getByTestId('instance-history');
+    await expect
+      .poll(async () => {
+        return instanceHistoryPanel.getByText('Service Task B').count();
+      })
+      .toBe(2);
+
+    // select flow node again, it should have 2 listeners (1 for each instance)
+    await processInstancePage.diagram.clickFlowNode('Service Task B');
+    await processInstancePage.listenersTabButton.click();
+    expect(
+      await page
+        .getByRole('row')
+        .filter({hasText: /execution listener/i})
+        .count(),
+    ).toBe(2);
+
+    // select a flow node instance, check it has only 1 corresponding listener
+    await instanceHistoryPanel.getByText('Service Task B').first().click();
+    await processInstancePage.listenersTabButton.click();
+    expect(
+      await page
+        .getByRole('row')
+        .filter({hasText: /execution listener/i})
+        .count(),
+    ).toBe(1);
   });
 });

--- a/operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceListeners.spec.ts
@@ -32,8 +32,7 @@ test.beforeAll(async ({request}) => {
     .toBe(200);
 });
 
-// @TODO: remove .skip when tests are fixed
-test.describe.skip('Process Instance Listeners', () => {
+test.describe('Process Instance Listeners', () => {
   test('Listeners tab button show/hide', async ({
     page,
     processInstancePage,
@@ -60,8 +59,7 @@ test.describe.skip('Process Instance Listeners', () => {
     await expect(page.getByText('Execution listener')).toBeVisible();
   });
 
-  // @TODO: remove skip flag when BE ticket is merged - https://github.com/camunda/camunda/issues/23942
-  test.skip('Listeners list filtered by flow node instance', async ({
+  test('Listeners list filtered by flow node instance', async ({
     page,
     processInstancePage,
   }) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
@@ -44,7 +44,7 @@ const Listeners: React.FC<Props> = observer(({listeners}) => {
             return;
           }
 
-          await processInstanceListenersStore.fetchPreviousInstances();
+          await processInstanceListenersStore.fetchPreviousListeners();
 
           if (
             processInstanceListenersStore.state?.listeners?.length ===
@@ -65,7 +65,7 @@ const Listeners: React.FC<Props> = observer(({listeners}) => {
             return;
           }
 
-          processInstanceListenersStore.fetchNextInstances();
+          processInstanceListenersStore.fetchNextListeners();
         }}
         rows={listeners?.map(
           ({listenerType, listenerKey, state, jobType, event, time}) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
@@ -39,13 +39,16 @@ const VariablePanel = observer(function VariablePanel() {
   }, [processInstanceId]);
 
   useEffect(() => {
-    if (!flowNodeInstanceId) {
+    if (!flowNodeInstanceId && flowNodeId) {
       fetchListeners({
         fetchType: 'initial',
         processInstanceId: processInstanceId,
         payload: {flowNodeId},
       });
-    } else {
+    } else if (
+      flowNodeInstanceId &&
+      !flowNodeSelectionStore.isRootNodeSelected
+    ) {
       fetchListeners({
         fetchType: 'initial',
         processInstanceId: processInstanceId,

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/index.tsx
@@ -23,6 +23,8 @@ const VariablePanel = observer(function VariablePanel() {
   const {processInstanceId = ''} = useProcessInstancePageParams();
 
   const flowNodeId = flowNodeSelectionStore.state.selection?.flowNodeId;
+  const flowNodeInstanceId =
+    flowNodeSelectionStore.state.selection?.flowNodeInstanceId;
 
   const {fetchListeners, state, listenersFailureCount, hasFlowNodeListeners} =
     processInstanceListenersStore;
@@ -37,14 +39,20 @@ const VariablePanel = observer(function VariablePanel() {
   }, [processInstanceId]);
 
   useEffect(() => {
-    if (flowNodeId) {
+    if (!flowNodeInstanceId) {
       fetchListeners({
         fetchType: 'initial',
         processInstanceId: processInstanceId,
         payload: {flowNodeId},
       });
+    } else {
+      fetchListeners({
+        fetchType: 'initial',
+        processInstanceId: processInstanceId,
+        payload: {flowNodeInstanceId},
+      });
     }
-  }, [fetchListeners, processInstanceId, flowNodeId]);
+  }, [fetchListeners, processInstanceId, flowNodeId, flowNodeInstanceId]);
 
   return (
     <TabView

--- a/operate/client/src/modules/api/processInstances/fetchProcessInstanceListeners.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessInstanceListeners.ts
@@ -14,7 +14,8 @@ type ListenersDto = {
 };
 
 type ListenerPayload = {
-  flowNodeId: string;
+  flowNodeId?: string;
+  flowNodeInstanceId?: string;
   sorting?: {
     sortBy: string;
     sortOrder: 'desc' | 'asc';

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -6,30 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {RequestHandler, rest} from 'msw';
-import {mockListenerInstancesShort} from 'modules/mocks/mockListenerInstances';
-import {ListenerPayload} from 'modules/api/processInstances/fetchProcessInstanceListeners';
+import {RequestHandler} from 'msw';
 
-const listenersHandler = [
-  rest.post(
-    '/api/process-instances/:instanceId/listeners',
-    async (req, res, ctx) => {
-      const body: ListenerPayload = await req.json();
-
-      if (body.flowNodeId) {
-        return res(
-          ctx.json({totalCount: 1, listeners: [mockListenerInstancesShort[0]]}),
-        );
-      } else if (body.flowNodeInstanceId) {
-        return res(
-          ctx.json({totalCount: 1, listeners: [mockListenerInstancesShort[1]]}),
-        );
-      }
-      return res(ctx.json([]));
-    },
-  ),
-];
-
-const handlers: RequestHandler[] = [...listenersHandler];
+const handlers: RequestHandler[] = [];
 
 export {handlers};

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -6,8 +6,30 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {RequestHandler} from 'msw';
+import {RequestHandler, rest} from 'msw';
+import {mockListenerInstancesShort} from 'modules/mocks/mockListenerInstances';
+import {ListenerPayload} from 'modules/api/processInstances/fetchProcessInstanceListeners';
 
-const handlers: RequestHandler[] = [];
+const listenersHandler = [
+  rest.post(
+    '/api/process-instances/:instanceId/listeners',
+    async (req, res, ctx) => {
+      const body: ListenerPayload = await req.json();
+
+      if (body.flowNodeId) {
+        return res(
+          ctx.json({totalCount: 1, listeners: [mockListenerInstancesShort[0]]}),
+        );
+      } else if (body.flowNodeInstanceId) {
+        return res(
+          ctx.json({totalCount: 1, listeners: [mockListenerInstancesShort[1]]}),
+        );
+      }
+      return res(ctx.json([]));
+    },
+  ),
+];
+
+const handlers: RequestHandler[] = [...listenersHandler];
 
 export {handlers};

--- a/operate/client/src/modules/mocks/mockListenerInstances.ts
+++ b/operate/client/src/modules/mocks/mockListenerInstances.ts
@@ -171,4 +171,25 @@ const mockListenerInstances: ListenerEntity[] = [
   },
 ];
 
-export {mockListenerInstances};
+const mockListenerInstancesShort: ListenerEntity[] = [
+  {
+    listenerType: 'EXECUTION_LISTENER',
+    listenerKey: 'FLOW NODE',
+    state: 'ACTIVE',
+    event: 'START',
+    jobType: 'EVENT',
+    time: '2024-01-02 10:52:16',
+    sortValues: ['1'],
+  },
+  {
+    listenerType: 'USER_TASK_LISTENER',
+    listenerKey: 'INSTANCE',
+    state: 'ACTIVE',
+    event: 'START',
+    jobType: 'EVENT',
+    time: '2024-01-02 10:53:16',
+    sortValues: ['2'],
+  },
+];
+
+export {mockListenerInstances, mockListenerInstancesShort};

--- a/operate/client/src/modules/stores/processInstanceListeners.test.ts
+++ b/operate/client/src/modules/stores/processInstanceListeners.test.ts
@@ -100,7 +100,7 @@ describe('stores/processInstancesListeners', () => {
       ],
     });
 
-    processInstanceListenersStore.fetchNextInstances();
+    processInstanceListenersStore.fetchNextListeners();
 
     expect(processInstanceListenersStore.state.status).toBe('fetching-next');
     await waitFor(() =>
@@ -124,7 +124,7 @@ describe('stores/processInstancesListeners', () => {
       listeners: [{...instance, listenerKey: '200'}],
     });
 
-    processInstanceListenersStore.fetchNextInstances();
+    processInstanceListenersStore.fetchNextListeners();
 
     expect(processInstanceListenersStore.state.status).toBe('fetching-next');
     await waitFor(() =>
@@ -159,7 +159,7 @@ describe('stores/processInstancesListeners', () => {
       listeners: [{...instance, listenerKey: '100'}],
     });
 
-    processInstanceListenersStore.fetchPreviousInstances();
+    processInstanceListenersStore.fetchPreviousListeners();
 
     expect(processInstanceListenersStore.state.status).toBe('fetching-prev');
     await waitFor(() =>
@@ -180,7 +180,7 @@ describe('stores/processInstancesListeners', () => {
       listeners: [{...instance, listenerKey: '200'}],
     });
 
-    processInstanceListenersStore.fetchPreviousInstances();
+    processInstanceListenersStore.fetchPreviousListeners();
 
     expect(processInstanceListenersStore.state.status).toBe('fetching-prev');
     await waitFor(() =>

--- a/operate/client/src/modules/stores/processInstanceListeners.test.ts
+++ b/operate/client/src/modules/stores/processInstanceListeners.test.ts
@@ -80,8 +80,6 @@ describe('stores/processInstancesListeners', () => {
   });
 
   it('should fetch next listeners', async () => {
-    mockFetchProcessInstanceListeners().withSuccess(mockListenerInstances);
-
     expect(processInstanceListenersStore.state.status).toBe('initial');
 
     processInstanceListenersStore.fetchListeners({
@@ -144,8 +142,6 @@ describe('stores/processInstancesListeners', () => {
   });
 
   it('should fetch previous listeners', async () => {
-    mockFetchProcessInstanceListeners().withSuccess(mockListenerInstances);
-
     expect(processInstanceListenersStore.state.status).toBe('initial');
 
     processInstanceListenersStore.fetchListeners({

--- a/operate/client/src/modules/stores/processInstanceListeners.ts
+++ b/operate/client/src/modules/stores/processInstanceListeners.ts
@@ -179,7 +179,7 @@ class ProcessInstanceListeners {
     );
   };
 
-  fetchPreviousInstances = async () => {
+  fetchPreviousListeners = async () => {
     this.startFetchingPrev();
 
     let payloadId = {};
@@ -201,7 +201,7 @@ class ProcessInstanceListeners {
     });
   };
 
-  fetchNextInstances = async () => {
+  fetchNextListeners = async () => {
     this.startFetchingNext();
 
     let payloadId = {};

--- a/operate/client/src/modules/stores/processInstanceListeners.ts
+++ b/operate/client/src/modules/stores/processInstanceListeners.ts
@@ -15,6 +15,11 @@ import {
 
 type FetchType = 'initial' | 'prev' | 'next';
 
+type CurrentId = {
+  type: 'flowNode' | 'flowNodeInstance' | null;
+  value: string;
+};
+
 type State = {
   listenersCount: number;
   listeners: ListenersDto['listeners'];
@@ -32,7 +37,7 @@ type State = {
     | 'fetched'
     | 'error';
   currentProcessInstanceId: ProcessInstanceEntity['id'];
-  currentFlowNodeId: string;
+  currentId: CurrentId;
 };
 
 const DEFAULT_STATE: State = {
@@ -42,14 +47,16 @@ const DEFAULT_STATE: State = {
   latestFetch: {fetchType: null, itemsCount: 0},
   status: 'initial',
   currentProcessInstanceId: '',
-  currentFlowNodeId: '',
+  currentId: {
+    type: null,
+    value: '',
+  },
 };
 
 const MAX_LISTENERS_STORED = 200;
 const MAX_LISTENERS_PER_REQUEST = 50;
 
 const DEFAULT_PAYLOAD: ListenerPayload = {
-  flowNodeId: '',
   pageSize: MAX_LISTENERS_PER_REQUEST,
   searchAfter: [],
   searchBefore: [],
@@ -175,11 +182,19 @@ class ProcessInstanceListeners {
   fetchPreviousInstances = async () => {
     this.startFetchingPrev();
 
+    let payloadId = {};
+
+    if (this.state.currentId.type === 'flowNode') {
+      payloadId = {flowNodeId: this.state.currentId.value};
+    } else if (this.state.currentId.type === 'flowNodeInstance') {
+      payloadId = {flowNodeInstanceId: this.state.currentId.value};
+    }
+
     return this.fetchListeners({
       fetchType: 'prev',
       processInstanceId: this.state.currentProcessInstanceId,
       payload: {
-        flowNodeId: this.state.currentFlowNodeId,
+        ...payloadId,
         searchBefore: this.state.listeners[0]?.sortValues,
         pageSize: MAX_LISTENERS_PER_REQUEST,
       },
@@ -189,11 +204,19 @@ class ProcessInstanceListeners {
   fetchNextInstances = async () => {
     this.startFetchingNext();
 
+    let payloadId = {};
+
+    if (this.state.currentId.type === 'flowNode') {
+      payloadId = {flowNodeId: this.state.currentId.value};
+    } else if (this.state.currentId.type === 'flowNodeInstance') {
+      payloadId = {flowNodeInstanceId: this.state.currentId.value};
+    }
+
     return this.fetchListeners({
       fetchType: 'next',
       processInstanceId: this.state.currentProcessInstanceId,
       payload: {
-        flowNodeId: this.state.currentFlowNodeId,
+        ...payloadId,
         searchAfter:
           this.state.listeners[this.state.listeners.length - 1]?.sortValues,
         pageSize: MAX_LISTENERS_PER_REQUEST,
@@ -211,14 +234,19 @@ class ProcessInstanceListeners {
     payload: ListenerPayload;
   }) => {
     this.state.currentProcessInstanceId = processInstanceId;
-    this.state.currentFlowNodeId = payload.flowNodeId;
+
+    if (payload.flowNodeId) {
+      this.state.currentId.value = payload.flowNodeId;
+      this.state.currentId.type = 'flowNode';
+    }
+
+    if (payload.flowNodeInstanceId) {
+      this.state.currentId.value = payload.flowNodeInstanceId;
+      this.state.currentId.type = 'flowNodeInstance';
+    }
 
     if (fetchType === 'initial') {
       this.startFetching();
-    }
-
-    if (!payload.flowNodeId) {
-      payload.flowNodeId = DEFAULT_PAYLOAD.flowNodeId;
     }
 
     if (!payload.pageSize) {

--- a/operate/client/src/modules/types/operate.d.ts
+++ b/operate/client/src/modules/types/operate.d.ts
@@ -102,7 +102,7 @@ interface DecisionInstanceEntity {
 }
 
 interface ListenerEntity {
-  listenerType: 'EXECUTION_LISTENER';
+  listenerType: 'EXECUTION_LISTENER' | 'USER_TASK_LISTENER';
   listenerKey: string;
   state: 'ACTIVE' | 'COMPLETED' | 'FAILED';
   jobType: string;


### PR DESCRIPTION
## Description

- Adds new (optional) parameter to the listeners request payload called `flowNodeInstanceId` to be able to get a filtered list of only the listeners corresponding to a specific flow node instance
- Makes `flowNodeId` optional in the listeners request payload
- Adapt store to handle both possibilities
- Add new E2E test case to check for difference between getting listeners for a flow node and a flow node instance

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23941
related to #23942 
