### PR TITLE
feat: add partial OS repository with delete documents support

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -199,6 +199,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-rest-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/OpenSearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/archiver/OpenSearchRepository.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.exporter.api.ExporterException;
+import io.micrometer.core.instrument.Timer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import javax.annotation.WillCloseWhenClosed;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch._types.Conflicts;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.Time;
+import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
+import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
+import org.slf4j.Logger;
+
+public final class OpenSearchRepository extends NoopArchiverRepository {
+  private static final String DATES_AGG = "datesAgg";
+  private static final String INSTANCES_AGG = "instancesAgg";
+  private static final String DATES_SORTED_AGG = "datesSortedAgg";
+  private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
+  private static final long AUTO_SLICES = 0; // see OS docs; 0 means auto
+
+  private final int partitionId;
+  private final ArchiverConfiguration config;
+  private final RetentionConfiguration retention;
+  private final String processInstanceIndex;
+  private final String batchOperationIndex;
+  private final OpenSearchAsyncClient client;
+  private final Executor executor;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+
+  private final CalendarInterval rolloverInterval;
+
+  public OpenSearchRepository(
+      final int partitionId,
+      final ArchiverConfiguration config,
+      final RetentionConfiguration retention,
+      final String processInstanceIndex,
+      final String batchOperationIndex,
+      @WillCloseWhenClosed final OpenSearchAsyncClient client,
+      final Executor executor,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    this.partitionId = partitionId;
+    this.config = config;
+    this.retention = retention;
+    this.processInstanceIndex = processInstanceIndex;
+    this.batchOperationIndex = batchOperationIndex;
+    this.client = client;
+    this.executor = executor;
+    this.metrics = metrics;
+    this.logger = logger;
+
+    rolloverInterval = mapCalendarInterval(config.getRolloverInterval());
+  }
+
+  @Override
+  public CompletableFuture<Void> deleteDocuments(
+      final String sourceIndexName,
+      final String idFieldName,
+      final List<String> processInstanceKeys) {
+    final TermsQuery termsQuery = buildIdTermsQuery(idFieldName, processInstanceKeys);
+    final var request =
+        new DeleteByQueryRequest.Builder()
+            .index(sourceIndexName)
+            .slices(AUTO_SLICES)
+            .conflicts(Conflicts.Proceed)
+            .query(q -> q.terms(termsQuery))
+            .build();
+
+    final var timer = Timer.start();
+    return sendRequestAsync(() -> client.deleteByQuery(request))
+        .whenCompleteAsync((ignored, error) -> metrics.measureArchiverDelete(timer), executor)
+        .thenApplyAsync(DeleteByQueryResponse::total, executor)
+        .thenApplyAsync(ok -> null, executor);
+  }
+
+  private TermsQuery buildIdTermsQuery(final String idFieldName, final List<String> idValues) {
+    return QueryBuilders.terms()
+        .field(idFieldName)
+        .terms(terms -> terms.value(idValues.stream().map(FieldValue::of).toList()))
+        .build();
+  }
+
+  private CalendarInterval mapCalendarInterval(final String alias) {
+    return Arrays.stream(CalendarInterval.values())
+        .filter(c -> c.aliases() != null)
+        .filter(c -> Arrays.binarySearch(c.aliases(), alias) >= 0)
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private <T> CompletableFuture<T> sendRequestAsync(final RequestSender<T> sender) {
+    try {
+      return sender.sendRequest();
+    } catch (final IOException e) {
+      return CompletableFuture.failedFuture(
+          new ExporterException(
+              "Failed to send request, likely because we failed to parse the request", e));
+    }
+  }
+
+  @FunctionalInterface
+  private interface RequestSender<T> {
+    CompletableFuture<T> sendRequest() throws IOException;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/OpenSearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/archiver/OpenSearchRepositoryIT.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.archiver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+import org.apache.http.HttpHost;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.testcontainers.OpensearchContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@SuppressWarnings("resource")
+@Testcontainers
+@AutoCloseResources
+final class OpenSearchRepositoryIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchRepositoryIT.class);
+
+  @Container
+  private static final OpensearchContainer<?> OPENSEARCH =
+      TestSearchContainers.createDefaultOpensearchContainer();
+
+  @AutoCloseResource private final RestClientTransport transport = createRestClient();
+  private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private final ArchiverConfiguration config = new ArchiverConfiguration();
+  private final RetentionConfiguration retention = new RetentionConfiguration();
+  private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
+  private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
+  private final OpenSearchClient testClient = new OpenSearchClient(transport);
+
+  @Test
+  void shouldDeleteDocuments() throws IOException {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(indexName, doc));
+    testClient.indices().refresh(r -> r.index(indexName));
+
+    // when - delete the first two documents
+    final var result =
+        repository.deleteDocuments(
+            indexName, "id", documents.stream().limit(2).map(TestDocument::id).toList());
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(indexName));
+    final var remaining =
+        testClient.search(r -> r.index(indexName).requestCache(false), TestDocument.class);
+    assertThat(remaining.hits().hits())
+        .as("only the third document is remaining")
+        .hasSize(1)
+        .first()
+        .extracting(Hit::id)
+        .isEqualTo("3");
+  }
+
+  private <T extends TDocument> void index(final String index, final T document) {
+    try {
+      testClient.index(b -> b.index(index).document(document).id(document.id()));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  // no need to close resource returned here, since the transport is closed above anyway
+  private OpenSearchRepository createRepository() {
+    final var client = new OpenSearchAsyncClient(transport);
+    final var metrics = new CamundaExporterMetrics(meterRegistry);
+
+    return new OpenSearchRepository(
+        1,
+        config,
+        retention,
+        processInstanceIndex,
+        batchOperationIndex,
+        client,
+        Runnable::run,
+        metrics,
+        LOGGER);
+  }
+
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(OPENSEARCH.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  }
+
+  private record TestDocument(String id) implements TDocument {}
+
+  private interface TDocument {
+    String id();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the beginning of an `OpenSearchRepository` implementation, right now only support `deleteDocuments`. We should implement each method as a separate PR, and finally one PR to integrate it in the `Archiver` itself.

Right now the `OpenSearchRepository` extends `NoopArchiverRepository` and overrides the functionality it implements, and we should keep that going until it implements everything, then swap to just implementing `ArchiverRepository`.

## Related issues

related to #24094 
