### PR TITLE
feat: add self-rescheduling task utility

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverJob.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface ArchiverJob {
+  CompletableFuture<Integer> archiveNextBatch();
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ReschedulingTask.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.zeebe.util.ExponentialBackoff;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+
+public final class ReschedulingTask implements Runnable {
+  private final ArchiverJob job;
+  private final int batchSize;
+  private final ScheduledExecutorService executor;
+  private final Logger logger;
+  private final ExponentialBackoff idleStrategy;
+  private final ExponentialBackoff errorStrategy;
+
+  private long delayMs;
+  private long errorDelayMs;
+
+  public ReschedulingTask(
+      final ArchiverJob job,
+      final int batchSize,
+      final long delayBetweenRunsMs,
+      final ScheduledExecutorService executor,
+      final Logger logger) {
+    this.job = job;
+    this.batchSize = batchSize;
+    this.executor = executor;
+    this.logger = logger;
+
+    idleStrategy = new ExponentialBackoff(60_000, delayBetweenRunsMs, 1.2, 0);
+    errorStrategy = new ExponentialBackoff(10_000, delayBetweenRunsMs, 1.2, 0);
+  }
+
+  @Override
+  public void run() {
+    var batchArchived = job.archiveNextBatch();
+    // while we could always expect this to return a non-null result, we don't necessarily want to
+    // stop, and more importantly, we want to make it transparent that something went wrong
+    if (batchArchived == null) {
+      logger.warn(
+          "Expected to archive a batch asynchronously, but no result returned for job {}; rescheduling anyway",
+          job);
+      batchArchived = CompletableFuture.completedFuture(0);
+    }
+
+    batchArchived
+        .thenApplyAsync(this::onBatchArchived, executor)
+        .exceptionallyAsync(this::onArchivingError, executor)
+        .thenAcceptAsync(this::rescheduleJob, executor);
+  }
+
+  private long onBatchArchived(final int count) {
+    errorDelayMs = 0;
+
+    // if we worked on as much as the batch size, then there's probably even more work to
+    // be done, so use the minimum delay between runs; otherwise, backoff from the last
+    // known delay
+    delayMs = count >= batchSize ? idleStrategy.applyAsLong(0) : idleStrategy.applyAsLong(delayMs);
+    return delayMs;
+  }
+
+  private long onArchivingError(final Throwable error) {
+    errorDelayMs = errorStrategy.applyAsLong(errorDelayMs);
+
+    logger.error("Error occurred while archiving data; operation will be retried", error);
+    return errorDelayMs;
+  }
+
+  private void rescheduleJob(final long delay) {
+    logger.trace("Rescheduling archiving job {} in {}ms", job, delay);
+    executor.schedule(this, delay, TimeUnit.MILLISECONDS);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ReschedulingTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ReschedulingTaskTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@AutoCloseResources
+final class ReschedulingTaskTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReschedulingTaskTest.class);
+
+  @AutoCloseResource
+  private final ScheduledThreadPoolExecutor executor =
+      Mockito.spy(new ScheduledThreadPoolExecutor(1));
+
+  @Test
+  void shouldRescheduleTaskOnError() {
+    // given
+    final var task = new ReschedulingTask(new FailingJob(), 1, 10, executor, LOGGER);
+
+    // when
+    task.run();
+
+    // then
+    final var inOrder = Mockito.inOrder(executor);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void shouldRescheduleTaskOnErrorWithDelay() {
+    // given
+    final var task = new ReschedulingTask(new FailingJob(), 1, 10, executor, LOGGER);
+
+    // when
+    task.run();
+
+    // then
+    final var inOrder = Mockito.inOrder(executor);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 12L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void shouldResetErrorDelayOnSuccessfulArchiving() {
+    // given
+    final var job =
+        new ArchiverJob() {
+          private final AtomicInteger count = new AtomicInteger();
+
+          @Override
+          public CompletableFuture<Integer> archiveNextBatch() {
+            final var runCount = count.getAndIncrement();
+            if (runCount == 0) {
+              return CompletableFuture.failedFuture(new RuntimeException("error"));
+            }
+
+            if (runCount == 2) {
+              return CompletableFuture.failedFuture(new RuntimeException("error"));
+            }
+
+            return CompletableFuture.completedFuture(1);
+          }
+        };
+    final var task = new ReschedulingTask(job, 1, 10L, executor, LOGGER);
+
+    // when
+    task.run();
+
+    // then - scheduled after the minimum delay on the first error, again on success, and then
+    // since we reset the error delay, again on the second error
+    final var inOrder = Mockito.inOrder(executor);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void shouldRescheduleEvenIfJobResultIsNull() {
+    // given
+    final var job =
+        new ArchiverJob() {
+          @Override
+          public CompletableFuture<Integer> archiveNextBatch() {
+            return null;
+          }
+        };
+    final var task = new ReschedulingTask(job, 1, 10L, executor, LOGGER);
+
+    // when
+    task.run();
+
+    // then
+    final var inOrder = Mockito.inOrder(executor);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  void shouldRescheduleTaskWithDelayOnPartialBatch() {
+    // given
+    final var job =
+        new ArchiverJob() {
+          @Override
+          public CompletableFuture<Integer> archiveNextBatch() {
+            return CompletableFuture.completedFuture(1);
+          }
+        };
+    final var task = new ReschedulingTask(job, 2, 10L, executor, LOGGER);
+
+    // when
+    task.run();
+
+    // then
+    final var inOrder = Mockito.inOrder(executor);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 10L, TimeUnit.MILLISECONDS);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 12L, TimeUnit.MILLISECONDS);
+    inOrder
+        .verify(executor, Mockito.timeout(5_000).times(1))
+        .schedule(task, 14L, TimeUnit.MILLISECONDS);
+  }
+
+  private static final class FailingJob implements ArchiverJob {
+    @Override
+    public CompletableFuture<Integer> archiveNextBatch() {
+      return CompletableFuture.failedFuture(new RuntimeException("failure"));
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds a self-rescheduling task utility for the archiver (and later possibly other background tasks), in preparation for the archiving jobs.

This is essentially copied from Operate's `AbstractArchiverJob`, with the logic kept mostly as is, but the code cleaned up and Zeebe-ified.

Some of the changes:

- Using Zeebe's `ExponentialBackoff` instead of Operate's `BackoffIdleStrategy`. I'm not married to this, and happy to change, but I think the behavior is largely the same overall (with some minor differences). The idea was to avoid adding a new dependency to the exporter, and since `BackoffIdleStrategy` is in a Spring-ified module, the other option was to duplicate it :shrug: 
- Shutdown of the task relies on always using the `*Async` variants of the chaining methods in `CompletionStage`/`CompletableFuture`, using the Archiver's executor. That way, if the executor is shutdown, then the callback is never called, nor is the task re-enqueued.
  - This means we have to always ensure we use those variants, which is easy to forget =/
- Test coverage on the rescheduling parts :)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24093 
