### PR TITLE
Do not create archiver if rollover is not enabled

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -92,14 +92,17 @@ public class CamundaExporter implements Exporter {
             provider.getIndexDescriptors(),
             provider.getIndexTemplateDescriptors(),
             configuration);
-    archiver =
-        Archiver.create(
-            context.getPartitionId(),
-            context.getConfiguration().getId().toLowerCase(),
-            configuration.getArchiver(),
-            provider,
-            metrics,
-            logger);
+
+    if (configuration.getArchiver().isRolloverEnabled()) {
+      archiver =
+          Archiver.create(
+              context.getPartitionId(),
+              context.getConfiguration().getId().toLowerCase(),
+              configuration.getArchiver(),
+              provider,
+              metrics,
+              logger);
+    }
 
     schemaManager.startup();
 


### PR DESCRIPTION
## Description

This PR checks the archiver configuration `IsRolloverEnabled` to determine if we should create the archiver. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/24290
