### PR TITLE
Migrate BatchOperations archive job to Camunda Exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -85,7 +86,9 @@ public final class Archiver implements CloseableSilently {
 
     final var processInstanceJob =
         createProcessInstanceJob(metrics, logger, resourceProvider, repository, executor);
-    archiver.start(config, processInstanceJob);
+    final var batchOperationJob =
+        createBatchOperationJob(metrics, logger, resourceProvider, repository, executor);
+    archiver.start(config, processInstanceJob, batchOperationJob);
 
     return archiver;
   }
@@ -106,6 +109,21 @@ public final class Archiver implements CloseableSilently {
         repository,
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
         dependantTemplates,
+        metrics,
+        logger,
+        executor);
+  }
+
+  private static BatchOperationArchiverJob createBatchOperationJob(
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final ExporterResourceProvider resourceProvider,
+      final ArchiverRepository repository,
+      final ScheduledThreadPoolExecutor executor) {
+
+    return new BatchOperationArchiverJob(
+        repository,
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class),
         metrics,
         logger,
         executor);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ArchiverRepository.java
@@ -15,6 +15,8 @@ import java.util.concurrent.Executor;
 public interface ArchiverRepository extends AutoCloseable {
   CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch();
 
+  CompletableFuture<ArchiveBatch> getBatchOperationsNextBatch();
+
   CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
 
   CompletableFuture<Void> deleteDocuments(
@@ -43,6 +45,11 @@ public interface ArchiverRepository extends AutoCloseable {
 
     @Override
     public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+      return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
+    }
+
+    @Override
+    public CompletableFuture<ArchiveBatch> getBatchOperationsNextBatch() {
       return CompletableFuture.completedFuture(new ArchiveBatch("2024-01-01", List.of()));
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
+import io.camunda.zeebe.util.FunctionUtil;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class BatchOperationArchiverJob implements ArchiverJob {
+
+  private final ArchiverRepository repository;
+  private final BatchOperationTemplate batchOperationTemplate;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+  private final Executor executor;
+
+  public BatchOperationArchiverJob(
+      final ArchiverRepository repository,
+      final BatchOperationTemplate batchOperationTemplate,
+      final CamundaExporterMetrics metrics,
+      final Logger logger,
+      final Executor executor) {
+    this.repository = repository;
+    this.metrics = metrics;
+    this.batchOperationTemplate = batchOperationTemplate;
+    this.logger = logger;
+    this.executor = executor;
+  }
+
+  @Override
+  public CompletableFuture<Integer> archiveNextBatch() {
+    return repository.getBatchOperationsNextBatch().thenComposeAsync(this::archiveBatch, executor);
+  }
+
+  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+
+    if (archiveBatch != null) {
+      logger.debug("Following batch operations are found for archiving: {}", archiveBatch);
+
+      return moveBatch(archiveBatch.finishDate(), archiveBatch.ids())
+          .thenApplyAsync(FunctionUtil.peek(metrics::operationsArchived), executor);
+    }
+
+    logger.debug("Nothing to archive");
+    return CompletableFuture.completedFuture(0);
+  }
+
+  private CompletableFuture<Integer> moveBatch(
+      final String finishDate, final List<String> processInstanceKeys) {
+    return repository
+        .moveDocuments(
+            batchOperationTemplate.getFullQualifiedName(),
+            batchOperationTemplate.getFullQualifiedName() + finishDate,
+            finishDate,
+            processInstanceKeys,
+            executor)
+        .thenApplyAsync(ok -> processInstanceKeys.size(), executor);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/BatchOperationArchiverJob.java
@@ -47,7 +47,7 @@ public class BatchOperationArchiverJob implements ArchiverJob {
       logger.debug("Following batch operations are found for archiving: {}", archiveBatch);
 
       return moveBatch(archiveBatch.finishDate(), archiveBatch.ids())
-          .thenApplyAsync(FunctionUtil.peek(metrics::operationsArchived), executor);
+          .thenApplyAsync(FunctionUtil.peek(metrics::batchOperationsArchived), executor);
     }
 
     logger.debug("Nothing to archive");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -23,6 +23,7 @@ public class CamundaExporterMetrics {
   private final AtomicInteger bulkMemorySize = new AtomicInteger(0);
   private final Timer flushLatency;
   private final Counter processInstancesArchived;
+  private final Counter batchOperationsArchived;
   private Timer.Sample flushLatencyMeasurement;
 
   public CamundaExporterMetrics(final MeterRegistry meterRegistry) {
@@ -35,6 +36,7 @@ public class CamundaExporterMetrics {
             .publishPercentileHistogram()
             .register(meterRegistry);
     processInstancesArchived = meterRegistry.counter(meterName("archived.process.instances"));
+    batchOperationsArchived = meterRegistry.counter(meterName("archived.batch.operations"));
   }
 
   public ResourceSample measureFlushDuration() {
@@ -79,6 +81,11 @@ public class CamundaExporterMetrics {
 
   public void recordProcessInstancesArchived(final int count) {
     processInstancesArchived.increment(count);
+  }
+
+  // counts the number of operations in the batch.
+  public void operationsArchived(final int count) {
+    batchOperationsArchived.increment(count);
   }
 
   private String meterName(final String name) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/metrics/CamundaExporterMetrics.java
@@ -83,8 +83,7 @@ public class CamundaExporterMetrics {
     processInstancesArchived.increment(count);
   }
 
-  // counts the number of operations in the batch.
-  public void operationsArchived(final int count) {
+  public void batchOperationsArchived(final int count) {
     batchOperationsArchived.increment(count);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/BatchOperationArchiverJobTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.archiver.TestRepository.DocumentMove;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executor;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class BatchOperationArchiverJobTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BatchOperationArchiverJobTest.class);
+
+  private final Executor executor = Runnable::run;
+  private final TestRepository repository = new TestRepository();
+  private final BatchOperationTemplate batchOperationTemplate =
+      new BatchOperationTemplate("", true);
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final CamundaExporterMetrics metrics = new CamundaExporterMetrics(meterRegistry);
+  private final BatchOperationArchiverJob job =
+      new BatchOperationArchiverJob(repository, batchOperationTemplate, metrics, LOGGER, executor);
+
+  @Test
+  void shouldReturnZeroIfNoBatchGiven() {
+    // given - when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+  }
+
+  @Test
+  void shouldReturnZeroIfNoBatchIdsGiven() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of());
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+  }
+
+  @Test
+  void shouldMoveBatchOperations() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var result = job.archiveNextBatch();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(3);
+    assertThat(repository.moves)
+        .contains(
+            new DocumentMove(
+                batchOperationTemplate.getFullQualifiedName(),
+                batchOperationTemplate.getFullQualifiedName() + "2024-01-01",
+                repository.batch.finishDate(),
+                List.of("1", "2", "3"),
+                executor));
+  }
+
+  @Test
+  void shouldRecordBatchOperationsIncrease() {
+    // given
+    repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
+
+    // when
+    final var count = job.archiveNextBatch().join() + job.archiveNextBatch().join();
+
+    // then
+    assertThat(meterRegistry.counter("zeebe.camunda.exporter.archived.batch.operations").count())
+        .isEqualTo(6)
+        .isEqualTo(count);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJobTest.java
@@ -9,8 +9,7 @@ package io.camunda.exporter.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
-import io.camunda.exporter.archiver.ProcessInstancesArchiverJobTest.TestRepository.DocumentMove;
+import io.camunda.exporter.archiver.TestRepository.DocumentMove;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
@@ -18,9 +17,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -164,35 +161,6 @@ final class ProcessInstancesArchiverJobTest {
     assertThat(meterRegistry.counter("zeebe.camunda.exporter.archived.process.instances").count())
         .isEqualTo(6)
         .isEqualTo(count);
-  }
-
-  static final class TestRepository extends NoopArchiverRepository {
-    private final List<DocumentMove> moves = new ArrayList<>();
-    private ArchiveBatch batch;
-
-    @Override
-    public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
-      return CompletableFuture.completedFuture(batch);
-    }
-
-    @Override
-    public CompletableFuture<Void> moveDocuments(
-        final String sourceIndexName,
-        final String destinationIndexName,
-        final String idFieldName,
-        final List<String> ids,
-        final Executor executor) {
-      moves.add(
-          new DocumentMove(sourceIndexName, destinationIndexName, idFieldName, ids, executor));
-      return CompletableFuture.completedFuture(null);
-    }
-
-    record DocumentMove(
-        String sourceIndexName,
-        String destinationIndexName,
-        String idFieldName,
-        List<String> ids,
-        Executor executor) {}
   }
 
   private static final class WeirdlyNamedDependant implements ProcessInstanceDependant {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/TestRepository.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+final class TestRepository extends NoopArchiverRepository {
+  final List<DocumentMove> moves = new ArrayList<>();
+  ArchiveBatch batch;
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getBatchOperationsNextBatch() {
+    return CompletableFuture.completedFuture(batch);
+  }
+
+  @Override
+  public CompletableFuture<Void> moveDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<String> ids,
+      final Executor executor) {
+    moves.add(new DocumentMove(sourceIndexName, destinationIndexName, idFieldName, ids, executor));
+    return CompletableFuture.completedFuture(null);
+  }
+
+  record DocumentMove(
+      String sourceIndexName,
+      String destinationIndexName,
+      String idFieldName,
+      List<String> ids,
+      Executor executor) {}
+}


### PR DESCRIPTION
## Description

This PR migrates the BatchOperationArchiverJob to the Camunda Exporter with no archiving logic yet implemented. Therfore the E2E will be added later. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/24093
