### PR TITLE
Add group deleted applier

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -488,6 +488,7 @@ public final class EventAppliers implements EventApplier {
     register(GroupIntent.UPDATED, new GroupUpdatedApplier(state.getGroupState()));
     register(GroupIntent.ENTITY_ADDED, new GroupEntityAddedApplier(state));
     register(GroupIntent.ENTITY_REMOVED, new GroupEntityRemovedApplier(state));
+    register(GroupIntent.DELETED, new GroupDeletedApplier(state));
   }
 
   private void registerScalingAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
+import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.BiConsumer;
+
+public class GroupDeletedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
+
+  private final MutableGroupState groupState;
+  private final MutableUserState userState;
+  private final MutableMappingState mappingState;
+  private final MutableAuthorizationState authorizationState;
+
+  public GroupDeletedApplier(final MutableProcessingState processingState) {
+    groupState = processingState.getGroupState();
+    userState = processingState.getUserState();
+    mappingState = processingState.getMappingState();
+    authorizationState = processingState.getAuthorizationState();
+  }
+
+  @Override
+  public void applyState(final long key, final GroupRecord value) {
+
+    // delete group key from entity states (user, mapping)
+    final var entitiesByTypeMap = groupState.getEntitiesByType(key);
+    for (final Entry<EntityType, List<Long>> entry : entitiesByTypeMap.entrySet()) {
+      switch (entry.getKey()) {
+        case EntityType.USER:
+          removeGroupFromState(key, entry.getValue(), userState::removeGroup);
+          break;
+        case EntityType.MAPPING:
+          removeGroupFromState(key, entry.getValue(), mappingState::removeGroup);
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Expected to remove entity '%d' for group '%d', but entities of type '%s' are not supported by groups.",
+                  value.getEntityKey(), key, value.getEntityType()));
+      }
+    }
+
+    // delete group from authorization state
+    authorizationState.deleteAuthorizationsByOwnerKeyPrefix(key);
+    authorizationState.deleteOwnerTypeByKey(key);
+
+    // delete group from group state
+    groupState.delete(key);
+  }
+
+  private void removeGroupFromState(
+      final long key, final List<Long> entityKeys, final BiConsumer<Long, Long> removalMethod) {
+    entityKeys.forEach(entityKey -> removalMethod.accept(entityKey, key));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -109,6 +109,24 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
+  public void delete(final long groupKey) {
+    this.groupKey.wrapLong(groupKey);
+
+    // remove record from GROUP_BY_NAME cf
+    groupName.wrapString(persistedGroup.getName());
+    groupByNameColumnFamily.deleteExisting(groupName);
+
+    // remove entries from ENTITY_BY_GROUP cf
+    entityTypeByGroupColumnFamily.whileEqualPrefix(
+        fkGroupKey,
+        (compositeKey, value) -> {
+          entityTypeByGroupColumnFamily.deleteExisting(compositeKey);
+        });
+
+    groupColumnFamily.deleteExisting(this.groupKey);
+  }
+
+  @Override
   public Optional<PersistedGroup> get(final long groupKey) {
     this.groupKey.wrapLong(groupKey);
     final var persistedGroup = groupColumnFamily.get(this.groupKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -19,4 +19,6 @@ public interface MutableGroupState extends GroupState {
   void addEntity(final long groupKey, final GroupRecord group);
 
   void removeEntity(final long groupKey, final long entityKey);
+
+  void delete(final long groupKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
@@ -172,7 +171,6 @@ public class EventAppliersTest {
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent))
             .filter(intent -> !(intent instanceof TenantIntent))
-            .filter(intent -> !(intent instanceof GroupIntent))
             // todo delete this filter after all the appliers are implemented
             .filter(intent -> !(intent instanceof MappingIntent));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -197,10 +197,10 @@ public class GroupStateTest {
 
     // then
     final var group = groupState.get(groupKey);
-    assertThat(group.isPresent()).isFalse();
+    assertThat(group).isEmpty();
 
     final var groupKeyByName = groupState.getGroupKeyByName(groupName);
-    assertThat(groupKeyByName.isPresent()).isFalse();
+    assertThat(groupKeyByName).isEmpty();
 
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -179,4 +179,30 @@ public class GroupStateTest {
     final var entityType = groupState.getEntitiesByType(groupKey);
     assertThat(entityType).containsOnly(Map.entry(EntityType.MAPPING, List.of(mappingKey)));
   }
+
+  @Test
+  void shouldDeleteGroup() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    groupRecord.setEntityKey(2L).setEntityType(EntityType.USER);
+    groupState.addEntity(groupKey, groupRecord);
+    groupRecord.setEntityKey(3L).setEntityType(EntityType.MAPPING);
+    groupState.addEntity(groupKey, groupRecord);
+
+    // when
+    groupState.delete(groupKey);
+
+    // then
+    final var group = groupState.get(groupKey);
+    assertThat(group.isPresent()).isFalse();
+
+    final var groupKeyByName = groupState.getGroupKeyByName(groupName);
+    assertThat(groupKeyByName.isPresent()).isFalse();
+
+    final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
+    assertThat(entitiesByGroup).isEmpty();
+  }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Provide an applier for `GroupIntent.DELETED` events, and the appropriate `GroupState` CRUD methods that are necessary for the data to be applied to the `DbGroupState`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23485
