### PR TITLE
Remove mapping from role

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleProcessors.java
@@ -58,6 +58,7 @@ public class RoleProcessors {
         new RoleRemoveEntityProcessor(
             processingState.getRoleState(),
             processingState.getUserState(),
+            processingState.getMappingState(),
             authCheckBehavior,
             keyGenerator,
             writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -32,6 +33,7 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
   private final RoleState roleState;
   private final UserState userState;
+  private final MappingState mappingState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -42,12 +44,14 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   public RoleRemoveEntityProcessor(
       final RoleState roleState,
       final UserState userState,
+      final MappingState mappingState,
       final AuthorizationCheckBehavior authCheckBehavior,
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
     this.roleState = roleState;
     this.userState = userState;
+    this.mappingState = mappingState;
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -113,6 +117,9 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
     if (EntityType.USER == entityType) {
       return userState.getUser(entityKey).isPresent();
+    }
+    if (EntityType.MAPPING == entityType) {
+      return mappingState.get(entityKey).isPresent();
     }
     return false;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -115,12 +115,10 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
   }
 
   private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
-    if (EntityType.USER == entityType) {
-      return userState.getUser(entityKey).isPresent();
-    }
-    if (EntityType.MAPPING == entityType) {
-      return mappingState.get(entityKey).isPresent();
-    }
-    return false;
+    return switch (entityType) {
+      case USER -> userState.getUser(entityKey).isPresent();
+      case MAPPING -> mappingState.get(entityKey).isPresent();
+      default -> false;
+    };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -472,9 +472,7 @@ public final class EventAppliers implements EventApplier {
         new RoleCreatedApplier(state.getRoleState(), state.getAuthorizationState()));
     register(RoleIntent.UPDATED, new RoleUpdatedApplier(state.getRoleState()));
     register(RoleIntent.ENTITY_ADDED, new RoleEntityAddedApplier(state));
-    register(
-        RoleIntent.ENTITY_REMOVED,
-        new RoleEntityRemovedApplier(state.getRoleState(), state.getUserState()));
+    register(RoleIntent.ENTITY_REMOVED, new RoleEntityRemovedApplier(state));
     register(
         RoleIntent.DELETED,
         new RoleDeletedApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/RoleEntityRemovedApplier.java
@@ -8,29 +8,36 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 
 public class RoleEntityRemovedApplier implements TypedEventApplier<RoleIntent, RoleRecord> {
 
   private final MutableRoleState roleState;
   private final MutableUserState userState;
+  private final MutableMappingState mappingState;
 
-  public RoleEntityRemovedApplier(
-      final MutableRoleState roleState, final MutableUserState userState) {
-    this.roleState = roleState;
-    this.userState = userState;
+  public RoleEntityRemovedApplier(final MutableProcessingState state) {
+    this.roleState = state.getRoleState();
+    this.userState = state.getUserState();
+    this.mappingState = state.getMappingState();
   }
 
   @Override
   public void applyState(final long key, final RoleRecord value) {
     roleState.removeEntity(value.getRoleKey(), value.getEntityKey());
-    if (value.getEntityType() == EntityType.USER) {
-      userState.removeRole(value.getEntityKey(), value.getRoleKey());
+    switch (value.getEntityType()) {
+      case USER -> userState.removeRole(value.getEntityKey(), value.getRoleKey());
+      case MAPPING -> mappingState.removeRole(value.getEntityKey(), value.getRoleKey());
+      default ->
+          throw new IllegalStateException(
+              String.format(
+                  "Expected to remove entity '%d' from role '%d', but entities of type '%s' cannot be removed from roles",
+                  value.getEntityKey(), value.getRoleKey(), value.getEntityType()));
     }
-    // todo remove entity to mapping state when implemented
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -17,4 +17,6 @@ public interface MutableMappingState extends MappingState {
   void addRole(final long mappingKey, final long roleKey);
 
   void addTenant(final long mappingKey, final String tenantId);
+
+  void removeRole(final long mappingKey, final long roleKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/RoleAppliersTest.java
@@ -38,6 +38,7 @@ public class RoleAppliersTest {
   private MutableMappingState mappingState;
   private RoleDeletedApplier roleDeletedApplier;
   private RoleEntityAddedApplier roleEntityAddedApplier;
+  private RoleEntityRemovedApplier roleEntityRemovedApplier;
 
   @BeforeEach
   public void setup() {
@@ -51,10 +52,11 @@ public class RoleAppliersTest {
             processingState.getUserState(),
             processingState.getAuthorizationState());
     roleEntityAddedApplier = new RoleEntityAddedApplier(processingState);
+    roleEntityRemovedApplier = new RoleEntityRemovedApplier(processingState);
   }
 
   @Test
-  void shouldAddEntityToRole() {
+  void shouldAddEntityToRoleWithTypeUser() {
     // given
     final long entityKey = 1L;
     userState.create(
@@ -135,5 +137,57 @@ public class RoleAppliersTest {
         authorizationState.getResourceIdentifiers(
             roleKey, AuthorizationResourceType.ROLE, PermissionType.DELETE);
     assertThat(resourceIdentifiers).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveEntityFromRoleWithTypeUser() {
+    // given
+    final long entityKey = 1L;
+    userState.create(
+        new UserRecord()
+            .setUserKey(entityKey)
+            .setUsername("username")
+            .setName("Foo")
+            .setEmail("foo@bar.com")
+            .setPassword("password"));
+    final long roleKey = 11L;
+    userState.addRole(entityKey, roleKey);
+    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
+    roleState.create(roleRecord);
+    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.USER);
+    roleState.addEntity(roleRecord);
+
+    // when
+    roleEntityRemovedApplier.applyState(roleKey, roleRecord);
+
+    // then
+    assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
+    final var persistedUser = userState.getUser(entityKey).get();
+    assertThat(persistedUser.getRoleKeysList()).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveEntityFromRoleWithTypeMapping() {
+    // given
+    final long entityKey = 1L;
+    mappingState.create(
+        new MappingRecord()
+            .setMappingKey(entityKey)
+            .setClaimName("claimName")
+            .setClaimValue("claimValue"));
+    final long roleKey = 11L;
+    mappingState.addRole(entityKey, 11L);
+    final var roleRecord = new RoleRecord().setRoleKey(roleKey).setName("foo");
+    roleState.create(roleRecord);
+    roleRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
+    roleState.addEntity(roleRecord);
+
+    // when
+    roleEntityRemovedApplier.applyState(roleKey, roleRecord);
+
+    // then
+    assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
+    final var persistedMapping = mappingState.get(entityKey).get();
+    assertThat(persistedMapping.getRoleKeysList()).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -82,4 +82,43 @@ public class MappingStateTest {
     // then
     assertThat(mapping).isEmpty();
   }
+
+  @Test
+  void shouldAddRole() {
+    // given
+    final long key = 1L;
+    final String claimName = "foo";
+    final String claimValue = "bar";
+    final var mapping =
+        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+    mappingState.create(mapping);
+    final long roleKey = 1L;
+
+    // when
+    mappingState.addRole(key, roleKey);
+
+    // then
+    final var persistedMapping = mappingState.get(key).get();
+    assertThat(persistedMapping.getRoleKeysList()).containsExactly(roleKey);
+  }
+
+  @Test
+  void shouldRemoveRole() {
+    // given
+    final long key = 1L;
+    final String claimName = "foo";
+    final String claimValue = "bar";
+    final var mapping =
+        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+    mappingState.create(mapping);
+    final long roleKey = 1L;
+    mappingState.addRole(key, roleKey);
+
+    // when
+    mappingState.removeRole(key, roleKey);
+
+    // then
+    final var persistedMapping = mappingState.get(key).get();
+    assertThat(persistedMapping.getRoleKeysList()).isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allow the RoleEntityRemovedApplier to remove the role key from the mapping state if the EntityType is MAPPING

## Related issues

closes #23873 
