### PR TITLE
Operation rejection from Task Listeners: changes to the processing

### DIFF
--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
@@ -34,6 +34,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private JobKind jobKind;
   private JobListenerEventType jobListenerEventType;
   private Set<String> changedAttributes;
+  private JobResultValueImpl result;
 
   public JobRecordValueImpl() {}
 
@@ -191,21 +192,30 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   }
 
   @Override
-  public String getTenantId() {
-    return tenantId;
-  }
-
-  public void setTenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  @Override
   public Set<String> getChangedAttributes() {
     return changedAttributes;
   }
 
   public void setChangedAttributes(final Set<String> changedAttributes) {
     this.changedAttributes = changedAttributes;
+  }
+
+  @Override
+  public JobResultValueImpl getResult() {
+    return result;
+  }
+
+  public void setResult(final JobResultValueImpl result) {
+    this.result = result;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -228,7 +238,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         tenantId,
         jobKind,
         jobListenerEventType,
-        changedAttributes);
+        changedAttributes,
+        result);
   }
 
   @Override
@@ -259,7 +270,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(tenantId, that.tenantId)
         && jobKind == that.jobKind
         && jobListenerEventType == that.jobListenerEventType
-        && Objects.equals(changedAttributes, that.changedAttributes);
+        && Objects.equals(changedAttributes, that.changedAttributes)
+        && Objects.equals(result, that.result);
   }
 
   @Override
@@ -307,6 +319,46 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + jobListenerEventType
         + ", changedAttributes="
         + changedAttributes
+        + ", result="
+        + result
         + '}';
+  }
+
+  public static class JobResultValueImpl implements JobResultValue{
+
+    private boolean denied;
+
+    @Override
+    public boolean isDenied() {
+      return denied;
+    }
+
+    public void setDenied(final boolean denied) {
+      this.denied = denied;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(denied);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final JobResultValueImpl that = (JobResultValueImpl) o;
+      return denied == that.denied;
+    }
+
+    @Override
+    public String toString() {
+      return "JobResultValueImpl{"
+          + "denied='" + denied
+          + '}';
+      }
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
@@ -34,7 +34,6 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private JobKind jobKind;
   private JobListenerEventType jobListenerEventType;
   private Set<String> changedAttributes;
-  private JobResultValueImpl result;
 
   public JobRecordValueImpl() {}
 
@@ -202,11 +201,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
 
   @Override
   public JobResultValueImpl getResult() {
-    return result;
-  }
-
-  public void setResult(final JobResultValueImpl result) {
-    this.result = result;
+    // Not used by importer, dummy implementation for compiler
+    return null;
   }
 
   @Override
@@ -238,8 +234,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         tenantId,
         jobKind,
         jobListenerEventType,
-        changedAttributes,
-        result);
+        changedAttributes);
   }
 
   @Override
@@ -270,8 +265,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(tenantId, that.tenantId)
         && jobKind == that.jobKind
         && jobListenerEventType == that.jobListenerEventType
-        && Objects.equals(changedAttributes, that.changedAttributes)
-        && Objects.equals(result, that.result);
+        && Objects.equals(changedAttributes, that.changedAttributes);
   }
 
   @Override
@@ -319,44 +313,14 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + jobListenerEventType
         + ", changedAttributes="
         + changedAttributes
-        + ", result="
-        + result
         + '}';
   }
 
   public static class JobResultValueImpl implements JobResultValue {
-
-    private boolean denied;
-
     @Override
     public boolean isDenied() {
-      return denied;
-    }
-
-    public void setDenied(final boolean denied) {
-      this.denied = denied;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(denied);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final JobResultValueImpl that = (JobResultValueImpl) o;
-      return denied == that.denied;
-    }
-
-    @Override
-    public String toString() {
-      return "JobResultValueImpl{" + "denied='" + denied + '}';
+      // Not used by importer, dummy implementation for compiler
+      return false;
     }
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
@@ -324,7 +324,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + '}';
   }
 
