### PR TITLE
refactor: create security-services modules with AuthorizationChecker

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -324,6 +324,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-services</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>document-store</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/application/commons/service/ServiceSecurityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/ServiceSecurityConfiguration.java
@@ -8,7 +8,9 @@
 package io.camunda.application.commons.service;
 
 import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
+import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -23,8 +25,15 @@ public class ServiceSecurityConfiguration {
 
   @Bean
   public SecurityContextProvider securityContextProvider(
-      final ServiceSecurityProperties serviceSecurityProperties) {
-    return new SecurityContextProvider(serviceSecurityProperties);
+      final ServiceSecurityProperties serviceSecurityProperties,
+      final AuthorizationChecker authorizationChecker) {
+    return new SecurityContextProvider(serviceSecurityProperties, authorizationChecker);
+  }
+
+  @Bean
+  public AuthorizationChecker authorizationChecker(
+      final AuthorizationSearchClient authorizationSearchClient) {
+    return new AuthorizationChecker(authorizationSearchClient);
   }
 
   @ConfigurationProperties("camunda.security")

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -923,6 +923,11 @@
         <artifactId>camunda-security-core</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-security-services</artifactId>
+        <version>${project.version}</version>
+      </dependency>
 
       <!-- Camunda Process Testing modules -->
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
@@ -149,9 +149,9 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
   }
 
   /**
-   * Annotation to be passed along with {@link CamundaExporterITInvocationProvider}'s {@link
-   * org.junit.jupiter.api.TestTemplate}. When applied, this indicates that the ZeebeClient should
-   * be created with the provided user's credentials.
+   * Annotation to be passed along with {@link BrokerWithCamundaExporterITInvocationProvider}'s
+   * {@link org.junit.jupiter.api.TestTemplate}. When applied, this indicates that the ZeebeClient
+   * should be created with the provided user's credentials.
    */
   @Target(ElementType.PARAMETER)
   @Retention(RetentionPolicy.RUNTIME)

--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -27,6 +27,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-services</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.clients;
 
+import io.camunda.search.clients.auth.DocumentAuthorizationQueryStrategy;
 import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.DecisionDefinitionEntity;
@@ -36,6 +37,7 @@ import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 
 public class SearchClients
     implements AuthorizationSearchClient,
@@ -77,8 +79,23 @@ public class SearchClients
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, AuthorizationEntity.class);
+  }
+
+  @Override
+  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
+    final var executor =
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
+    return executor.findAll(filter, AuthorizationEntity.class);
   }
 
   @Override
@@ -90,7 +107,11 @@ public class SearchClients
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
       final DecisionDefinitionQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, DecisionDefinitionEntity.class);
   }
 
@@ -98,7 +119,11 @@ public class SearchClients
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
       final DecisionInstanceQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, DecisionInstanceEntity.class);
   }
 
@@ -106,7 +131,11 @@ public class SearchClients
   public SearchQueryResult<DecisionRequirementsEntity> searchDecisionRequirements(
       final DecisionRequirementsQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, DecisionRequirementsEntity.class);
   }
 
@@ -114,21 +143,33 @@ public class SearchClients
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, FlowNodeInstanceEntity.class);
   }
 
   @Override
   public SearchQueryResult<FormEntity> searchForms(final FormQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, FormEntity.class);
   }
 
   @Override
   public SearchQueryResult<IncidentEntity> searchIncidents(final IncidentQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, IncidentEntity.class);
   }
 
@@ -136,7 +177,11 @@ public class SearchClients
   public SearchQueryResult<ProcessDefinitionEntity> searchProcessDefinitions(
       final ProcessDefinitionQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, ProcessDefinitionEntity.class);
   }
 
