### PR TITLE
Fix Operate FE E2E tests locally

### DIFF
--- a/operate/client/e2e-playwright/pages/DecisionInstance.ts
+++ b/operate/client/e2e-playwright/pages/DecisionInstance.ts
@@ -8,6 +8,7 @@
 
 import {Locator, Page} from '@playwright/test';
 import {Paths} from 'modules/Routes';
+import {relativizePath} from './utils/relativizePath';
 
 export class DecisionInstance {
   private page: Page;
@@ -47,6 +48,8 @@ export class DecisionInstance {
   }: {
     decisionInstanceKey: string;
   }) {
-    await this.page.goto(Paths.decisionInstance(decisionInstanceKey));
+    await this.page.goto(
+      relativizePath(Paths.decisionInstance(decisionInstanceKey)),
+    );
   }
 }

--- a/operate/client/e2e-playwright/pages/Decisions.ts
+++ b/operate/client/e2e-playwright/pages/Decisions.ts
@@ -10,6 +10,7 @@ import {Page, Locator} from '@playwright/test';
 import {Paths} from 'modules/Routes';
 import {convertToQueryString} from '../utils/convertToQueryString';
 import {DeleteResourceModal} from './components/DeleteResourceModal';
+import {relativizePath} from './utils/relativizePath';
 
 type OptionalFilter =
   | 'Process Instance Key'
@@ -81,12 +82,14 @@ export class Decisions {
     options?: Parameters<Page['goto']>[1];
   }) {
     if (searchParams === undefined) {
-      await this.page.goto(Paths.decisions());
+      await this.page.goto(relativizePath(Paths.decisions()));
       return;
     }
 
     await this.page.goto(
-      `${Paths.decisions()}?${convertToQueryString(searchParams)}`,
+      relativizePath(
+        `${Paths.decisions()}?${convertToQueryString(searchParams)}`,
+      ),
       options,
     );
   }

--- a/operate/client/e2e-playwright/pages/Login.ts
+++ b/operate/client/e2e-playwright/pages/Login.ts
@@ -8,6 +8,7 @@
 
 import {Page, Locator} from '@playwright/test';
 import {Paths} from 'modules/Routes';
+import {relativizePath} from './utils/relativizePath';
 
 export class Login {
   private page: Page;
@@ -45,6 +46,6 @@ export class Login {
   }
 
   async navigateToLogin() {
-    await this.page.goto(Paths.login());
+    await this.page.goto(relativizePath(Paths.login()));
   }
 }

--- a/operate/client/e2e-playwright/pages/ProcessInstance.ts
+++ b/operate/client/e2e-playwright/pages/ProcessInstance.ts
@@ -9,6 +9,7 @@
 import {Page, Locator} from '@playwright/test';
 import {Paths} from 'modules/Routes';
 import {Diagram} from './components/Diagram';
+import {relativizePath} from './utils/relativizePath';
 
 export class ProcessInstance {
   private page: Page;
@@ -96,7 +97,7 @@ export class ProcessInstance {
     id: string;
     options?: Parameters<Page['goto']>[1];
   }) {
-    await this.page.goto(Paths.processInstance(id), options);
+    await this.page.goto(relativizePath(Paths.processInstance(id)), options);
   }
 
   async getNthTreeNodeTestId(n: number) {

--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -14,6 +14,7 @@ import MigrationModal from '../components/MigrationModal';
 import MoveModificationModal from '../components/MoveModificationModal';
 import {Diagram} from '../components/Diagram';
 import {FiltersPanel} from './FiltersPanel';
+import {relativizePath} from '../utils/relativizePath';
 
 export class Processes {
   private page: Page;
@@ -63,12 +64,14 @@ export class Processes {
     options?: Parameters<Page['goto']>[1];
   }) {
     if (searchParams === undefined) {
-      await this.page.goto(Paths.processes());
+      await this.page.goto(relativizePath(Paths.processes()));
       return;
     }
 
     await this.page.goto(
-      `${Paths.processes()}?${convertToQueryString(searchParams)}`,
+      relativizePath(
+        `${Paths.processes()}?${convertToQueryString(searchParams)}`,
+      ),
       options,
     );
   }

--- a/operate/client/e2e-playwright/pages/utils/relativizePath.ts
+++ b/operate/client/e2e-playwright/pages/utils/relativizePath.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+const IS_LOCAL = !Boolean(process.env.CI);
+
+const relativizePath = (path: string) => {
+  return IS_LOCAL ? `.${path}` : path;
+};
+
+export {relativizePath};

--- a/operate/client/e2e-playwright/pages/utils/relativizePath.ts
+++ b/operate/client/e2e-playwright/pages/utils/relativizePath.ts
@@ -6,10 +6,8 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-const IS_LOCAL = !Boolean(process.env.CI);
-
 const relativizePath = (path: string) => {
-  return IS_LOCAL ? `.${path}` : path;
+  return `.${path}`;
 };
 
 export {relativizePath};


### PR DESCRIPTION
## Description

- Create helper function to add dot to relativize path locally for e2e tests
- Use helper function in all `goto` function uses to avoid tests breaking locally

## Additional Information

closes #24266 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
