### PR TITLE
Failed to retrieve mappings fix

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/elasticsearch/ElasticsearchEngineClient.java
@@ -196,7 +196,12 @@ public class ElasticsearchEngineClient implements SearchEngineClient {
   private Map<String, TypeMapping> getCurrentMappings(
       final MappingSource mappingSource, final String namePattern) throws IOException {
     if (mappingSource == MappingSource.INDEX) {
-      return client.indices().getMapping(req -> req.index(namePattern)).result().entrySet().stream()
+      return client
+          .indices()
+          .getMapping(req -> req.index(namePattern).ignoreUnavailable(true))
+          .result()
+          .entrySet()
+          .stream()
           .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().mappings()));
     } else if (mappingSource == MappingSource.INDEX_TEMPLATE) {
       return client

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/opensearch/OpensearchEngineClient.java
@@ -266,7 +266,12 @@ public class OpensearchEngineClient implements SearchEngineClient {
   private Map<String, TypeMapping> getCurrentMappings(
       final MappingSource mappingSource, final String namePattern) throws IOException {
     if (mappingSource == MappingSource.INDEX) {
-      return client.indices().getMapping(req -> req.index(namePattern)).result().entrySet().stream()
+      return client
+          .indices()
+          .getMapping(req -> req.index(namePattern).ignoreUnavailable(true))
+          .result()
+          .entrySet()
+          .stream()
           .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().mappings()));
     } else if (mappingSource == MappingSource.INDEX_TEMPLATE) {
       return client

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/ElasticsearchEngineClientIT.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.schema;
 
 import static io.camunda.exporter.schema.SchemaTestUtil.validateMappings;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.*;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
@@ -142,6 +143,22 @@ public class ElasticsearchEngineClientIT {
                 .name("world")
                 .typeDefinition(Map.of("type", "keyword"))
                 .build());
+  }
+
+  @Test
+  void shouldNotThrowErrorIfRetrievingMappingsWhereOnlySubsetOfIndicesExist() {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
+
+    elsEngineClient.createIndex(index, new IndexSettings());
+
+    // when, tnen
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                elsEngineClient.getMappings(
+                    index.getFullQualifiedName() + "*,foo*", MappingSource.INDEX));
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/OpensearchEngineClientIT.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.schema;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -228,6 +229,22 @@ public class OpensearchEngineClientIT {
                 .name("world")
                 .typeDefinition(Map.of("type", "keyword"))
                 .build());
+  }
+
+  @Test
+  void shouldNotThrowErrorIfRetrievingMappingsWhereOnlySubsetOfIndicesExist() {
+    // given
+    final var index =
+        SchemaTestUtil.mockIndex("index_qualified_name", "alias", "index_name", "/mappings.json");
+
+    opensearchEngineClient.createIndex(index, new IndexSettings());
+
+    // when, then
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                opensearchEngineClient.getMappings(
+                    index.getFullQualifiedName() + "*,foo*", MappingSource.INDEX));
   }
 
   @Test


### PR DESCRIPTION
## Description

Fails to retrieve mappings when a subset of indices in the query exists e.g. if index `foo` exists a `getMapping("foo*,bar*")` will fail this is fixed by the `ignore_unavailable` field being set referenced [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-mapping.html)

The other logs resulting in this error mentioned in the issue was a connection issue to the Elastic instance

## Related issues

closes #24354 
