### PR TITLE
Exporter template creation warns if already exists

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -192,6 +192,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -192,18 +192,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -198,6 +198,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -84,6 +84,15 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
       client.indices().putIndexTemplate(request);
       LOG.debug("Template [{}] was successfully created", templateDescriptor.getTemplateName());
     } catch (final IOException | ElasticsearchException e) {
+      if (e.getMessage()
+          .contains(
+              String.format(
+                  "index template [%s] already exists", templateDescriptor.getTemplateName()))) {
+        LOG.warn(
+            "Did not create index template [{}] as it already exists",
+            templateDescriptor.getTemplateName());
+        return;
+      }
       final var errMsg =
           String.format("Template [%s] was NOT created", templateDescriptor.getTemplateName());
       LOG.error(errMsg, e);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -83,23 +83,25 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
     try {
       client.indices().putIndexTemplate(request);
       LOG.debug("Template [{}] was successfully created", templateDescriptor.getTemplateName());
-    } catch (final IOException | ElasticsearchException e) {
-      if (e instanceof ElasticsearchException) {
-        // Creation should only occur once during initialisation but multiple partitions with
-        // their own exporter will create race conditions where multiple exporters try to
-        // create the same template
-        final var errorReason = ((ElasticsearchException) e).error().reason();
-        if (errorReason != null
-            && errorReason.equals(
-                "index template [" + templateDescriptor.getTemplateName() + "] already exists")) {
-          LOG.debug(errorReason);
-          return;
-        }
-      }
+    } catch (final IOException e) {
       final var errMsg =
           String.format("Template [%s] was NOT created", templateDescriptor.getTemplateName());
       LOG.error(errMsg, e);
       throw new ElasticsearchExporterException(errMsg, e);
+    } catch (final ElasticsearchException e) {
+      // Creation should only occur once during initialisation but multiple partitions with
+      // their own exporter will create race conditions where multiple exporters try to
+      // create the same template
+      final var errorReason = e.error().reason();
+      if (errorReason != null
+          && errorReason.equals(
+              "index template [" + templateDescriptor.getTemplateName() + "] already exists")) {
+        LOG.debug(errorReason);
+        return;
+      }
+
+      LOG.error(errorReason, e);
+      throw new ElasticsearchExporterException(errorReason, e);
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -88,7 +88,7 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           .contains(
               String.format(
                   "index template [%s] already exists", templateDescriptor.getTemplateName()))) {
-        LOG.warn(
+        LOG.debug(
             "Did not create index template [{}] as it already exists",
             templateDescriptor.getTemplateName());
         return;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -88,6 +88,9 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
           .contains(
               String.format(
                   "index template [%s] already exists", templateDescriptor.getTemplateName()))) {
+        // Creation should only occur once during initialisation but multiple partitions with
+        // their own exporter will create race conditions where multiple exporters try to
+        // create the same template
         LOG.debug(
             "Did not create index template [{}] as it already exists",
             templateDescriptor.getTemplateName());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -91,7 +91,7 @@ public class OpensearchEngineClient implements SearchEngineClient {
               .indices()
               .existsIndexTemplate(req -> req.name(templateDescriptor.getTemplateName()))
               .value()) {
-        LOG.warn(
+        LOG.debug(
             "Did not create index template [{}] as it already exists",
             templateDescriptor.getTemplateName());
         return;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -91,6 +91,9 @@ public class OpensearchEngineClient implements SearchEngineClient {
               .indices()
               .existsIndexTemplate(req -> req.name(templateDescriptor.getTemplateName()))
               .value()) {
+        // Creation should only occur once during initialisation but multiple partitions with
+        // their own exporter will create race conditions where multiple exporters try to
+        // create the same template
         LOG.debug(
             "Did not create index template [{}] as it already exists",
             templateDescriptor.getTemplateName());

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -91,10 +91,10 @@ public class OpensearchEngineClient implements SearchEngineClient {
               .indices()
               .existsIndexTemplate(req -> req.name(templateDescriptor.getTemplateName()))
               .value()) {
-        throw new OpensearchExporterException(
-            String.format(
-                "Cannot update template [%s] as create = true",
-                templateDescriptor.getTemplateName()));
+        LOG.warn(
+            "Did not create index template [{}] as it already exists",
+            templateDescriptor.getTemplateName());
+        return;
       }
 
       client.indices().putIndexTemplate(request);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -11,6 +11,7 @@ import static io.camunda.exporter.schema.SchemaTestUtil.validateMappings;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
@@ -63,6 +64,7 @@ public class ElasticsearchEngineClientIT {
     logWatcher = new ListAppender<>();
     logWatcher.start();
     ((Logger) LoggerFactory.getLogger(ElasticsearchEngineClient.class)).addAppender(logWatcher);
+    ((Logger) LoggerFactory.getLogger(ElasticsearchEngineClient.class)).setLevel(Level.ALL);
   }
 
   @Test
@@ -129,11 +131,15 @@ public class ElasticsearchEngineClientIT {
     elsEngineClient.createIndexTemplate(indexTemplate, settings, true);
 
     // then
-    assertThat(logWatcher.list.stream().map(ILoggingEvent::getFormattedMessage))
-        .contains(
-            String.format(
-                "Did not create index template [%s] as it already exists",
-                indexTemplate.getTemplateName()));
+    assertThat(logWatcher.list.stream())
+        .anyMatch(
+            log ->
+                log.getLevel().equals(Level.DEBUG)
+                    && log.getFormattedMessage()
+                        .contains(
+                            String.format(
+                                "Did not create index template [%s] as it already exists",
+                                indexTemplate.getTemplateName())));
   }
 
   @Test


### PR DESCRIPTION
## Description

Instead of an `ERROR` log and throwing an exception warns if trying to create an already existing template.

Opensearch does not require the feature manually implemented as `putIndexTemplate` requests are already idempotent.

## Related issues

closes #24251 
