### PR TITLE
Implement group entity add applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -486,6 +486,7 @@ public final class EventAppliers implements EventApplier {
         GroupIntent.CREATED,
         new GroupCreatedApplier(state.getGroupState(), state.getAuthorizationState()));
     register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
+    register(GroupIntent.ADD_ENTITY, new GroupEntityAddedApplier(state));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -486,7 +486,7 @@ public final class EventAppliers implements EventApplier {
         GroupIntent.CREATED,
         new GroupCreatedApplier(state.getGroupState(), state.getAuthorizationState()));
     register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
-    register(GroupIntent.ADD_ENTITY, new GroupEntityAddedApplier(state));
+    register(GroupIntent.ENTITY_ADDED, new GroupEntityAddedApplier(state));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
+import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+
+public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
+
+  private final MutableGroupState groupState;
+  private final MutableUserState userState;
+  private final MutableMappingState mappingState;
+
+  public GroupEntityAddedApplier(final MutableProcessingState processingState) {
+    groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
+    mappingState = processingState.getMappingState();
+  }
+
+  @Override
+  public void applyState(final long key, final GroupRecord value) {
+    groupState.addEntity(key, value);
+    switch (value.getEntityType()) {
+      case USER -> userState.addGroup(value.getEntityKey(), key);
+      case MAPPING -> mappingState.addGroup(value.getEntityKey(), key);
+      default ->
+          throw new IllegalStateException(
+              String.format(
+                  "Expected to add entity '%d' to group '%d', but entities of type '%s' cannot be added to groups.",
+                  value.getEntityKey(), key, value.getEntityType()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -120,6 +120,18 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public void addGroup(final long mappingKey, final long groupKey) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
+      persistedMapping.addGroupKey(groupKey);
+      mappingColumnFamily.update(claim, persistedMapping);
+    }
+  }
+
+  @Override
   public Optional<PersistedMapping> get(final long key) {
     mappingKey.wrapLong(key);
     final var fk = claimByKeyColumnFamily.get(mappingKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -28,14 +28,17 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
       new ArrayProperty<>("roleKeys", LongValue::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>("tenantIds", StringValue::new);
+  private final ArrayProperty<LongValue> groupKeysProp =
+      new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedMapping() {
-    super(5);
-    declareProperty(mappingKeyProp);
-    declareProperty(claimNameProp);
-    declareProperty(claimValueProp);
-    declareProperty(roleKeysProp);
-    declareProperty(tenantIdsProp);
+    super(6);
+    declareProperty(mappingKeyProp)
+        .declareProperty(claimNameProp)
+        .declareProperty(claimValueProp)
+        .declareProperty(roleKeysProp)
+        .declareProperty(tenantIdsProp)
+        .declareProperty(groupKeysProp);
   }
 
   public long getMappingKey() {
@@ -97,6 +100,23 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
 
   public PersistedMapping addTenantId(final String tenantId) {
     tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
+    return this;
+  }
+
+  public List<Long> getGroupKeysList() {
+    return StreamSupport.stream(groupKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
+  }
+
+  public PersistedMapping setGroupKeysList(final List<Long> groupKeys) {
+    groupKeysProp.reset();
+    groupKeys.forEach(groupKey -> groupKeysProp.add().setValue(groupKey));
+    return this;
+  }
+
+  public PersistedMapping addGroupKey(final long groupKey) {
+    groupKeysProp.add().setValue(groupKey);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -47,7 +47,7 @@ public class DbGroupState implements MutableGroupState {
     groupKey = new DbLong();
     groupColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.GROUPS, transactionContext, groupKey, persistedGroup);
+            ZbColumnFamilies.GROUPS, transactionContext, groupKey, new PersistedGroup());
 
     fkGroupKey = new DbForeignKey<>(groupKey, ZbColumnFamilies.GROUPS);
     entityKey = new DbLong();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -18,6 +18,11 @@ import io.camunda.zeebe.engine.state.authorization.EntityTypeValue;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class DbGroupState implements MutableGroupState {
@@ -89,6 +94,14 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
+  public void addEntity(final long groupKey, final GroupRecord group) {
+    this.groupKey.wrapLong(groupKey);
+    entityKey.wrapLong(group.getEntityKey());
+    entityTypeValue.setEntityType(group.getEntityType());
+    entityTypeByGroupColumnFamily.insert(fkGroupKeyAndEntityKey, entityTypeValue);
+  }
+
+  @Override
   public Optional<PersistedGroup> get(final long groupKey) {
     this.groupKey.wrapLong(groupKey);
     final var persistedGroup = groupColumnFamily.get(this.groupKey);
@@ -100,5 +113,27 @@ public class DbGroupState implements MutableGroupState {
     this.groupName.wrapString(groupName);
     final var groupKey = groupByNameColumnFamily.get(this.groupName);
     return Optional.ofNullable(groupKey).map(key -> key.inner().getValue());
+  }
+
+  @Override
+  public Optional<EntityType> getEntityType(final long groupKey, final long entityKey) {
+    this.groupKey.wrapLong(groupKey);
+    this.entityKey.wrapLong(entityKey);
+    final var entityType = entityTypeByGroupColumnFamily.get(fkGroupKeyAndEntityKey);
+    return Optional.ofNullable(entityType).map(EntityTypeValue::getEntityType);
+  }
+
+  @Override
+  public Map<EntityType, List<Long>> getEntitiesByType(final long groupKey) {
+    this.groupKey.wrapLong(groupKey);
+    final Map<EntityType, List<Long>> entitiesMap = new HashMap<>();
+    entityTypeByGroupColumnFamily.whileEqualPrefix(
+        fkGroupKey,
+        (compositeKey, value) -> {
+          final var entityType = value.getEntityType();
+          final var entityKey = compositeKey.second().getValue();
+          entitiesMap.computeIfAbsent(entityType, k -> new ArrayList<>()).add(entityKey);
+        });
+    return entitiesMap;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -21,8 +21,7 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   public PersistedGroup() {
     super(2);
-    declareProperty(groupKeyProp);
-    declareProperty(nameProp);
+    declareProperty(groupKeyProp).declareProperty(nameProp);
   }
 
   public long getGroupKey() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/GroupState.java
@@ -8,6 +8,9 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.group.PersistedGroup;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface GroupState {
@@ -15,4 +18,8 @@ public interface GroupState {
   Optional<PersistedGroup> get(long groupKey);
 
   Optional<Long> getGroupKeyByName(String groupName);
+
+  Optional<EntityType> getEntityType(long groupKey, long entityKey);
+
+  Map<EntityType, List<Long>> getEntitiesByType(long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -15,4 +15,6 @@ public interface MutableGroupState extends GroupState {
   void create(final long groupKey, final GroupRecord group);
 
   void update(final long groupKey, final GroupRecord group);
+
+  void addEntity(final long groupKey, final GroupRecord group);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,6 +16,8 @@ public interface MutableMappingState extends MappingState {
 
   void addRole(final long mappingKey, final long roleKey);
 
+  void addGroup(final long mappingKey, final long groupKey);
+
   void addTenant(final long mappingKey, final String tenantId);
 
   void removeRole(final long mappingKey, final long roleKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -21,4 +21,6 @@ public interface MutableUserState extends UserState {
   void addTenantId(final long userKey, final String tenantId);
 
   void removeTenant(final long userKey, final String tenantId);
+
+  void addGroup(final long userKey, final long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -45,7 +45,7 @@ public class DbTenantState implements MutableTenantState {
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     tenantsColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.TENANTS, transactionContext, tenantKey, persistedTenant);
+            ZbColumnFamilies.TENANTS, transactionContext, tenantKey, new PersistedTenant());
 
     fkTenantKey = new DbForeignKey<>(tenantKey, ZbColumnFamilies.TENANTS);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -96,6 +96,14 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
+  public void addGroup(final long userKey, final long groupKey) {
+    this.userKey.wrapLong(userKey);
+    final var persistedUser = userByUserKeyColumnFamily.get(this.userKey);
+    persistedUser.addGroupKey(groupKey);
+    userByUserKeyColumnFamily.update(this.userKey, persistedUser);
+  }
+
+  @Override
   public Optional<PersistedUser> getUser(final DirectBuffer username) {
     this.username.wrapBuffer(username);
     final var key = userKeyByUsernameColumnFamily.get(this.username);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -44,7 +44,7 @@ public class DbUserState implements UserState, MutableUserState {
             ZbColumnFamilies.USER_KEY_BY_USERNAME, transactionContext, username, fkUserKey);
     userByUserKeyColumnFamily =
         zeebeDb.createColumnFamily(
-            ZbColumnFamilies.USERS, transactionContext, userKey, persistedUser);
+            ZbColumnFamilies.USERS, transactionContext, userKey, new PersistedUser());
   }
 
   @Override
@@ -79,9 +79,7 @@ public class DbUserState implements UserState, MutableUserState {
   public void addTenantId(final long userKey, final String tenantId) {
     this.userKey.wrapLong(userKey);
     final var persistedUser = userByUserKeyColumnFamily.get(this.userKey);
-    final var tenantIds = persistedUser.getTenantIdsList();
-    tenantIds.add(tenantId);
-    persistedUser.setTenantIdsList(tenantIds);
+    persistedUser.addTenantId(tenantId);
     userByUserKeyColumnFamily.update(this.userKey, persistedUser);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
@@ -15,11 +15,10 @@ import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.UserType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 public class PersistedUser extends UnpackedObject implements DbValue {
 
@@ -100,23 +99,19 @@ public class PersistedUser extends UnpackedObject implements DbValue {
 
   public List<String> getTenantIdsList() {
     return StreamSupport.stream(tenantIdsProp.spliterator(), false)
-        .map(StringValue::toString)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
         .collect(Collectors.toList());
   }
 
   public PersistedUser setTenantIdsList(final List<String> tenantIds) {
     tenantIdsProp.reset();
-    tenantIds.forEach(
-        tenantId -> {
-          final DirectBuffer buffer = new UnsafeBuffer(tenantId.getBytes());
-          tenantIdsProp.add().wrap(buffer);
-        });
+    tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
     return this;
   }
 
   public PersistedUser addTenantId(final String tenantId) {
-    final DirectBuffer buffer = new UnsafeBuffer(tenantId.getBytes());
-    tenantIdsProp.add().wrap(buffer);
+    tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
@@ -29,10 +29,15 @@ public class PersistedUser extends UnpackedObject implements DbValue {
       new ArrayProperty<>("roleKeys", LongValue::new);
   private final ArrayProperty<StringValue> tenantIdsProp =
       new ArrayProperty<>("tenantIds", StringValue::new);
+  private final ArrayProperty<LongValue> groupKeysProp =
+      new ArrayProperty<>("groupKeys", LongValue::new);
 
   public PersistedUser() {
-    super(1);
-    declareProperty(userProp);
+    super(4);
+    declareProperty(userProp)
+        .declareProperty(roleKeysProp)
+        .declareProperty(tenantIdsProp)
+        .declareProperty(groupKeysProp);
   }
 
   public PersistedUser copy() {
@@ -40,6 +45,7 @@ public class PersistedUser extends UnpackedObject implements DbValue {
     copy.setUser(getUser());
     copy.setRoleKeysList(getRoleKeysList());
     copy.setTenantIdsList(getTenantIdsList());
+    copy.setGroupKeysList(getGroupKeysList());
     return copy;
   }
 
@@ -111,6 +117,23 @@ public class PersistedUser extends UnpackedObject implements DbValue {
   public PersistedUser addTenantId(final String tenantId) {
     final DirectBuffer buffer = new UnsafeBuffer(tenantId.getBytes());
     tenantIdsProp.add().wrap(buffer);
+    return this;
+  }
+
+  public List<Long> getGroupKeysList() {
+    return StreamSupport.stream(groupKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
+  }
+
+  public PersistedUser setGroupKeysList(final List<Long> groupKeys) {
+    groupKeysProp.reset();
+    groupKeys.forEach(groupKey -> groupKeysProp.add().setValue(groupKey));
+    return this;
+  }
+
+  public PersistedUser addGroupKey(final long groupKey) {
+    groupKeysProp.add().setValue(groupKey);
     return this;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -13,6 +13,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,5 +112,48 @@ public class GroupStateTest {
     final var groupKeyByName = groupState.getGroupKeyByName(updatedGroupName);
     assertThat(groupKeyByName.isPresent()).isTrue();
     assertThat(groupKeyByName.get()).isEqualTo(groupKey);
+  }
+
+  @Test
+  void shouldAddEntity() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+
+    // when
+    final var userKey = 2L;
+    final var userEntityType = EntityType.USER;
+    groupRecord.setEntityKey(userKey).setEntityType(userEntityType);
+    groupState.addEntity(groupKey, groupRecord);
+
+    // then
+    final var entityType = groupState.getEntityType(groupKey, userKey);
+    assertThat(entityType.isPresent()).isTrue();
+    assertThat(entityType.get()).isEqualTo(userEntityType);
+  }
+
+  @Test
+  void shouldReturnEntitiesByType() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    final var userKey = 2L;
+    groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
+    groupState.addEntity(groupKey, groupRecord);
+    final var mappingKey = 3L;
+    groupRecord.setEntityKey(mappingKey).setEntityType(EntityType.MAPPING);
+    groupState.addEntity(groupKey, groupRecord);
+
+    // when
+    final var entities = groupState.getEntitiesByType(groupKey);
+
+    // then
+    assertThat(entities)
+        .containsEntry(EntityType.USER, List.of(userKey))
+        .containsEntry(EntityType.MAPPING, List.of(mappingKey));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Provide an applier for `Group.ENTITY_ADDED` events, and the appropriate `GroupState` CRUD methods that are necessary for the data to be applied to the `DbGroupState`.

ℹ️ Note: I also adjusted the `PersistedUser` and `PersistedMapping` classes. The `PersistedUser` had some undeclared properties.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23480
related to #23874
