### PR TITLE
test: fix e2e generation naming for 8.6

### DIFF
--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -65,7 +65,7 @@ jobs:
           - branch: 'main'
             generation_template: 'Zeebe SNAPSHOT'
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-major-minor-version) }}
-            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-major-minor-version) }}
+            generation_template: ${{ format('Camunda {0}+gen1', needs.get-versions.outputs.latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-major-minor-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}


### PR DESCRIPTION
Mirrors changes from https://github.com/camunda/camunda/pull/23457 to also fix E2E