### PR TITLE
Fix some issues seen in flaky CamundaExporterIT tests

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/exceptions/PersistenceException.java
@@ -11,9 +11,6 @@ public class PersistenceException extends Exception {
 
   private static final long serialVersionUID = 1L;
 
-  @SuppressWarnings("checkstyle:MutableException")
-  private Integer failingRequestId;
-
   public PersistenceException() {}
 
   public PersistenceException(final String message) {
@@ -24,21 +21,7 @@ public class PersistenceException extends Exception {
     super(message, cause);
   }
 
-  public PersistenceException(
-      final String message, final Throwable cause, final Integer failingRequestId) {
-    super(message, cause);
-    this.failingRequestId = failingRequestId;
-  }
-
   public PersistenceException(final Throwable cause) {
     super(cause);
-  }
-
-  public Integer getFailingRequestId() {
-    return failingRequestId;
-  }
-
-  public void setFailingRequestId(final Integer failingRequestId) {
-    this.failingRequestId = failingRequestId;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter.store;
 
-import io.camunda.exporter.exceptions.OpensearchExporterException;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.utils.OpensearchScriptBuilder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
@@ -241,10 +240,7 @@ public class OpensearchBatchRequest implements BatchRequest {
                   responseItem.id(),
                   responseItem.error().reason()),
               "error on OpenSearch BulkRequest");
-          throw new PersistenceException(
-              "Operation failed: " + responseItem.error().reason(),
-              new OpensearchExporterException(responseItem.error().reason()),
-              Integer.valueOf(responseItem.id()));
+          throw new PersistenceException("Operation failed: " + responseItem.error().reason());
         }
       }
     } catch (final IOException | OpenSearchException ex) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -369,8 +369,8 @@ final class CamundaExporterIT {
         final ExportHandler<S, T> handler)
         throws IOException {
 
+      final var currentTime = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
       try (final var mocked = mockStatic(OffsetDateTime.class)) {
-        final var currentTime = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
         mocked.when(OffsetDateTime::now).thenReturn(currentTime);
 
         final var record =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -369,33 +369,32 @@ final class CamundaExporterIT {
         final ExportHandler<S, T> handler)
         throws IOException {
 
-      final var currentTime = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
-      final var mocked = mockStatic(OffsetDateTime.class);
-      mocked.when(OffsetDateTime::now).thenReturn(currentTime);
+      try (final var mocked = mockStatic(OffsetDateTime.class)) {
+        final var currentTime = OffsetDateTime.now().truncatedTo(ChronoUnit.MILLIS);
+        mocked.when(OffsetDateTime::now).thenReturn(currentTime);
 
-      final var record =
-          (Record<T>)
-              customRecordGenerators
-                  .getOrDefault(handler.getClass(), this::defaultRecordGenerator)
-                  .apply(handler);
-      customRecordGenerators.put(handler.getClass(), (ignored) -> record);
+        final var record =
+            (Record<T>)
+                customRecordGenerators
+                    .getOrDefault(handler.getClass(), this::defaultRecordGenerator)
+                    .apply(handler);
+        customRecordGenerators.put(handler.getClass(), (ignored) -> record);
 
-      final var entityId = handler.generateIds(record).getFirst();
-      final var expectedEntity = handler.createNewEntity(entityId);
-      handler.updateEntity(record, expectedEntity);
-      exporter.export(record);
+        final var entityId = handler.generateIds(record).getFirst();
+        final var expectedEntity = handler.createNewEntity(entityId);
+        handler.updateEntity(record, expectedEntity);
+        exporter.export(record);
 
-      mocked.close();
+        final var responseEntity =
+            clientAdapter.get(
+                expectedEntity.getId(), handler.getIndexName(), handler.getEntityType());
 
-      final var responseEntity =
-          clientAdapter.get(
-              expectedEntity.getId(), handler.getIndexName(), handler.getEntityType());
-
-      assertThat(responseEntity)
-          .describedAs(
-              "Handler [%s] correctly handles a [%s] record",
-              handler.getClass().getSimpleName(), handler.getHandledValueType())
-          .isEqualTo(expectedEntity);
+        assertThat(responseEntity)
+            .describedAs(
+                "Handler [%s] correctly handles a [%s] record",
+                handler.getClass().getSimpleName(), handler.getHandledValueType())
+            .isEqualTo(expectedEntity);
+      }
     }
 
     private <S extends ExporterEntity<S>, T extends RecordValue> Record<T> recordGenerator(


### PR DESCRIPTION
## Description
- surround mockStatic with try-with-resources. So if one test failed or threw exception, the mock closes and do not affect subsequent tests
- remove failing requestId from PersistenceException. Some requestIds were long or other formats, leading to NumberFormatException. This information is not actually needed in the exception

**PS:** tests are still flaky, but those will cover other issues when solved

## Related issues

related to #23888
