### PR TITLE
Implement group entity remove applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -487,6 +487,7 @@ public final class EventAppliers implements EventApplier {
         new GroupCreatedApplier(state.getGroupState(), state.getAuthorizationState()));
     register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
     register(GroupIntent.ENTITY_ADDED, new GroupEntityAddedApplier(state));
+    register(GroupIntent.ENTITY_REMOVED, new GroupEntityRemovedApplier(state));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
+import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+
+public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
+
+  private final MutableGroupState groupState;
+  private final MutableUserState userState;
+  private final MutableMappingState mappingState;
+
+  public GroupEntityRemovedApplier(final MutableProcessingState processingState) {
+    groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
+    mappingState = processingState.getMappingState();
+  }
+
+  @Override
+  public void applyState(final long key, final GroupRecord value) {
+    final var entityKey = value.getEntityKey();
+    groupState.removeEntity(key, entityKey);
+    switch (value.getEntityType()) {
+      case USER -> userState.removeGroup(entityKey, key);
+      case MAPPING -> mappingState.removeGroup(entityKey, key);
+      default ->
+          throw new IllegalStateException(
+              String.format(
+                  "Expected to remove entity '%d' from group '%d', but entities of type '%s' cannot be removed from groups.",
+                  entityKey, key, value.getEntityType()));
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -118,6 +118,20 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public void removeGroup(final long mappingKey, final long groupKey) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
+      final List<Long> groupKeys = persistedMapping.getGroupKeysList();
+      groupKeys.remove(groupKey);
+      persistedMapping.setGroupKeysList(groupKeys);
+      mappingColumnFamily.update(claim, persistedMapping);
+    }
+  }
+
+  @Override
   public void removeTenant(final long mappingKey, final String tenantId) {
     this.mappingKey.wrapLong(mappingKey);
     final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -102,6 +102,13 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
+  public void removeEntity(final long groupKey, final long entityKey) {
+    this.groupKey.wrapLong(groupKey);
+    this.entityKey.wrapLong(entityKey);
+    entityTypeByGroupColumnFamily.deleteExisting(fkGroupKeyAndEntityKey);
+  }
+
+  @Override
   public Optional<PersistedGroup> get(final long groupKey) {
     this.groupKey.wrapLong(groupKey);
     final var persistedGroup = groupColumnFamily.get(this.groupKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -17,4 +17,6 @@ public interface MutableGroupState extends GroupState {
   void update(final long groupKey, final GroupRecord group);
 
   void addEntity(final long groupKey, final GroupRecord group);
+
+  void removeEntity(final long groupKey, final long entityKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -22,5 +22,7 @@ public interface MutableMappingState extends MappingState {
 
   void removeRole(final long mappingKey, final long roleKey);
 
+  void removeGroup(final long mappingKey, final long groupKey);
+
   void removeTenant(final long mappingKey, final String tenantId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserState.java
@@ -23,4 +23,6 @@ public interface MutableUserState extends UserState {
   void removeTenant(final long userKey, final String tenantId);
 
   void addGroup(final long userKey, final long groupKey);
+
+  void removeGroup(final long userKey, final long groupKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/DbUserState.java
@@ -102,6 +102,16 @@ public class DbUserState implements UserState, MutableUserState {
   }
 
   @Override
+  public void removeGroup(final long userKey, final long groupKey) {
+    this.userKey.wrapLong(userKey);
+    final var persistedUser = userByUserKeyColumnFamily.get(this.userKey);
+    final List<Long> groupKeys = persistedUser.getGroupKeysList();
+    groupKeys.remove(groupKey);
+    persistedUser.setGroupKeysList(groupKeys);
+    userByUserKeyColumnFamily.update(this.userKey, persistedUser);
+  }
+
+  @Override
   public Optional<PersistedUser> getUser(final DirectBuffer username) {
     this.username.wrapBuffer(username);
     final var key = userKeyByUsernameColumnFamily.get(this.username);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -145,4 +145,66 @@ public class GroupAppliersTest {
     final var persistedMapping = mappingState.get(entityKey).get();
     assertThat(persistedMapping.getGroupKeysList()).containsExactly(groupKey);
   }
+
+  @Test
+  void shoulRemoveUserEntityFromGroup() {
+    // given
+    final var entityKey = 1L;
+    final var userRecord =
+        new UserRecord()
+            .setUserKey(entityKey)
+            .setName("test")
+            .setUsername("username")
+            .setPassword("password")
+            .setEmail("test@example.com");
+    userState.create(userRecord);
+    final var groupEntityAddedApplier = new GroupEntityAddedApplier(processingState);
+    final var groupEnetityRemovedApplier = new GroupEntityRemovedApplier(processingState);
+    final var groupKey = 2L;
+    final var groupName = "group";
+    final var entityType = EntityType.USER;
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupEntityAddedApplier.applyState(groupKey, groupRecord);
+
+    // when
+    groupEnetityRemovedApplier.applyState(groupKey, groupRecord);
+
+    // then
+    final var entitiesByType = groupState.getEntitiesByType(groupKey);
+    assertThat(entitiesByType).isEmpty();
+    final var persistedUser = userState.getUser(entityKey).get();
+    assertThat(persistedUser.getGroupKeysList()).isEmpty();
+  }
+
+  @Test
+  void shouldRemoveMappingEntityFromGroup() {
+    // given
+    final var entityKey = 1L;
+    final var mappingRecord =
+        new MappingRecord()
+            .setMappingKey(entityKey)
+            .setClaimName("claimName")
+            .setClaimValue("claimValue");
+    mappingState.create(mappingRecord);
+    final var groupEntityAddedApplier = new GroupEntityAddedApplier(processingState);
+    final var groupEnetityRemovedApplier = new GroupEntityRemovedApplier(processingState);
+    final var groupKey = 2L;
+    final var groupName = "group";
+    final var entityType = EntityType.MAPPING;
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    groupRecord.setEntityKey(entityKey).setEntityType(entityType);
+    groupEntityAddedApplier.applyState(groupKey, groupRecord);
+
+    // when
+    groupEnetityRemovedApplier.applyState(groupKey, groupRecord);
+
+    // then
+    final var entitiesByType = groupState.getEntitiesByType(groupKey);
+    assertThat(entitiesByType).isEmpty();
+    final var persistedMapping = mappingState.get(entityKey).get();
+    assertThat(persistedMapping.getGroupKeysList()).isEmpty();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -155,5 +156,27 @@ public class GroupStateTest {
     assertThat(entities)
         .containsEntry(EntityType.USER, List.of(userKey))
         .containsEntry(EntityType.MAPPING, List.of(mappingKey));
+  }
+
+  @Test
+  void shouldRemoveEntity() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    final var userKey = 2L;
+    groupRecord.setEntityKey(userKey).setEntityType(EntityType.USER);
+    groupState.addEntity(groupKey, groupRecord);
+    final var mappingKey = 3L;
+    groupRecord.setEntityKey(mappingKey).setEntityType(EntityType.MAPPING);
+    groupState.addEntity(groupKey, groupRecord);
+
+    // when
+    groupState.removeEntity(groupKey, userKey);
+
+    // then
+    final var entityType = groupState.getEntitiesByType(groupKey);
+    assertThat(entityType).containsOnly(Map.entry(EntityType.MAPPING, List.of(mappingKey)));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Provide an applier for `Group.ENTITY_REMOVED` events, and the appropriate `GroupState` CRUD methods that are necessary for the data to be applied to the `DbGroupState`.

ℹ️ This PR should be reviewed after #24366.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23484
related to #23875
