### PR TITLE
feat: Extend License for isCommercial and expiresAt - Optimize

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -384,7 +384,7 @@
     <dependency>
       <groupId>org.camunda.bpm</groupId>
       <artifactId>camunda-license-check</artifactId>
-      <version>2.9.0</version>
+      <version>2.10.0</version>
     </dependency>
 
     <!-- ClassGraph  -->

--- a/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
@@ -84,7 +84,9 @@ public class CamundaLicense {
         isValid = false;
       } else {
         isCommercial = licenseKey.isCommercial();
-        validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+        if (licenseKey.getValidUntil() != null) {
+          validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+        }
         isValid = true;
       }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
@@ -29,7 +29,7 @@ public class CamundaLicense {
   private boolean isValid;
   private LicenseType licenseType;
   private boolean isCommercial;
-  private OffsetDateTime validUntil;
+  private OffsetDateTime expiresAt;
   private boolean isInitialized;
 
   public CamundaLicense(final String license) {
@@ -49,7 +49,7 @@ public class CamundaLicense {
   }
 
   public synchronized OffsetDateTime expiresAt() {
-    return validUntil;
+    return expiresAt;
   }
 
   public synchronized void initializeWithLicense(final String license) {
@@ -85,7 +85,7 @@ public class CamundaLicense {
       } else {
         isCommercial = licenseKey.isCommercial();
         if (licenseKey.getValidUntil() != null) {
-          validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+          expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
         }
         isValid = true;
       }

--- a/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.optimize.license;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.camunda.bpm.licensecheck.InvalidLicenseException;
 import org.camunda.bpm.licensecheck.LicenseKey;
 import org.camunda.bpm.licensecheck.LicenseKeyImpl;
@@ -26,6 +28,8 @@ public class CamundaLicense {
   private static final Logger LOGGER = LoggerFactory.getLogger(CamundaLicense.class);
   private boolean isValid;
   private LicenseType licenseType;
+  private boolean isCommercial;
+  private OffsetDateTime validUntil;
   private boolean isInitialized;
 
   public CamundaLicense(final String license) {
@@ -38,6 +42,14 @@ public class CamundaLicense {
 
   public synchronized LicenseType getLicenseType() {
     return licenseType;
+  }
+
+  public synchronized boolean isCommercial() {
+    return isCommercial;
+  }
+
+  public synchronized OffsetDateTime expiresAt() {
+    return validUntil;
   }
 
   public synchronized void initializeWithLicense(final String license) {
@@ -71,6 +83,8 @@ public class CamundaLicense {
             "Expected a valid licenseType property on the Camunda License, but none were found.");
         isValid = false;
       } else {
+        isCommercial = licenseKey.isCommercial();
+        validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
         isValid = true;
       }
 

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/CamundaLicenseService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/CamundaLicenseService.java
@@ -34,7 +34,7 @@ public class CamundaLicenseService {
     return license.isCommercial();
   }
 
-  public OffsetDateTime getCamundaLicenseExpirationDate() {
+  public OffsetDateTime getCamundaLicenseExpiresAt() {
     return license.expiresAt();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/CamundaLicenseService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/CamundaLicenseService.java
@@ -9,6 +9,7 @@ package io.camunda.optimize.service;
 
 import io.camunda.optimize.license.CamundaLicense;
 import io.camunda.optimize.license.LicenseType;
+import java.time.OffsetDateTime;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -27,5 +28,13 @@ public class CamundaLicenseService {
 
   public LicenseType getCamundaLicenseType() {
     return license.getLicenseType();
+  }
+
+  public boolean isCommercialCamundaLicense() {
+    return license.isCommercial();
+  }
+
+  public OffsetDateTime getCamundaLicenseExpirationDate() {
+    return license.expiresAt();
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -24,6 +24,9 @@ import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.OptimizeProfile;
 import io.camunda.optimize.service.util.configuration.engine.EngineConfiguration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +38,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class UIConfigurationService {
 
+  public static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("uuuu-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
   private static final Logger LOG = org.slf4j.LoggerFactory.getLogger(UIConfigurationService.class);
   private final ConfigurationService configurationService;
   private final OptimizeVersionService versionService;
@@ -89,6 +94,9 @@ public class UIConfigurationService {
     uiConfigurationDto.setOptimizeDatabase(ConfigurationService.getDatabaseType(environment));
     uiConfigurationDto.setValidLicense(isCamundaLicenseValid());
     uiConfigurationDto.setLicenseType(getLicenseType().getName());
+    uiConfigurationDto.setCommercial(isCommercialCamundaLicense());
+    uiConfigurationDto.setLicenseType(
+        DATE_TIME_FORMATTER.format(getCamundaLicenseExpirationDate()));
 
     final MixpanelConfigResponseDto mixpanel = uiConfigurationDto.getMixpanel();
     mixpanel.setEnabled(configurationService.getAnalytics().isEnabled());
@@ -127,6 +135,14 @@ public class UIConfigurationService {
 
   private LicenseType getLicenseType() {
     return camundaLicenseService.getCamundaLicenseType();
+  }
+
+  private boolean isCommercialCamundaLicense() {
+    return camundaLicenseService.isCommercialCamundaLicense();
+  }
+
+  private OffsetDateTime getCamundaLicenseExpirationDate() {
+    return camundaLicenseService.getCamundaLicenseExpirationDate();
   }
 
   private boolean isEnterpriseMode(final OptimizeProfile optimizeProfile) {

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -95,8 +95,11 @@ public class UIConfigurationService {
     uiConfigurationDto.setValidLicense(isCamundaLicenseValid());
     uiConfigurationDto.setLicenseType(getLicenseType().getName());
     uiConfigurationDto.setCommercial(isCommercialCamundaLicense());
-    uiConfigurationDto.setLicenseType(
-        DATE_TIME_FORMATTER.format(getCamundaLicenseExpirationDate()));
+    final OffsetDateTime expirationDate = getCamundaLicenseExpirationDate();
+    uiConfigurationDto.setExpiresAt(
+        expirationDate == null
+            ? null
+            : DATE_TIME_FORMATTER.format(getCamundaLicenseExpirationDate()));
 
     final MixpanelConfigResponseDto mixpanel = uiConfigurationDto.getMixpanel();
     mixpanel.setEnabled(configurationService.getAnalytics().isEnabled());

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/UIConfigurationService.java
@@ -95,11 +95,9 @@ public class UIConfigurationService {
     uiConfigurationDto.setValidLicense(isCamundaLicenseValid());
     uiConfigurationDto.setLicenseType(getLicenseType().getName());
     uiConfigurationDto.setCommercial(isCommercialCamundaLicense());
-    final OffsetDateTime expirationDate = getCamundaLicenseExpirationDate();
+    final OffsetDateTime expirationDate = getCamundaLicenseExpiresAt();
     uiConfigurationDto.setExpiresAt(
-        expirationDate == null
-            ? null
-            : DATE_TIME_FORMATTER.format(getCamundaLicenseExpirationDate()));
+        expirationDate == null ? null : DATE_TIME_FORMATTER.format(getCamundaLicenseExpiresAt()));
 
     final MixpanelConfigResponseDto mixpanel = uiConfigurationDto.getMixpanel();
     mixpanel.setEnabled(configurationService.getAnalytics().isEnabled());
@@ -144,8 +142,8 @@ public class UIConfigurationService {
     return camundaLicenseService.isCommercialCamundaLicense();
   }
 
-  private OffsetDateTime getCamundaLicenseExpirationDate() {
-    return camundaLicenseService.getCamundaLicenseExpirationDate();
+  private OffsetDateTime getCamundaLicenseExpiresAt() {
+    return camundaLicenseService.getCamundaLicenseExpiresAt();
   }
 
   private boolean isEnterpriseMode(final OptimizeProfile optimizeProfile) {

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -52,6 +52,7 @@ import org.springframework.core.env.Environment;
 public class UIConfigurationServiceTest {
 
   private static OffsetDateTime testDate;
+  private static final String testDateString = "2024-10-29T15:14:13Z";
   @InjectMocks UIConfigurationService underTest;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -81,7 +82,7 @@ public class UIConfigurationServiceTest {
 
   @BeforeAll
   public static void beforeAll() {
-    testDate = OffsetDateTime.parse("2024-10-29T15:14:13Z");
+    testDate = OffsetDateTime.parse(testDateString);
   }
 
   @ParameterizedTest
@@ -179,7 +180,7 @@ public class UIConfigurationServiceTest {
     assertThat(configurationResponse.getLicenseType()).isEqualTo("saas");
     assertThat(configurationResponse.isValidLicense()).isEqualTo(true);
     assertThat(configurationResponse.isCommercial()).isEqualTo(false);
-    assertThat(configurationResponse.getExpiresAt()).isEqualTo("2024-10-29T15:14:13Z");
+    assertThat(configurationResponse.getExpiresAt()).isEqualTo(testDateString);
   }
 
   @Test
@@ -187,7 +188,7 @@ public class UIConfigurationServiceTest {
     // given
     initializeMocks();
     when(environment.getActiveProfiles()).thenReturn(new String[] {CLOUD_PROFILE});
-    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(null);
+    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(null);
 
     // when
     final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
@@ -208,6 +209,6 @@ public class UIConfigurationServiceTest {
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
     when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
-    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
+    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(testDate);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -191,6 +191,6 @@ public class UIConfigurationServiceTest {
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
     when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
-    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
+    // when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -51,8 +51,8 @@ import org.springframework.core.env.Environment;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class UIConfigurationServiceTest {
 
-  private static OffsetDateTime testDate;
-  private static final String testDateString = "2024-10-29T15:14:13Z";
+  private static OffsetDateTime TEST_DATE;
+  private static final String TEST_DATE_STRING = "2024-10-29T15:14:13Z";
   @InjectMocks UIConfigurationService underTest;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -82,7 +82,7 @@ public class UIConfigurationServiceTest {
 
   @BeforeAll
   public static void beforeAll() {
-    testDate = OffsetDateTime.parse(testDateString);
+    TEST_DATE = OffsetDateTime.parse(TEST_DATE_STRING);
   }
 
   @ParameterizedTest
@@ -180,7 +180,7 @@ public class UIConfigurationServiceTest {
     assertThat(configurationResponse.getLicenseType()).isEqualTo("saas");
     assertThat(configurationResponse.isValidLicense()).isEqualTo(true);
     assertThat(configurationResponse.isCommercial()).isEqualTo(false);
-    assertThat(configurationResponse.getExpiresAt()).isEqualTo(testDateString);
+    assertThat(configurationResponse.getExpiresAt()).isEqualTo(TEST_DATE_STRING);
   }
 
   @Test
@@ -209,6 +209,6 @@ public class UIConfigurationServiceTest {
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
     when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
-    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(testDate);
+    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(TEST_DATE);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -29,9 +29,11 @@ import io.camunda.optimize.service.tenant.TenantService;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
 import io.camunda.optimize.service.util.configuration.DatabaseType;
 import io.camunda.optimize.service.util.configuration.OptimizeProfile;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -49,6 +51,7 @@ import org.springframework.core.env.Environment;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class UIConfigurationServiceTest {
 
+  private static OffsetDateTime testDate;
   @InjectMocks UIConfigurationService underTest;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -74,6 +77,11 @@ public class UIConfigurationServiceTest {
     return Stream.of(
         Arguments.of(CLOUD_PROFILE, true),
         Arguments.of(CCSM_PROFILE, false)); // false by default because it's not mocked
+  }
+
+  @BeforeAll
+  public static void beforeAll() {
+    testDate = OffsetDateTime.parse("2024-10-29T15:14:13Z");
   }
 
   @ParameterizedTest
@@ -170,6 +178,8 @@ public class UIConfigurationServiceTest {
     // then
     assertThat(configurationResponse.getLicenseType()).isEqualTo("saas");
     assertThat(configurationResponse.isValidLicense()).isEqualTo(true);
+    assertThat(configurationResponse.isCommercial()).isEqualTo(true);
+    assertThat(configurationResponse.getExpiresAt()).isEqualTo("2024-10-29T15:14:13Z");
   }
 
   private void initializeMocks() {
@@ -180,5 +190,7 @@ public class UIConfigurationServiceTest {
         .thenReturn(DatabaseType.ELASTICSEARCH.toString());
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
+    when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
+    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -178,7 +178,7 @@ public class UIConfigurationServiceTest {
     // then
     assertThat(configurationResponse.getLicenseType()).isEqualTo("saas");
     assertThat(configurationResponse.isValidLicense()).isEqualTo(true);
-    assertThat(configurationResponse.isCommercial()).isEqualTo(true);
+    assertThat(configurationResponse.isCommercial()).isEqualTo(false);
     assertThat(configurationResponse.getExpiresAt()).isEqualTo("2024-10-29T15:14:13Z");
   }
 

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -51,7 +51,7 @@ import org.springframework.core.env.Environment;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class UIConfigurationServiceTest {
 
-  private static OffsetDateTime TEST_DATE;
+  private static OffsetDateTime testDate;
   private static final String TEST_DATE_STRING = "2024-10-29T15:14:13Z";
   @InjectMocks UIConfigurationService underTest;
 
@@ -82,7 +82,7 @@ public class UIConfigurationServiceTest {
 
   @BeforeAll
   public static void beforeAll() {
-    TEST_DATE = OffsetDateTime.parse(TEST_DATE_STRING);
+    testDate = OffsetDateTime.parse(TEST_DATE_STRING);
   }
 
   @ParameterizedTest
@@ -209,6 +209,6 @@ public class UIConfigurationServiceTest {
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
     when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
-    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(TEST_DATE);
+    when(camundaLicenseService.getCamundaLicenseExpiresAt()).thenReturn(testDate);
   }
 }

--- a/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
+++ b/optimize/backend/src/test/java/io/camunda/optimize/service/uiconfiguration/UIConfigurationServiceTest.java
@@ -182,6 +182,23 @@ public class UIConfigurationServiceTest {
     assertThat(configurationResponse.getExpiresAt()).isEqualTo("2024-10-29T15:14:13Z");
   }
 
+  @Test
+  public void testCamundaLicenseReturnsNullWhenThereIsNoExpiration() {
+    // given
+    initializeMocks();
+    when(environment.getActiveProfiles()).thenReturn(new String[] {CLOUD_PROFILE});
+    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(null);
+
+    // when
+    final UIConfigurationResponseDto configurationResponse = underTest.getUIConfiguration();
+
+    // then
+    assertThat(configurationResponse.getLicenseType()).isEqualTo("saas");
+    assertThat(configurationResponse.isValidLicense()).isEqualTo(true);
+    assertThat(configurationResponse.isCommercial()).isEqualTo(false);
+    assertThat(configurationResponse.getExpiresAt()).isEqualTo(null);
+  }
+
   private void initializeMocks() {
     when(configurationService.getConfiguredWebhooks()).thenReturn(Collections.emptyMap());
     when(identity.users()).thenReturn(identityUsers);
@@ -191,6 +208,6 @@ public class UIConfigurationServiceTest {
     when(camundaLicenseService.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(camundaLicenseService.isCamundaLicenseValid()).thenReturn(true);
     when(camundaLicenseService.isCommercialCamundaLicense()).thenReturn(false);
-    // when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
+    when(camundaLicenseService.getCamundaLicenseExpirationDate()).thenReturn(testDate);
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/ui_configuration/UIConfigurationResponseDto.java
@@ -33,6 +33,8 @@ public class UIConfigurationResponseDto {
   private DatabaseType optimizeDatabase;
   private boolean validLicense;
   private String licenseType;
+  private boolean isCommercial;
+  private String expiresAt;
 
   private MixpanelConfigResponseDto mixpanel = new MixpanelConfigResponseDto();
 
@@ -86,228 +88,247 @@ public class UIConfigurationResponseDto {
   public UIConfigurationResponseDto() {}
 
   public boolean isEmailEnabled() {
-    return this.emailEnabled;
-  }
-
-  public boolean isSharingEnabled() {
-    return this.sharingEnabled;
-  }
-
-  public boolean isTenantsAvailable() {
-    return this.tenantsAvailable;
-  }
-
-  public boolean isUserSearchAvailable() {
-    return this.userSearchAvailable;
-  }
-
-  public boolean isUserTaskAssigneeAnalyticsEnabled() {
-    return this.userTaskAssigneeAnalyticsEnabled;
-  }
-
-  public String getOptimizeVersion() {
-    return this.optimizeVersion;
-  }
-
-  public String getOptimizeDocsVersion() {
-    return this.optimizeDocsVersion;
-  }
-
-  public boolean isEnterpriseMode() {
-    return this.isEnterpriseMode;
-  }
-
-  public OptimizeProfile getOptimizeProfile() {
-    return this.optimizeProfile;
-  }
-
-  public Map<String, WebappsEndpointDto> getWebappsEndpoints() {
-    return this.webappsEndpoints;
-  }
-
-  public Map<AppName, String> getWebappsLinks() {
-    return this.webappsLinks;
-  }
-
-  public String getNotificationsUrl() {
-    return this.notificationsUrl;
-  }
-
-  public List<String> getWebhooks() {
-    return this.webhooks;
-  }
-
-  public boolean isLogoutHidden() {
-    return this.logoutHidden;
-  }
-
-  public int getMaxNumDataSourcesForReport() {
-    return this.maxNumDataSourcesForReport;
-  }
-
-  public Integer getExportCsvLimit() {
-    return this.exportCsvLimit;
-  }
-
-  public DatabaseType getOptimizeDatabase() {
-    return this.optimizeDatabase;
-  }
-
-  public boolean isValidLicense() {
-    return this.validLicense;
-  }
-
-  public String getLicenseType() {
-    return this.licenseType;
-  }
-
-  public MixpanelConfigResponseDto getMixpanel() {
-    return this.mixpanel;
-  }
-
-  public OnboardingResponseDto getOnboarding() {
-    return this.onboarding;
+    return emailEnabled;
   }
 
   public void setEmailEnabled(final boolean emailEnabled) {
     this.emailEnabled = emailEnabled;
   }
 
+  public boolean isSharingEnabled() {
+    return sharingEnabled;
+  }
+
   public void setSharingEnabled(final boolean sharingEnabled) {
     this.sharingEnabled = sharingEnabled;
+  }
+
+  public boolean isTenantsAvailable() {
+    return tenantsAvailable;
   }
 
   public void setTenantsAvailable(final boolean tenantsAvailable) {
     this.tenantsAvailable = tenantsAvailable;
   }
 
+  public boolean isUserSearchAvailable() {
+    return userSearchAvailable;
+  }
+
   public void setUserSearchAvailable(final boolean userSearchAvailable) {
     this.userSearchAvailable = userSearchAvailable;
+  }
+
+  public boolean isUserTaskAssigneeAnalyticsEnabled() {
+    return userTaskAssigneeAnalyticsEnabled;
   }
 
   public void setUserTaskAssigneeAnalyticsEnabled(final boolean userTaskAssigneeAnalyticsEnabled) {
     this.userTaskAssigneeAnalyticsEnabled = userTaskAssigneeAnalyticsEnabled;
   }
 
+  public String getOptimizeVersion() {
+    return optimizeVersion;
+  }
+
   public void setOptimizeVersion(final String optimizeVersion) {
     this.optimizeVersion = optimizeVersion;
+  }
+
+  public String getOptimizeDocsVersion() {
+    return optimizeDocsVersion;
   }
 
   public void setOptimizeDocsVersion(final String optimizeDocsVersion) {
     this.optimizeDocsVersion = optimizeDocsVersion;
   }
 
+  public boolean isEnterpriseMode() {
+    return isEnterpriseMode;
+  }
+
   public void setEnterpriseMode(final boolean isEnterpriseMode) {
     this.isEnterpriseMode = isEnterpriseMode;
+  }
+
+  public OptimizeProfile getOptimizeProfile() {
+    return optimizeProfile;
   }
 
   public void setOptimizeProfile(final OptimizeProfile optimizeProfile) {
     this.optimizeProfile = optimizeProfile;
   }
 
+  public Map<String, WebappsEndpointDto> getWebappsEndpoints() {
+    return webappsEndpoints;
+  }
+
   public void setWebappsEndpoints(final Map<String, WebappsEndpointDto> webappsEndpoints) {
     this.webappsEndpoints = webappsEndpoints;
+  }
+
+  public Map<AppName, String> getWebappsLinks() {
+    return webappsLinks;
   }
 
   public void setWebappsLinks(final Map<AppName, String> webappsLinks) {
     this.webappsLinks = webappsLinks;
   }
 
+  public String getNotificationsUrl() {
+    return notificationsUrl;
+  }
+
   public void setNotificationsUrl(final String notificationsUrl) {
     this.notificationsUrl = notificationsUrl;
+  }
+
+  public List<String> getWebhooks() {
+    return webhooks;
   }
 
   public void setWebhooks(final List<String> webhooks) {
     this.webhooks = webhooks;
   }
 
+  public boolean isLogoutHidden() {
+    return logoutHidden;
+  }
+
   public void setLogoutHidden(final boolean logoutHidden) {
     this.logoutHidden = logoutHidden;
+  }
+
+  public int getMaxNumDataSourcesForReport() {
+    return maxNumDataSourcesForReport;
   }
 
   public void setMaxNumDataSourcesForReport(final int maxNumDataSourcesForReport) {
     this.maxNumDataSourcesForReport = maxNumDataSourcesForReport;
   }
 
+  public Integer getExportCsvLimit() {
+    return exportCsvLimit;
+  }
+
   public void setExportCsvLimit(final Integer exportCsvLimit) {
     this.exportCsvLimit = exportCsvLimit;
+  }
+
+  public DatabaseType getOptimizeDatabase() {
+    return optimizeDatabase;
   }
 
   public void setOptimizeDatabase(final DatabaseType optimizeDatabase) {
     this.optimizeDatabase = optimizeDatabase;
   }
 
+  public boolean isValidLicense() {
+    return validLicense;
+  }
+
   public void setValidLicense(final boolean validLicense) {
     this.validLicense = validLicense;
+  }
+
+  public String getLicenseType() {
+    return licenseType;
   }
 
   public void setLicenseType(final String licenseType) {
     this.licenseType = licenseType;
   }
 
+  public boolean isCommercial() {
+    return isCommercial;
+  }
+
+  public void setCommercial(final boolean isCommercial) {
+    this.isCommercial = isCommercial;
+  }
+
+  public String getExpiresAt() {
+    return expiresAt;
+  }
+
+  public void setExpiresAt(final String expiresAt) {
+    this.expiresAt = expiresAt;
+  }
+
+  public MixpanelConfigResponseDto getMixpanel() {
+    return mixpanel;
+  }
+
   public void setMixpanel(final MixpanelConfigResponseDto mixpanel) {
     this.mixpanel = mixpanel;
+  }
+
+  public OnboardingResponseDto getOnboarding() {
+    return onboarding;
   }
 
   public void setOnboarding(final OnboardingResponseDto onboarding) {
     this.onboarding = onboarding;
   }
 
-  public boolean equals(final Object o) {
-    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
-  }
-
   protected boolean canEqual(final Object other) {
     return other instanceof UIConfigurationResponseDto;
   }
 
+  @Override
   public int hashCode() {
     return org.apache.commons.lang3.builder.HashCodeBuilder.reflectionHashCode(this);
   }
 
+  @Override
+  public boolean equals(final Object o) {
+    return org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals(this, o);
+  }
+
+  @Override
   public String toString() {
     return "UIConfigurationResponseDto(emailEnabled="
-        + this.isEmailEnabled()
+        + isEmailEnabled()
         + ", sharingEnabled="
-        + this.isSharingEnabled()
+        + isSharingEnabled()
         + ", tenantsAvailable="
-        + this.isTenantsAvailable()
+        + isTenantsAvailable()
         + ", userSearchAvailable="
-        + this.isUserSearchAvailable()
+        + isUserSearchAvailable()
         + ", userTaskAssigneeAnalyticsEnabled="
-        + this.isUserTaskAssigneeAnalyticsEnabled()
+        + isUserTaskAssigneeAnalyticsEnabled()
         + ", optimizeVersion="
-        + this.getOptimizeVersion()
+        + getOptimizeVersion()
         + ", optimizeDocsVersion="
-        + this.getOptimizeDocsVersion()
+        + getOptimizeDocsVersion()
         + ", isEnterpriseMode="
-        + this.isEnterpriseMode()
+        + isEnterpriseMode()
         + ", optimizeProfile="
-        + this.getOptimizeProfile()
+        + getOptimizeProfile()
         + ", webappsEndpoints="
-        + this.getWebappsEndpoints()
+        + getWebappsEndpoints()
         + ", webappsLinks="
-        + this.getWebappsLinks()
+        + getWebappsLinks()
         + ", notificationsUrl="
-        + this.getNotificationsUrl()
+        + getNotificationsUrl()
         + ", webhooks="
-        + this.getWebhooks()
+        + getWebhooks()
         + ", logoutHidden="
-        + this.isLogoutHidden()
+        + isLogoutHidden()
         + ", maxNumDataSourcesForReport="
-        + this.getMaxNumDataSourcesForReport()
+        + getMaxNumDataSourcesForReport()
         + ", exportCsvLimit="
-        + this.getExportCsvLimit()
+        + getExportCsvLimit()
         + ", optimizeDatabase="
-        + this.getOptimizeDatabase()
+        + getOptimizeDatabase()
         + ", validLicense="
-        + this.isValidLicense()
+        + isValidLicense()
         + ", licenseType="
-        + this.getLicenseType()
+        + getLicenseType()
         + ", mixpanel="
-        + this.getMixpanel()
+        + getMixpanel()
         + ", onboarding="
-        + this.getOnboarding()
+        + getOnboarding()
         + ")";
   }
 }

--- a/service/src/main/java/io/camunda/service/ManagementServices.java
+++ b/service/src/main/java/io/camunda/service/ManagementServices.java
@@ -31,7 +31,7 @@ public final class ManagementServices {
     return license.isCommercial();
   }
 
-  public OffsetDateTime getCamundaLicenseExpirationDate() {
+  public OffsetDateTime getCamundaLicenseExpiresAt() {
     return license.expiresAt();
   }
 }

--- a/service/src/main/java/io/camunda/service/license/CamundaLicense.java
+++ b/service/src/main/java/io/camunda/service/license/CamundaLicense.java
@@ -81,7 +81,9 @@ public class CamundaLicense {
         isValid = false;
       } else {
         isCommercial = licenseKey.isCommercial();
-        validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+        if (licenseKey.getValidUntil() != null) {
+          validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+        }
         isValid = true;
       }
 

--- a/service/src/main/java/io/camunda/service/license/CamundaLicense.java
+++ b/service/src/main/java/io/camunda/service/license/CamundaLicense.java
@@ -23,7 +23,7 @@ public class CamundaLicense {
   private boolean isValid;
   private LicenseType licenseType;
   private boolean isCommercial;
-  private OffsetDateTime validUntil;
+  private OffsetDateTime expiresAt;
   private boolean isInitialized;
 
   @VisibleForTesting
@@ -46,7 +46,7 @@ public class CamundaLicense {
   }
 
   public synchronized OffsetDateTime expiresAt() {
-    return validUntil;
+    return expiresAt;
   }
 
   public synchronized void initializeWithLicense(final String license) {
@@ -82,7 +82,7 @@ public class CamundaLicense {
       } else {
         isCommercial = licenseKey.isCommercial();
         if (licenseKey.getValidUntil() != null) {
-          validUntil = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+          expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
         }
         isValid = true;
       }

--- a/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
+++ b/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
@@ -188,4 +188,25 @@ public class CamundaLicenseTest {
     // then
     assertEquals(testDate.toInstant().atOffset(ZoneOffset.UTC), testLicense.expiresAt());
   }
+
+  @Test
+  public void shouldReturnNullWhenThereIsNoExpirationDate() throws InvalidLicenseException {
+    // given
+    final CamundaLicense testLicense = Mockito.spy(CamundaLicense.class);
+    final LicenseKey mockKey = mock(LicenseKey.class);
+
+    final Map<String, String> testProperties = new HashMap<>();
+    testProperties.put(LICENSE_TYPE_KEY, PRODUCTION_LICENSE_TYPE);
+    when(mockKey.getProperties()).thenReturn(testProperties);
+
+    when(mockKey.getValidUntil()).thenReturn(null);
+
+    Mockito.doReturn(mockKey).when(testLicense).getLicenseKey(anyString());
+
+    // when
+    testLicense.initializeWithLicense(TEST_LICENSE);
+
+    // then
+    assertEquals(null, testLicense.expiresAt());
+  }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3971,6 +3971,7 @@ components:
           description: The date when the Camunda license expires
           type: string
           format: date-time
+          nullable: true
     BrokerInfo:
       description: Provides information on a broker node.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.service.ManagementServices;
 import io.camunda.zeebe.gateway.protocol.rest.LicenseResponse;
 import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import org.springframework.http.MediaType;
@@ -36,8 +37,9 @@ public class LicenseController {
     response.setValidLicense(managementServices.isCamundaLicenseValid());
     response.setLicenseType(managementServices.getCamundaLicenseType().getName());
     response.setIsCommercial(managementServices.isCommercialCamundaLicense());
+    final OffsetDateTime expirationDate = managementServices.getCamundaLicenseExpirationDate();
     response.setExpiresAt(
-        DATE_TIME_FORMATTER.format(managementServices.getCamundaLicenseExpirationDate()));
+        expirationDate == null ? null : DATE_TIME_FORMATTER.format(expirationDate));
 
     return response;
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
@@ -37,7 +37,7 @@ public class LicenseController {
     response.setValidLicense(managementServices.isCamundaLicenseValid());
     response.setLicenseType(managementServices.getCamundaLicenseType().getName());
     response.setIsCommercial(managementServices.isCommercialCamundaLicense());
-    final OffsetDateTime expirationDate = managementServices.getCamundaLicenseExpirationDate();
+    final OffsetDateTime expirationDate = managementServices.getCamundaLicenseExpiresAt();
     response.setExpiresAt(
         expirationDate == null ? null : DATE_TIME_FORMATTER.format(expirationDate));
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
@@ -33,6 +33,14 @@ public class LicenseControllerTest extends RestControllerTest {
           "expiresAt": "2024-10-29T15:14:13Z"
       }""";
 
+  static final String EXPECTED_LICENSE_RESPONSE_NO_EXPIRATION =
+      """
+      {
+          "validLicense": true,
+          "licenseType": "saas",
+          "isCommercial": true
+      }""";
+
   @MockBean ManagementServices managementServices;
 
   @Test
@@ -56,6 +64,33 @@ public class LicenseControllerTest extends RestControllerTest {
         .contentType(MediaType.APPLICATION_JSON)
         .expectBody()
         .json(EXPECTED_LICENSE_RESPONSE);
+
+    verify(managementServices).isCamundaLicenseValid();
+    verify(managementServices).getCamundaLicenseType();
+    verify(managementServices).isCommercialCamundaLicense();
+    verify(managementServices).getCamundaLicenseExpirationDate();
+  }
+
+  @Test
+  void shouldReturnWithoutExpirationDateWhenThereIsNoExpirationOnLicense() {
+    // given
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
+    when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
+    when(managementServices.getCamundaLicenseExpirationDate()).thenReturn(null);
+
+    // when / then
+    webClient
+        .get()
+        .uri(LICENSE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_LICENSE_RESPONSE_NO_EXPIRATION);
 
     verify(managementServices).isCamundaLicenseValid();
     verify(managementServices).getCamundaLicenseType();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
@@ -49,7 +49,7 @@ public class LicenseControllerTest extends RestControllerTest {
     when(managementServices.isCamundaLicenseValid()).thenReturn(true);
     when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
-    when(managementServices.getCamundaLicenseExpirationDate())
+    when(managementServices.getCamundaLicenseExpiresAt())
         .thenReturn(OffsetDateTime.parse("2024-10-29T15:14:13Z"));
 
     // when / then
@@ -68,7 +68,7 @@ public class LicenseControllerTest extends RestControllerTest {
     verify(managementServices).isCamundaLicenseValid();
     verify(managementServices).getCamundaLicenseType();
     verify(managementServices).isCommercialCamundaLicense();
-    verify(managementServices).getCamundaLicenseExpirationDate();
+    verify(managementServices).getCamundaLicenseExpiresAt();
   }
 
   @Test
@@ -77,7 +77,7 @@ public class LicenseControllerTest extends RestControllerTest {
     when(managementServices.isCamundaLicenseValid()).thenReturn(true);
     when(managementServices.getCamundaLicenseType()).thenReturn(LicenseType.SAAS);
     when(managementServices.isCommercialCamundaLicense()).thenReturn(true);
-    when(managementServices.getCamundaLicenseExpirationDate()).thenReturn(null);
+    when(managementServices.getCamundaLicenseExpiresAt()).thenReturn(null);
 
     // when / then
     webClient
@@ -95,6 +95,6 @@ public class LicenseControllerTest extends RestControllerTest {
     verify(managementServices).isCamundaLicenseValid();
     verify(managementServices).getCamundaLicenseType();
     verify(managementServices).isCommercialCamundaLicense();
-    verify(managementServices).getCamundaLicenseExpirationDate();
+    verify(managementServices).getCamundaLicenseExpiresAt();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add `isCommerical` and `expiresAt` to the `/ui-configuration` endpoint. These are two new fields from the license checker, and they need to be exposed so that they can be read by the front end

Also, be able to handle an unlimited license. These licenses functionally do not have an expiration date

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24339

Previous license work for Optimize was done with this PR: https://github.com/camunda/camunda/pull/21631
