### PR TITLE
Check authorization on Job activation

### DIFF
--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -53,6 +53,7 @@ public final class JobServices<T> extends ApiServices<JobServices<T>> {
             .setTimeout(request.timeout())
             .setWorker(request.worker())
             .setVariables(request.fetchVariable());
+    brokerRequest.setAuthorization(authentication.token());
     activateJobsHandler.activateJobs(
         brokerRequest, responseObserver, cancelationHandlerConsumer, request.requestTimeout());
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -10,12 +10,15 @@ package io.camunda.zeebe.engine.processing.identity;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 public final class AuthorizationCheckBehavior {
@@ -37,20 +40,15 @@ public final class AuthorizationCheckBehavior {
   }
 
   /**
-   * Checks if a user is Authorized to perform an action on a resource. The user key is taken from *
+   * Checks if a user is Authorized to perform an action on a resource. The user key is taken from
    * the authorizations of the command.
    *
-   * <p>The caller of this method should provide a Map of resource identifiers. Examples of this
-   * are:
+   * <p>The caller of this method should provide an {@link AuthorizationRequest}. This object
+   * contains the data required to do the check.
    *
-   * <ul>
-   *   <li>Key: bpmnProcessId, Value: myProcess
-   *   <li>Key: processInstanceKey, Value: 1234567890
-   * </ul>
-   *
-   * @param request the authorization request to check authorization for. This contains the resource
-   *     type and permission type
-   * @return true if the user is authorized, false otherwise
+   * @param request the authorization request to check authorization for. This contains the command,
+   *     the resource type, the permission type and a set of resource identifiers
+   * @return true if the entity is authorized, false otherwise
    */
   public boolean isAuthorized(final AuthorizationRequest request) {
     if (!engineConfig.isEnableAuthorization()) {
@@ -62,36 +60,45 @@ public final class AuthorizationCheckBehavior {
       return true;
     }
 
-    final var userKey =
-        (Long) request.getCommand().getAuthorizations().get(Authorization.AUTHORIZED_USER_KEY);
-    if (userKey == null) {
-      return false;
-    }
+    Set<String> authorizedResourceIdentifiers = Collections.emptySet();
 
-    final var userOptional = userState.getUser(userKey);
-    if (userOptional.isEmpty()) {
-      return false;
+    final var userKey = getUserKey(request);
+    if (userKey.isPresent()) {
+      authorizedResourceIdentifiers = getAuthorizedResourceIdentifiers(userKey.get(), request);
     }
-    final var user = userOptional.get();
-
-    // The default user has all permissions
-    if (user.getUserType().equals(UserType.DEFAULT)) {
-      return true;
-    }
-
-    final var authorizedResourceIdentifiers =
-        getAuthorizedResourceIdentifiers(
-            userKey, request.getResourceType(), request.getPermissionType());
 
     // Check if authorizations contain a resource identifier that matches the required resource
     // identifiers
     return hasRequiredPermission(request.getResourceIds(), authorizedResourceIdentifiers);
   }
 
+  private static Optional<Long> getUserKey(final AuthorizationRequest request) {
+    return Optional.ofNullable(
+        (Long) request.getCommand().getAuthorizations().get(Authorization.AUTHORIZED_USER_KEY));
+  }
+
+  private Set<String> getAuthorizedResourceIdentifiers(
+      final long userKey, final AuthorizationRequest request) {
+    return getAuthorizedResourceIdentifiers(
+        userKey, request.getResourceType(), request.getPermissionType());
+  }
+
   private Set<String> getAuthorizedResourceIdentifiers(
       final long userKey,
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType) {
+    final var userOptional = userState.getUser(userKey);
+    if (userOptional.isEmpty()) {
+      return Collections.emptySet();
+    }
+    final var user = userOptional.get();
+
+    // The default user has all permissions
+    if (user.getUserType().equals(UserType.DEFAULT)) {
+      // TODO this should change when we introduce a default "admin" role to the default user
+      return Set.of(WILDCARD_PERMISSION);
+    }
+
     // Get resource identifiers for this user, resource type and permission type from state
     return authorizationState.getResourceIdentifiers(userKey, resourceType, permissionType);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -37,7 +38,7 @@ import java.util.Collections;
 import java.util.Map;
 import org.agrona.DirectBuffer;
 
-@ExcludeAuthorizationCheck // TODO remove this when auth checks are implemented for this class
+@ExcludeAuthorizationCheck
 public final class JobBatchActivateProcessor implements TypedRecordProcessor<JobBatchRecord> {
 
   private final StateWriter stateWriter;
@@ -53,12 +54,14 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
       final Writers writers,
       final ProcessingState state,
       final KeyGenerator keyGenerator,
-      final JobMetrics jobMetrics) {
+      final JobMetrics jobMetrics,
+      final AuthorizationCheckBehavior authCheckBehavior) {
 
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
-    jobBatchCollector = new JobBatchCollector(state, stateWriter::canWriteEventOfLength);
+    jobBatchCollector =
+        new JobBatchCollector(state, stateWriter::canWriteEventOfLength, authCheckBehavior);
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -105,7 +105,11 @@ public final class JobEventProcessors {
             ValueType.JOB_BATCH,
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
-                writers, processingState, processingState.getKeyGenerator(), jobMetrics))
+                writers,
+                processingState,
+                processingState.getKeyGenerator(),
+                jobMetrics,
+                authCheckBehavior))
         .withListener(
             new JobTimeoutCheckerScheduler(
                 scheduledTaskStateFactory.get().getJobState(),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.MockTypedRecord;
@@ -57,7 +58,10 @@ final class JobBatchCollectorTest {
 
   @BeforeEach
   void beforeEach() {
-    collector = new JobBatchCollector(state, lengthEvaluator);
+    final var authorizationCheckBehavior =
+        new AuthorizationCheckBehavior(
+            state.getAuthorizationState(), state.getUserState(), new EngineConfiguration());
+    collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior);
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -98,8 +98,9 @@ public class JobController {
       final ActivateJobsRequest activationRequest) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
     final var responseObserver = responseObserverProvider.apply(result);
-    jobServices.activateJobs(
-        activationRequest, responseObserver, responseObserver::setCancelationHandler);
+    jobServices
+        .withAuthentication(RequestMapper.getAuthentication())
+        .activateJobs(activationRequest, responseObserver, responseObserver::setCancelationHandler);
     return result.handleAsync(
         (res, ex) -> {
           responseObserver.invokeCancelationHandler();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobBatchActivateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobBatchActivateAuthorizationIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@AutoCloseResources
+@Testcontainers
+@ZeebeIntegration
+@TestMethodOrder(OrderAnnotation.class)
+public class JobBatchActivateAuthorizationIT {
+
+  public static final String JOB_TYPE = "jobType";
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withBrokerConfig(
+              b -> b.getExperimental().getEngine().getAuthorizations().setEnableAuthorization(true))
+          .withGatewayConfig(c -> c.getLongPolling().setEnabled(false))
+          .withAdditionalProfile(Profile.AUTH_BASIC);
+
+  private static AuthorizationsUtil authUtil;
+  private static ZeebeClient defaultUserClient;
+
+  @BeforeAll
+  static void beforeAll() {
+    BROKER.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    BROKER.start();
+
+    final var defaultUsername = "demo";
+    defaultUserClient = createClient(BROKER, defaultUsername, "demo");
+    authUtil = new AuthorizationsUtil(BROKER, defaultUserClient, CONTAINER.getHttpHostAddress());
+
+    authUtil.awaitUserExistsInElasticsearch(defaultUsername);
+  }
+
+  @Test
+  @Order(1) // we need to run this first, otherwise it will activate jobs of the other testcases
+  void shouldBeAuthorizedToActivateAllJobsWithDefaultUser() {
+    // given
+    final var processId1 = Strings.newRandomValidBpmnId();
+    final var processId2 = Strings.newRandomValidBpmnId();
+    createJobs(processId1, processId2);
+
+    // when
+    final var response =
+        defaultUserClient
+            .newActivateJobsCommand()
+            .jobType(JOB_TYPE)
+            .maxJobsToActivate(2)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs())
+        .hasSize(2)
+        .extracting(ActivatedJob::getBpmnProcessId)
+        .containsExactlyInAnyOrder(processId1, processId2);
+  }
+
+  @Test
+  @Order(2)
+  void shouldBeAuthorizedToActivateMultipleJobsWithUser() {
+    // given
+    final var processId1 = Strings.newRandomValidBpmnId();
+    final var processId2 = Strings.newRandomValidBpmnId();
+    createJobs(processId1, processId2);
+    // and user has permission for both processes
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUserWithPermissions(
+        username,
+        password,
+        new Permissions(
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE,
+            List.of(processId1, processId2)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response =
+          client.newActivateJobsCommand().jobType(JOB_TYPE).maxJobsToActivate(2).send().join();
+
+      // then
+      assertThat(response.getJobs())
+          .hasSize(2)
+          .extracting(ActivatedJob::getBpmnProcessId)
+          .containsExactlyInAnyOrder(processId1, processId2);
+    }
+  }
+
+  @Test
+  @Order(3)
+  void shouldBeAuthorizedToActivateSingleJobWithUser() {
+    // given
+    final var processId1 = Strings.newRandomValidBpmnId();
+    final var processId2 = Strings.newRandomValidBpmnId();
+    createJobs(processId1, processId2);
+    // and user has permission for only one of the processes
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUserWithPermissions(
+        username,
+        password,
+        new Permissions(
+            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(processId1)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response =
+          client.newActivateJobsCommand().jobType(JOB_TYPE).maxJobsToActivate(2).send().join();
+
+      // then
+      assertThat(response.getJobs())
+          .hasSize(1)
+          .extracting(ActivatedJob::getBpmnProcessId)
+          .containsOnly(processId1);
+    }
+  }
+
+  @Test
+  @Order(4)
+  void shouldNotActivateJobsWithUnauthorizedUser() {
+    // given
+    final var processId1 = Strings.newRandomValidBpmnId();
+    final var processId2 = Strings.newRandomValidBpmnId();
+    createJobs(processId1, processId2);
+    // and user has permission for none of the processes
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUser(username, password);
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when
+      final var response =
+          client
+              .newActivateJobsCommand()
+              .jobType(JOB_TYPE)
+              .maxJobsToActivate(2)
+              .timeout(Duration.ofMinutes(10))
+              .send()
+              .join();
+
+      // then
+      assertThat(response.getJobs()).isEmpty();
+    }
+  }
+
+  private static void createJobs(final String... processIds) {
+    for (final String processId : processIds) {
+      defaultUserClient
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess(processId)
+                  .startEvent()
+                  .serviceTask("serviceTask", t -> t.zeebeJobType(JOB_TYPE))
+                  .endEvent()
+                  .done(),
+              "%s.xml".formatted(processId))
+          .send()
+          .join();
+
+      defaultUserClient
+          .newCreateInstanceCommand()
+          .bpmnProcessId(processId)
+          .latestVersion()
+          .send()
+          .join();
+    }
+
+    RecordingExporter.jobRecords(JobIntent.CREATED).limit(processIds.length).await();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Users must be authorized to activate Jobs. This authorization is done at a bpmnProcessId level. Since job activation happens in batches, there could be multiple jobs with different process ids. Users are not necessarily authorized for
all of these jobs. The decision was made to ignore jobs that the user lacks authorizations for. We do this by getting a set of process ids that the user is authorized for and comparing these with the process id of the job itself. If the user is not authorized we will skip this job and continue with the next one.
There is one exception to the rule. If the user has a wildcard permission (*) it is authorized to activate all jobs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22890 
