### PR TITLE
Fix flaky tests for camunda exporter handlers

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -192,12 +192,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -192,6 +192,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -42,7 +42,6 @@ import io.camunda.exporter.schema.SchemaTestUtil;
 import io.camunda.exporter.utils.CamundaExporterHandlerITInvocationProvider;
 import io.camunda.exporter.utils.CamundaExporterITInvocationProvider;
 import io.camunda.exporter.utils.SearchClientAdapter;
-import io.camunda.exporter.utils.TestSupport;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
@@ -104,7 +103,6 @@ import org.testcontainers.containers.GenericContainer;
  */
 @TestInstance(Lifecycle.PER_CLASS)
 @ExtendWith(CamundaExporterITInvocationProvider.class)
-// @Disabled("flaky test")
 final class CamundaExporterIT {
 
   private final ProtocolFactory factory = new ProtocolFactory();

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterHandlerITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterHandlerITInvocationProvider.java
@@ -16,6 +16,9 @@ import io.camunda.exporter.DefaultExporterResourceProvider;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.handlers.operation.OperationFromIncidentHandler;
+import io.camunda.exporter.handlers.operation.OperationFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.operation.OperationFromVariableDocumentHandler;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
@@ -29,6 +32,12 @@ import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 
 public class CamundaExporterHandlerITInvocationProvider
     extends CamundaExporterITInvocationProvider {
+  @Override
+  public void afterEach(final ExtensionContext context) {
+    //    we don't want to clear indices and templates after each test as each invocation context
+    //    now providers the same exporter, limiting the amount of schema startups
+  }
+
   @Override
   public boolean supportsTestTemplate(final ExtensionContext extensionContext) {
     // we only want to template tests in the class which ask for exporter, client
@@ -67,6 +76,13 @@ public class CamundaExporterHandlerITInvocationProvider
     provider.init(osConfig, ClientAdapter.of(elsConfig)::getProcessCacheLoader);
 
     return provider.getExportHandlers().stream()
+        .filter(
+            handler ->
+                !List.of(
+                        OperationFromIncidentHandler.class,
+                        OperationFromProcessInstanceHandler.class,
+                        OperationFromVariableDocumentHandler.class)
+                    .contains(handler.getClass()))
         .map(
             handler ->
                 List.of(

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterHandlerITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterHandlerITInvocationProvider.java
@@ -97,7 +97,7 @@ public class CamundaExporterHandlerITInvocationProvider
         .flatMap(List::stream);
   }
 
-  private boolean isAnOperationHandler(final ExportHandler<?, ?> handler) {
+  public static boolean isAnOperationHandler(final ExportHandler<?, ?> handler) {
     return List.of(
             OperationFromIncidentHandler.class,
             OperationFromProcessInstanceHandler.class,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -42,17 +42,17 @@ public class CamundaExporterITInvocationProvider
         AfterEachCallback {
 
   public static final String CONFIG_PREFIX = "camunda-record";
+  private static final ElasticsearchContainer elsContainer =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+  private static final OpensearchContainer<?> osContainer =
+      TestSearchContainers.createDefaultOpensearchContainer();
   protected SearchClientAdapter elsClientAdapter;
   protected SearchClientAdapter osClientAdapter;
-  private final ElasticsearchContainer elsContainer =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
-  private final OpensearchContainer<?> osContainer =
-      TestSearchContainers.createDefaultOpensearchContainer();
   private ElasticsearchClient elsClient;
   private OpenSearchClient osClient;
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  protected ExporterConfiguration getConfigWithConnectionDetails(
+  public static ExporterConfiguration getConfigWithConnectionDetails(
       final ConnectionTypes connectionType) {
     final var config = new ExporterConfiguration();
     config.getIndex().setPrefix(CONFIG_PREFIX);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -42,9 +42,9 @@ public class CamundaExporterITInvocationProvider
         AfterEachCallback {
 
   public static final String CONFIG_PREFIX = "camunda-record";
-  private static final ElasticsearchContainer elsContainer =
+  private static final ElasticsearchContainer ELS_CONTAINER =
       TestSearchContainers.createDefeaultElasticsearchContainer();
-  private static final OpensearchContainer<?> osContainer =
+  private static final OpensearchContainer<?> OS_CONTAINER =
       TestSearchContainers.createDefaultOpensearchContainer();
   protected SearchClientAdapter elsClientAdapter;
   protected SearchClientAdapter osClientAdapter;
@@ -58,9 +58,9 @@ public class CamundaExporterITInvocationProvider
     config.getIndex().setPrefix(CONFIG_PREFIX);
     config.getBulk().setSize(1); // force flushing on the first record
     if (connectionType == ELASTICSEARCH) {
-      config.getConnect().setUrl(elsContainer.getHttpHostAddress());
+      config.getConnect().setUrl(ELS_CONTAINER.getHttpHostAddress());
     } else if (connectionType == OPENSEARCH) {
-      config.getConnect().setUrl(osContainer.getHttpHostAddress());
+      config.getConnect().setUrl(OS_CONTAINER.getHttpHostAddress());
     }
     config.getConnect().setType(connectionType.getType());
     return config;
@@ -79,8 +79,8 @@ public class CamundaExporterITInvocationProvider
 
   @Override
   public void beforeAll(final ExtensionContext context) {
-    elsContainer.start();
-    osContainer.start();
+    ELS_CONTAINER.start();
+    OS_CONTAINER.start();
 
     final var osConfig = getConfigWithConnectionDetails(OPENSEARCH);
     osClient = new OpensearchConnector(osConfig.getConnect()).createClient();
@@ -90,8 +90,8 @@ public class CamundaExporterITInvocationProvider
     elsClient = new ElasticsearchConnector(elsConfig.getConnect()).createClient();
     elsClientAdapter = new SearchClientAdapter(elsClient);
 
-    closeables.add(elsContainer);
-    closeables.add(osContainer);
+    closeables.add(ELS_CONTAINER);
+    closeables.add(OS_CONTAINER);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
@@ -13,8 +13,6 @@ import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplate
 import co.elastic.clients.json.JsonpMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.exporter.SchemaResourceSerializer;
 import java.io.IOException;
 import java.util.Objects;
@@ -25,7 +23,7 @@ import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.IndexState;
 
 public class SearchClientAdapter {
-  private static final ObjectMapper MAPPER = getObjectMapper();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
   private static final JsonpMapper ELS_JSON_MAPPER =
       new co.elastic.clients.json.jackson.JacksonJsonpMapper(MAPPER);
   private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSON_MAPPER =
@@ -44,14 +42,6 @@ public class SearchClientAdapter {
     Objects.requireNonNull(osClient, "osClient cannot be null");
     elsClient = null;
     this.osClient = osClient;
-  }
-
-  public static ObjectMapper getObjectMapper() {
-    final JavaTimeModule javaTimeModule = new JavaTimeModule();
-
-    return new ObjectMapper()
-        .registerModule(javaTimeModule)
-        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
   }
 
   private JsonNode opensearchIndexToNode(final IndexState index) throws IOException {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
@@ -151,6 +151,16 @@ public class SearchClientAdapter {
     return null;
   }
 
+  public String index(final String id, final String index, final Object document)
+      throws IOException {
+    if (elsClient != null) {
+      return elsClient.index(i -> i.index(index).id(id).document(document)).result().jsonValue();
+    } else if (osClient != null) {
+      return osClient.index(i -> i.index(index).id(id).document(document)).result().jsonValue();
+    }
+    return "";
+  }
+
   public <T> T get(final String id, final String index, final Class<T> classType)
       throws IOException {
     if (elsClient != null) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/SearchClientAdapter.java
@@ -13,6 +13,8 @@ import co.elastic.clients.elasticsearch.indices.get_index_template.IndexTemplate
 import co.elastic.clients.json.JsonpMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.exporter.SchemaResourceSerializer;
 import java.io.IOException;
 import java.util.Objects;
@@ -23,7 +25,7 @@ import org.opensearch.client.opensearch.generic.Requests;
 import org.opensearch.client.opensearch.indices.IndexState;
 
 public class SearchClientAdapter {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final ObjectMapper MAPPER = getObjectMapper();
   private static final JsonpMapper ELS_JSON_MAPPER =
       new co.elastic.clients.json.jackson.JacksonJsonpMapper(MAPPER);
   private static final org.opensearch.client.json.JsonpMapper OPENSEARCH_JSON_MAPPER =
@@ -42,6 +44,14 @@ public class SearchClientAdapter {
     Objects.requireNonNull(osClient, "osClient cannot be null");
     elsClient = null;
     this.osClient = osClient;
+  }
+
+  public static ObjectMapper getObjectMapper() {
+    final JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+    return new ObjectMapper()
+        .registerModule(javaTimeModule)
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
   }
 
   private JsonNode opensearchIndexToNode(final IndexState index) throws IOException {


### PR DESCRIPTION
## Description

Fix flaky tests for the handlers this was done by 
- excluding operation handlers from the original handler tests 
- add a parameterized test for all the operation handler tests which create an initial entity the operation handlers can update.
## Checklist

## Related issues

closes #
