### PR TITLE
Add process instances archiver job

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/ProcessInstanceDependant.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/ProcessInstanceDependant.java
@@ -12,4 +12,8 @@ public interface ProcessInstanceDependant {
   String PROCESS_INSTANCE_KEY = "processInstanceKey";
 
   String getFullQualifiedName();
+
+  default String getProcessInstanceDependantField() {
+    return PROCESS_INSTANCE_KEY;
+  }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -8,9 +8,11 @@
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 
-public class TaskTemplate extends TasklistTemplateDescriptor implements Prio3Backup {
+public class TaskTemplate extends TasklistTemplateDescriptor
+    implements Prio3Backup, ProcessInstanceDependant {
 
   public static final String INDEX_NAME = "task";
   public static final String INDEX_VERSION = "8.5.0";
@@ -70,5 +72,10 @@ public class TaskTemplate extends TasklistTemplateDescriptor implements Prio3Bac
   @Override
   public String getVersion() {
     return INDEX_VERSION;
+  }
+
+  @Override
+  public String getProcessInstanceDependantField() {
+    return PROCESS_INSTANCE_ID;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -23,7 +23,6 @@ import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 import co.elastic.clients.util.VisibleForTesting;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.archiver.Archiver;
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -48,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class CamundaExporter implements Exporter {
   private static final Logger LOG = LoggerFactory.getLogger(CamundaExporter.class);
 
+  private Context context;
   private Controller controller;
   private ExporterConfiguration configuration;
   private ClientAdapter clientAdapter;
@@ -56,7 +56,6 @@ public class CamundaExporter implements Exporter {
   private final ExporterResourceProvider provider;
   private CamundaExporterMetrics metrics;
   private Logger logger;
-  private int partitionId;
   private Archiver archiver;
 
   public CamundaExporter() {
@@ -70,7 +69,7 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void configure(final Context context) {
-    partitionId = context.getPartitionId();
+    this.context = context;
     logger = context.getLogger();
     configuration = context.getConfiguration().instantiate(ExporterConfiguration.class);
     ConfigValidator.validate(configuration);
@@ -95,9 +94,10 @@ public class CamundaExporter implements Exporter {
             configuration);
     archiver =
         Archiver.create(
-            partitionId,
-            new NoopArchiverRepository(),
+            context.getPartitionId(),
+            context.getConfiguration().getId().toLowerCase(),
             configuration.getArchiver(),
+            provider,
             metrics,
             logger);
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -9,6 +9,8 @@ package io.camunda.exporter;
 
 import static java.util.Map.entry;
 
+import io.camunda.exporter.archiver.ArchiverRepository;
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.exporter.cache.ProcessCacheImpl;
 import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ConnectionTypes;
@@ -216,8 +218,20 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   }
 
   @Override
+  public <T extends IndexTemplateDescriptor> T getIndexTemplateDescriptor(
+      final Class<T> descriptorClass) {
+    return descriptorClass.cast(templateDescriptorsMap.get(descriptorClass));
+  }
+
+  @Override
   public Set<ExportHandler> getExportHandlers() {
     // Register all handlers here
     return exportHandlers;
+  }
+
+  @Override
+  public ArchiverRepository newArchiverRepository() {
+    // TODO: return appropriate implementation
+    return new NoopArchiverRepository();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter;
 
+import io.camunda.exporter.archiver.ArchiverRepository;
 import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
@@ -36,7 +37,19 @@ public interface ExporterResourceProvider {
   Collection<IndexTemplateDescriptor> getIndexTemplateDescriptors();
 
   /**
+   * @param descriptorClass the expected descriptor type
+   * @return the index template descriptor instance for the given class.
+   * @param <T> the expected descriptor type
+   */
+  <T extends IndexTemplateDescriptor> T getIndexTemplateDescriptor(Class<T> descriptorClass);
+
+  /**
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
   Set<ExportHandler> getExportHandlers();
+
+  /**
+   * @return a new archiver repository scoped to the current partition
+   */
+  ArchiverRepository newArchiverRepository();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiveBatch.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import java.util.List;
+
+public record ArchiveBatch(String finishDate, List<String> ids) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -43,6 +43,10 @@ public final class Archiver implements CloseableSilently {
 
   @Override
   public void close() {
+    // Close executor first before anything else; this will ensure any callbacks are not triggered
+    // in case we close any underlying resource (e.g. repository) and would want to perform
+    // unnecessary error handling in any of these callbacks
+    //
     // avoid calling executor.close, which will await 1d (!) until termination
     // we also don't need to wait for the jobs to fully finish, as we should be able to handle
     // partial jobs (e.g. node crash/restart)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
@@ -7,9 +7,66 @@
  */
 package io.camunda.exporter.archiver;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
 /** Placeholder interface for future abstracted access to the underlying storage (e.g. ES/OS). */
 public interface ArchiverRepository extends AutoCloseable {
-  static final class NoopArchiverRepository implements ArchiverRepository {
+  CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch();
+
+  CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
+
+  CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<String> processInstanceKeys);
+
+  CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<String> processInstanceKeys);
+
+  default CompletableFuture<Void> moveDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<String> ids,
+      final Executor executor) {
+    return reindexDocuments(sourceIndexName, destinationIndexName, idFieldName, ids)
+        .thenComposeAsync(ok -> setIndexLifeCycle(destinationIndexName), executor)
+        .thenComposeAsync(ok -> deleteDocuments(sourceIndexName, idFieldName, ids), executor);
+  }
+
+  class NoopArchiverRepository implements ArchiverRepository {
+
+    @Override
+    public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+      return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
+    }
+
+    @Override
+    public CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> deleteDocuments(
+        final String sourceIndexName,
+        final String idFieldName,
+        final List<String> processInstanceKeys) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> reindexDocuments(
+        final String sourceIndexName,
+        final String destinationIndexName,
+        final String idFieldName,
+        final List<String> processInstanceKeys) {
+      return CompletableFuture.completedFuture(null);
+    }
 
     @Override
     public void close() throws Exception {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
@@ -70,7 +70,7 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
                     repository.moveDocuments(
                         dependant.getFullQualifiedName(),
                         dependant.getFullQualifiedName() + finishDate,
-                        ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                        dependant.getProcessInstanceDependantField(),
                         processInstanceKeys,
                         executor))
             .toArray(CompletableFuture[]::new);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
@@ -46,7 +46,7 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
   }
 
   private CompletableFuture<Integer> archiveBatch(final ArchiveBatch batch) {
-    if (batch != null) {
+    if (batch != null && !(batch.ids() == null || batch.ids().isEmpty())) {
       logger.debug("Following process instances are found for archiving: {}", batch);
 
       return moveDependants(batch.finishDate(), batch.ids())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.zeebe.util.FunctionUtil;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class ProcessInstancesArchiverJob implements ArchiverJob {
+
+  private final ArchiverRepository repository;
+  private final ListViewTemplate template;
+  private final List<ProcessInstanceDependant> dependants;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+  private final Executor executor;
+
+  public ProcessInstancesArchiverJob(
+      final ArchiverRepository repository,
+      final ListViewTemplate template,
+      final List<ProcessInstanceDependant> dependants,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    this.repository = repository;
+    this.template = template;
+    this.dependants = dependants;
+    this.metrics = metrics;
+    this.logger = logger;
+    this.executor = executor;
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveNextBatch() {
+    return repository.getProcessInstancesNextBatch().thenComposeAsync(this::archiveBatch, executor);
+  }
+
+  private CompletableFuture<Integer> archiveBatch(final ArchiveBatch batch) {
+    if (batch != null) {
+      logger.debug("Following process instances are found for archiving: {}", batch);
+
+      return moveDependants(batch.finishDate(), batch.ids())
+          .thenComposeAsync(
+              count -> moveProcessInstances(batch.finishDate(), batch.ids()), executor)
+          // we want to make sure the rescheduling happens after we update the metrics, so we peek
+          // instead of creating an additional pipeline on the interim future
+          .thenApplyAsync(FunctionUtil.peek(metrics::recordProcessInstancesArchived), executor);
+    }
+
+    logger.debug("Nothing to archive");
+    return CompletableFuture.completedFuture(0);
+  }
+
+  private CompletableFuture<Void> moveDependants(
+      final String finishDate, final List<String> processInstanceKeys) {
+    final var movedDocuments =
+        dependants.stream()
+            .map(
+                dependant ->
+                    repository.moveDocuments(
+                        dependant.getFullQualifiedName(),
+                        dependant.getFullQualifiedName() + finishDate,
+                        ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                        processInstanceKeys,
+                        executor))
+            .toArray(CompletableFuture[]::new);
+    return CompletableFuture.allOf(movedDocuments);
+  }
+
+  private CompletableFuture<Integer> moveProcessInstances(
+      final String finishDate, final List<String> processInstanceKeys) {
+    return repository
+        .moveDocuments(
+            template.getFullQualifiedName(),
+            template.getFullQualifiedName() + finishDate,
+            ListViewTemplate.PROCESS_INSTANCE_KEY,
+            processInstanceKeys,
+            executor)
+        .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -22,6 +22,7 @@ public class CamundaExporterMetrics {
   private final MeterRegistry meterRegistry;
   private final AtomicInteger bulkMemorySize = new AtomicInteger(0);
   private final Timer flushLatency;
+  private final Counter processInstancesArchived;
   private Timer.Sample flushLatencyMeasurement;
 
   public CamundaExporterMetrics(final MeterRegistry meterRegistry) {
@@ -33,6 +34,7 @@ public class CamundaExporterMetrics {
                 "Time of how long a export buffer is open and collects new records before flushing, meaning latency until the next flush is done.")
             .publishPercentileHistogram()
             .register(meterRegistry);
+    processInstancesArchived = meterRegistry.counter(meterName("archived.process.instances"));
   }
 
   public ResourceSample measureFlushDuration() {
@@ -73,6 +75,10 @@ public class CamundaExporterMetrics {
     if (flushLatencyMeasurement != null) {
       flushLatencyMeasurement.stop(flushLatency);
     }
+  }
+
+  public void recordProcessInstancesArchived(final int count) {
+    processInstancesArchived.increment(count);
   }
 
   private String meterName(final String name) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ArchiverTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ArchiverTest.java
@@ -10,11 +10,9 @@ package io.camunda.exporter.archiver;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
-import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,13 +27,7 @@ final class ArchiverTest {
   final class CloseTest {
     private final CloseableRepository repository = new CloseableRepository();
     private final Archiver archiver =
-        new Archiver(
-            1,
-            repository,
-            new ArchiverConfiguration(),
-            new CamundaExporterMetrics(new SimpleMeterRegistry()),
-            LoggerFactory.getLogger(ArchiverTest.class),
-            executor);
+        new Archiver(1, repository, LoggerFactory.getLogger(ArchiverTest.class), executor);
 
     @Test
     void shouldCloseExecutorOnClose() {
@@ -64,7 +56,7 @@ final class ArchiverTest {
       assertThatCode(archiver::close).doesNotThrowAnyException();
     }
 
-    private static final class CloseableRepository implements ArchiverRepository {
+    private static final class CloseableRepository extends NoopArchiverRepository {
       private boolean isClosed;
       private Exception exception;
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJobTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.archiver.ProcessInstancesArchiverJobTest.TestRepository.DocumentMove;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ProcessInstancesArchiverJobTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ProcessInstancesArchiverJobTest.class);
+
+  private final Executor executor = Runnable::run;
+  private final TestRepository repository = new TestRepository();
+  private final ListViewTemplate processInstanceTemplate = new ListViewTemplate("", true);
+  private final DecisionInstanceTemplate decisionInstanceTemplate =
+      new DecisionInstanceTemplate("", true);
+  private final SequenceFlowTemplate sequenceFlowTemplate = new SequenceFlowTemplate("", true);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final ProcessInstancesArchiverJob job =
+      new ProcessInstancesArchiverJob(
+          repository,
+          processInstanceTemplate,
+          List.of(sequenceFlowTemplate, decisionInstanceTemplate),
+          metrics,
+          LOGGER,
+          executor);
+
+  @Test
+  void shouldReturnZeroIfNoBatchGiven() {
+    // given - when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+  }
+
+  @Test
+  void shouldReturnZeroIfNoBatchIdsGiven() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of());
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+  }
+
+  @Test
+  void shouldMoveDependants() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(3);
+    assertThat(repository.moves)
+        .contains(
+            new DocumentMove(
+                sequenceFlowTemplate.getFullQualifiedName(),
+                sequenceFlowTemplate.getFullQualifiedName() + "2024-01-01",
+                ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                List.of("1", "2", "3"),
+                executor),
+            new DocumentMove(
+                decisionInstanceTemplate.getFullQualifiedName(),
+                decisionInstanceTemplate.getFullQualifiedName() + "2024-01-01",
+                ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                List.of("1", "2", "3"),
+                executor));
+  }
+
+  @Test
+  void shouldMoveProcessInstances() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(3);
+    assertThat(repository.moves)
+        .contains(
+            new DocumentMove(
+                processInstanceTemplate.getFullQualifiedName(),
+                processInstanceTemplate.getFullQualifiedName() + "2024-01-01",
+                ProcessInstanceDependant.PROCESS_INSTANCE_KEY,
+                List.of("1", "2", "3"),
+                executor));
+  }
+
+  @Test
+  void shouldMoveDependantsBeforeProcessInstances() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(3);
+    assertThat(repository.moves)
+        .map(DocumentMove::sourceIndexName)
+        .containsExactly(
+            sequenceFlowTemplate.getFullQualifiedName(),
+            decisionInstanceTemplate.getFullQualifiedName(),
+            processInstanceTemplate.getFullQualifiedName());
+  }
+
+  @Test
+  void shouldRecordProcessInstancesArchived() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var count = job.archiveNextBatch().join() + job.archiveNextBatch().join();
+
+    // then
+    assertThat(meterRegistry.counter("zeebe.camunda.exporter.archived.process.instances").count())
+        .isEqualTo(6)
+        .isEqualTo(count);
+  }
+
+  static final class TestRepository extends NoopArchiverRepository {
+    private final List<DocumentMove> moves = new ArrayList<>();
+    private ArchiveBatch batch;
+
+    @Override
+    public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+      return CompletableFuture.completedFuture(batch);
+    }
+
+    @Override
+    public CompletableFuture<Void> moveDocuments(
+        final String sourceIndexName,
+        final String destinationIndexName,
+        final String idFieldName,
+        final List<String> ids,
+        final Executor executor) {
+      moves.add(
+          new DocumentMove(sourceIndexName, destinationIndexName, idFieldName, ids, executor));
+      return CompletableFuture.completedFuture(null);
+    }
+
+    record DocumentMove(
+        String sourceIndexName,
+        String destinationIndexName,
+        String idFieldName,
+        List<String> ids,
+        Executor executor) {}
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ReschedulingTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ReschedulingTaskTest.java
@@ -137,6 +137,8 @@ final class ReschedulingTaskTest {
     task.run();
 
     // then
+    // FYI - the back off is exponential, but at low values it looks like it's always adding the
+    // same value
     final var inOrder = Mockito.inOrder(executor);
     inOrder
         .verify(executor, Mockito.timeout(5_000).times(1))

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FunctionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FunctionUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+
+public final class FunctionUtil {
+  private FunctionUtil() {}
+
+  /**
+   * A utility method to easily peak at a value and return itself. Mostly used for cases where you
+   * want to chain and the API expects a {@link java.util.function.Function}, but you just want to
+   * accept via a {@link Consumer} and return the original value as is, i.e. you want to take a peek
+   * at the value.
+   *
+   * <p>For example, can be useful to peek at a value during a future chain:
+   *
+   * <pre>{@code
+   * final CompletableFuture<Object> myFuture = api.getAsync();
+   * return myFuture.thenApply(FunctionUtil.peek(value -> log(value)));
+   * }</pre>
+   *
+   * This is especially useful, because alternatives would be using `thenAccept`, which would erase
+   * the value from the return chain, or starting a different pipeline by not chaining directly. If
+   * the order of operations does not matter to you, then you can gladly use the multiple pipelines.
+   * If the order matters (and in most cases, it does, if only to be able to still clearly think
+   * about how the code is executed), then you should use this.
+   *
+   * @param consumer the consumer which will peek at the value; ideally should be side-effect free
+   * @return a {@link UnaryOperator} which will simply return the same value as it was given
+   * @param <T> the type of the expected value
+   */
+  public static <T> UnaryOperator<T> peek(final Consumer<T> consumer) {
+    return value -> {
+      consumer.accept(value);
+      return value;
+    };
+  }
+}


### PR DESCRIPTION
## Description

This PR migrates the process instances (and dependants) archiving job logic. It mostly relies on the archiver repository implementation to interact with the DB, meaning it still doesn't _actually_ do anything yet, so we don't have integration tests.

The only general changes were moving some of the methods from the original `Archiver` (e.g. `moveDocuments`) to the repository, moving to composition (instead of inheritance) with `ReschedulingTask` (see #24252), and simplifying the `ArchiverJob` interface (I noticed in the end, we only really care about `archiveNextBatch`).

## Related issues

related to #24093 