@@ -144,35 +189,55 @@ public class SearchClients
   public SearchQueryResult<ProcessInstanceEntity> searchProcessInstances(
       final ProcessInstanceQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, ProcessInstanceEntity.class);
   }
 
   @Override
   public SearchQueryResult<RoleEntity> searchRoles(final RoleQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, RoleEntity.class);
   }
 
   @Override
   public SearchQueryResult<UserEntity> searchUsers(final UserQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, UserEntity.class);
   }
 
   @Override
   public SearchQueryResult<UserTaskEntity> searchUserTasks(final UserTaskQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, UserTaskEntity.class);
   }
 
   @Override
   public SearchQueryResult<VariableEntity> searchVariables(final VariableQuery filter) {
     final var executor =
-        new SearchClientBasedQueryExecutor(searchClient, transformers, securityContext);
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext);
     return executor.search(filter, VariableEntity.class);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategy.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategy.java
@@ -9,26 +9,15 @@ package io.camunda.search.clients.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.matchNone;
-import static io.camunda.search.page.SearchQueryPage.DEFAULT_SIZE;
 import static io.camunda.security.auth.Authorization.WILDCARD;
 
-import io.camunda.search.clients.DocumentBasedSearchClient;
-import io.camunda.search.clients.core.RequestBuilders;
+import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
-import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.clients.transformers.auth.AuthorizationQueryTransformers;
-import io.camunda.search.clients.transformers.filter.FilterTransformer;
-import io.camunda.search.entities.AuthorizationEntity;
-import io.camunda.search.filter.AuthorizationFilter;
-import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.query.SearchQueryBase;
-import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
-import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.ArrayList;
-import java.util.List;
+import io.camunda.security.impl.AuthorizationChecker;
 
 /**
  * Document based datastore (ES/OS) strategy implementation of {@link AuthorizationQueryStrategy}.
@@ -37,13 +26,11 @@ import java.util.List;
  */
 public class DocumentAuthorizationQueryStrategy implements AuthorizationQueryStrategy {
 
-  private final DocumentBasedSearchClient searchClient;
-  private final ServiceTransformers serviceTransformers;
+  private final AuthorizationChecker authorizationChecker;
 
   public DocumentAuthorizationQueryStrategy(
-      final DocumentBasedSearchClient searchClient, final ServiceTransformers serviceTransformers) {
-    this.searchClient = searchClient;
-    this.serviceTransformers = serviceTransformers;
+      final AuthorizationSearchClient authorizationSearchClient) {
+    authorizationChecker = new AuthorizationChecker(authorizationSearchClient);
   }
 
   @Override
@@ -55,10 +42,7 @@ public class DocumentAuthorizationQueryStrategy implements AuthorizationQueryStr
       return searchQueryRequest;
     }
     // fetch the authorization entities for the authenticated user
