### PR TITLE
Remove mapping from tenant

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantProcessors.java
@@ -57,7 +57,7 @@ public class TenantProcessors {
             ValueType.TENANT,
             TenantIntent.REMOVE_ENTITY,
             new TenantRemoveEntityProcessor(
-                processingState.getTenantState(),
+                processingState,
                 authCheckBehavior,
                 keyGenerator,
                 writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -47,7 +47,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
       final KeyGenerator keyGenerator,
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior) {
-    this.tenantState = state.getTenantState();
+    tenantState = state.getTenantState();
     userState = state.getUserState();
     mappingState = state.getMappingState();
     this.authCheckBehavior = authCheckBehavior;
@@ -96,6 +96,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
           RejectionType.NOT_FOUND,
           "Expected to remove entity with key '%s' from tenant with key '%s', but the entity is not assigned to this tenant."
               .formatted(record.getEntityKey(), tenantKey));
+      return;
     }
 
     stateWriter.appendFollowUpEvent(tenantKey, TenantIntent.ENTITY_REMOVED, record);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -499,9 +499,7 @@ public final class EventAppliers implements EventApplier {
         new TenantCreatedApplier(state.getTenantState(), state.getAuthorizationState()));
     register(TenantIntent.UPDATED, new TenantUpdatedApplier(state.getTenantState()));
     register(TenantIntent.ENTITY_ADDED, new TenantEntityAddedApplier(state));
