### PR TITLE
fix: commit last transaction after running migrations

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -54,6 +54,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
         new DbMigratorImpl(new ClusterContextImpl(context.getPartitionCount()), processingState);
     try {
       dbMigrator.runMigrations();
+      zeebeDbContext.getCurrentTransaction().commit();
     } catch (final Exception e) {
       return CompletableActorFuture.completedExceptionally(e);
     }


### PR DESCRIPTION
Running migrations might end with an open transaction that contains changes that are not committed yet. To avoid losing these changes, the `MigrationTransitionStep` will do one last commit.

closes https://github.com/camunda/camunda/issues/24352
