### PR TITLE
test: extend date test cases for user task controller

### DIFF
--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -79,6 +79,18 @@ public class UserTaskControllerTest extends RestControllerTest {
                     .flatMap(r -> Stream.of(Pair.of(r, url))));
   }
 
+  static Stream<Pair<String, String>> validDateInputsAndUrls() {
+    return urls()
+        .flatMap(
+            url ->
+                Stream.of(
+                        "2023-11-11T10:10:10.1010Z",
+                        "2023-11-11T10:10:10Z",
+                        "2023-11-11T10:10:10.1010+01:00",
+                        "2023-11-11T10:10:10.1010+01:00[Europe/Paris]")
+                    .flatMap(date -> Stream.of(Pair.of(date, url))));
+  }
+
   @BeforeEach
   void setupServices() {
     Mockito.when(userTaskServices.withAuthentication(any(Authentication.class)))
@@ -409,6 +421,43 @@ public class UserTaskControllerTest extends RestControllerTest {
   }
 
   @ParameterizedTest
+  @MethodSource("validDateInputsAndUrls")
+  void shouldUpdateTaskWithDateChanges(final Pair<String, String> dateAndUrl) {
+    // given
+    Mockito.when(userTaskServices.updateUserTask(anyLong(), any(), anyString()))
+        .thenReturn(BROKER_RESPONSE);
+    final var request =
+        """
+            {
+              "changeset": {
+                "dueDate": "%s",
+                "followUpDate": "%s"
+              }
+            }"""
+            .formatted(dateAndUrl.getLeft(), dateAndUrl.getLeft());
+
+    // when / then
+    webClient
+        .patch()
+        .uri(dateAndUrl.getRight() + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent()
+        .expectBody()
+        .isEmpty();
+
+    final var argumentCaptor = ArgumentCaptor.forClass(UserTaskRecord.class);
+    Mockito.verify(userTaskServices).updateUserTask(eq(1L), argumentCaptor.capture(), eq(""));
+    Assertions.assertThat(argumentCaptor.getValue())
+        .hasChangedAttributes(UserTaskRecord.DUE_DATE, UserTaskRecord.FOLLOW_UP_DATE)
+        .hasDueDate(dateAndUrl.getLeft())
+        .hasFollowUpDate(dateAndUrl.getLeft());
+  }
+
+  @ParameterizedTest
   @MethodSource("urls")
   void shouldYieldBadRequestWhenUpdateTaskWithoutActionAndChanges(final String baseUrl) {
     // given
@@ -501,6 +550,47 @@ public class UserTaskControllerTest extends RestControllerTest {
               "status": 400,
               "title": "INVALID_ARGUMENT",
               "detail": "The provided follow-up date 'foo' cannot be parsed as a date according to RFC 3339, section 5.6.",
+              "instance": "%s"
+            }"""
+            .formatted(baseUrl + "/1");
+
+    // when / then
+    webClient
+        .patch()
+        .uri(baseUrl + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody);
+
+    Mockito.verifyNoInteractions(userTaskServices);
+  }
+
+  @ParameterizedTest
+  @MethodSource("urls")
+  void shouldYieldBadRequestWhenUpdateTaskWithInvalidOffsetFollowUpDate(final String baseUrl) {
+    // given
+    final var request =
+        """
+            {
+              "changeset": {
+                "followUpDate": "2023-11-11T12:12:12.1234+0100"
+              }
+            }""";
+
+    final var expectedBody =
+        """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "The provided follow-up date '2023-11-11T12:12:12.1234+0100' cannot be parsed as a date according to RFC 3339, section 5.6.",
               "instance": "%s"
             }"""
             .formatted(baseUrl + "/1");

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -87,7 +87,7 @@ public class UserTaskControllerTest extends RestControllerTest {
                         "2023-11-11T10:10:10.1010Z",
                         "2023-11-11T10:10:10Z",
                         "2023-11-11T10:10:10.1010+01:00",
-                        "2023-11-11T10:10:10.1010+01:00[Europe/Paris]")
+                        "2023-11-11T10:10:10.101010101+01:00")
                     .flatMap(date -> Stream.of(Pair.of(date, url))));
   }
 
@@ -580,7 +580,8 @@ public class UserTaskControllerTest extends RestControllerTest {
         """
             {
               "changeset": {
-                "followUpDate": "2023-11-11T12:12:12.1234+0100"
+                "followUpDate": "2023-11-11T12:12:12.1234+0100",
+                "dueDate": "2023-11-11T10:10:10.1010+01:00[Europe/Paris]"
               }
             }""";
 
@@ -590,7 +591,10 @@ public class UserTaskControllerTest extends RestControllerTest {
               "type": "about:blank",
               "status": 400,
               "title": "INVALID_ARGUMENT",
-              "detail": "The provided follow-up date '2023-11-11T12:12:12.1234+0100' cannot be parsed as a date according to RFC 3339, section 5.6.",
+              "detail": "The provided due date '2023-11-11T10:10:10.1010+01:00[Europe/Paris]' \
+            cannot be parsed as a date according to RFC 3339, section 5.6. The provided follow-up \
+            date '2023-11-11T12:12:12.1234+0100' cannot be parsed as a date according to RFC 3339, \
+            section 5.6.",
               "instance": "%s"
             }"""
             .formatted(baseUrl + "/1");


### PR DESCRIPTION
## Description

Extends tests for the date input validation of the user task controller for updating user tasks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

n/a