-    register(
-        TenantIntent.ENTITY_REMOVED,
-        new TenantEntityRemovedApplier(state.getTenantState(), state.getUserState()));
+    register(TenantIntent.ENTITY_REMOVED, new TenantEntityRemovedApplier(state));
     register(
         TenantIntent.DELETED,
         new TenantDeletedApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
@@ -17,11 +19,12 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
 
   private final MutableTenantState tenantState;
   private final MutableUserState userState;
+  private final MutableMappingState mappingState;
 
-  public TenantEntityRemovedApplier(
-      final MutableTenantState tenantState, final MutableUserState userState) {
-    this.tenantState = tenantState;
-    this.userState = userState;
+  public TenantEntityRemovedApplier(final MutableProcessingState state) {
+    this.tenantState = state.getTenantState();
+    this.userState = state.getUserState();
+    this.mappingState = state.getMappingState();
   }
 
   @Override
@@ -29,6 +32,7 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
     tenantState.removeEntity(tenant.getTenantKey(), tenant.getEntityKey());
     switch (tenant.getEntityType()) {
       case USER -> userState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
+      case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->
           throw new UnsupportedOperationException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -72,10 +72,10 @@ public class DbMappingState implements MutableMappingState {
     this.mappingKey.wrapLong(mappingKey);
     final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
     if (fkClaim != null) {
-      final var fkKey = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(fkKey);
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
       persistedMapping.addRoleKey(roleKey);
-      mappingColumnFamily.update(fkKey, persistedMapping);
+      mappingColumnFamily.update(claim, persistedMapping);
     }
   }
 
@@ -96,12 +96,26 @@ public class DbMappingState implements MutableMappingState {
     this.mappingKey.wrapLong(mappingKey);
     final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
     if (fkClaim != null) {
-      final var fkKey = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(fkKey);
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
       final List<Long> roleKeys = persistedMapping.getRoleKeysList();
       roleKeys.remove(roleKey);
       persistedMapping.setRoleKeysList(roleKeys);
-      mappingColumnFamily.update(fkKey, persistedMapping);
+      mappingColumnFamily.update(claim, persistedMapping);
+    }
+  }
+
+  @Override
+  public void removeTenant(final long mappingKey, final String tenantId) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
+      final List<String> tenantIds = persistedMapping.getTenantIdsList();
+      tenantIds.remove(tenantId);
+      persistedMapping.setTenantIdsList(tenantIds);
+      mappingColumnFamily.update(claim, persistedMapping);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -19,4 +19,6 @@ public interface MutableMappingState extends MappingState {
   void addTenant(final long mappingKey, final String tenantId);
 
   void removeRole(final long mappingKey, final long roleKey);
+
+  void removeTenant(final long mappingKey, final String tenantId);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantTest.java
@@ -106,7 +106,41 @@ public class RemoveEntityTenantTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove entity with key '%s' from tenant with key '%s', but the entity is not assigned to this tenant."
+            "Expected to remove entity with key '%s' from tenant with key '%s', but the entity does not exist."
                 .formatted(1L, tenantKey));
+  }
+
+  @Test
+  public void shouldRejectIfEntityIsNotAssigned() {
+    // given
+    final var tenantId = UUID.randomUUID().toString();
+    final var tenantRecord = engine.tenant().newTenant().withTenantId(tenantId).create();
+
+    // when
+    final var createdTenant = tenantRecord.getValue();
+    final var tenantKey = createdTenant.getTenantKey();
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var notAssignedUpdateRecord =
+        engine
+            .tenant()
+            .removeEntity(tenantKey)
+            .withEntityKey(userKey)
+            .withEntityType(EntityType.USER)
+            .expectRejection()
+            .remove();
+
+    assertThat(notAssignedUpdateRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to remove entity with key '%s' from tenant with key '%s', but the entity is not assigned to this tenant."
+                .formatted(userKey, tenantKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -62,8 +62,10 @@ public class TenantAppliersTest {
     final var tenantId = UUID.randomUUID().toString();
     createTenant(tenantKey, tenantId);
     createUser(entityKey, "username");
+
     // when
     associateUserWithTenant(tenantKey, tenantId, entityKey);
+
     // then
     assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
         .containsExactly(entityKey);
@@ -107,15 +109,20 @@ public class TenantAppliersTest {
       createUser(userKey, "user" + userKey);
       associateUserWithTenant(tenantKey, tenantId, userKey);
     }
+
     // Ensure the tenant and associated users exist before deletion
     assertThat(tenantState.getTenantByKey(tenantKey)).isPresent();
     assertUsersAreAssociatedWithTenant(userKeys, tenantId);
+
     // when
     tenantDeletedApplier.applyState(tenantKey, tenantRecord);
+
     // then verify tenant is deleted
     assertThat(tenantState.getTenantByKey(tenantKey)).isEmpty();
+
     // Verify all associated users are no longer linked to the tenant
     assertUsersAreNotAssociatedWithAnyTenant(userKeys);
+
     // Verify owner type and permissions are removed
     assertThat(authorizationState.getOwnerType(tenantKey)).isEmpty();
     final var resourceIdentifiers =
@@ -129,12 +136,16 @@ public class TenantAppliersTest {
     // given
     final long tenantKey = UUID.randomUUID().hashCode();
     final var tenantId = UUID.randomUUID().toString();
+
     // Create tenant without any entities
     final TenantRecord tenantRecord = createTenant(tenantKey, tenantId);
+
     // Ensure the tenant exists before deletion
     assertThat(tenantState.getTenantByKey(tenantKey)).isPresent();
+
     // when
     tenantDeletedApplier.applyState(tenantKey, tenantRecord);
+
     // then
     assertThat(tenantState.getTenantByKey(tenantKey)).isEmpty();
     final var ownerType = authorizationState.getOwnerType(tenantKey);
@@ -154,11 +165,13 @@ public class TenantAppliersTest {
     createTenant(tenantKey, tenantId);
     createUser(entityKey, "username");
     associateUserWithTenant(tenantKey, tenantId, entityKey);
+
     // Ensure the user is associated with the tenant before removal
     assertThat(tenantState.getEntitiesByType(tenantKey).get(EntityType.USER))
         .containsExactly(entityKey);
     final var persistedUser = userState.getUser(entityKey).get();
     assertThat(persistedUser.getTenantIdsList()).containsExactly(tenantId);
+
     // when
     final var tenantRecord =
         new TenantRecord()
@@ -167,6 +180,7 @@ public class TenantAppliersTest {
             .setEntityKey(entityKey)
             .setEntityType(EntityType.USER);
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
+
     // then
     assertThat(tenantState.getEntitiesByType(tenantKey)).isEmpty();
     final var updatedUser = userState.getUser(entityKey).get();
@@ -188,12 +202,15 @@ public class TenantAppliersTest {
     tenantState.createTenant(tenantRecord);
     tenantRecord.setEntityKey(entityKey).setEntityType(EntityType.MAPPING);
     tenantEntityAddedApplier.applyState(tenantKey, tenantRecord);
+
     // Ensure the mapping is associated with the tenant before removal
     assertThat(tenantState.getEntityType(tenantKey, entityKey).get().equals(EntityType.MAPPING));
     final var persistedMapping = mappingState.get(entityKey).get();
     assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
+
     // when
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
+
     // then
     assertThat(tenantState.getEntityType(tenantKey, entityKey)).isEmpty();
     final var updatedMapping = mappingState.get(entityKey).get();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -121,4 +121,43 @@ public class MappingStateTest {
     final var persistedMapping = mappingState.get(key).get();
     assertThat(persistedMapping.getRoleKeysList()).isEmpty();
   }
+
+  @Test
+  void shouldAddTenant() {
+    // given
+    final long key = 1L;
+    final String claimName = "foo";
+    final String claimValue = "bar";
+    final var mapping =
+        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+    mappingState.create(mapping);
+    final String tenantId = "tenantId";
+
+    // when
+    mappingState.addTenant(key, tenantId);
+
+    // then
+    final var persistedMapping = mappingState.get(key).get();
+    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
+  }
+
+  @Test
+  void shouldRemoveTenant() {
+    // given
+    final long key = 1L;
+    final String claimName = "foo";
+    final String claimValue = "bar";
+    final var mapping =
+        new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
+    mappingState.create(mapping);
+    final String tenantId = "tenantId";
+    mappingState.addTenant(key, tenantId);
+
+    // when
+    mappingState.removeTenant(key, tenantId);
+
+    // then
+    final var persistedMapping = mappingState.get(key).get();
+    assertThat(persistedMapping.getTenantIdsList()).isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR allow the TenantEntityRemovedApplier to remove the tenant Id from the mapping state if the EntityType is MAPPING

## Related issues

closes #23877 
