### PR TITLE
[Backport stable/8.6] fix: commit last transaction after running migrations

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -54,6 +54,7 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
         new DbMigratorImpl(new ClusterContextImpl(context.getPartitionCount()), processingState);
     try {
       dbMigrator.runMigrations();
+      zeebeDbContext.getCurrentTransaction().commit();
     } catch (final Exception e) {
       return CompletableActorFuture.completedExceptionally(e);
     }


### PR DESCRIPTION
# Description
Backport of #24353 to `stable/8.6`.

relates to camunda/camunda#24352
original author: @lenaschoenburg