-  public static class JobResultValueImpl implements JobResultValue{
+  public static class JobResultValueImpl implements JobResultValue {
 
     private boolean denied;
 
@@ -356,9 +356,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
 
     @Override
     public String toString() {
-      return "JobResultValueImpl{"
-          + "denied='" + denied
-          + '}';
-      }
+      return "JobResultValueImpl{" + "denied='" + denied + '}';
+    }
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -34,6 +34,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private JobKind jobKind;
   private JobListenerEventType jobListenerEventType;
   private Set<String> changedAttributes;
+  private JobResultValueImpl result;
 
   public JobRecordValueImpl() {}
 
@@ -191,21 +192,30 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   }
 
   @Override
-  public String getTenantId() {
-    return tenantId;
-  }
-
-  public void setTenantId(final String tenantId) {
-    this.tenantId = tenantId;
-  }
-
-  @Override
   public Set<String> getChangedAttributes() {
     return changedAttributes;
   }
 
   public void setChangedAttributes(final Set<String> changedAttributes) {
     this.changedAttributes = changedAttributes;
+  }
+
+  @Override
+  public JobResultValueImpl getResult() {
+    return result;
+  }
+
+  public void setResult(final JobResultValueImpl result) {
+    this.result = result;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
   }
 
   @Override
@@ -228,7 +238,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         tenantId,
         jobKind,
         jobListenerEventType,
-        changedAttributes);
+        changedAttributes,
+        result);
   }
 
   @Override
@@ -259,7 +270,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(tenantId, that.tenantId)
         && jobKind == that.jobKind
         && jobListenerEventType == that.jobListenerEventType
-        && Objects.equals(changedAttributes, that.changedAttributes);
+        && Objects.equals(changedAttributes, that.changedAttributes)
+        && Objects.equals(result, that.result);
   }
 
   @Override
@@ -307,6 +319,46 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + jobListenerEventType
         + ", changedAttributes="
         + changedAttributes
+        + ", result="
+        + result
         + '}';
+  }
+
+  public static class JobResultValueImpl implements JobResultValue{
+
+    private boolean denied;
+
+    @Override
+    public boolean isDenied() {
+      return denied;
+    }
+
+    public void setDenied(final boolean denied) {
+      this.denied = denied;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(denied);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final JobResultValueImpl that = (JobResultValueImpl) o;
+      return denied == that.denied;
+    }
+
+    @Override
+    public String toString() {
+      return "JobResultValueImpl{"
+          + "denied='" + denied
+          + '}';
+    }
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -34,7 +34,6 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private JobKind jobKind;
   private JobListenerEventType jobListenerEventType;
   private Set<String> changedAttributes;
-  private JobResultValueImpl result;
 
   public JobRecordValueImpl() {}
 
@@ -202,11 +201,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
 
   @Override
   public JobResultValueImpl getResult() {
-    return result;
-  }
-
-  public void setResult(final JobResultValueImpl result) {
-    this.result = result;
+    // Not used by importer, dummy implementation for compiler
+    return null;
   }
 
   @Override
@@ -238,8 +234,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         tenantId,
         jobKind,
         jobListenerEventType,
-        changedAttributes,
-        result);
+        changedAttributes);
   }
 
   @Override
@@ -270,8 +265,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(tenantId, that.tenantId)
         && jobKind == that.jobKind
         && jobListenerEventType == that.jobListenerEventType
-        && Objects.equals(changedAttributes, that.changedAttributes)
-        && Objects.equals(result, that.result);
+        && Objects.equals(changedAttributes, that.changedAttributes);
   }
 
   @Override
@@ -319,44 +313,14 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + jobListenerEventType
         + ", changedAttributes="
         + changedAttributes
-        + ", result="
-        + result
         + '}';
   }
 
   public static class JobResultValueImpl implements JobResultValue {
-
-    private boolean denied;
-
     @Override
     public boolean isDenied() {
-      return denied;
-    }
-
-    public void setDenied(final boolean denied) {
-      this.denied = denied;
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(denied);
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final JobResultValueImpl that = (JobResultValueImpl) o;
-      return denied == that.denied;
-    }
-
-    @Override
-    public String toString() {
-      return "JobResultValueImpl{" + "denied='" + denied + '}';
+      // Not used by importer, dummy implementation for compiler
+      return false;
     }
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -324,7 +324,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + '}';
   }
 
