### PR TITLE
feat: add group updated applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -485,6 +485,7 @@ public final class EventAppliers implements EventApplier {
     register(
         GroupIntent.CREATED,
         new GroupCreatedApplier(state.getGroupState(), state.getAuthorizationState()));
+    register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupUpdatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupUpdatedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+
+public class GroupUpdatedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
+
+  private final MutableGroupState groupState;
+
+  public GroupUpdatedApplier(final MutableGroupState groupState) {
+    this.groupState = groupState;
+  }
+
+  @Override
+  public void applyState(final long key, final GroupRecord value) {
+    groupState.update(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -13,4 +13,6 @@ import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 public interface MutableGroupState extends GroupState {
 
   void create(final long groupKey, final GroupRecord group);
+
+  void update(final long groupKey, final GroupRecord group);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -50,4 +50,30 @@ public class GroupAppliersTest {
     assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
     assertThat(persistedGroup.getName()).isEqualTo(groupName);
   }
+
+  @Test
+  void shouldUpdateGroup() {
+    // given
+    final var groupUpdatedApplier = new GroupUpdatedApplier(groupState);
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var updatedGroupName = "updatedGroup";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    final var persistedGroup = groupState.get(groupKey);
+    assertThat(persistedGroup.isPresent()).isTrue();
+    assertThat(persistedGroup.get().getName()).isEqualTo(groupName);
+    final var updatedGroupRecord =
+        new GroupRecord().setGroupKey(groupKey).setName(updatedGroupName);
+
+    // when
+    groupUpdatedApplier.applyState(groupKey, updatedGroupRecord);
+
+    // then
+    final var group = groupState.get(groupKey);
+    assertThat(group.isPresent()).isTrue();
+    final var persistedUpdatedGroup = group.get();
+    assertThat(persistedUpdatedGroup.getGroupKey()).isEqualTo(groupKey);
+    assertThat(persistedUpdatedGroup.getName()).isEqualTo(updatedGroupRecord.getName());
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -101,18 +101,14 @@ public class GroupStateTest {
     groupState.update(groupKey, groupRecord);
 
     // then
-    var group = groupState.get(groupKey);
+    final var group = groupState.get(groupKey);
     assertThat(group.isPresent()).isTrue();
-    var persistedGroup = group.get();
+    final var persistedGroup = group.get();
     assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
     assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
 
     final var groupKeyByName = groupState.getGroupKeyByName(updatedGroupName);
     assertThat(groupKeyByName.isPresent()).isTrue();
-    group = groupState.get(groupKeyByName.get());
-    assertThat(group.isPresent()).isTrue();
-    persistedGroup = group.get();
-    assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
-    assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
+    assertThat(groupKeyByName.get()).isEqualTo(groupKey);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -85,4 +85,34 @@ public class GroupStateTest {
     // then
     assertThat(key.isPresent()).isFalse();
   }
+
+  @Test
+  void shouldUpdateGroup() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+
+    final var updatedGroupName = "updatedGroup";
+    groupRecord.setName(updatedGroupName);
+
+    // when
+    groupState.update(groupKey, groupRecord);
+
+    // then
+    var group = groupState.get(groupKey);
+    assertThat(group.isPresent()).isTrue();
+    var persistedGroup = group.get();
+    assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
+    assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
+
+    final var groupKeyByName = groupState.getGroupKeyByName(updatedGroupName);
+    assertThat(groupKeyByName.isPresent()).isTrue();
+    group = groupState.get(groupKeyByName.get());
+    assertThat(group.isPresent()).isTrue();
+    persistedGroup = group.get();
+    assertThat(persistedGroup.getGroupKey()).isEqualTo(groupKey);
+    assertThat(persistedGroup.getName()).isEqualTo(updatedGroupName);
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add an engine event applier for group updated events. Furthermore, expand the GroupState with a mutable update event, so that events of this type may mutate the DbGroupState.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23482 
