### PR TITLE
Implement Elasticsearch archiver repository

### DIFF
--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.connect.es;
 
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
@@ -67,6 +68,22 @@ public final class ElasticsearchConnector {
 
     // And create the API client
     return new ElasticsearchClient(transport);
+  }
+
+  public ElasticsearchAsyncClient createAsyncClient() {
+    LOGGER.debug("Creating async Elasticsearch Client ...");
+
+    // Load plugins
+    pluginRepository.load(configuration.getInterceptorPlugins());
+
+    // create rest client
+    final var restClient = createRestClient(configuration);
+
+    // Create the transport with a Jackson mapper
+    final var transport = new RestClientTransport(restClient, new JacksonJsonpMapper(objectMapper));
+
+    // And create the API client
+    return new ElasticsearchAsyncClient(transport);
   }
 
   private RestClient createRestClient(final ConnectConfiguration configuration) {

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -192,6 +192,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -98,7 +98,7 @@ public class CamundaExporter implements Exporter {
           Archiver.create(
               context.getPartitionId(),
               context.getConfiguration().getId().toLowerCase(),
-              configuration.getArchiver(),
+              configuration,
               provider,
               metrics,
               logger);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -9,8 +9,6 @@ package io.camunda.exporter;
 
 import static java.util.Map.entry;
 
-import io.camunda.exporter.archiver.ArchiverRepository;
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.exporter.cache.ProcessCacheImpl;
 import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ConnectionTypes;
@@ -86,13 +84,14 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
       templateDescriptorsMap;
 
   private Set<ExportHandler> exportHandlers;
+  private boolean isElasticsearch;
 
   @Override
   public void init(
       final ExporterConfiguration configuration,
       final ProcessCacheLoaderFactory processCacheLoaderFactory) {
     final var globalPrefix = configuration.getIndex().getPrefix();
-    final var isElasticsearch =
+    isElasticsearch =
         ConnectionTypes.from(configuration.getConnect().getType())
             .equals(ConnectionTypes.ELASTICSEARCH);
 
@@ -236,11 +235,5 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   public Set<ExportHandler> getExportHandlers() {
     // Register all handlers here
     return exportHandlers;
-  }
-
-  @Override
-  public ArchiverRepository newArchiverRepository() {
-    // TODO: return appropriate implementation
-    return new NoopArchiverRepository();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.exporter;
 
-import io.camunda.exporter.archiver.ArchiverRepository;
 import io.camunda.exporter.cache.ProcessCacheLoaderFactory;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.ExportHandler;
@@ -47,9 +46,4 @@ public interface ExporterResourceProvider {
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
   Set<ExportHandler> getExportHandlers();
-
-  /**
-   * @return a new archiver repository scoped to the current partition
-   */
-  ArchiverRepository newArchiverRepository();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -8,15 +8,22 @@
 package io.camunda.exporter.archiver;
 
 import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.config.ConnectionTypes;
+import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
+import java.util.ArrayList;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
@@ -71,7 +78,7 @@ public final class Archiver implements CloseableSilently {
   public static Archiver create(
       final int partitionId,
       final String exporterId,
-      final ArchiverConfiguration config,
+      final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
@@ -81,15 +88,15 @@ public final class Archiver implements CloseableSilently {
             .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(logger))
             .factory();
     final var executor = defaultExecutor(threadFactory);
-    final var repository = resourceProvider.newArchiverRepository();
+    final var repository =
+        createRepository(config, resourceProvider, partitionId, executor, metrics, logger);
     final var archiver = new Archiver(partitionId, repository, logger, executor);
-
     final var processInstanceJob =
         createProcessInstanceJob(metrics, logger, resourceProvider, repository, executor);
     final var batchOperationJob =
         createBatchOperationJob(metrics, logger, resourceProvider, repository, executor);
-    archiver.start(config, processInstanceJob, batchOperationJob);
 
+    archiver.start(config.getArchiver(), processInstanceJob, batchOperationJob);
     return archiver;
   }
 
@@ -99,11 +106,17 @@ public final class Archiver implements CloseableSilently {
       final ExporterResourceProvider resourceProvider,
       final ArchiverRepository repository,
       final ScheduledThreadPoolExecutor executor) {
-    final var dependantTemplates =
-        resourceProvider.getIndexTemplateDescriptors().stream()
-            .filter(ProcessInstanceDependant.class::isInstance)
-            .map(ProcessInstanceDependant.class::cast)
-            .toList();
+    final var dependantTemplates = new ArrayList<ProcessInstanceDependant>();
+    resourceProvider.getIndexTemplateDescriptors().stream()
+        .filter(ProcessInstanceDependant.class::isInstance)
+        .map(ProcessInstanceDependant.class::cast)
+        .forEach(dependantTemplates::add);
+
+    // add a special case just for TaskTemplate, which has 2 kinds of documents in the same
+    // index
+    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
+    dependantTemplates.add(
+        new ProcessInstanceDependantAdapter(taskTemplate.getFullQualifiedName(), TaskTemplate.ID));
 
     return new ProcessInstancesArchiverJob(
         repository,
@@ -137,5 +150,45 @@ public final class Archiver implements CloseableSilently {
     executor.setRemoveOnCancelPolicy(true);
 
     return executor;
+  }
+
+  private static ArchiverRepository createRepository(
+      final ExporterConfiguration config,
+      final ExporterResourceProvider resourceProvider,
+      final int partitionId,
+      final Executor executor,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    final var listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    return switch (ConnectionTypes.from(config.getConnect().getType())) {
+      case ELASTICSEARCH -> {
+        final var connector = new ElasticsearchConnector(config.getConnect());
+        yield new ElasticsearchRepository(
+            partitionId,
+            config.getArchiver(),
+            config.getRetention(),
+            listViewTemplate,
+            connector.createAsyncClient(),
+            executor,
+            metrics,
+            logger);
+      }
+      default -> new NoopArchiverRepository();
+    };
+  }
+
+  private record ProcessInstanceDependantAdapter(String name, String field)
+      implements ProcessInstanceDependant {
+
+    @Override
+    public String getFullQualifiedName() {
+      return name;
+    }
+
+    @Override
+    public String getProcessInstanceDependantField() {
+      return field;
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/Archiver.java
@@ -161,6 +161,8 @@ public final class Archiver implements CloseableSilently {
       final Logger logger) {
     final var listViewTemplate =
         resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
     return switch (ConnectionTypes.from(config.getConnect().getType())) {
       case ELASTICSEARCH -> {
         final var connector = new ElasticsearchConnector(config.getConnect());
@@ -168,7 +170,8 @@ public final class Archiver implements CloseableSilently {
             partitionId,
             config.getArchiver(),
             config.getRetention(),
-            listViewTemplate,
+            listViewTemplate.getFullQualifiedName(),
+            batchOperationTemplate.getFullQualifiedName(),
             connector.createAsyncClient(),
             executor,
             metrics,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
@@ -77,7 +77,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
     this.config = config;
     this.retention = retention;
     this.processInstanceIndex = processInstanceIndex;
-    this.batchOperationIndex = batchOperationTemplate;
+    this.batchOperationIndex = batchOperationIndex;
     this.client = client;
     this.executor = executor;
     this.metrics = metrics;
@@ -204,10 +204,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
         QueryBuilders.bool(q -> q.must(endDateQ, isProcessInstanceQ, partitionQ));
 
     return createSearchRequest(
-        processInstanceIndex.getFullQualifiedName(),
-        combinedQuery,
-        aggregation,
-        ListViewTemplate.END_DATE);
+        processInstanceIndex, combinedQuery, aggregation, ListViewTemplate.END_DATE);
   }
 
   private ArchiveBatch createArchiveBatch(final SubmitResponse<?> search) {
@@ -276,10 +273,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
                     .lte(JsonData.of(config.getArchivingTimePoint())));
 
     return createSearchRequest(
-        batchOperationIndex.getFullQualifiedName(),
-        endDateQ,
-        aggregation,
-        BatchOperationTemplate.END_DATE);
+        batchOperationIndex, endDateQ, aggregation, BatchOperationTemplate.END_DATE);
   }
 
   private SubmitRequest createSearchRequest(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
@@ -185,7 +185,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
         AggregationBuilders.dateHistogram()
             .field(ListViewTemplate.END_DATE)
             .calendarInterval(rolloverInterval)
-            .format(config.getRolloverDateFormat())
+            .format(config.getElsRolloverDateFormat())
             .keyed(false) // get result as an array (not a map)
             .build();
     final var sortAggregation =

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
@@ -54,8 +54,8 @@ public final class ElasticsearchRepository implements ArchiverRepository {
   private final int partitionId;
   private final ArchiverConfiguration config;
   private final RetentionConfiguration retention;
-  private final ListViewTemplate processInstanceTemplate;
-  private final BatchOperationTemplate batchOperationTemplate;
+  private final String processInstanceIndex;
+  private final String batchOperationIndex;
   private final ElasticsearchAsyncClient client;
   private final Executor executor;
   private final CamundaExporterMetrics metrics;
@@ -67,8 +67,8 @@ public final class ElasticsearchRepository implements ArchiverRepository {
       final int partitionId,
       final ArchiverConfiguration config,
       final RetentionConfiguration retention,
-      final ListViewTemplate processInstanceTemplate,
-      final BatchOperationTemplate batchOperationTemplate,
+      final String processInstanceIndex,
+      final String batchOperationIndex,
       @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
       final CamundaExporterMetrics metrics,
@@ -76,8 +76,8 @@ public final class ElasticsearchRepository implements ArchiverRepository {
     this.partitionId = partitionId;
     this.config = config;
     this.retention = retention;
-    this.processInstanceTemplate = processInstanceTemplate;
-    this.batchOperationTemplate = batchOperationTemplate;
+    this.processInstanceIndex = processInstanceIndex;
+    this.batchOperationIndex = batchOperationTemplate;
     this.client = client;
     this.executor = executor;
     this.metrics = metrics;
@@ -204,7 +204,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
         QueryBuilders.bool(q -> q.must(endDateQ, isProcessInstanceQ, partitionQ));
 
     return createSearchRequest(
-        processInstanceTemplate.getFullQualifiedName(),
+        processInstanceIndex.getFullQualifiedName(),
         combinedQuery,
         aggregation,
         ListViewTemplate.END_DATE);
@@ -276,7 +276,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
                     .lte(JsonData.of(config.getArchivingTimePoint())));
 
     return createSearchRequest(
-        batchOperationTemplate.getFullQualifiedName(),
+        batchOperationIndex.getFullQualifiedName(),
         endDateQ,
         aggregation,
         BatchOperationTemplate.END_DATE);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
@@ -125,6 +125,7 @@ public final class ElasticsearchRepository implements ArchiverRepository {
             .settings(
                 settings ->
                     settings.lifecycle(lifecycle -> lifecycle.name(retention.getPolicyName())))
+            .index(destinationIndexName)
             .allowNoIndices(true)
             .ignoreUnavailable(true)
             .build();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ElasticsearchRepository.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.Conflicts;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Slices;
+import co.elastic.clients.elasticsearch._types.SlicesCalculation;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch.async_search.SubmitRequest;
+import co.elastic.clients.elasticsearch.async_search.SubmitResponse;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.reindex.Source;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.ExistsRequest;
+import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
+import co.elastic.clients.json.JsonData;
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.micrometer.core.instrument.Timer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.WillCloseWhenClosed;
+import org.slf4j.Logger;
+
+public final class ElasticsearchRepository implements ArchiverRepository {
+  private static final String DATES_AGG = "datesAgg";
+  private static final String INSTANCES_AGG = "instancesAgg";
+  private static final String DATES_SORTED_AGG = "datesSortedAgg";
+  private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
+  private static final Slices AUTO_SLICES =
+      Slices.of(slices -> slices.computed(SlicesCalculation.Auto));
+
+  private final int partitionId;
+  private final ArchiverConfiguration config;
+  private final RetentionConfiguration retention;
+  private final ListViewTemplate template;
+  private final ElasticsearchAsyncClient client;
+  private final Executor executor;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+
+  private final CalendarInterval rolloverInterval;
+
+  public ElasticsearchRepository(
+      final int partitionId,
+      final ArchiverConfiguration config,
+      final RetentionConfiguration retention,
+      final ListViewTemplate template,
+      @WillCloseWhenClosed final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    this.partitionId = partitionId;
+    this.config = config;
+    this.retention = retention;
+    this.template = template;
+    this.client = client;
+    this.executor = executor;
+    this.metrics = metrics;
+    this.logger = logger;
+
+    rolloverInterval = mapCalendarInterval(config.getRolloverInterval());
+  }
+
+  @Override
+  public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
+    final var aggregation = createFinishedInstancesAggregation();
+    final var searchRequest = createFinishedInstancesSearchRequest(aggregation);
+
+    final var timer = Timer.start();
+    return client
+        .asyncSearch()
+        .submit(searchRequest, SearchResult.class)
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
+        .thenApplyAsync(this::createArchiveBatch, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName) {
+    if (!retention.isEnabled()) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    final var existsRequest = new ExistsRequest.Builder().index(destinationIndexName).build();
+    final var settingsRequest =
+        new PutIndicesSettingsRequest.Builder()
+            .settings(
+                settings ->
+                    settings.lifecycle(lifecycle -> lifecycle.name(retention.getPolicyName())))
+            .build();
+
+    return client
+        .indices()
+        .exists(existsRequest)
+        .thenComposeAsync(
+            response -> {
+              if (!response.value()) {
+                // TODO: verify this is the expected behavior
+                return CompletableFuture.completedFuture(null);
+              }
+
+              return client.indices().putSettings(settingsRequest);
+            },
+            executor)
+        .thenApplyAsync(ok -> null, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<String> processInstanceKeys) {
+    final TermsQuery termsQuery = buildIdTermsQuery(idFieldName, processInstanceKeys);
+    final var request =
+        new DeleteByQueryRequest.Builder()
+            .index(sourceIndexName)
+            .waitForCompletion(true)
+            .slices(AUTO_SLICES)
+            .conflicts(Conflicts.Proceed)
+            .query(q -> q.terms(termsQuery))
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .deleteByQuery(request)
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverDelete(timer), executor)
+        .thenApplyAsync(DeleteByQueryResponse::total, executor)
+        .thenApplyAsync(ok -> null, executor);
+  }
+
+  @Override
+  public CompletableFuture<Void> reindexDocuments(
+      final String sourceIndexName,
+      final String destinationIndexName,
+      final String idFieldName,
+      final List<String> processInstanceKeys) {
+    final var source =
+        new Source.Builder()
+            .index(sourceIndexName)
+            .query(q -> q.terms(buildIdTermsQuery(idFieldName, processInstanceKeys)))
+            .build();
+    final var request =
+        new ReindexRequest.Builder()
+            .source(source)
+            .dest(dest -> dest.index(destinationIndexName))
+            .conflicts(Conflicts.Proceed)
+            .scroll(REINDEX_SCROLL_TIMEOUT)
+            .slices(AUTO_SLICES)
+            .build();
+
+    final var timer = Timer.start();
+    return client
+        .reindex(request)
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverReindex(timer), executor)
+        .thenApplyAsync(ignored -> null, executor);
+  }
+
+  @Override
+  public void close() throws Exception {
+    // TODO: verify if I close the transport that any pending futures are cancelled
+    client._transport().close();
+  }
+
+  private Aggregation createFinishedInstancesAggregation() {
+    final var dateAggregation =
+        AggregationBuilders.dateHistogram()
+            .field(ListViewTemplate.END_DATE)
+            .calendarInterval(rolloverInterval)
+            .format(config.getRolloverDateFormat())
+            .keyed(false) // get result as an array (not a map)
+            .build();
+    final var sortAggregation =
+        AggregationBuilders.bucketSort()
+            .sort(sort -> sort.field(b -> b.field("_key")))
+            .size(1) // we want to get only one bucket at a time
+            .build();
+    // we need process instance ids, also taking into account batch size
+    final var instanceAggregation =
+        AggregationBuilders.topHits()
+            .size(config.getRolloverBatchSize())
+            .sort(sort -> sort.field(b -> b.field(ListViewTemplate.ID).order(SortOrder.Asc)))
+            .source(source -> source.filter(filter -> filter.includes(ListViewTemplate.ID)))
+            .build();
+    return new Aggregation.Builder()
+        .dateHistogram(dateAggregation)
+        .aggregations(DATES_SORTED_AGG, Aggregation.of(b -> b.bucketSort(sortAggregation)))
+        .aggregations(INSTANCES_AGG, Aggregation.of(b -> b.topHits(instanceAggregation)))
+        .build();
+  }
+
+  private SubmitRequest createFinishedInstancesSearchRequest(final Aggregation aggregation) {
+    final var endDateQ =
+        QueryBuilders.range(
+            q ->
+                q.field(ListViewTemplate.END_DATE)
+                    .lte(JsonData.of(config.getArchivingTimePoint())));
+    final var isProcessInstanceQ =
+        QueryBuilders.term(
+            q ->
+                q.field(ListViewTemplate.JOIN_RELATION)
+                    .value(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION));
+    final var partitionQ =
+        QueryBuilders.term(q -> q.field(ListViewTemplate.PARTITION_ID).value(partitionId));
+    final var combinedQuery =
+        QueryBuilders.bool(q -> q.must(endDateQ, isProcessInstanceQ, partitionQ));
+
+    logger.debug(
+        "Finished process instances for archiving request: \n{}\n and aggregation: \n{}",
+        combinedQuery.toString(),
+        aggregation.toString());
+    return new SubmitRequest.Builder()
+        .index(template.getFullQualifiedName())
+        .requestCache(false)
+        .source(source -> source.fetch(false))
+        .query(query -> query.constantScore(q -> q.filter(combinedQuery)))
+        .aggregations(DATES_AGG, aggregation)
+        .sort(
+            sort ->
+                sort.field(field -> field.field(ListViewTemplate.END_DATE).order(SortOrder.Asc)))
+        .size(0)
+        .build();
+  }
+
+  private ArchiveBatch createArchiveBatch(final SubmitResponse<?> search) {
+    final List<DateHistogramBucket> buckets =
+        search.response().aggregations().get(DATES_AGG).dateHistogram().buckets().array();
+
+    if (buckets.isEmpty()) {
+      return null;
+    }
+
+    final var bucket = buckets.getFirst();
+    final var finishDate = bucket.keyAsString();
+    final List<String> ids =
+        bucket.aggregations().get(INSTANCES_AGG).topHits().hits().hits().stream()
+            .map(Hit::id)
+            .toList();
+    return new ArchiveBatch(finishDate, ids);
+  }
+
+  private TermsQuery buildIdTermsQuery(final String idFieldName, final List<String> idValues) {
+    return QueryBuilders.terms()
+        .field(idFieldName)
+        .terms(terms -> terms.value(idValues.stream().map(FieldValue::of).toList()))
+        .build();
+  }
+
+  private CalendarInterval mapCalendarInterval(final String alias) {
+    return Arrays.stream(CalendarInterval.values())
+        .filter(c -> c.aliases() != null)
+        .filter(c -> Arrays.binarySearch(c.aliases(), alias) >= 0)
+        .findFirst()
+        .orElseThrow();
+  }
+
+  // Visible for Jackson
+  public record SearchResult(String id) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/ProcessInstancesArchiverJob.java
@@ -47,7 +47,7 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
 
   private CompletableFuture<Integer> archiveBatch(final ArchiveBatch batch) {
     if (batch != null && !(batch.ids() == null || batch.ids().isEmpty())) {
-      logger.debug("Following process instances are found for archiving: {}", batch);
+      logger.trace("Following process instances are found for archiving: {}", batch);
 
       return moveDependants(batch.finishDate(), batch.ids())
           .thenComposeAsync(
@@ -57,7 +57,7 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
           .thenApplyAsync(FunctionUtil.peek(metrics::recordProcessInstancesArchived), executor);
     }
 
-    logger.debug("Nothing to archive");
+    logger.trace("Nothing to archive");
     return CompletableFuture.completedFuture(0);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ElasticsearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/ElasticsearchRepositoryIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.ilm.Phase;
+import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings("resource")
+@Testcontainers
+@AutoCloseResources
+final class ElasticsearchRepositoryIT {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRepositoryIT.class);
+
+  @Container
+  private static final ElasticsearchContainer ELASTIC =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @AutoCloseResource private final RestClientTransport transport = createRestClient();
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final ArchiverConfiguration config = new ArchiverConfiguration();
+  private final RetentionConfiguration retention = new RetentionConfiguration();
+  private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
+  private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
+  private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
+
+  @Test
+  void shouldDeleteDocuments() throws IOException {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestDocument("1", "2024-01-01"),
+            new TestDocument("2", "2024-01-04"),
+            new TestDocument("3", "2024-01-02"));
+    documents.forEach(doc -> index(indexName, doc));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete the first two documents
+    final var result =
+        repository.deleteDocuments(
+            indexName, "id", documents.stream().limit(2).map(TestDocument::id).toList());
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(indexName));
+    final var remaining =
+        testClient.search(r -> r.index(indexName).requestCache(false), TestDocument.class);
+    assertThat(remaining.hits().hits())
+        .as("only the third document is remaining")
+        .hasSize(1)
+        .first()
+        .extracting(Hit::id)
+        .isEqualTo("3");
+  }
+
+  @Test
+  void shouldSetIndexLifeCycle() throws IOException {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    testClient.indices().create(r -> r.index(indexName));
+    final var initialLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .lifecycle();
+    assertThat(initialLifecycle).isNull();
+    retention.setEnabled(true);
+    retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
+
+    // when
+    final var result = repository.setIndexLifeCycle(indexName);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    final var actualLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .index()
+            .lifecycle();
+    assertThat(actualLifecycle)
+        .isNotNull()
+        .extracting(IndexSettingsLifecycle::name)
+        .isEqualTo("operate_delete_archived_indices");
+  }
+
+  @Test
+  void shouldNotSetIndexLifecycleIfRetentionIsDisabled() throws IOException {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    testClient.indices().create(r -> r.index(indexName));
+    final var initialLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .lifecycle();
+    assertThat(initialLifecycle).isNull();
+    retention.setEnabled(false);
+    retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
+
+    // when
+    final var result = repository.setIndexLifeCycle(indexName);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO);
+    final var actualLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .index()
+            .lifecycle();
+    assertThat(actualLifecycle).isNull();
+  }
+
+  @Test
+  void shouldReindexDocuments() throws IOException {
+    // given
+    final var sourceIndexName = UUID.randomUUID().toString();
+    final var destIndexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(
+            new TestDocument("1", "2024-01-01"),
+            new TestDocument("2", "2024-01-04"),
+            new TestDocument("3", "2024-01-02"));
+    documents.forEach(doc -> index(sourceIndexName, doc));
+    testClient.indices().refresh(r -> r.index(sourceIndexName));
+    testClient.indices().create(r -> r.index(destIndexName));
+
+    // when - delete the first two documents
+    final var result =
+        repository.reindexDocuments(
+            sourceIndexName,
+            destIndexName,
+            "id",
+            documents.stream().limit(2).map(TestDocument::id).toList());
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(destIndexName));
+    final var remaining =
+        testClient.search(r -> r.index(sourceIndexName).requestCache(false), TestDocument.class);
+    final var reindexed =
+        testClient.search(r -> r.index(destIndexName).requestCache(false), TestDocument.class);
+    assertThat(reindexed.hits().hits())
+        .as("only first two documents were reindexed")
+        .hasSize(2)
+        .map(Hit::id)
+        .containsExactlyInAnyOrder("1", "2");
+    assertThat(remaining.hits().hits())
+        .as("all documents are remaining")
+        .hasSize(3)
+        .extracting(Hit::id)
+        .containsExactlyInAnyOrder("1", "2", "3");
+  }
+
+  private void index(final String index, final TestDocument document) {
+    try {
+      testClient.index(b -> b.index(index).document(document).id(document.id()));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private void putLifecyclePolicy() throws IOException {
+    final var ilmClient = testClient.ilm();
+    final var phase =
+        Phase.of(
+            d -> d.minAge(t -> t.time("30d")).actions(JsonData.of(Map.of("delete", Map.of()))));
+    ilmClient.putLifecycle(
+        l -> l.name(retention.getPolicyName()).policy(p -> p.phases(h -> h.delete(phase))));
+  }
+
+  // no need to close resource returned here, since the transport is closed above anyway
+  private ElasticsearchRepository createRepository() {
+    final var client = new ElasticsearchAsyncClient(transport);
+    final var metrics = new CamundaExporterMetrics(meterRegistry);
+
+    return new ElasticsearchRepository(
+        1,
+        config,
+        retention,
+        processInstanceIndex,
+        batchOperationIndex,
+        client,
+        Runnable::run,
+        metrics,
+        LOGGER);
+  }
+
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(ELASTIC.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  }
+
+  /**
+   * NOTE: the fields of this class have to match the ID and END_DATE fields in {@link
+   * io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate} and {@link
+   * io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate}
+   *
+   * <p>If those change in the future, please keep them up to date here. If you need to split the
+   * document types as the names diverge, then go ahead and do so.
+   */
+  private record TestDocument(String id, String endDate) {}
+}


### PR DESCRIPTION
## Description

> [!Note]
> This is only tested manually at the moment. I will add test. This will make the PR bigger however, which is why I think we could do a first pass already, reduce the overall burden.

This PR adds an Elasticsearch implementation of the `ArchiverRepository`. 

Creation of the repository was moved from the resource provider to the `Archiver` itself. This is because the resource provider doesn't really know anything about the ES connection in itself. I thought about putting in the `ClientAdapter`, but since the repository needs to know about the `Archiver`'s executor, it broke all kinds of abstraction. So in the end, the `Archiver` will build it itself, and thus needs the complete `ExporterConfiguration` at this point. It's a little bit more coupling than I'd like, but acceptable.

You'll note in the `Archiver` that we create a custom `ProcessInstanceDependant` based on the `TaskTemplate`. This is because, as opposed to other templates, that one has two kinds of documents which are linked to process instances by different fields. I've asked [here](https://camunda.slack.com/archives/C06F0GLJNFM/p1730750256298019) if we can change that, but for now, it means we need this special adapter.

Other than that, I ported the pre-existing ES repository code to the new ES asynchronous client. This was surprisingly straightforward. While porting, I kept the same logic, but changed one thing in the asynchronous search: instead of keyed results for the date histogram, I went with an array. I mention it because there was an explicit comment in the old repository specifying we want a `keyed` result, but then we were just grabbing the first bucket (and specifying we only want _one_ bucket). It seemed more natural to use an array for this.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24094 