-  public static class JobResultValueImpl implements JobResultValue{
+  public static class JobResultValueImpl implements JobResultValue {
 
     private boolean denied;
 
@@ -356,9 +356,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
 
     @Override
     public String toString() {
-      return "JobResultValueImpl{"
-          + "denied='" + denied
-          + '}';
+      return "JobResultValueImpl{" + "denied='" + denied + '}';
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -111,6 +111,13 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           */
           final var userTask =
               userTaskState.getIntermediateState(elementInstance.getUserTaskKey()).getRecord();
+
+          if (!value.getResult().isApproved()) {
+            commandWriter.appendFollowUpCommand(
+                userTask.getUserTaskKey(), UserTaskIntent.REJECT_TASK_LISTENER, userTask);
+            return;
+          }
+
           commandWriter.appendFollowUpCommand(
               userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
           return;
@@ -154,6 +161,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
       final CommandControl<JobRecord> commandControl,
       final JobRecord job) {
     job.setVariables(command.getValue().getVariablesBuffer());
+    job.setResult(command.getValue().getResult());
 
     commandControl.accept(JobIntent.COMPLETED, job);
     jobMetrics.jobCompleted(job.getType(), job.getJobKind());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -112,7 +112,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           final var userTask =
               userTaskState.getIntermediateState(elementInstance.getUserTaskKey()).getRecord();
 
-          if (!value.getResult().isApproved()) {
+          if (value.getResult().isDenied()) {
             commandWriter.appendFollowUpCommand(
                 userTask.getUserTaskKey(), UserTaskIntent.REJECT_TASK_LISTENER, userTask);
             return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -114,7 +114,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
 
           if (value.getResult().isDenied()) {
             commandWriter.appendFollowUpCommand(
-                userTask.getUserTaskKey(), UserTaskIntent.REJECT_TASK_LISTENER, userTask);
+                userTask.getUserTaskKey(), UserTaskIntent.DENY_TASK_LISTENER, userTask);
             return;
           }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -52,6 +52,29 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   }
 
   @Override
+  public void writeRejection(
+      final long key,
+      final Intent intent,
+      final UnifiedRecordValue value,
+      final ValueType valueType,
+      final RejectionType type,
+      final String reason,
+      final long requestId,
+      final int requestStreamId) {
+    resultBuilder()
+        .withResponse(
+            RecordType.COMMAND_REJECTION,
+            key,
+            intent,
+            value,
+            valueType,
+            type,
+            reason,
+            requestId,
+            requestStreamId);
+  }
+
+  @Override
   public void writeEvent(final TypedRecord<?> event) {
     writeResponse(
         event.getKey(),
@@ -95,29 +118,6 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
             valueType,
             RejectionType.NULL_VAL,
             "",
-            requestId,
-            requestStreamId);
-  }
-
-  @Override
-  public void writeRejection(
-      final Intent intent,
-      final long key,
-      final UnifiedRecordValue value,
-      final ValueType valueType,
-      final RejectionType type,
-      final String reason,
-      final long requestId,
-      final int requestStreamId) {
-    resultBuilder()
-        .withResponse(
-            RecordType.COMMAND_REJECTION,
-            key,
-            intent,
-            value,
-            valueType,
-            type,
-            reason,
             requestId,
             requestStreamId);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -94,6 +95,29 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
             valueType,
             RejectionType.NULL_VAL,
             "",
+            requestId,
+            requestStreamId);
+  }
+
+  @Override
+  public void writeRejection(
+      final Intent intent,
+      final long key,
+      final UnifiedRecordValue value,
+      final ValueType valueType,
+      final RejectionType type,
+      final String reason,
+      final long requestId,
+      final int requestStreamId) {
+    resultBuilder()
+        .withResponse(
+            RecordType.COMMAND_REJECTION,
+            key,
+            intent,
+            value,
+            valueType,
+            type,
+            reason,
             requestId,
             requestStreamId);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -26,8 +26,8 @@ public interface TypedResponseWriter {
       final int requestStreamId);
 
   void writeRejection(
-      final Intent intent,
       final long key,
+      final Intent intent,
       final UnifiedRecordValue value,
       final ValueType valueType,
       final RejectionType type,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.streamprocessor.writers;
 
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -19,6 +20,16 @@ public interface TypedResponseWriter {
 
   void writeRejection(
       final TypedRecord<?> command,
+      final RejectionType type,
+      final String reason,
+      final long requestId,
+      final int requestStreamId);
+
+  void writeRejection(
+      final Intent intent,
+      final long key,
+      final UnifiedRecordValue value,
+      final ValueType valueType,
       final RejectionType type,
       final String reason,
       final long requestId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -76,9 +76,11 @@ public final class UserTaskCommandProcessors {
       final Map<UserTaskIntent, UserTaskCommandProcessor> commandToProcessor) {
     final var missingProcessors =
         UserTaskIntent.commands().stream()
-            // Exclude COMPLETE_TASK_LISTENER as it doesn't require a dedicated processor.
+            // Exclude COMPLETE_TASK_LISTENER and REJECT_TASK_LISTENER as they don't require a
+            // dedicated processor.
             // This intent is handled internally within UserTaskProcessor
             .filter(intent -> intent != UserTaskIntent.COMPLETE_TASK_LISTENER)
+            .filter(intent -> intent != UserTaskIntent.REJECT_TASK_LISTENER)
             .filter(intent -> !commandToProcessor.containsKey(intent))
             .collect(Collectors.toSet());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandProcessors.java
@@ -80,7 +80,7 @@ public final class UserTaskCommandProcessors {
             // dedicated processor.
             // This intent is handled internally within UserTaskProcessor
             .filter(intent -> intent != UserTaskIntent.COMPLETE_TASK_LISTENER)
-            .filter(intent -> intent != UserTaskIntent.REJECT_TASK_LISTENER)
+            .filter(intent -> intent != UserTaskIntent.DENY_TASK_LISTENER)
             .filter(intent -> !commandToProcessor.containsKey(intent))
             .collect(Collectors.toSet());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -215,15 +215,13 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     stateWriter.appendFollowUpEvent(persistedRecord.getUserTaskKey(), intent, persistedRecord);
 
-    rejectionWriter.appendRejection(
-        command,
-        RejectionType.INVALID_STATE,
-        USER_TASK_COMPLETION_REJECTION.formatted(persistedRecord.getUserTaskKey()));
-
     recordRequestMetadata.ifPresent(
         metadata -> {
           responseWriter.writeRejection(
-              command,
+              UserTaskIntent.COMPLETE,
+              command.getKey(),
+              command.getValue(),
+              command.getValueType(),
               RejectionType.INVALID_STATE,
               USER_TASK_COMPLETION_REJECTION.formatted(persistedRecord.getUserTaskKey()),
               metadata.getRequestId(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -83,7 +83,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     switch (intent) {
       case ASSIGN, CLAIM, COMPLETE, UPDATE -> processOperationCommand(command, intent);
       case COMPLETE_TASK_LISTENER -> processCompleteTaskListener(command);
-      case DENY_TASK_LISTENER -> processRejectTaskListener(command);
+      case DENY_TASK_LISTENER -> processDenyTaskListener(command);
       default -> throw new UnsupportedOperationException("Unexpected user task intent: " + intent);
     }
   }
@@ -104,7 +104,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
             () -> commandProcessor.onFinalizeCommand(command, persistedRecord));
   }
 
-  private void processRejectTaskListener(final TypedRecord<UserTaskRecord> command) {
+  private void processDenyTaskListener(final TypedRecord<UserTaskRecord> command) {
     final var lifecycleState = userTaskState.getLifecycleState(command.getKey());
     final var persistedRecord = userTaskState.getUserTask(command.getKey());
 
@@ -218,8 +218,8 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     recordRequestMetadata.ifPresent(
         metadata -> {
           responseWriter.writeRejection(
-              UserTaskIntent.COMPLETE,
               command.getKey(),
+              UserTaskIntent.COMPLETE,
               command.getValue(),
               command.getValueType(),
               RejectionType.INVALID_STATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -402,6 +402,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
     register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));
+    register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));
   }
 
   private void registerCompensationSubscriptionApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletionDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletionDeniedApplier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskCompletionDeniedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public UserTaskCompletionDeniedApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+    elementInstanceState = processingState.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+    userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+    if (elementInstance != null) {
+      final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+      if (scopeInstance != null && scopeInstance.isActive()) {
+        elementInstance.resetTaskListenerIndices();
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
 import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
@@ -526,6 +527,221 @@ public class TaskListenerTest {
     // complete the listener job without variables to have a completed process
     // and prevent flakiness in other tests
     ENGINE.job().ofInstance(processInstanceKey).withType(LISTENER_TYPE).complete();
+  }
+
+  @Test
+  public void shouldCompleteTaskWithTaskListenerWhenJobResultDeniedIsNotSet() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult())
+        .complete();
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that `COMPLETE_TASK_LISTENER` events were triggered between user task"
+                + " `COMPLETING` and `COMPLETED` events")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldCompleteUserTaskWhenTaskListenerAcceptsTheOperation() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(false))
+        .complete();
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that `COMPLETE_TASK_LISTENER` events were triggered between user "
+                + "task `COMPLETING` and `COMPLETED` events")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldRejectUserTaskCompletionWhenTaskListenerRejectsTheOperation() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(true))
+        .complete();
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that `REJECT_TASK_LISTENER` and `COMPLETION_DENIED` are written "
+                + "after `COMPLETING` event")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.REJECT_TASK_LISTENER,
+            UserTaskIntent.COMPLETION_DENIED);
+  }
+
+  @Test
+  public void shouldCompleteTaskWhenTaskListenerAcceptsOperationAfterRejection() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(true))
+        .complete();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+
+    completeRecreatedJobWithType(ENGINE, processInstanceKey, LISTENER_TYPE);
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that `COMPLETING` `COMPLETE_TASK_LISTENER` and `COMPLETED"
+                + "` events are present after `REJECT_TASK_LISTENER` and `COMPLETION_DENIED` events")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.REJECT_TASK_LISTENER,
+            UserTaskIntent.COMPLETION_DENIED,
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldCompleteAllTaskListenersWhenFirstTaskListenerAcceptOperationAfterRejection() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            createProcessWithCompleteTaskListeners(
+                LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(true))
+        .complete();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    completeRecreatedJobWithType(ENGINE, processInstanceKey, LISTENER_TYPE);
+    completeJobs(processInstanceKey, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3");
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that all three `COMPLETE_TASK_LISTENER` events were triggered after the "
+                + "rejection from the first Task Listener")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.REJECT_TASK_LISTENER,
+            UserTaskIntent.COMPLETION_DENIED,
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETED);
+  }
+
+  @Test
+  public void shouldAssignAndCompleteTaskAfterTaskListenerRejectsTheCompletion() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(true))
+        .complete();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("Test Assignee").assign();
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+
+    completeRecreatedJobWithType(ENGINE, processInstanceKey, LISTENER_TYPE);
+
+    // then
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
+        .extracting(Record::getIntent)
+        .describedAs(
+            "Ensure that user task could be assigned after completion was rejected from the"
+                + " `COMPLETE` Task Listener. Ensure that user task could be completed after assignment"
+                + " and `COMPLETE_TASK_LISTENER` event was triggered successfully")
+        .containsSubsequence(
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.REJECT_TASK_LISTENER,
+            UserTaskIntent.COMPLETION_DENIED,
+            UserTaskIntent.ASSIGNING,
+            UserTaskIntent.ASSIGNED,
+            UserTaskIntent.COMPLETING,
+            UserTaskIntent.COMPLETE_TASK_LISTENER,
+            UserTaskIntent.COMPLETED);
+  }
+
+  private static void completeRecreatedJobWithType(
+      final EngineRule engine, final long processInstanceKey, final String jobType) {
+    final long jobKey =
+        jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(jobType)
+            .skip(1)
+            .getFirst()
+            .getKey();
+    engine.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
   }
 
   private void assertThatProcessInstanceCompleted(final long processInstanceKey) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -83,6 +84,11 @@ public final class JobClient {
 
   public JobClient withVariables(final Map<String, Object> variables) {
     jobRecord.setVariables(MsgPackUtil.asMsgPack(variables));
+    return this;
+  }
+
+  public JobClient withResult(final JobResult result) {
+    jobRecord.setResult(result);
     return this;
   }
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -100,6 +100,13 @@
                 },
                 "changedAttributes": {
                   "type": "text"
+                },
+                "result": {
+                  "properties": {
+                    "denied": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -81,6 +81,13 @@
             },
             "changedAttributes": {
               "type": "text"
+            },
+            "result": {
+              "properties": {
+                "denied": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -100,6 +100,13 @@
                 },
                 "changedAttributes": {
                   "type": "text"
+                },
+                "result": {
+                  "properties": {
+                    "denied": {
+                      "type": "boolean"
+                    }
+                  }
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -81,6 +81,13 @@
             },
             "changedAttributes": {
               "type": "text"
+            },
+            "result": {
+              "properties": {
+                "denied": {
+                  "type": "boolean"
+                }
+              }
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -132,7 +132,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
-    resultProp.getValue().setFields(record.getResult());
+    resultProp.getValue().wrap(record.getResult());
   }
 
   public void wrap(final JobRecord record) {
@@ -276,7 +276,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   public JobRecord setResult(final JobResult result) {
-    resultProp.getValue().setFields(result);
+    resultProp.getValue().wrap(result);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -270,6 +270,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  @Override
+  public JobResult getResult() {
+    return resultProp.getValue();
+  }
+
+  public JobRecord setResult(final JobResult result) {
+    resultProp.getValue().setFields(result);
+    return this;
+  }
+
   public JobRecord setProcessDefinitionVersion(final int version) {
     processDefinitionVersionProp.setValue(version);
     return this;
@@ -359,15 +369,6 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
-  }
-
-  public JobResult getResult() {
-    return resultProp.getValue();
-  }
-
-  public JobRecord setResult(final JobResult result) {
-    resultProp.getValue().setFields(result);
-    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
@@ -80,9 +81,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final ObjectProperty<JobResult> resultProp =
+      new ObjectProperty<>("result", new JobResult());
 
   public JobRecord() {
-    super(21);
+    super(22);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -103,7 +106,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(resultProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -128,6 +132,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
     setChangedAttributes(record.getChangedAttributes());
+    resultProp.getValue().setFields(record.getResult());
   }
 
   public void wrap(final JobRecord record) {
@@ -354,6 +359,15 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setType(final DirectBuffer buf) {
     return setType(buf, 0, buf.capacity());
+  }
+
+  public JobResult getResult() {
+    return resultProp.getValue();
+  }
+
+  public JobRecord setResult(final JobResult result) {
+    resultProp.getValue().setFields(result);
+    return this;
   }
 
   public JobRecord setListenerEventType(final JobListenerEventType jobListenerEventType) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.job;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 
+@JsonIgnoreProperties({"empty", "encodedLength", "length"})
 public class JobResult extends UnpackedObject {
 
   private final BooleanProperty deniedProp = new BooleanProperty("denied", false);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -10,9 +10,15 @@ package io.camunda.zeebe.protocol.impl.record.value.job;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultValue;
 
-@JsonIgnoreProperties({"empty", "encodedLength", "length"})
-public class JobResult extends UnpackedObject {
+@JsonIgnoreProperties({
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "empty",
+  "encodedLength",
+  "length"
+})
+public class JobResult extends UnpackedObject implements JobResultValue {
 
   private final BooleanProperty deniedProp = new BooleanProperty("denied", false);
 
@@ -26,6 +32,7 @@ public class JobResult extends UnpackedObject {
     deniedProp.setValue(result.isDenied());
   }
 
+  @Override
   public boolean isDenied() {
     return deniedProp.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
+
+public class JobResult extends UnpackedObject {
+
+  private final BooleanProperty approvedProp = new BooleanProperty("approved", true);
+
+  public JobResult() {
+    super(1);
+    declareProperty(approvedProp);
+  }
+
+  /** Sets all properties to current instance from provided user task job data */
+  public void setFields(final JobResult result) {
+    approvedProp.setValue(result.isApproved());
+  }
+
+  public boolean isApproved() {
+    return approvedProp.getValue();
+  }
+
+  public JobResult setApproved(final boolean approved) {
+    approvedProp.setValue(approved);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -28,7 +28,7 @@ public class JobResult extends UnpackedObject implements JobResultValue {
   }
 
   /** Sets all properties to current instance from provided user task job data */
-  public void setFields(final JobResult result) {
+  public void wrap(final JobResult result) {
     deniedProp.setValue(result.isDenied());
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -12,24 +12,24 @@ import io.camunda.zeebe.msgpack.property.BooleanProperty;
 
 public class JobResult extends UnpackedObject {
 
-  private final BooleanProperty approvedProp = new BooleanProperty("approved", true);
+  private final BooleanProperty deniedProp = new BooleanProperty("denied", false);
 
   public JobResult() {
     super(1);
-    declareProperty(approvedProp);
+    declareProperty(deniedProp);
   }
 
   /** Sets all properties to current instance from provided user task job data */
   public void setFields(final JobResult result) {
-    approvedProp.setValue(result.isApproved());
+    deniedProp.setValue(result.isDenied());
   }
 
-  public boolean isApproved() {
-    return approvedProp.getValue();
+  public boolean isDenied() {
+    return deniedProp.getValue();
   }
 
-  public JobResult setApproved(final boolean approved) {
-    approvedProp.setValue(approved);
+  public JobResult setDenied(final boolean denied) {
+    deniedProp.setValue(denied);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
@@ -688,6 +689,7 @@ final class JsonSerializableToJsonTest {
               final String activityId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
+              final JobResult result = new JobResult().setDenied(true);
 
               jobRecord
                   .setWorker(wrapString(worker))
@@ -705,7 +707,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessInstanceKey(processInstanceKey)
                   .setElementId(wrapString(activityId))
                   .setElementInstanceKey(activityInstanceKey)
-                  .setChangedAttributes(changedAttributes);
+                  .setChangedAttributes(changedAttributes)
+                  .setResult(result);
 
               return record;
             },
@@ -742,7 +745,10 @@ final class JsonSerializableToJsonTest {
               "deadline": 1000,
               "timeout": -1,
               "tenantId": "<default>",
-              "changedAttributes": ["bar", "foo"]
+              "changedAttributes": ["bar", "foo"],
+              "result": {
+                "denied": true
+              }
             }
           ],
           "timeout": 2,
@@ -793,6 +799,7 @@ final class JsonSerializableToJsonTest {
               final String elementId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
+              final JobResult result = new JobResult().setDenied(true);
 
               final Map<String, String> customHeaders =
                   Collections.singletonMap("workerVersion", "42");
@@ -815,7 +822,8 @@ final class JsonSerializableToJsonTest {
                       .setProcessInstanceKey(processInstanceKey)
                       .setElementId(wrapString(elementId))
                       .setElementInstanceKey(activityInstanceKey)
-                      .setChangedAttributes(changedAttributes);
+                      .setChangedAttributes(changedAttributes)
+                      .setResult(result);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -846,7 +854,10 @@ final class JsonSerializableToJsonTest {
           "deadline": 13,
           "timeout": 14,
           "tenantId": "<default>",
-          "changedAttributes": ["bar", "foo"]
+          "changedAttributes": ["bar", "foo"],
+          "result": {
+            "denied": true
+           }
         }
         """
       },
@@ -879,7 +890,10 @@ final class JsonSerializableToJsonTest {
           "deadline": -1,
           "timeout": -1,
           "tenantId": "<default>",
-          "changedAttributes": []
+          "changedAttributes": [],
+          "result": {
+            "denied": false
+          }
         }
         """
       },
@@ -917,7 +931,10 @@ final class JsonSerializableToJsonTest {
           "processDefinitionVersion": -1,
           "customHeaders": {},
           "tenantId": "<default>",
-          "changedAttributes": []
+          "changedAttributes": [],
+          "result": {
+            "denied": false
+          }
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -51,7 +51,24 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * operations defined by the listener are fully executed before proceeding with the original task
    * command.
    */
-  COMPLETE_TASK_LISTENER(15);
+  COMPLETE_TASK_LISTENER(15),
+  /**
+   * Represents the intent that means Task Listener denied the operation and the creation of the
+   * next task listener or the finalization of the original user task command (COMPLETE) is not
+   * happening, but instead, COMPLETION_DENIED event will be written in order to revert the User
+   * Task to CREATED state. The job for the Task Listener itself in this case completes
+   * successfully.
+   *
+   * <p>Until this intent is written, the processing of the user task is paused, ensuring that the
+   * operations defined by the listener are fully executed before proceeding with the original task
+   * command.
+   */
+  REJECT_TASK_LISTENER(16),
+  /**
+   * Represents the intent indicating that the User Task will not be completed, but rather will be
+   * reverted to the CREATED state.
+   */
+  COMPLETION_DENIED(17);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -103,6 +120,10 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return MIGRATED;
       case 15:
         return COMPLETE_TASK_LISTENER;
+      case 16:
+        return REJECT_TASK_LISTENER;
+      case 17:
+        return COMPLETION_DENIED;
       default:
         return UNKNOWN;
     }
@@ -127,6 +148,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case UPDATING:
       case UPDATED:
       case MIGRATED:
+      case COMPLETION_DENIED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -60,10 +60,10 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * successfully.
    *
    * <p>Until this intent is written, the processing of the user task is paused, ensuring that the
-   * operations defined by the listener are fully executed before proceeding with the original task
-   * command.
+   * operations defined by the listener are fully executed before reverting the User Task to the
+   * CREATED state.
    */
-  REJECT_TASK_LISTENER(16),
+  DENY_TASK_LISTENER(16),
   /**
    * Represents the intent indicating that the User Task will not be completed, but rather will be
    * reverted to the CREATED state.
@@ -121,7 +121,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case 15:
         return COMPLETE_TASK_LISTENER;
       case 16:
-        return REJECT_TASK_LISTENER;
+        return DENY_TASK_LISTENER;
       case 17:
         return COMPLETION_DENIED;
       default:

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -127,4 +127,16 @@ public interface JobRecordValue
   JobListenerEventType getJobListenerEventType();
 
   Set<String> getChangedAttributes();
+
+  JobResultValue getResult();
+
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableJobResultValue.Builder.class)
+  interface JobResultValue {
+
+    /**
+     * @return true if the operation was rejected by Task Listener
+     */
+    boolean isDenied();
+  }
 }


### PR DESCRIPTION
## Description
This PR is a the first one out of three that are related to [Teach Task Listeners how to reject events](https://github.com/camunda/camunda/issues/23709) issue.

This PR contains:
- Introducing JobResult to JobRecord
- Changes to processing logic 
- Changes to importers 

The following 2 PRs will contain:
- PR#2: changes to gRPC and REST protocols, changes to request mappers, job controller, job services and broker request to complete the job.
- PR#3: changes related to Java Client

In this PR:

-  Adding `JobResult` field to `JobRecord`:  currently, `JobResult` will have only one boolean field which is `denied` and is `false` by default (initially the approach was to name the field `approved`, however, due to proto3 limitations the decision was made to switch to `denied`. Please see [this commit](https://github.com/camunda/camunda/commit/60bc99f2c712665b0a4af6f4d25443d41693d145) for more details). This
field indicates if the job worker denied the work based on some conditions. 
- Two new intents were added:
  -  `REJECT_TASK_LISTENER` represents the intent that means Task Listener has denied the operation and creation of the next task listener or the finalisation of the original user task command (`COMPLETE`) is not happening, but instead, `COMPLETION_DENIED` event will be written in order to revert the User Task to `CREATED` state (new `UserTaskCompletionDeniedApplier` was introduced for that purpose). The job for the Task Listener itself in this case completes successfully.
- `JobCompleteProcessor` will now have an additional validation to check if JobResult `denied` field is set. If it's value is `true`, then `REJECT_TASK_LISTENER` follow up command will be written.
- `UserTaskProcessor` will take care of processing the rejection and writing a `COMPLETION_DENIED` follow up event.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates #23709
closes #24554
