### PR TITLE
feat: enforce no periods in operation summaries in c8 rest spec

### DIFF
--- a/.github/vacuum-ruleset.yaml
+++ b/.github/vacuum-ruleset.yaml
@@ -602,3 +602,21 @@ rules:
         then:
             function: typedEnum
         type: validation
+    no-period-in-summary:
+        category:
+            id: operations
+            name: Operations
+        description: Path summary must not include period
+        formats:
+            - oas3
+            - oas3_1
+            - oas2
+        severity: error
+        given: $.paths[*][*].summary
+        id: summaryPeriod
+        then:
+            function: pattern
+            functionOptions:
+                notMatch: ^.*\.$
+        type: validation
+  

--- a/.github/vacuum-ruleset.yaml
+++ b/.github/vacuum-ruleset.yaml
@@ -604,6 +604,7 @@ rules:
         type: validation
     no-period-in-summary:
         category:
+            description: Operations are the core of the contract, they define paths and HTTP methods. These rules check operations have been well constructed, looks for operationId, parameter, schema and return types in depth.
             id: operations
             name: Operations
         description: Path summary must not include period
@@ -613,7 +614,8 @@ rules:
             - oas2
         severity: error
         given: $.paths[*][*].summary
-        id: summaryPeriod
+        howToFix: Summaries are short descriptions often used in navigation bars, they must not contain periods at the end. Please remove the period at the end of the summary text.
+        id: no-period-in-summary
         then:
             function: pattern
             functionOptions:


### PR DESCRIPTION
## Description

Adds a vacuum rule for preventing periods at the end of a `summary` on an operation in the C8 REST API spec. This is a check I've been doing manually when tagged on PR reviews which modify the spec.

The `severity` is set to `error`, so that CI will fail in a PR that introduces this case.

## Example of CI failing due to a violation

https://github.com/camunda/camunda/actions/runs/11619851657/job/32360394116?pr=24281

(I added a commit to this branch which included a violation just to capture that workflow execution, then rolled the branch back to remove that commit.)

## Vacuum output when the spec includes a violation

![image](https://github.com/user-attachments/assets/06181a0d-1fe2-4c45-80bb-0d455b694506)

## Vacuum output when there are no violations

<img width="1716" alt="image" src="https://github.com/user-attachments/assets/f3081adf-b080-42b2-9e10-b860b700d281">

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

