### PR TITLE
feat: add role endpoints

### DIFF
--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRoleUpdateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.role.BrokerRoleCreateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
-import java.util.Set;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, RoleEntity> {
@@ -60,15 +60,16 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
     return sendBrokerRequest(new BrokerRoleUpdateRequest(roleKey).setName(name));
   }
 
-  public RoleEntity getByRoleKey(final Long roleKey) {
-    final SearchQueryResult<RoleEntity> result =
-        search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.roleKey(roleKey)).build());
-    if (result.total() < 1) {
-      throw new NotFoundException(String.format("Role with roleKey %d not found", roleKey));
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
-    }
+  public RoleEntity getRole(final Long roleKey) {
+    return findRole(roleKey)
+        .orElseThrow(
+            () -> new NotFoundException("Role with roleKey %d not found".formatted(roleKey)));
   }
 
-  public record RoleDTO(long roleKey, String name, Set<Long> assignedMemberKeys) {}
+  public Optional<RoleEntity> findRole(final Long roleKey) {
+    return search(SearchQueryBuilders.roleSearchQuery().filter(f -> f.roleKey(roleKey)).build())
+        .items()
+        .stream()
+        .findFirst();
+  }
 }

--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -52,13 +52,12 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
         brokerClient, securityContextProvider, roleSearchClient, authentication);
   }
 