-    final var resourceType = securityContext.authorization().resourceType();
-    final var permissionType = securityContext.authorization().permissionType();
-    final var resourceKeys =
-        retrieveAuthorizedResources(securityContext.authentication(), resourceType, permissionType);
+    final var resourceKeys = authorizationChecker.retrieveAuthorizedResourceKeys(securityContext);
 
     if (resourceKeys.contains(WILDCARD)) {
       return searchQueryRequest;
@@ -69,6 +53,8 @@ public class DocumentAuthorizationQueryStrategy implements AuthorizationQueryStr
     if (resourceKeys.isEmpty()) {
       authorizedQuery = matchNone();
     } else {
+      final var resourceType = securityContext.authorization().resourceType();
+      final var permissionType = securityContext.authorization().permissionType();
       authorizedQuery =
           and(
               searchQueryRequest.query(),
@@ -85,58 +71,5 @@ public class DocumentAuthorizationQueryStrategy implements AuthorizationQueryStr
                 .from(searchQueryRequest.from())
                 .size(searchQueryRequest.size())
                 .source(searchQueryRequest.source()));
-  }
-
-  private List<String> retrieveAuthorizedResources(
-      final Authentication authentication,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType) {
-    final List<Long> ownerKeys = collectOwnerKeys(authentication);
-    final var authenticationQuery =
-        buildAuthorizationSearchQuery(resourceType, permissionType, ownerKeys);
-    final var authorizationEntities =
-        searchClient.findAll(authenticationQuery, AuthorizationEntity.class);
-    return authorizationEntities.stream()
-        .flatMap(
-            e ->
-                e.permissions().stream()
-                    .filter(permission -> permissionType.equals(permission.type()))
-                    .flatMap(permission -> permission.resourceIds().stream()))
-        .toList();
-  }
-
-  private SearchQueryRequest buildAuthorizationSearchQuery(
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType,
-      final List<Long> ownerKeys) {
-    final FilterTransformer<AuthorizationFilter> authorizationFilterTransformer =
-        getAuthorizationFilterTransformer();
-
-    final AuthorizationFilter authorizationFilter =
-        FilterBuilders.authorization(
-            f ->
-                f.resourceType(resourceType.name())
-                    .ownerKeys(ownerKeys)
-                    .permissionType(permissionType));
-    return RequestBuilders.searchRequest(
-        b ->
-            b.index(authorizationFilterTransformer.toIndices(authorizationFilter))
-                .query(authorizationFilterTransformer.toSearchQuery(authorizationFilter))
-                .size(DEFAULT_SIZE));
-  }
-
-  private List<Long> collectOwnerKeys(final Authentication authentication) {
-    final List<Long> ownerKeys = new ArrayList<>();
-    if (authentication.authenticatedUserKey() != null) {
-      ownerKeys.add(authentication.authenticatedUserKey());
-    }
-    if (authentication.authenticatedGroupKeys() != null) {
-      ownerKeys.addAll(authentication.authenticatedGroupKeys());
-    }
-    return ownerKeys;
-  }
-
-  private FilterTransformer<AuthorizationFilter> getAuthorizationFilterTransformer() {
-    return serviceTransformers.getFilterTransformer(AuthorizationFilter.class);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/AuthorizationFilterTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -23,7 +24,7 @@ public final class AuthorizationFilterTransformer
     return and(
         longTerms("ownerKey", filter.ownerKeys()),
         filter.ownerType() == null ? null : term("ownerType", filter.ownerType()),
-        filter.resourceKey() == null ? null : term("permissions.resourceIds", filter.resourceKey()),
+        stringTerms("permissions.resourceIds", filter.resourceKeys()),
         filter.resourceType() == null ? null : term("resourceType", filter.resourceType()),
         filter.permissionType() == null
             ? null

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
@@ -9,8 +9,10 @@ package io.camunda.search.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -47,6 +49,7 @@ class SearchClientBasedQueryExecutorTest {
           null);
 
   @Mock private DocumentBasedSearchClient searchClient;
+  @Mock private AuthorizationQueryStrategy authorizationQueryStrategy;
   private final ServiceTransformers serviceTransformers = ServiceTransformers.newInstance(false);
 
   private SearchClientBasedQueryExecutor queryExecutor;
@@ -55,7 +58,10 @@ class SearchClientBasedQueryExecutorTest {
   void setUp() {
     queryExecutor =
         new SearchClientBasedQueryExecutor(
-            searchClient, serviceTransformers, SecurityContext.withoutAuthentication());
+            searchClient,
+            serviceTransformers,
+            authorizationQueryStrategy,
+            SecurityContext.withoutAuthentication());
   }
 
   @Test
@@ -67,8 +73,11 @@ class SearchClientBasedQueryExecutorTest {
     final SearchQueryResponse<ProcessInstanceEntity> processInstanceEntityResponse =
         createProcessInstanceEntityResponse(demoProcessInstance);
 
-    when(searchClient.search(any(SearchQueryRequest.class), any(Class.class)))
+    when(searchClient.search(any(SearchQueryRequest.class), eq(ProcessInstanceEntity.class)))
         .thenReturn(processInstanceEntityResponse);
+    when(authorizationQueryStrategy.applyAuthorizationToQuery(
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+        .thenAnswer(i -> i.getArgument(0));
 
     // When we search
     final var searchResult = queryExecutor.search(searchAllQuery, ProcessInstanceEntity.class);
@@ -77,6 +86,27 @@ class SearchClientBasedQueryExecutorTest {
     final List<ProcessInstanceEntity> items = searchResult.items();
     assertThat(items).hasSize(1);
     assertThat(items.getFirst().key()).isEqualTo(demoProcessInstance.key());
+  }
+
+  @Test
+  void shouldFindAllUsingTransformers() {
+    // Given our search Query
+    final var searchAllQuery = new ProcessInstanceQuery.Builder().build();
+
+    // And our search client returns stuff
+    final var processInstanceEntityResponse = List.of(demoProcessInstance);
+
+    when(searchClient.findAll(any(SearchQueryRequest.class), eq(ProcessInstanceEntity.class)))
+        .thenReturn(processInstanceEntityResponse);
+    when(authorizationQueryStrategy.applyAuthorizationToQuery(
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+        .thenAnswer(i -> i.getArgument(0));
+
+    // When we search
+    final var searchResult = queryExecutor.findAll(searchAllQuery, ProcessInstanceEntity.class);
+
+    assertThat(searchResult).hasSize(1);
+    assertThat(searchResult.getFirst().key()).isEqualTo(demoProcessInstance.key());
   }
 
   private SearchQueryResponse<ProcessInstanceEntity> createProcessInstanceEntityResponse(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AuthorizationQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/AuthorizationQueryTransformerTest.java
@@ -57,7 +57,7 @@ public class AuthorizationQueryTransformerTest extends AbstractTransformerTest {
             "ownerType",
             "user"),
         Arguments.of(
-            (Function<Builder, ObjectBuilder<AuthorizationFilter>>) f -> f.resourceKey("456"),
+            (Function<Builder, ObjectBuilder<AuthorizationFilter>>) f -> f.resourceKeys("456"),
             "permissions.resourceIds",
             "456"),
         Arguments.of(

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -52,6 +52,7 @@ import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,6 +97,11 @@ public class RdbmsSearchClient
   @Override
   public SearchQueryResult<AuthorizationEntity> searchAuthorizations(
       final AuthorizationQuery filter) {
+    return null;
+  }
+
+  @Override
+  public List<AuthorizationEntity> findAllAuthorizations(final AuthorizationQuery filter) {
     return null;
   }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/AuthorizationSearchClient.java
@@ -11,10 +11,13 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
+import java.util.List;
 
 public interface AuthorizationSearchClient {
 
   SearchQueryResult<AuthorizationEntity> searchAuthorizations(AuthorizationQuery filter);
+
+  List<AuthorizationEntity> findAllAuthorizations(AuthorizationQuery filter);
 
   AuthorizationSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/AuthorizationFilter.java
@@ -17,14 +17,14 @@ import java.util.List;
 public record AuthorizationFilter(
     List<Long> ownerKeys,
     String ownerType,
-    String resourceKey,
+    List<String> resourceKeys,
     String resourceType,
     PermissionType permissionType)
     implements FilterBase {
   public static final class Builder implements ObjectBuilder<AuthorizationFilter> {
     private List<Long> ownerKeys;
     private String ownerType;
-    private String resourceKey;
+    private List<String> resourceKeys;
     private String resourceType;
     private PermissionType permissionType;
 
@@ -42,9 +42,13 @@ public record AuthorizationFilter(
       return this;
     }
 
-    public Builder resourceKey(final String value) {
-      resourceKey = value;
+    public Builder resourceKeys(final List<String> value) {
+      resourceKeys = value;
       return this;
+    }
+
+    public Builder resourceKeys(final String... values) {
+      return resourceKeys(collectValuesAsList(values));
     }
 
     public Builder resourceType(final String value) {
@@ -60,7 +64,7 @@ public record AuthorizationFilter(
     @Override
     public AuthorizationFilter build() {
       return new AuthorizationFilter(
-          ownerKeys, ownerType, resourceKey, resourceType, permissionType);
+          ownerKeys, ownerType, resourceKeys, resourceType, permissionType);
     }
   }
 }

--- a/security/security-services/pom.xml
+++ b/security/security-services/pom.xml
@@ -10,19 +10,26 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.camunda</groupId>
-    <artifactId>zeebe-parent</artifactId>
+    <artifactId>camunda-security</artifactId>
     <version>8.7.0-SNAPSHOT</version>
-    <relativePath>../parent/pom.xml</relativePath>
   </parent>
 
-  <artifactId>camunda-security</artifactId>
-  <packaging>pom</packaging>
+  <artifactId>camunda-security-services</artifactId>
+  <name>Camunda Security Services</name>
 
-  <name>Camunda Security Parent</name>
-
-  <modules>
-    <module>security-core</module>
-    <module>security-services</module>
-  </modules>
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-domain</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.impl;
+
+import static io.camunda.security.auth.Authorization.WILDCARD;
+
+import io.camunda.search.clients.AuthorizationSearchClient;
+import io.camunda.search.query.AuthorizationQuery;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.SecurityContext;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The AuthorizationChecker class provides methods for checking resource authorization by
+ * interacting with the AuthorizationSearchClient. It retrieves authorized resource keys or checks
+ * if a specific resource key is authorized, based on the provided SecurityContext.
+ */
+public class AuthorizationChecker {
+
+  private final AuthorizationSearchClient authorizationSearchClient;
+
+  public AuthorizationChecker(final AuthorizationSearchClient authorizationSearchClient) {
+    this.authorizationSearchClient =
+        authorizationSearchClient.withSecurityContext(SecurityContext.withoutAuthentication());
+  }
+
+  /**
+   * Retrieves a list of authorized resource keys for the given SecurityContext. The resource keys
+   * represent resources that the user or one of their groups or roles, as specified in the
+   * SecurityContext, has access to based on the defined resource type and permission type.
+   *
+   * @param securityContext the context containing authorization and authentication information
+   * @return a list of authorized resource keys for the user or group in the SecurityContext
+   */
+  public List<String> retrieveAuthorizedResourceKeys(final SecurityContext securityContext) {
+    final var ownerKeys = collectOwnerKeys(securityContext.authentication());
+    final var resourceType = securityContext.authorization().resourceType();
+    final var permissionType = securityContext.authorization().permissionType();
+    final var authorizationEntities =
+        authorizationSearchClient.findAllAuthorizations(
+            AuthorizationQuery.of(
+                q ->
+                    q.filter(
+                        f ->
+                            f.ownerKeys(ownerKeys)
+                                .resourceType(resourceType.name())
+                                .permissionType(permissionType))));
+    return authorizationEntities.stream()
+        .flatMap(
+            e ->
+                e.permissions().stream()
+                    .filter(permission -> permissionType.equals(permission.type()))
+                    .flatMap(permission -> permission.resourceIds().stream()))
+        .toList();
+  }
+
+  /**
+   * Checks if a specific resource key is authorized for the user or one of their groups or roles
+   * defined in the provided SecurityContext. The authorization check is based on the resource type
+   * and permission type in the SecurityContext.
+   *
+   * @param resourceKey the resource key to check authorization for
+   * @param securityContext the context containing authorization and authentication information
+   * @return true if the resource key is authorized, false otherwise
+   */
+  public boolean isAuthorized(final String resourceKey, final SecurityContext securityContext) {
+    final var ownerKeys = collectOwnerKeys(securityContext.authentication());
+    final var resourceType = securityContext.authorization().resourceType();
+    final var permissionType = securityContext.authorization().permissionType();
+    return authorizationSearchClient
+            .searchAuthorizations(
+                AuthorizationQuery.of(
+                    q ->
+                        q.filter(
+                                f ->
+                                    f.ownerKeys(ownerKeys)
+                                        .resourceType(resourceType.name())
+                                        .permissionType(permissionType)
+                                        .resourceKeys(List.of(WILDCARD, resourceKey)))
+                            .page(p -> p.size(1))))
+            .total()
+        > 0;
+  }
+
+  private List<Long> collectOwnerKeys(final Authentication authentication) {
+    final List<Long> ownerKeys = new ArrayList<>();
+    ownerKeys.add(authentication.authenticatedUserKey());
+    if (authentication.authenticatedGroupKeys() != null) {
+      ownerKeys.addAll(authentication.authenticatedGroupKeys());
+    }
+    return ownerKeys;
+  }
+}

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -62,6 +62,10 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-services</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.agrona</groupId>

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -66,7 +66,7 @@ public class AuthorizationServices
                     fn.filter(
                             f ->
                                 f.resourceType(resourceType.name())
-                                    .resourceKey(
+                                    .resourceKeys(
                                         resourceId != null && !resourceId.isEmpty()
                                             ? resourceId
                                             : null)

--- a/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
+++ b/service/src/main/java/io/camunda/service/security/SecurityContextProvider.java
@@ -12,13 +12,18 @@ import io.camunda.security.auth.Authorization;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.auth.SecurityContext.Builder;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
 
 public class SecurityContextProvider {
 
   private final SecurityConfiguration securityConfiguration;
+  private final AuthorizationChecker authorizationChecker;
 
-  public SecurityContextProvider(final SecurityConfiguration securityConfiguration) {
+  public SecurityContextProvider(
+      final SecurityConfiguration securityConfiguration,
+      final AuthorizationChecker authorizationChecker) {
     this.securityConfiguration = securityConfiguration;
+    this.authorizationChecker = authorizationChecker;
   }
 
   public SecurityContext provideSecurityContext(
@@ -33,5 +38,16 @@ public class SecurityContextProvider {
 
   public SecurityContext provideSecurityContext(final Authentication authentication) {
     return provideSecurityContext(authentication, null);
+  }
+
+  public boolean isAuthorized(
+      final String resourceKey,
+      final Authentication authentication,
+      final Authorization authorization) {
+    final var securityContext = provideSecurityContext(authentication, authorization);
+    if (securityContext.requiresAuthorizationChecks()) {
+      return authorizationChecker.isAuthorized(resourceKey, securityContext);
+    }
+    return true;
   }
 }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -25,6 +25,7 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -45,7 +46,8 @@ public final class ProcessInstanceServiceTest {
     client = mock(ProcessInstanceSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     securityConfiguration = new SecurityConfiguration();
-    final var securityContextProvider = new SecurityContextProvider(securityConfiguration);
+    final var securityContextProvider =
+        new SecurityContextProvider(securityConfiguration, mock(AuthorizationChecker.class));
     services =
         new ProcessInstanceServices(
             mock(BrokerClient.class), securityContextProvider, client, null);

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -112,6 +112,11 @@
       <groupId>io.camunda</groupId>
       <artifactId>camunda-security-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-services</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <!-- rest api dependencies -->
     <dependency>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -362,7 +362,7 @@ public class JobControllerLongPollingTest extends RestControllerTest {
         final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
       return new JobServices<>(
           brokerClient,
-          new SecurityContextProvider(new SecurityConfiguration()),
+          new SecurityContextProvider(new SecurityConfiguration(), null),
           activateJobsHandler,
           null);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerRoundRobinTest.java
@@ -392,7 +392,7 @@ public class JobControllerRoundRobinTest extends RestControllerTest {
         final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
       return new JobServices<>(
           brokerClient,
-          new SecurityContextProvider(new SecurityConfiguration()),
+          new SecurityContextProvider(new SecurityConfiguration(), null),
           activateJobsHandler,
           null);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`camunda-security-services` module providing [`AuthorizationChecker`](https://github.com/camunda/camunda/pull/24400/files#diff-02f314d2c0da150bb8d8ab36731d7209368e274e002a10b7460ce4788e99d435) service with minimal dependencies:
- `camunda-security-core`
- `camunda-search-domain`
- `camunda-search-client`

This allows `AuthorizationChecker` to enable shared and reusable permission checks across modules that need to validate authorizations against data in ES/OS (and later RDBMS). 
In this pull request, `AuthorizationChecker` is used in `camunda-service` to apply the authorization checks on GET endpoints, and within `camunda-search-client-query-transfomers` to append authorization filters to search queries. 
It can be also used in `operate-webapp` to apply the permission checks for v1 endpoints (it can be autowired as spring is still used in Operate)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23180
