### PR TITLE
ci: use non-preemptible runners for jobs with highest disconnect rate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -52,6 +52,11 @@ self-hosted-runner:
   - gcp-perf-core-4-default
   - gcp-perf-core-8-default
   - gcp-perf-core-16-default
-  # by Zeebe team, to be deprecated after https://github.com/camunda/camunda/issues/18212
-  - amd64
-  - '16'
+  - gcp-perf-core-2-release
+  - gcp-perf-core-4-release
+  - gcp-perf-core-8-release
+  - gcp-perf-core-16-release
+  - gcp-perf-core-2-longrunning
+  - gcp-perf-core-4-longrunning
+  - gcp-perf-core-8-longrunning
+  - gcp-perf-core-16-longrunning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-perf-core-8-default
+            runs-on: gcp-perf-core-8-longrunning
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"
@@ -547,7 +547,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-  
+
   openapi-lint:
     name: C8 REST OpenAPI linting
     timeout-minutes: 2
@@ -561,7 +561,7 @@ jobs:
         run: curl -fsSL https://quobix.com/scripts/install_vacuum.sh | sh > /dev/null
         shell: bash
       - name: Run OpenAPI Linter
-        run: vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml -r .github/vacuum-ruleset.yaml -d -e 
+        run: vacuum lint zeebe/gateway-protocol/src/main/proto/rest-api.yaml -r .github/vacuum-ruleset.yaml -d -e
         shell: bash
       - name: Observe build status
         if: always()

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -31,7 +31,7 @@ jobs:
           - os: linux
             runner: gcp-perf-core-8-default
           - os: linux
-            runner: "aws-arm-core-4-default"
+            runner: "aws-arm-core-4-longrunning"
             arch: arm64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

**Observation:** Over the last 7 days we have around 1500-2000 GHA jobs in this monorepo running on self-hosted runners, with around 1-1.5% disconnect rate (aka runners disconnects for whatever reason before job is finished):

![image](https://github.com/user-attachments/assets/27da71dc-d401-43f6-9c88-90d50caaea8c)

This triggers the related [alert](https://github.com/camunda/camunda/wiki/CI-Runbooks#selfhosted-runner-high-disconnect-rate) very frequently.

Those disconnects happen very often for the same 3 GHA jobs and nearly never for other jobs on self-hosted runners:

![image](https://github.com/user-attachments/assets/d468ae20-1769-4d3e-a820-b2a3aa50d640)

It is unclear yet what these 3 GHA jobs have in common (if anything) that makes them experience higher disconnect rates. One hypothesis is that those jobs have longer runtimes than the others → more likely to experience node preemption.

**Experiment:** This PR starts the experiment of switching these 3 (Edit: only 2) GHA jobs to use non-preemptible runners (more expensive, less likely to disconnect?). We can monitor whether this reduces the disconnect rate and if so decide whether we are fine with the additional financial cost. Needs https://github.com/camunda/infra-core/pull/8566

"[IT] Zeebe QA - Integration Tests" was not moved to stable runners yet since that (for some reason) proved unreliable in the merge queue repeatedly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
