### PR TITLE
feat: support user delete events

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -38,7 +38,8 @@ import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.SequenceFlowHandler;
 import io.camunda.exporter.handlers.TaskCompletedMetricHandler;
-import io.camunda.exporter.handlers.UserHandler;
+import io.camunda.exporter.handlers.UserCreatedUpdatedHandler;
+import io.camunda.exporter.handlers.UserDeletedHandler;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
@@ -147,7 +148,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
 
     exportHandlers =
         Set.of(
-            new UserHandler(indexDescriptorsMap.get(UserIndex.class).getFullQualifiedName()),
+            new UserCreatedUpdatedHandler(
+                indexDescriptorsMap.get(UserIndex.class).getFullQualifiedName()),
+            new UserDeletedHandler(indexDescriptorsMap.get(UserIndex.class).getFullQualifiedName()),
             new AuthorizationHandler(
                 indexDescriptorsMap.get(AuthorizationIndex.class).getFullQualifiedName()),
             new DecisionHandler(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandler.java
@@ -12,13 +12,18 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import java.util.List;
+import java.util.Set;
 
-public class UserHandler implements ExportHandler<UserEntity, UserRecordValue> {
+public class UserCreatedUpdatedHandler implements ExportHandler<UserEntity, UserRecordValue> {
+  private static final Set<Intent> SUPPORTED_INTENTS =
+      Set.of(UserIntent.CREATED, UserIntent.UPDATED);
   private final String indexName;
 
-  public UserHandler(final String indexName) {
+  public UserCreatedUpdatedHandler(final String indexName) {
     this.indexName = indexName;
   }
 
@@ -34,7 +39,8 @@ public class UserHandler implements ExportHandler<UserEntity, UserRecordValue> {
 
   @Override
   public boolean handlesRecord(final Record<UserRecordValue> record) {
-    return getHandledValueType().equals(record.getValueType());
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENTS.contains(record.getIntent());
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserDeletedHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import java.util.List;
+import java.util.Set;
+
+public class UserDeletedHandler implements ExportHandler<UserEntity, UserRecordValue> {
+  private static final Set<Intent> SUPPORTED_INTENTS = Set.of(UserIntent.DELETED);
+  private final String indexName;
+
+  public UserDeletedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER;
+  }
+
+  @Override
+  public Class<UserEntity> getEntityType() {
+    return UserEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public UserEntity createNewEntity(final String id) {
+    return new UserEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<UserRecordValue> record, final UserEntity entity) {
+    final UserRecordValue value = record.getValue();
+    entity
+        .setKey(value.getUserKey())
+        .setUsername(value.getUsername())
+        .setName(value.getName())
+        .setEmail(value.getEmail())
+        .setPassword(value.getPassword());
+  }
+
+  @Override
+  public void flush(final UserEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.delete(indexName, entity.getId());
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserCreatedUpdatedHandlerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableUserRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class UserCreatedUpdatedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-user";
+  private final UserCreatedUpdatedHandler underTest = new UserCreatedUpdatedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(UserEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserRecordValue> userCreatedRecord =
+        factory.generateRecordWithIntent(ValueType.USER, UserIntent.CREATED);
+    final Record<UserRecordValue> userUpdatedRecord =
+        factory.generateRecordWithIntent(ValueType.USER, UserIntent.UPDATED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(userCreatedRecord)).isTrue();
+    assertThat(underTest.handlesRecord(userUpdatedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<UserRecordValue> userRecord =
+        factory.generateRecordWithIntent(ValueType.USER, UserIntent.DELETED);
+
+    // when
+    final var idList = underTest.generateIds(userRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(userRecord.getKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final long recordKey = 123L;
+
+    final UserRecordValue userRecordValue =
+        ImmutableUserRecordValue.builder()
+            .from(factory.generateObject(UserRecordValue.class))
+            .withName("updated-foo")
+            .withUsername("updated-bar")
+            .withPassword("updated-baz")
+            .withEmail("updated-baz@foo")
+            .withUserKey(recordKey)
+            .build();
+
+    final Record<UserRecordValue> userRecord =
+        factory.generateRecord(
+            ValueType.USER,
+            r -> r.withIntent(UserIntent.CREATED).withValue(userRecordValue).withKey(recordKey));
+
+    // when
+    final UserEntity userEntity =
+        new UserEntity().setName("foo").setUsername("bar").setEmail("baz").setPassword("baz");
+    underTest.updateEntity(userRecord, userEntity);
+
+    // then
+    assertThat(userEntity.getName()).isEqualTo("updated-foo");
+    assertThat(userEntity.getUsername()).isEqualTo("updated-bar");
+    assertThat(userEntity.getEmail()).isEqualTo("updated-baz@foo");
+    assertThat(userEntity.getPassword()).isEqualTo("updated-baz");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() throws PersistenceException {
+    // given
+    final UserEntity inputEntity = new UserEntity().setId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserDeletedHandlerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.UserEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class UserDeletedHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-user";
+  private final UserDeletedHandler underTest = new UserDeletedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.USER);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(UserEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<UserRecordValue> userRecord =
+        factory.generateRecordWithIntent(ValueType.USER, UserIntent.DELETED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(userRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<UserRecordValue> userRecord =
+        factory.generateRecordWithIntent(ValueType.USER, UserIntent.DELETED);
+
+    // when
+    final var idList = underTest.generateIds(userRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(userRecord.getKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldDeleteEntityOnFlush() throws PersistenceException {
+    // given
+    final UserEntity inputEntity = new UserEntity().setId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR achieves two tasks:
1. The existing user handler is refined to handle creates and updates
2. A new handler is introduced that processes user delete commands

Some notes:
* I think in the future the `CamundaExporterIT` will have issues with these new handlers as the current tests revert to a default record generator which selects an intent at random related to the value type. When we have handlers that only support certain intents then the records may not be picked up due to a mismatch in intent values and therefore the tests will fail (because no record has been exported).
* I tried to add in an IT that also considers intents (which worked fine for user create) however failed when it came to the user delete side because there is some additional setup required there. Its likely that in those circumstances we want the tests to be specific and the handlers not included in the current generic tests.
