### PR TITLE
feat: redistribute deployments to new partitions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -50,6 +50,7 @@ import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
 import io.camunda.zeebe.engine.processing.user.UserProcessors;
 import io.camunda.zeebe.engine.processing.usertask.UserTaskProcessor;
 import io.camunda.zeebe.engine.scaling.ScalingProcessors;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionBehavior;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -265,8 +266,10 @@ public final class EngineProcessors {
         writers,
         commandDistributionBehavior);
 
+    final var redistributionBehavior =
+        new RedistributionBehavior(writers, commandDistributionBehavior, processingState);
     ScalingProcessors.addScalingProcessors(
-        typedRecordProcessors, writers, keyGenerator, processingState);
+        redistributionBehavior, typedRecordProcessors, writers, keyGenerator, processingState);
 
     TenantProcessors.addTenantProcessors(
         typedRecordProcessors,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -300,6 +300,10 @@ public final class CommandDistributionBehavior {
     }
 
     ContinuationRequestBuilder afterQueue(String queue);
+
+    default ContinuationRequestBuilder afterQueue(final DistributionQueue queue) {
+      return afterQueue(queue.getQueueId());
+    }
   }
 
   public interface DistributionRequestBuilder {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -36,7 +36,7 @@ public final class ScalingProcessors {
     typedRecordProcessors.onCommand(
         ValueType.REDISTRIBUTION,
         RedistributionIntent.START,
-        new RedistributionStartProcessor(writers));
+        new RedistributionStartProcessor(redistributionBehavior, writers));
     typedRecordProcessors.onCommand(
         ValueType.REDISTRIBUTION,
         RedistributionIntent.CONTINUE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -9,8 +9,13 @@ package io.camunda.zeebe.engine.scaling;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionBehavior;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionCompleteProcessor;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionContinueProcessor;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStartProcessor;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -19,6 +24,7 @@ public final class ScalingProcessors {
   private ScalingProcessors() {}
 
   public static void addScalingProcessors(
+      final RedistributionBehavior redistributionBehavior,
       final TypedRecordProcessors typedRecordProcessors,
       final Writers writers,
       final KeyGenerator keyGenerator,
@@ -27,5 +33,17 @@ public final class ScalingProcessors {
         ValueType.SCALE,
         ScaleIntent.SCALE_UP,
         new ScaleUpProcessor(keyGenerator, writers, processingState));
+    typedRecordProcessors.onCommand(
+        ValueType.REDISTRIBUTION,
+        RedistributionIntent.START,
+        new RedistributionStartProcessor(writers));
+    typedRecordProcessors.onCommand(
+        ValueType.REDISTRIBUTION,
+        RedistributionIntent.CONTINUE,
+        new RedistributionContinueProcessor(redistributionBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.REDISTRIBUTION,
+        RedistributionIntent.COMPLETE,
+        new RedistributionCompleteProcessor(writers));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/ScalingProcessors.java
@@ -36,7 +36,7 @@ public final class ScalingProcessors {
     typedRecordProcessors.onCommand(
         ValueType.REDISTRIBUTION,
         RedistributionIntent.START,
-        new RedistributionStartProcessor(redistributionBehavior, writers));
+        new RedistributionStartProcessor(redistributionBehavior));
     typedRecordProcessors.onCommand(
         ValueType.REDISTRIBUTION,
         RedistributionIntent.CONTINUE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import java.util.Objects;
 
 public final class DbRedistributionState implements MutableRedistributionState {
   private final ColumnFamily<DbString, PersistedState> columnFamily;
@@ -44,7 +45,8 @@ public final class DbRedistributionState implements MutableRedistributionState {
 
   @Override
   public void updateState(final RedistributionStage stage, final RedistributionProgress progress) {
-    final var persistedState = columnFamily.get(key);
+    final var persistedState =
+        Objects.requireNonNullElseGet(columnFamily.get(key), PersistedState::new);
     persistedState.stage.setValue(RedistributionStage.stageToIndex(stage));
     persistedState.progress.getValue().copyFrom(progress);
     columnFamily.upsert(key, persistedState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
@@ -33,13 +33,17 @@ public final class DbRedistributionState implements MutableRedistributionState {
   @Override
   public RedistributionStage getStage() {
     final var persistedState = redistributionColumnFamily.get(key);
-    return RedistributionStage.indexToStage(persistedState.stage.getValue());
+    return persistedState == null
+        ? new RedistributionStage.Done()
+        : RedistributionStage.indexToStage(persistedState.stage.getValue());
   }
 
   @Override
   public RedistributionProgress getProgress() {
     final var persistedState = redistributionColumnFamily.get(key);
-    return persistedState.progress.getValue();
+    return persistedState == null
+        ? new RedistributionProgress()
+        : persistedState.progress.getValue();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+
+public final class DbRedistributionState implements MutableRedistributionState {
+  private final ColumnFamily<DbString, PersistedState> columnFamily;
+  private final DbString key = new DbString();
+
+  public DbRedistributionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    key.wrapString("redistributionState");
+    columnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.REDISTRIBUTION, transactionContext, key, new PersistedState());
+  }
+
+  @Override
+  public RedistributionStage getStage() {
+    final var persistedState = columnFamily.get(key);
+    return RedistributionStage.indexToStage(persistedState.stage.getValue());
+  }
+
+  @Override
+  public RedistributionProgress getProgress() {
+    final var persistedState = columnFamily.get(key);
+    return persistedState.progress.getValue();
+  }
+
+  @Override
+  public void updateState(final RedistributionStage stage, final RedistributionProgress progress) {
+    final var persistedState = columnFamily.get(key);
+    persistedState.stage.setValue(RedistributionStage.stageToIndex(stage));
+    persistedState.progress.getValue().copyFrom(progress);
+    columnFamily.upsert(key, persistedState);
+  }
+
+  private static final class PersistedState extends UnpackedObject implements DbValue {
+    private final IntegerProperty stage =
+        new IntegerProperty(
+            "stage", RedistributionStage.stageToIndex(new RedistributionStage.Done()));
+
+    private final ObjectProperty<RedistributionProgress> progress =
+        new ObjectProperty<>("progress", new RedistributionProgress());
+
+    public PersistedState() {
+      super(2);
+      declareProperty(stage);
+      declareProperty(progress);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DbRedistributionState.java
@@ -52,6 +52,11 @@ public final class DbRedistributionState implements MutableRedistributionState {
     redistributionColumnFamily.upsert(key, persistedState);
   }
 
+  @Override
+  public void clearState() {
+    redistributionColumnFamily.deleteExisting(key);
+  }
+
   private static final class PersistedState extends UnpackedObject implements DbValue {
     private final IntegerProperty stage =
         new IntegerProperty(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/DeploymentRedistributor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Deployments;
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import java.util.List;
+import java.util.SequencedCollection;
+import java.util.Set;
+
+public final class DeploymentRedistributor
+    implements ResourceRedistributor<Deployments, DeploymentRecord> {
+  DeploymentState deploymentState;
+
+  public DeploymentRedistributor(final ProcessingState processingState) {
+    deploymentState = processingState.getDeploymentState();
+  }
+
+  @Override
+  public SequencedCollection<Redistribution<DeploymentRecord>> nextRedistributions(
+      final RedistributionProgress progress) {
+
+    final var previousDeploymentKey = progress.getDeploymentKey();
+
+    // TODO: Rehydrate the deployment record with all referenced resources
+    final var deployment = deploymentState.nextDeployment(previousDeploymentKey);
+    if (deployment == null) {
+      return List.of();
+    }
+    final var deploymentKey = deployment.getDeploymentKey();
+
+    // TODO: Should also contain all the resources within the deployment, i.e. processes etc.
+    final var resources =
+        Set.<RedistributableResource>of(new RedistributableResource.Deployment(deploymentKey));
+
+    return List.of(
+        new Redistribution<>(
+            deploymentKey, ValueType.DEPLOYMENT, DeploymentIntent.CREATE, deployment, resources));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
@@ -12,4 +12,7 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgres
 public interface MutableRedistributionState extends RedistributionState {
 
   void updateState(RedistributionStage stage, RedistributionProgress progress);
+
+  /** Clears the state, removing the stage and progress. */
+  void clearState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+
+public interface MutableRedistributionState extends RedistributionState {
+
+  void updateState(RedistributionStage stage, RedistributionProgress progress);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/MutableRedistributionState.java
@@ -11,6 +11,8 @@ import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgres
 
 public interface MutableRedistributionState extends RedistributionState {
 
+  void initializeState(RedistributionStage stage, RedistributionProgress progress);
+
   void updateState(RedistributionStage stage, RedistributionProgress progress);
 
   /** Clears the state, removing the stage and progress. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributableResource.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributableResource.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+public sealed interface RedistributableResource {
+  record Deployment(long key) implements RedistributableResource {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
@@ -44,6 +44,13 @@ public final class RedistributionBehavior {
     redistributionState = processingState.getRedistributionState();
   }
 
+  public void startRedistribution(final long redistributionKey) {
+    stateWriter.appendFollowUpEvent(
+        redistributionKey, RedistributionIntent.STARTED, new RedistributionRecord());
+    commandWriter.appendFollowUpCommand(
+        redistributionKey, RedistributionIntent.CONTINUE, new RedistributionRecord());
+  }
+
   public void continueRedistribution(final long redistributionKey) {
     // get current state and matching redistributor
     final var stage = redistributionState.getStage();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
@@ -113,9 +113,10 @@ public final class RedistributionBehavior {
       final RedistributionStage currentStage) {
     final var nextStage = RedistributionStage.nextStage(currentStage);
 
-    final var continuedRedistribution = new RedistributionRecord();
-    continuedRedistribution.setProgress(progress);
-    continuedRedistribution.setStage(RedistributionStage.stageToIndex(nextStage));
+    final var continuedRedistribution =
+        new RedistributionRecord()
+            .setProgress(progress)
+            .setStage(RedistributionStage.stageToIndex(nextStage));
 
     stateWriter.appendFollowUpEvent(
         redistributionKey, RedistributionIntent.CONTINUED, continuedRedistribution);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
@@ -75,7 +75,7 @@ public final class RedistributionBehavior {
     // find partitions to redistribute to
     final var currentPartitions = routingState.currentPartitions();
     final var desiredPartitions = routingState.desiredPartitions();
-    final var newPartitions = new IntHashSet(desiredPartitions.size() - currentPartitions.size());
+    final var newPartitions = new IntHashSet(desiredPartitions.size());
     newPartitions.addAll(desiredPartitions);
     newPartitions.removeAll(currentPartitions);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionBehavior.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributableResource.Deployment;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Done;
+import io.camunda.zeebe.engine.scaling.redistribution.ResourceRedistributor.Redistribution;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.RoutingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+import java.util.SequencedCollection;
+import org.agrona.collections.IntHashSet;
+
+public final class RedistributionBehavior {
+  private final TypedCommandWriter commandWriter;
+  private final StateWriter stateWriter;
+  private final CommandDistributionBehavior distributionBehavior;
+  private final RoutingState routingState;
+  private final ProcessingState processingState;
+  private final RedistributionState redistributionState;
+
+  public RedistributionBehavior(
+      final Writers writers,
+      final CommandDistributionBehavior distributionBehavior,
+      final ProcessingState processingState) {
+    commandWriter = writers.command();
+    stateWriter = writers.state();
+    this.distributionBehavior = distributionBehavior;
+    routingState = processingState.getRoutingState();
+    this.processingState = processingState;
+    redistributionState = processingState.getRedistributionState();
+  }
+
+  public void continueRedistribution(final long redistributionKey) {
+    // get current state and matching redistributor
+    final var stage = redistributionState.getStage();
+    final var progress = redistributionState.getProgress();
+    final var redistributor = redistributorForCurrentStage(stage);
+
+    // get all new redistributions
+    final var redistributions = redistributor.nextRedistributions(progress);
+
+    if (redistributions.isEmpty()) {
+      advanceToNextStage(redistributionKey, progress, stage);
+    } else {
+      advanceInSameStage(redistributionKey, progress, stage, redistributions);
+    }
+  }
+
+  private void advanceInSameStage(
+      final long redistributionKey,
+      final RedistributionProgress progress,
+      final RedistributionStage stage,
+      final SequencedCollection<? extends Redistribution<?>> redistributions) {
+    // find partitions to redistribute to
+    final var currentPartitions = routingState.currentPartitions();
+    final var desiredPartitions = routingState.desiredPartitions();
+    final var newPartitions = new IntHashSet(desiredPartitions.size() - currentPartitions.size());
+    newPartitions.addAll(desiredPartitions);
+    newPartitions.removeAll(currentPartitions);
+
+    // enqueue all redistributions
+    for (final var redistribution : redistributions) {
+      distributionBehavior
+          .withKey(redistribution.distributionKey())
+          .inQueue(DistributionQueue.REDISTRIBUTION)
+          .forPartitions(newPartitions)
+          .distribute(
+              redistribution.distributionValueType(),
+              redistribution.distributionIntent(),
+              redistribution.distributionValue());
+    }
+
+    // Update progress
+    updateProgress(progress, redistributions);
+    final var continuedRedistribution = new RedistributionRecord();
+    continuedRedistribution.setProgress(progress);
+    continuedRedistribution.setStage(RedistributionStage.stageToIndex(stage));
+    stateWriter.appendFollowUpEvent(
+        redistributionKey, RedistributionIntent.CONTINUED, continuedRedistribution);
+
+    // Request continuation once this batch of redistributions is done
+    distributionBehavior
+        .withKey(redistributionKey)
+        .afterQueue(DistributionQueue.REDISTRIBUTION)
+        .continueWith(
+            ValueType.REDISTRIBUTION, RedistributionIntent.CONTINUE, new RedistributionRecord());
+  }
+
+  private void advanceToNextStage(
+      final long redistributionKey,
+      final RedistributionProgress progress,
+      final RedistributionStage currentStage) {
+    final var nextStage = RedistributionStage.nextStage(currentStage);
+
+    final var continuedRedistribution = new RedistributionRecord();
+    continuedRedistribution.setProgress(progress);
+    continuedRedistribution.setStage(RedistributionStage.stageToIndex(nextStage));
+
+    stateWriter.appendFollowUpEvent(
+        redistributionKey, RedistributionIntent.CONTINUED, continuedRedistribution);
+
+    if (nextStage instanceof Done) {
+      commandWriter.appendFollowUpCommand(
+          redistributionKey, RedistributionIntent.COMPLETE, new RedistributionRecord());
+    } else {
+      commandWriter.appendFollowUpCommand(
+          redistributionKey, RedistributionIntent.CONTINUE, new RedistributionRecord());
+    }
+  }
+
+  private void updateProgress(
+      final RedistributionProgress progress,
+      final SequencedCollection<? extends Redistribution<?>> redistributions) {
+    for (final var redistribution : redistributions) {
+      for (final var resource : redistribution.containedResources()) {
+        switch (resource) {
+          case Deployment(final var deploymentKey) -> progress.claimDeploymentKey(deploymentKey);
+        }
+      }
+    }
+  }
+
+  /**
+   * Extend this method for each new {@link RedistributionStage}. The must be one {@link
+   * ResourceRedistributor} for each stage.
+   */
+  private ResourceRedistributor<?, ?> redistributorForCurrentStage(
+      final RedistributionStage stage) {
+    return switch (stage) {
+      case final RedistributionStage.Deployments ignored ->
+          new DeploymentRedistributor(processingState);
+      case final RedistributionStage.Done ignored -> null;
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompleteProcessor.java
@@ -12,7 +12,9 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class RedistributionCompleteProcessor implements TypedRecordProcessor<RedistributionRecord> {
@@ -28,6 +30,6 @@ public class RedistributionCompleteProcessor implements TypedRecordProcessor<Red
   public void processRecord(final TypedRecord<RedistributionRecord> record) {
     stateWriter.appendFollowUpEvent(
         record.getKey(), RedistributionIntent.COMPLETED, record.getValue());
-    // TODO: Continue scaling
+    stateWriter.appendFollowUpEvent(record.getKey(), ScaleIntent.SCALED_UP, new ScaleRecord());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompleteProcessor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class RedistributionCompleteProcessor implements TypedRecordProcessor<RedistributionRecord> {
+  private final StateWriter stateWriter;
+  private final TypedCommandWriter commandWriter;
+
+  public RedistributionCompleteProcessor(final Writers writers) {
+    stateWriter = writers.state();
+    commandWriter = writers.command();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<RedistributionRecord> record) {
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), RedistributionIntent.COMPLETED, record.getValue());
+    // TODO: Continue scaling
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompletedApplier.java
@@ -7,10 +7,8 @@
  */
 package io.camunda.zeebe.engine.scaling.redistribution;
 
-import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Done;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
 import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 
@@ -24,6 +22,6 @@ public class RedistributionCompletedApplier
 
   @Override
   public void applyState(final long key, final RedistributionRecord value) {
-    redistributionState.updateState(new Done(), new RedistributionProgress());
+    redistributionState.clearState();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionCompletedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Done;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+
+public class RedistributionCompletedApplier
+    implements TypedEventApplier<RedistributionIntent, RedistributionRecord> {
+  private final MutableRedistributionState redistributionState;
+
+  public RedistributionCompletedApplier(final MutableProcessingState processingState) {
+    redistributionState = processingState.getRedistributionState();
+  }
+
+  @Override
+  public void applyState(final long key, final RedistributionRecord value) {
+    redistributionState.updateState(new Done(), new RedistributionProgress());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionContinueProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionContinueProcessor.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class RedistributionContinueProcessor implements TypedRecordProcessor<RedistributionRecord> {
+  private final RedistributionBehavior redistributionBehavior;
+
+  public RedistributionContinueProcessor(final RedistributionBehavior redistributionBehavior) {
+    this.redistributionBehavior = redistributionBehavior;
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<RedistributionRecord> record) {
+    redistributionBehavior.continueRedistribution(record.getKey());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionContinuedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionContinuedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+
+public final class RedistributionContinuedApplier
+    implements TypedEventApplier<RedistributionIntent, RedistributionRecord> {
+  private final MutableRedistributionState redistributionState;
+
+  public RedistributionContinuedApplier(final MutableProcessingState processingState) {
+    redistributionState = processingState.getRedistributionState();
+  }
+
+  @Override
+  public void applyState(final long key, final RedistributionRecord value) {
+    redistributionState.updateState(
+        RedistributionStage.indexToStage(value.getStage()), value.getProgress());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStage.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import java.util.Objects;
+
+/**
+ * Redistribution is organized in stages. Each stage needs to be defined here and mapped to an index
+ * that determines the order of stages. Stages with a lower index are completed before stages with
+ * higher indexes.
+ */
+public sealed interface RedistributionStage {
+
+  /** All stages need to be mapped to a unique index here. Use */
+  static int stageToIndex(final RedistributionStage stage) {
+    return switch (stage) {
+      case final Done ignored -> 0;
+      case final Deployments ignored -> 1;
+    };
+  }
+
+  static RedistributionStage indexToStage(final int index) {
+    return switch (index) {
+      case 0 -> new Done();
+      case 1 -> new Deployments();
+      default -> null;
+    };
+  }
+
+  static RedistributionStage nextStage(final RedistributionStage currentStage) {
+    final var nextIndex = stageToIndex(currentStage) + 1;
+    final var nextStage = indexToStage(nextIndex);
+    return Objects.requireNonNullElseGet(nextStage, Done::new);
+  }
+
+  record Done() implements RedistributionStage {}
+
+  record Deployments() implements RedistributionStage {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
@@ -8,26 +8,18 @@
 package io.camunda.zeebe.engine.scaling.redistribution;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
-import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class RedistributionStartProcessor implements TypedRecordProcessor<RedistributionRecord> {
   private final RedistributionBehavior redistributionBehavior;
-  private final StateWriter stateWriter;
 
-  public RedistributionStartProcessor(
-      final RedistributionBehavior redistributionBehavior, final Writers writers) {
+  public RedistributionStartProcessor(final RedistributionBehavior redistributionBehavior) {
     this.redistributionBehavior = redistributionBehavior;
-    stateWriter = writers.state();
   }
 
   @Override
   public void processRecord(final TypedRecord<RedistributionRecord> record) {
-    stateWriter.appendFollowUpEvent(
-        record.getKey(), RedistributionIntent.STARTED, record.getValue());
-    redistributionBehavior.continueRedistribution(record.getKey());
+    redistributionBehavior.startRedistribution(record.getKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class RedistributionStartProcessor implements TypedRecordProcessor<RedistributionRecord> {
+  private final StateWriter stateWriter;
+
+  public RedistributionStartProcessor(final Writers writers) {
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<RedistributionRecord> record) {
+    stateWriter.appendFollowUpEvent(
+        record.getKey(), RedistributionIntent.STARTED, record.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartProcessor.java
@@ -15,9 +15,12 @@ import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class RedistributionStartProcessor implements TypedRecordProcessor<RedistributionRecord> {
+  private final RedistributionBehavior redistributionBehavior;
   private final StateWriter stateWriter;
 
-  public RedistributionStartProcessor(final Writers writers) {
+  public RedistributionStartProcessor(
+      final RedistributionBehavior redistributionBehavior, final Writers writers) {
+    this.redistributionBehavior = redistributionBehavior;
     stateWriter = writers.state();
   }
 
@@ -25,5 +28,6 @@ public class RedistributionStartProcessor implements TypedRecordProcessor<Redist
   public void processRecord(final TypedRecord<RedistributionRecord> record) {
     stateWriter.appendFollowUpEvent(
         record.getKey(), RedistributionIntent.STARTED, record.getValue());
+    redistributionBehavior.continueRedistribution(record.getKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartedApplier.java
@@ -24,7 +24,7 @@ public class RedistributionStartedApplier
 
   @Override
   public void applyState(final long key, final RedistributionRecord value) {
-    redistributionState.updateState(
+    redistributionState.initializeState(
         RedistributionStage.nextStage(new Done()), new RedistributionProgress());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStartedApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Done;
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
+
+public class RedistributionStartedApplier
+    implements TypedEventApplier<RedistributionIntent, RedistributionRecord> {
+  private final MutableRedistributionState redistributionState;
+
+  public RedistributionStartedApplier(final MutableProcessingState processingState) {
+    redistributionState = processingState.getRedistributionState();
+  }
+
+  @Override
+  public void applyState(final long key, final RedistributionRecord value) {
+    redistributionState.updateState(
+        RedistributionStage.nextStage(new Done()), new RedistributionProgress());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionState.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+
+public interface RedistributionState {
+
+  RedistributionStage getStage();
+
+  RedistributionProgress getProgress();
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/ResourceRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/scaling/redistribution/ResourceRedistributor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.SequencedCollection;
+import java.util.Set;
+
+/**
+ * A {@link ResourceRedistributor} is responsible for producing one or multiple {@link
+ * Redistribution}. It is up to the implementation to decide whether it wants to do one
+ * redistribution at a time or several at once. This is mostly a performance consideration.
+ *
+ * <p>A redistribution is a command that contains one or many resources. It will be sent via {@link
+ * io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior} such that a matching
+ * processor creates all the contained resources.
+ *
+ * <p>We allow each redistribution to contain multiple resources to support resource nesting as done
+ * for Deployments. Each contained resource must be mentioned by its natural key. This allows the
+ * {@link RedistributionBehavior} to track progress for each resource independently and not just on
+ * a per-redistribution basis, which is necessary to support resources that can be modified outside
+ * of their "parent" resource. For example, we want to redistribute entire deployments at once but
+ * need to know which contained resources were already redistributed or not to support resource
+ * deletion.
+ *
+ * @param <S> Marker type to associate this redistributor to a specific stage
+ * @param <V> The specific type of record values that get redistributed
+ */
+public interface ResourceRedistributor<
+    S extends RedistributionStage, V extends UnifiedRecordValue> {
+
+  /**
+   * Is called multiple times by the {@link RedistributionBehavior}. Implementations should find the
+   * next redistributions and return them
+   *
+   * @param progress The recorded progress until now. This contains resource keys that were already
+   *     redistributed.
+   * @return A sequence of {@link Redistribution} or an empty sequence to indicate that this
+   *     redistributor is done, and we can move on to the next {@link RedistributionStage}.
+   */
+  SequencedCollection<Redistribution<V>> nextRedistributions(RedistributionProgress progress);
+
+  /**
+   * Contains all data necessary to redistribute one or several resources.
+   *
+   * @param distributionKey The key that will be used for distributing. Some resources require that
+   *     they are distributed with a specific key, some don't care and can deal with a newly
+   *     generated key.
+   * @param distributionValueType The value type of the distribution command.
+   * @param distributionIntent The intent of the distribution command.
+   * @param distributionValue The actual value of the distribution command.
+   * @param containedResources A set of {@link RedistributableResource} that are contained in this
+   *     redistribution. Some redistributions might contain many resources. For example, deployments
+   *     get redistributed as one but each contains many resources of different types.
+   * @param <V> The implementation type of the actual distribution command value.
+   */
+  record Redistribution<V extends UnifiedRecordValue>(
+      long distributionKey,
+      ValueType distributionValueType,
+      Intent distributionIntent,
+      V distributionValue,
+      Set<RedistributableResource> containedResources) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -12,6 +12,8 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.scaling.redistribution.DbRedistributionState;
+import io.camunda.zeebe.engine.scaling.redistribution.MutableRedistributionState;
 import io.camunda.zeebe.engine.state.authorization.DbAuthorizationState;
 import io.camunda.zeebe.engine.state.authorization.DbMappingState;
 import io.camunda.zeebe.engine.state.authorization.DbRoleState;
@@ -112,6 +114,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableClockState clockState;
   private final MutableAuthorizationState authorizationState;
   private final MutableRoutingState routingState;
+  private final MutableRedistributionState redistributionState;
   private final MutableTenantState tenantState;
   private final MutableRoleState roleState;
   private final MutableGroupState groupState;
@@ -164,6 +167,7 @@ public class ProcessingDbState implements MutableProcessingState {
     clockState = new DbClockState(zeebeDb, transactionContext);
     authorizationState = new DbAuthorizationState(zeebeDb, transactionContext);
     routingState = new DbRoutingState(zeebeDb, transactionContext);
+    redistributionState = new DbRedistributionState(zeebeDb, transactionContext);
     roleState = new DbRoleState(zeebeDb, transactionContext);
     groupState = new DbGroupState(zeebeDb, transactionContext);
     tenantState = new DbTenantState(zeebeDb, transactionContext);
@@ -296,6 +300,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableRoutingState getRoutingState() {
     return routingState;
+  }
+
+  @Override
+  public MutableRedistributionState getRedistributionState() {
+    return redistributionState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.scaling.ScaledUpApplier;
 import io.camunda.zeebe.engine.scaling.ScalingUpApplier;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionCompletedApplier;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionContinuedApplier;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStartedApplier;
 import io.camunda.zeebe.engine.state.EventApplier;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
 import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForVersion;
@@ -57,6 +60,7 @@ import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -501,6 +505,9 @@ public final class EventAppliers implements EventApplier {
   private void registerScalingAppliers(final MutableProcessingState state) {
     register(ScaleIntent.SCALING_UP, new ScalingUpApplier(state.getRoutingState()));
     register(ScaleIntent.SCALED_UP, new ScaledUpApplier(state.getRoutingState()));
+    register(RedistributionIntent.STARTED, new RedistributionStartedApplier(state));
+    register(RedistributionIntent.CONTINUED, new RedistributionContinuedApplier(state));
+    register(RedistributionIntent.COMPLETED, new RedistributionCompletedApplier(state));
   }
 
   private void registerTenantAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -162,6 +162,12 @@ public final class DbDeploymentState implements MutableDeploymentState {
           nextRawDeployment.set(rawDeployment);
           return false;
         });
-    return nextRawDeployment.get() == null ? null : nextRawDeployment.get().getDeploymentRecord();
+    if (nextRawDeployment.get() == null) {
+      return null;
+    }
+
+    final var copy = new DeploymentRecord();
+    copy.copyFrom(nextRawDeployment.get().getDeploymentRecord());
+    return copy;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -151,4 +151,17 @@ public final class DbDeploymentState implements MutableDeploymentState {
           pendingDeploymentVisitor.visit(deploymentKey, partitionId, lastDeployment.get());
         });
   }
+
+  @Override
+  public DeploymentRecord nextDeployment(final long previousDeploymentKey) {
+    final var nextRawDeployment = new MutableReference<DeploymentRaw>();
+    deploymentKey.wrapLong(previousDeploymentKey + 1);
+    deploymentRawColumnFamily.whileTrue(
+        deploymentKey,
+        (deploymentKey, rawDeployment) -> {
+          nextRawDeployment.set(rawDeployment);
+          return false;
+        });
+    return nextRawDeployment.get() == null ? null : nextRawDeployment.get().getDeploymentRecord();
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DistributionQueue.java
@@ -9,7 +9,8 @@ package io.camunda.zeebe.engine.state.distribution;
 
 public enum DistributionQueue {
   IDENTITY("IDENTITY"),
-  DEPLOYMENT("DEPLOYMENT");
+  DEPLOYMENT("DEPLOYMENT"),
+  REDISTRIBUTION("REDISTRIBUTION");
 
   private final String queueId;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
@@ -35,8 +35,8 @@ public interface DeploymentState {
   void foreachPendingDeploymentDistribution(PendingDeploymentVisitor pendingDeploymentVisitor);
 
   /**
-   * Returns the first deployment that has a higher key than the provided one or null if no such
-   * deployment exists.
+   * Returns a copy of the first deployment that has a higher key than the provided one or null if
+   * no such deployment exists.
    */
   DeploymentRecord nextDeployment(long previousDeploymentKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
@@ -34,6 +34,12 @@ public interface DeploymentState {
 
   void foreachPendingDeploymentDistribution(PendingDeploymentVisitor pendingDeploymentVisitor);
 
+  /**
+   * Returns the first deployment that has a higher key than the provided one or null if no such
+   * deployment exists.
+   */
+  DeploymentRecord nextDeployment(long previousDeploymentKey);
+
   @FunctionalInterface
   interface PendingDeploymentVisitor {
     void visit(final long deploymentKey, final int partitionId, final DirectBuffer directBuffer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 
@@ -63,6 +64,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
   AuthorizationState getAuthorizationState();
 
   RoutingState getRoutingState();
+
+  RedistributionState getRedistributionState();
 
   int getPartitionId();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.mutable;
 
+import io.camunda.zeebe.engine.scaling.redistribution.MutableRedistributionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
@@ -83,6 +84,9 @@ public interface MutableProcessingState extends ProcessingState {
 
   @Override
   MutableRoutingState getRoutingState();
+
+  @Override
+  MutableRedistributionState getRedistributionState();
 
   @Override
   MutableClockState getClockState();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -29,7 +29,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public class ScaleUpTest {
-  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(3);
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -140,7 +140,7 @@ public class ScaleUpTest {
   @Test
   public void shouldRejectScaleDown() {
     // given
-    ((MutableRoutingState) engine.getProcessingState().getRoutingState()).initializeRoutingInfo(2);
+    ((MutableRoutingState) engine.getProcessingState(1).getRoutingState()).initializeRoutingInfo(2);
     final var command =
         RecordToWrite.command()
             .scale(ScaleIntent.SCALE_UP, new ScaleRecord().setDesiredPartitionCount(1));
@@ -162,8 +162,8 @@ public class ScaleUpTest {
   @Test
   public void shouldRejectRedundantScaleUp() {
     // given - a scale up from 1 to 3 was already requested
-    ((MutableRoutingState) engine.getProcessingState().getRoutingState()).initializeRoutingInfo(1);
-    ((MutableRoutingState) engine.getProcessingState().getRoutingState())
+    ((MutableRoutingState) engine.getProcessingState(1).getRoutingState()).initializeRoutingInfo(1);
+    ((MutableRoutingState) engine.getProcessingState(1).getRoutingState())
         .setDesiredPartitions(Set.of(1, 2, 3));
 
     // when
@@ -182,6 +182,6 @@ public class ScaleUpTest {
   }
 
   private void initRoutingState() {
-    ((MutableRoutingState) engine.getProcessingState().getRoutingState()).initializeRoutingInfo(1);
+    ((MutableRoutingState) engine.getProcessingState(1).getRoutingState()).initializeRoutingInfo(1);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/ScaleUpTest.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,10 +33,6 @@ import org.junit.Test;
 
 public class ScaleUpTest {
   @Rule public final EngineRule engine = EngineRule.multiplePartition(3);
-
-  @Rule
-  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
-      new RecordingExporterTestWatcher();
 
   @Before
   public void beforeEach() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStageTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import io.camunda.zeebe.util.ReflectUtil;
+import java.lang.reflect.InvocationTargetException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class RedistributionStageTest {
+  @Test
+  void shouldMapAllIndexesConsistently() {
+    // given
+    final var allStages =
+        ReflectUtil.implementationsOfSealedInterface(RedistributionStage.class)
+            .map(
+                stageClass -> {
+                  try {
+                    return stageClass.getConstructor().newInstance();
+                  } catch (final InstantiationException
+                      | IllegalAccessException
+                      | InvocationTargetException
+                      | NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+
+    // then
+    Assertions.assertThat(allStages)
+        .allSatisfy(
+            stage ->
+                Assertions.assertThat(stage)
+                    .as("Stage " + stage + " should be mapped to an index consistently")
+                    .isEqualTo(
+                        RedistributionStage.indexToStage(RedistributionStage.stageToIndex(stage))));
+  }
+
+  @Test
+  void shouldIterateThroughStages() {
+    // given
+    final var allStages =
+        Stream.iterate(new RedistributionStage.Done(), RedistributionStage::nextStage)
+            .skip(1)
+            .takeWhile(stage -> !(stage instanceof RedistributionStage.Done));
+
+    // then
+    Assertions.assertThat(allStages).containsExactly(new RedistributionStage.Deployments());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/scaling/redistribution/RedistributionStateTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.scaling.redistribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Deployments;
+import io.camunda.zeebe.engine.scaling.redistribution.RedistributionStage.Done;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class RedistributionStateTest {
+  private MutableProcessingState processingState;
+  private MutableRedistributionState redistributionState;
+
+  @BeforeEach
+  public void setup() {
+    redistributionState = processingState.getRedistributionState();
+  }
+
+  @Test
+  void shouldInitializeState() {
+    // given
+    final var stage = new Deployments();
+    final var progress = new RedistributionProgress().claimDeploymentKey(123);
+
+    // when
+    redistributionState.initializeState(stage, progress);
+
+    // then
+    assertThat(redistributionState.getStage()).isEqualTo(stage);
+    assertThat(redistributionState.getProgress()).isEqualTo(progress);
+  }
+
+  @Test
+  void shouldUpdateState() {
+    // given
+    final var initialStage = new Done();
+    final var initialProgress = new RedistributionProgress();
+    redistributionState.initializeState(initialStage, initialProgress);
+
+    final var updatedStage = RedistributionStage.nextStage(initialStage);
+    final var updatedProgress = initialProgress.claimDeploymentKey(123);
+
+    // when
+    redistributionState.updateState(updatedStage, updatedProgress);
+
+    // then
+    assertThat(redistributionState.getStage()).isEqualTo(updatedStage);
+    assertThat(redistributionState.getProgress()).isEqualTo(updatedProgress);
+  }
+
+  @Test
+  void shouldClearState() {
+    // given
+    final var stage = new Done();
+    final var progress = new RedistributionProgress().claimDeploymentKey(123);
+    redistributionState.initializeState(stage, progress);
+
+    // when
+    redistributionState.clearState();
+
+    // then
+    assertThat(redistributionState.getStage()).isEqualTo(new Done());
+    assertThat(redistributionState.getProgress()).isEqualTo(new RedistributionProgress());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -248,6 +248,36 @@ public class DeploymentStateTest {
     assertThat(pendings).isEmpty();
   }
 
+  @Test
+  public void shouldFindNextDeployment() {
+    // given
+    final var deployment1 = createDeployment();
+    final var deployment2 = createDeployment();
+    deploymentState.storeDeploymentRecord(1, deployment1);
+    deploymentState.storeDeploymentRecord(2, deployment2);
+
+    // when
+    final var nextDeployment = deploymentState.nextDeployment(1);
+
+    // then
+    assertThat(nextDeployment).isEqualTo(deployment2);
+  }
+
+  @Test
+  public void shouldStopFindingNextDeployments() {
+    // given
+    final var deployment1 = createDeployment();
+    final var deployment2 = createDeployment();
+    deploymentState.storeDeploymentRecord(1, deployment1);
+    deploymentState.storeDeploymentRecord(2, deployment2);
+
+    // when
+    final var nextDeployment = deploymentState.nextDeployment(2);
+
+    // then
+    assertThat(nextDeployment).isNull();
+  }
+
   private DeploymentRecord createDeployment() {
     final var modelInstance =
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -102,6 +102,7 @@ final class TestSupport {
             ValueType.PROCESS_INSTANCE_RESULT,
             ValueType.CLOCK,
             ValueType.SCALE,
+            ValueType.REDISTRIBUTION,
             // these are not yet supported
             ValueType.ROLE,
             ValueType.TENANT,

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -102,6 +102,7 @@ final class TestSupport {
             ValueType.PROCESS_INSTANCE_RESULT,
             ValueType.CLOCK,
             ValueType.SCALE,
+            ValueType.REDISTRIBUTION,
             // these are not yet supported
             ValueType.ROLE,
             ValueType.TENANT,

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -53,6 +54,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.TENANT, TenantRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MAPPING, MappingRecord::new);
     RECORDS_BY_TYPE.put(ValueType.GROUP, GroupRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.REDISTRIBUTION, RedistributionRecord::new);
   }
 
   /*

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionProgress.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionProgress.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.scaling;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.record.value.scaling.RedistributionProgressValue;
+
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "encodedLength",
+  "length",
+  "empty"
+})
+public final class RedistributionProgress extends UnpackedObject
+    implements RedistributionProgressValue {
+  LongProperty deployment = new LongProperty("deployment", -1);
+
+  public RedistributionProgress() {
+    super(1);
+    declareProperty(deployment);
+  }
+
+  @Override
+  public long getDeploymentKey() {
+    return deployment.getValue();
+  }
+
+  public RedistributionProgress claimDeploymentKey(final long deploymentKey) {
+    if (deploymentKey > deployment.getValue()) {
+      deployment.setValue(deploymentKey);
+    }
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionProgress.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionProgress.java
@@ -20,21 +20,27 @@ import io.camunda.zeebe.protocol.record.value.scaling.RedistributionProgressValu
 })
 public final class RedistributionProgress extends UnpackedObject
     implements RedistributionProgressValue {
-  LongProperty deployment = new LongProperty("deployment", -1);
+
+  /**
+   * The key of the latest deployment that has been redistributed. Deployments with keys less than
+   * this value have been redistributed, while deployments with keys greater than this value are not
+   * yet redistributed.
+   */
+  LongProperty deploymentKey = new LongProperty("deploymentKey", -1);
 
   public RedistributionProgress() {
     super(1);
-    declareProperty(deployment);
+    declareProperty(deploymentKey);
   }
 
   @Override
   public long getDeploymentKey() {
-    return deployment.getValue();
+    return deploymentKey.getValue();
   }
 
   public RedistributionProgress claimDeploymentKey(final long deploymentKey) {
-    if (deploymentKey > deployment.getValue()) {
-      deployment.setValue(deploymentKey);
+    if (deploymentKey > this.deploymentKey.getValue()) {
+      this.deploymentKey.setValue(deploymentKey);
     }
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/scaling/RedistributionRecord.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.scaling;
+
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.scaling.RedistributionRecordValue;
+
+public class RedistributionRecord extends UnifiedRecordValue implements RedistributionRecordValue {
+  private final IntegerProperty stage = new IntegerProperty("stage", -1);
+  private final ObjectProperty<RedistributionProgress> progress =
+      new ObjectProperty<>("progress", new RedistributionProgress());
+
+  public RedistributionRecord() {
+    super(2);
+    declareProperty(stage);
+    declareProperty(progress);
+  }
+
+  @Override
+  public int getStage() {
+    return stage.getValue();
+  }
+
+  public RedistributionRecord setStage(final int stage) {
+    this.stage.setValue(stage);
+    return this;
+  }
+
+  @Override
+  public RedistributionProgress getProgress() {
+    return progress.getValue();
+  }
+
+  public RedistributionRecord setProgress(final RedistributionProgress progress) {
+    this.progress.getValue().copyFrom(progress);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -57,6 +57,8 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationVariableInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionProgress;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
@@ -2780,6 +2782,38 @@ final class JsonSerializableToJsonTest {
         """
         {
          "desiredPartitionCount": 5
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////////// RedistributionRecord //////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "RedistributionRecord (empty)",
+        (Supplier<RedistributionRecord>) RedistributionRecord::new,
+        """
+        {
+          "stage": -1,
+          "progress": {
+            "deploymentKey": -1
+          }
+        }
+        """
+      },
+      {
+        "RedistributionRecord",
+        (Supplier<RedistributionRecord>)
+            () ->
+                new RedistributionRecord()
+                    .setStage(2)
+                    .setProgress(new RedistributionProgress().claimDeploymentKey(123)),
+        """
+        {
+          "stage": 2,
+          "progress": {
+            "deploymentKey": 123
+          }
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -215,7 +215,9 @@ public enum ZbColumnFamilies implements EnumValue {
 
   GROUPS(110),
   ENTITY_BY_GROUP(111),
-  GROUP_BY_NAME(112);
+  GROUP_BY_NAME(112),
+
+  REDISTRIBUTION(113);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -58,6 +58,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
@@ -101,6 +102,7 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRec
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.protocol.record.value.management.CheckpointRecordValue;
+import io.camunda.zeebe.protocol.record.value.scaling.RedistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.scaling.ScaleRecordValue;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -252,6 +254,9 @@ public final class ValueTypeMapping {
     mapping.put(ValueType.ROLE, new Mapping<>(RoleRecordValue.class, RoleIntent.class));
     mapping.put(ValueType.TENANT, new Mapping<>(TenantRecordValue.class, TenantIntent.class));
     mapping.put(ValueType.SCALE, new Mapping<>(ScaleRecordValue.class, ScaleIntent.class));
+    mapping.put(
+        ValueType.REDISTRIBUTION,
+        new Mapping<>(RedistributionRecordValue.class, RedistributionIntent.class));
     mapping.put(ValueType.GROUP, new Mapping<>(GroupRecordValue.class, GroupIntent.class));
     mapping.put(ValueType.MAPPING, new Mapping<>(MappingRecordValue.class, MappingIntent.class));
     return mapping;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_CORRELATION;
 
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.intent.scaling.RedistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.scaling.ScaleIntent;
 import java.util.Arrays;
 import java.util.Collection;
@@ -67,6 +68,7 @@ public interface Intent {
           RoleIntent.class,
           TenantIntent.class,
           ScaleIntent.class,
+          RedistributionIntent.class,
           GroupIntent.class,
           MappingIntent.class);
   short NULL_VAL = 255;
@@ -166,6 +168,8 @@ public interface Intent {
         return TenantIntent.from(intent);
       case SCALE:
         return ScaleIntent.from(intent);
+      case REDISTRIBUTION:
+        return RedistributionIntent.from(intent);
       case GROUP:
         return GroupIntent.from(intent);
       case MAPPING:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/scaling/RedistributionIntent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent.scaling;
+
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
+public enum RedistributionIntent implements Intent {
+  START((short) 1, false),
+  STARTED((short) 2, true),
+  CONTINUE((short) 3, false),
+  CONTINUED((short) 4, true),
+  COMPLETE((short) 5, false),
+  COMPLETED((short) 6, true);
+
+  private final short value;
+  private final boolean isEvent;
+
+  RedistributionIntent(final short value, final boolean isEvent) {
+    this.value = value;
+    this.isEvent = isEvent;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return isEvent;
+  }
+
+  public static Intent from(final short intent) {
+    switch (intent) {
+      case 1:
+        return START;
+      case 2:
+        return STARTED;
+      case 3:
+        return CONTINUE;
+      case 4:
+        return CONTINUED;
+      case 5:
+        return COMPLETE;
+      case 6:
+        return COMPLETED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/RedistributionProgressValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/RedistributionProgressValue.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.scaling;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableRedistributionProgressValue.Builder.class)
+public interface RedistributionProgressValue extends RecordValue {
+  long getDeploymentKey();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/RedistributionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/scaling/RedistributionRecordValue.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value.scaling;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableRedistributionRecordValue.Builder.class)
+public interface RedistributionRecordValue extends RecordValue {
+  int getStage();
+
+  RedistributionProgressValue getProgress();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -65,6 +65,7 @@
       <validValue name="MAPPING">47</validValue>
 
       <!-- Management records / record not related to process automation -->
+      <validValue name="REDISTRIBUTION">252</validValue>
       <validValue name="SCALE">253</validValue>
       <validValue name="CHECKPOINT">254</validValue>
     </enum>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstan
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceResultRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.scaling.RedistributionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.scaling.ScaleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
@@ -110,6 +111,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.SCALE, ScaleRecord.class);
     registry.put(ValueType.MAPPING, MappingRecord.class);
     registry.put(ValueType.GROUP, GroupRecord.class);
+    registry.put(ValueType.REDISTRIBUTION, RedistributionRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 


### PR DESCRIPTION
This implements redistribution of deployments to all new partitions during scaling up.
When scaling starts, it initiates redistribution. Redistribution is organized into several stages itself, the first being deployments. During each stage, a redistributor is asked to provide the next redistributions. These then get enqueued for distribution to new partitions. Once a batch of redistributions are acknowledged, the redistributor is asked for the next ones until it returns none.
During this, the redistribution behavior keeps track of resources that were redistributed. Notably, each redistribution may contain multiple resources. This is because we redistribute deployments which in turn contain many different resources.

Relates to https://github.com/camunda/camunda/issues/24013.