-  public CompletableFuture<RoleRecord> createRole(final RoleDTO request) {
-    return sendBrokerRequest(new BrokerRoleCreateRequest().setName(request.name()));
+  public CompletableFuture<RoleRecord> createRole(final String name) {
+    return sendBrokerRequest(new BrokerRoleCreateRequest().setName(name));
   }
 
-  public CompletableFuture<RoleRecord> updateRole(final RoleDTO request) {
-    return sendBrokerRequest(
-        new BrokerRoleUpdateRequest(request.roleKey()).setName(request.name()));
+  public CompletableFuture<RoleRecord> updateRole(final long roleKey, final String name) {
+    return sendBrokerRequest(new BrokerRoleUpdateRequest(roleKey).setName(name));
   }
 
   public RoleEntity getByRoleKey(final Long roleKey) {

--- a/service/src/test/java/io/camunda/service/RoleServiceTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServiceTest.java
@@ -20,7 +20,6 @@ import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
-import io.camunda.service.RoleServices.RoleDTO;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRoleUpdateRequest;
@@ -28,7 +27,6 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import java.util.List;
-import java.util.Set;
 import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -104,17 +102,18 @@ public class RoleServiceTest {
   @Test
   public void shouldUpdateName() {
     // given
-    final var roleDTO = new RoleDTO(100, "UpdatedName", Set.of());
+    final var roleKey = 100L;
+    final var name = "UpdatedName";
 
     // when
-    services.updateRole(roleDTO);
+    services.updateRole(roleKey, name);
 
     // then
     final BrokerRoleUpdateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
     assertThat(request.getIntent()).isEqualTo(RoleIntent.UPDATE);
     assertThat(request.getValueType()).isEqualTo(ValueType.ROLE);
-    assertThat(request.getKey()).isEqualTo(roleDTO.roleKey());
+    assertThat(request.getKey()).isEqualTo(roleKey);
     final RoleRecord brokerRequestValue = request.getRequestWriter();
-    assertThat(brokerRequestValue.getName()).isEqualTo(roleDTO.name());
+    assertThat(brokerRequestValue.getName()).isEqualTo(name);
   }
 }

--- a/service/src/test/java/io/camunda/service/RoleServiceTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServiceTest.java
@@ -8,14 +8,12 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.entities.RoleEntity;
-import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
@@ -81,10 +79,10 @@ public class RoleServiceTest {
     when(client.searchRoles(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getByRoleKey(1L);
+    final var searchQueryResult = services.findRole(1L);
 
     // then
-    assertThat(searchQueryResult).isEqualTo(entity);
+    assertThat(searchQueryResult).contains(entity);
   }
 
   @Test
@@ -94,9 +92,7 @@ public class RoleServiceTest {
     when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
 
     // when / then
-    final var exception =
-        assertThrowsExactly(NotFoundException.class, () -> services.getByRoleKey(key));
-    assertThat(exception.getMessage()).isEqualTo("Role with roleKey 100 not found");
+    assertThat(services.findRole(key)).isEmpty();
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1902,6 +1902,8 @@ paths:
         - Role
       operationId: createRole
       summary: Create role
+      description: |
+        Create a new role
       requestBody:
         content:
           application/json:
@@ -1924,13 +1926,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "401":
-          description: |
-            The request to create a role was unauthorized.
-            More details are provided in the response body.
-          content:
-            application/problem+json:
-              schema:
-                $ref: "#/components/schemas/ProblemDetail"
+          $ref: "#/components/responses/Unauthorized"
         "403":
           description: |
             The request to create a role was denied.
@@ -1940,13 +1936,41 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
-          description: An internal error occurred while processing the request.
+          $ref: "#/components/responses/InternalServerError"
+
+  /roles/{roleKey}:
+    get:
+      tags:
+        - Role
+      operationId: getRole
+      summary: Get role
+      description: |
+        Get a role by its key
+      parameters:
+        - name: roleKey
+          in: path
+          required: true
+          description: The role key.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: The role is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoleItem"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: The role with the given key was not found.
           content:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-
-  /roles/{roleKey}:
+        "500":
+          $ref: "#/components/responses/InternalServerError"
     patch:
       tags:
         - Role
@@ -1977,6 +2001,8 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
         "404":
           description: The role with the roleKey is not found.
           content:
@@ -1984,13 +2010,43 @@ paths:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
+          $ref: "#/components/responses/InternalServerError"
+
+  /roles/search:
+    post:
+      tags:
+        - Role
+      operationId: searchRoles
+      summary: Query roles
+      description: |
+        Search for roles based on given criteria.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleSearchQueryRequest"
+      responses:
+        "200":
+          description: The roles search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoleSearchQueryResponse"
+        "400":
           description: >
-            An internal error occurred while processing the request.
+            The role search query failed.
+            More details are provided in the response body.
           content:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-
+        "500":
+          description: An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /messages/publication:
     post:
       tags:
@@ -3846,6 +3902,7 @@ components:
       properties:
         name:
           type: "string"
+          description: The display name of the new role
     RoleCreateResponse:
       type: "object"
       properties:
@@ -3865,6 +3922,39 @@ components:
       properties:
         name:
           type: string
+          description: The updated display name of the role.
+    RoleItem:
+      description: Role search response item.
+      type: object
+      properties:
+        roleKey:
+          type: integer
+          description: The role key.
+          format: int64
+        name:
+          type: string
+          description: The role name.
+        assignedMemberKeys:
+          type: array
+          description: The set of keys of members assigned to the role.
+          items:
+            type: integer
+            format: int64
+    RoleSearchQueryRequest:
+      description: Role search request.
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+    RoleSearchQueryResponse:
+      description: Role search response.
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleItem"
     TopologyResponse:
       description: The response of a topology request.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -40,6 +40,7 @@ tags:
   - name: Process definition
   - name: Process instance
   - name: Resource
+  - name: Role
   - name: Signal
   - name: User
   - name: User task
@@ -1895,6 +1896,101 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /roles:
+    post:
+      tags:
+        - Role
+      operationId: createRole
+      summary: Create role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleCreateRequest"
+      responses:
+        "202":
+          description: |
+            The role was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RoleCreateResponse"
+        "400":
+          description: |
+            The role could not be created.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          description: |
+            The request to create a role was unauthorized.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          description: |
+            The request to create a role was denied.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          description: An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
+  /roles/{roleKey}:
+    patch:
+      tags:
+        - Role
+      operationId: updateRole
+      summary: Update role
+      description: Update a role with the given key.
+      parameters:
+        - name: roleKey
+          in: path
+          required: true
+          description: The key of the role to update.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RoleUpdateRequest"
+      responses:
+        "204":
+          description: The role was updated successfully.
+        "400":
+          description: >
+            The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: The role with the roleKey is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          description: >
+            An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
   /messages/publication:
     post:
       tags:
@@ -3745,6 +3841,30 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/UserResponse"
+    RoleCreateRequest:
+      type: "object"
+      properties:
+        name:
+          type: "string"
+    RoleCreateResponse:
+      type: "object"
+      properties:
+        roleKey:
+          description: The key of the created role
+          type: "integer"
+          format: "int64"
+    RoleUpdateRequest:
+      type: object
+      properties:
+        changeset:
+          $ref: "#/components/schemas/RoleChangeset"
+      required:
+        - changeset
+    RoleChangeset:
+      type: object
+      properties:
+        name:
+          type: string
     TopologyResponse:
       description: The response of a topology request.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -71,12 +71,15 @@ import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.MigrateProcessInstanceRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ModifyProcessInstanceActivateInstruction;
 import io.camunda.zeebe.gateway.protocol.rest.ModifyProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
 import io.camunda.zeebe.gateway.protocol.rest.SetVariableRequest;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.gateway.rest.validator.RoleRequestValidator;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
@@ -243,6 +246,20 @@ public class RequestMapper {
                 new UpdateJobChangeset(
                     updateRequest.getChangeset().getRetries(),
                     updateRequest.getChangeset().getTimeout())));
+  }
+
+  public static Either<ProblemDetail, UpdateRoleRequest> toRoleUpdateRequest(
+      final RoleUpdateRequest roleUpdateRequest, final long roleKey) {
+    return getResult(
+        RoleRequestValidator.validateUpdateRequest(roleUpdateRequest),
+        () -> new UpdateRoleRequest(roleKey, roleUpdateRequest.getChangeset().getName()));
+  }
+
+  public static Either<ProblemDetail, CreateRoleRequest> toRoleCreateRequest(
+      final RoleCreateRequest roleCreateRequest) {
+    return getResult(
+        RoleRequestValidator.validateCreateRequest(roleCreateRequest),
+        () -> new CreateRoleRequest(roleCreateRequest.getName()));
   }
 
   public static Either<ProblemDetail, PatchAuthorizationRequest> toAuthorizationPatchRequest(
@@ -725,4 +742,8 @@ public class RequestMapper {
 
   public record DecisionEvaluationRequest(
       String decisionId, Long decisionKey, Map<String, Object> variables, String tenantId) {}
+
+  public record CreateRoleRequest(String name) {}
+
+  public record UpdateRoleRequest(long roleKey, String name) {}
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -36,10 +36,12 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.MatchedDecisionRuleItem;
 import io.camunda.zeebe.gateway.protocol.rest.MessageCorrelationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.MessagePublicationResponse;
+import io.camunda.zeebe.gateway.protocol.rest.RoleCreateResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SignalBroadcastResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserCreateResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.msgpack.value.ValueArray;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
@@ -320,6 +322,11 @@ public final class ResponseMapper {
 
   public static ResponseEntity<Object> toUserCreateResponse(final UserRecord userRecord) {
     final var response = new UserCreateResponse().userKey(userRecord.getUserKey());
+    return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
+  }
+
+  public static ResponseEntity<Object> toRoleCreateResponse(final RoleRecord roleRecord) {
+    final var response = new RoleCreateResponse().roleKey(roleRecord.getRoleKey());
     return new ResponseEntity<>(response, HttpStatus.ACCEPTED);
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -45,6 +45,7 @@ import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.TypedSearchQueryBuilder;
 import io.camunda.search.query.UserQuery;
@@ -58,6 +59,7 @@ import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.IncidentSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
+import io.camunda.search.sort.RoleSort;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.search.sort.UserSort;
@@ -110,6 +112,19 @@ public final class SearchQueryRequestMapper {
             SearchQueryRequestMapper::applyProcessInstanceSortField);
     final var filter = toProcessInstanceFilter(request.getFilter());
     return buildSearchQuery(filter, sort, page, SearchQueryBuilders::processInstanceSearchQuery);
+  }
+
+  public static Either<ProblemDetail, RoleQuery> toRoleQuery(final RoleSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.roleSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            request.getSort(),
+            SortOptionBuilders::role,
+            SearchQueryRequestMapper::applyRoleSortField);
+    return buildSearchQuery(null, sort, page, SearchQueryBuilders::roleSearchQuery);
   }
 
   public static Either<ProblemDetail, DecisionDefinitionQuery> toDecisionDefinitionQuery(
@@ -584,6 +599,21 @@ public final class SearchQueryRequestMapper {
         case "versionTag" -> builder.versionTag();
         case "processDefinitionId" -> builder.processDefinitionId();
         case "tenantId" -> builder.tenantId();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  private static List<String> applyRoleSortField(
+      final String field, final RoleSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case "roleKey" -> builder.roleKey();
+        case "name" -> builder.name();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -23,6 +23,7 @@ import io.camunda.search.entities.FormEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -55,6 +56,8 @@ import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceItem;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceStateEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
+import io.camunda.zeebe.gateway.protocol.rest.RoleItem;
+import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
@@ -91,6 +94,15 @@ public final class SearchQueryResponseMapper {
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toProcessInstances)
                 .orElseGet(Collections::emptyList));
+  }
+
+  public static RoleSearchQueryResponse toRoleSearchQueryResponse(
+      final SearchQueryResult<RoleEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new RoleSearchQueryResponse()
+        .page(page)
+        .items(
+            ofNullable(result.items()).map(SearchQueryResponseMapper::toRoles).orElseGet(List::of));
   }
 
   public static DecisionDefinitionSearchQueryResponse toDecisionDefinitionSearchQueryResponse(
@@ -214,6 +226,17 @@ public final class SearchQueryResponseMapper {
         .state((p.state() == null) ? null : ProcessInstanceStateEnum.fromValue(p.state().name()))
         .hasIncident(p.incident())
         .tenantId(p.tenantId());
+  }
+
+  private static List<RoleItem> toRoles(final List<RoleEntity> roles) {
+    return roles.stream().map(SearchQueryResponseMapper::toRole).toList();
+  }
+
+  private static RoleItem toRole(final RoleEntity roleEntity) {
+    return new RoleItem()
+        .roleKey(roleEntity.roleKey())
+        .name(roleEntity.name())
+        .assignedMemberKeys(roleEntity.assignedMemberKeys().stream().sorted().toList());
   }
 
   private static List<DecisionDefinitionItem> toDecisionDefinitions(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.usermanagement;
+
+import io.camunda.service.RoleServices;
+import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RequestMapper.CreateRoleRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper.UpdateRoleRequest;
+import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping("/v2/roles")
+public class RoleController {
+  private final RoleServices roleServices;
+
+  public RoleController(final RoleServices roleServices) {
+    this.roleServices = roleServices;
+  }
+
+  @PostMapping(
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> createRole(
+      @RequestBody final RoleCreateRequest createRoleRequest) {
+    return RequestMapper.toRoleCreateRequest(createRoleRequest)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createRole);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> createRole(
+      final CreateRoleRequest createRoleRequest) {
+    return RequestMapper.executeServiceMethod(
+        () ->
+            roleServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .createRole(createRoleRequest.name()),
+        ResponseMapper::toRoleCreateResponse);
+  }
+
+  @PatchMapping(
+      path = "/{roleKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> updateRole(
+      @PathVariable final long roleKey, @RequestBody final RoleUpdateRequest roleUpdateRequest) {
+    return RequestMapper.toRoleUpdateRequest(roleUpdateRequest, roleKey)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateRole);
+  }
+
+  public CompletableFuture<ResponseEntity<Object>> updateRole(
+      final UpdateRoleRequest updateRoleRequest) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            roleServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .updateRole(updateRoleRequest.roleKey(), updateRoleRequest.name()));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryController.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.usermanagement;
+
+import io.camunda.search.query.RoleQuery;
+import io.camunda.service.RoleServices;
+import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestQueryController;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestQueryController
+@RequestMapping("/v2/roles")
+public class RoleQueryController {
+  private final RoleServices roleServices;
+
+  public RoleQueryController(final RoleServices roleServices) {
+    this.roleServices = roleServices;
+  }
+
+  @GetMapping(
+      path = "/{roleKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public ResponseEntity<Object> getRole(@PathVariable final long roleKey) {
+    try {
+      return ResponseEntity.ok().body(roleServices.getRole(roleKey));
+    } catch (final Exception exception) {
+      return RestErrorMapper.mapErrorToResponse(exception);
+    }
+  }
+
+  @PostMapping(
+      path = "/search",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<RoleSearchQueryResponse> searchRoles(
+      @RequestBody(required = false) final RoleSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toRoleQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<RoleSearchQueryResponse> search(final RoleQuery query) {
+    try {
+      final var result = roleServices.search(query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toRoleSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return RestErrorMapper.mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/RoleRequestValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validate;
+
+import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public final class RoleRequestValidator {
+  private RoleRequestValidator() {}
+
+  public static Optional<ProblemDetail> validateRoleName(final String name) {
+    return validate(
+        violations -> {
+          if (name == null || name.isBlank()) {
+            violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("name"));
+          }
+        });
+  }
+
+  public static Optional<ProblemDetail> validateUpdateRequest(final RoleUpdateRequest request) {
+    return validateRoleName(request.getChangeset().getName());
+  }
+
+  public static Optional<ProblemDetail> validateCreateRequest(final RoleCreateRequest request) {
+    return validateRoleName(request.getName());
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -119,6 +119,7 @@ public class RoleControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
+    // then
     verify(roleServices, times(1)).updateRole(roleKey, roleName);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.usermanagement;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.RoleServices;
+import io.camunda.service.exception.CamundaBrokerException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.gateway.protocol.rest.RoleChangeset;
+import io.camunda.zeebe.gateway.protocol.rest.RoleCreateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.RoleUpdateRequest;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(RoleController.class)
+public class RoleControllerTest extends RestControllerTest {
+
+  private static final String ROLE_BASE_URL = "/v2/roles";
+
+  @MockBean private RoleServices roleServices;
+
+  @BeforeEach
+  void setup() {
+    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
+  }
+
+  @Test
+  void createRoleShouldReturnAccepted() {
+    // given
+    final var roleName = "Test Role";
+    when(roleServices.createRole(roleName))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new RoleRecord().setEntityKey(100L).setName(roleName)));
+
+    // when
+    webClient
+        .post()
+        .uri(ROLE_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new RoleCreateRequest().name(roleName))
+        .exchange()
+        .expectStatus()
+        .isAccepted();
+
+    // then
+    verify(roleServices, times(1)).createRole(roleName);
+  }
+
+  @Test
+  void createRoleWithEmptyNameShouldFail() {
+    // given
+    final var roleName = "";
+
+    // when
+    webClient
+        .post()
+        .uri(ROLE_BASE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new RoleCreateRequest().name(roleName))
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "No name provided.",
+              "instance": "%s"
+            }"""
+                .formatted(ROLE_BASE_URL));
+
+    // then
+    verifyNoInteractions(roleServices);
+  }
+
+  @Test
+  void updateRoleShouldReturnNoContent() {
+    // given
+    final var roleKey = 100L;
+    final var roleName = "Updated Role Name";
+    when(roleServices.updateRole(roleKey, roleName))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new RoleRecord().setEntityKey(100L).setName(roleName)));
+
+    // when
+    webClient
+        .patch()
+        .uri("%s/%s".formatted(ROLE_BASE_URL, roleKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new RoleUpdateRequest().changeset(new RoleChangeset().name(roleName)))
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    verify(roleServices, times(1)).updateRole(roleKey, roleName);
+  }
+
+  @Test
+  void updateRoleWithEmptyNameShouldFail() {
+    // given
+    final var roleKey = 100L;
+    final var roleName = "";
+    final var uri = "%s/%s".formatted(ROLE_BASE_URL, roleKey);
+
+    // when / then
+    webClient
+        .patch()
+        .uri(uri)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new RoleUpdateRequest().changeset(new RoleChangeset().name(roleName)))
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "status": 400,
+              "title": "INVALID_ARGUMENT",
+              "detail": "No name provided.",
+              "instance": "%s"
+            }"""
+                .formatted(uri));
+
+    verifyNoInteractions(roleServices);
+  }
+
+  @Test
+  void updateNonExistingRoleShouldReturnError() {
+    // given
+    final var roleKey = 100L;
+    final var roleName = "Updated Role Name";
+    final var path = "%s/%s".formatted(ROLE_BASE_URL, roleKey);
+    when(roleServices.updateRole(roleKey, roleName))
+        .thenReturn(
+            CompletableFuture.failedFuture(
+                new CamundaBrokerException(
+                    new BrokerRejection(
+                        RoleIntent.UPDATE, roleKey, RejectionType.NOT_FOUND, "Role not found"))));
+
+    // when / then
+    webClient
+        .patch()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(new RoleUpdateRequest().changeset(new RoleChangeset().name(roleName)))
+        .exchange()
+        .expectStatus()
+        .isNotFound();
+
+    verify(roleServices, times(1)).updateRole(roleKey, roleName);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.usermanagement;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.RoleQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.sort.RoleSort;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.RoleServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(value = RoleQueryController.class, properties = "camunda.rest.query.enabled=true")
+public class RoleQueryControllerTest extends RestControllerTest {
+  private static final String ROLE_BASE_URL = "/v2/roles";
+
+  @MockBean private RoleServices roleServices;
+
+  @BeforeEach
+  void setup() {
+    when(roleServices.withAuthentication(any(Authentication.class))).thenReturn(roleServices);
+  }
+
+  @Test
+  void getRoleShouldReturnOk() {
+    // given
+    final var role = new RoleEntity(100L, "Role Name", Set.of());
+    when(roleServices.getRole(role.roleKey())).thenReturn(role);
+
+    // when
+    webClient
+        .get()
+        .uri("%s/%s".formatted(ROLE_BASE_URL, role.roleKey()))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody()
+        .json(
+            """
+            {
+              "name": "Role Name",
+              "roleKey": 100
+            }""");
+
+    // then
+    verify(roleServices, times(1)).getRole(role.roleKey());
+  }
+
+  @Test
+  void getNonExistingRoleShouldReturnNotFound() {
+    // given
+    final var roleKey = 100L;
+    final var path = "%s/%s".formatted(ROLE_BASE_URL, roleKey);
+    when(roleServices.getRole(roleKey)).thenThrow(new NotFoundException("role not found"));
+
+    // when
+    webClient
+        .get()
+        .uri(path)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNotFound()
+        .expectBody()
+        .json(
+            """
+            {
+              "type": "about:blank",
+              "title": "NOT_FOUND",
+              "status": 404,
+              "detail": "role not found",
+              "instance": "%s"
+            }"""
+                .formatted(path));
+
+    // then
+    verify(roleServices, times(1)).getRole(roleKey);
+  }
+
+  @Test
+  void shouldSearchRolesWithEmptyQuery() {
+    // given
+    when(roleServices.search(any(RoleQuery.class)))
+        .thenReturn(
+            new SearchQueryResult.Builder<RoleEntity>()
+                .total(3)
+                .sortValues(new Object[] {})
+                .items(
+                    List.of(
+                        new RoleEntity(100L, "Role 1", Set.of()),
+                        new RoleEntity(200L, "Role 2", Set.of(1L, 2L)),
+                        new RoleEntity(300L, "Role 12", Set.of(3L))))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(ROLE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(
+            """
+          {
+             "items": [
+               {
+                 "roleKey": 100,
+                 "name": "Role 1",
+                 "assignedMemberKeys": []
+               },
+               {
+                 "roleKey": 200,
+                 "name": "Role 2",
+                 "assignedMemberKeys": [1, 2]
+               },
+               {
+                 "roleKey": 300,
+                 "name": "Role 12",
+                 "assignedMemberKeys": [3]
+               }
+             ],
+             "page": {
+               "totalItems": 3,
+               "firstSortValues": [],
+               "lastSortValues": []
+             }
+           }""");
+
+    verify(roleServices).search(new RoleQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSortAndPaginateSearchResult() {
+    // given
+    when(roleServices.search(any(RoleQuery.class)))
+        .thenReturn(
+            new SearchQueryResult.Builder<RoleEntity>()
+                .total(3)
+                .items(
+                    List.of(
+                        new RoleEntity(100L, "Role 1", Set.of()),
+                        new RoleEntity(300L, "Role 12", Set.of()),
+                        new RoleEntity(200L, "Role 2", Set.of())))
+                .build());
+
+    // when / then
+    webClient
+        .post()
+        .uri("%s/search".formatted(ROLE_BASE_URL))
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(
+            """
+            {
+              "sort":  [{"field": "name", "order":  "asc"}],
+              "page":  {"from":  20, "limit":  10}
+            }
+             """)
+        .exchange()
+        .expectStatus()
+        .isOk();
+
+    verify(roleServices)
+        .search(
+            new RoleQuery.Builder()
+                .sort(RoleSort.of(builder -> builder.name().asc()))
+                .page(SearchQueryPage.of(builder -> builder.from(20).size(10)))
+                .build());
+  }
+}


### PR DESCRIPTION
## Description

This PR adds endpoints for retrieving, creating and updating roles. It's part of #22389.

- [x] Create role - `POST /v2/roles`
- [x] Search roles - `POST /v2/roles/search` 
- [x] Get a single role - `GET /v2/roles/{key}`
- [x] Update a role - `PATCH /v2/roles/{key}`

### Acceptance Criteria
- [ ] Unit tests
