### PR TITLE
Add user permissions on user creation

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -12,16 +12,22 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -35,6 +41,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   private final TypedResponseWriter responseWriter;
   private final CommandDistributionBehavior distributionBehavior;
   private final AuthorizationCheckBehavior authCheckBehavior;
+  private final TypedCommandWriter commandWriter;
 
   public UserCreateProcessor(
       final KeyGenerator keyGenerator,
@@ -47,6 +54,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
+    commandWriter = writers.command();
     this.distributionBehavior = distributionBehavior;
     this.authCheckBehavior = authCheckBehavior;
   }
@@ -64,7 +72,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
       return;
     }
 
-    final var username = command.getValue().getUsernameBuffer();
+    final var username = command.getValue().getUsername();
     final var user = userState.getUser(username);
 
     if (user.isPresent()) {
@@ -80,6 +88,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     command.getValue().setUserKey(key);
 
     stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
+    addUserPermissions(key, username);
     responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
 
     distributionBehavior
@@ -93,5 +102,20 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     stateWriter.appendFollowUpEvent(command.getKey(), UserIntent.CREATED, command.getValue());
 
     distributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void addUserPermissions(final long key, final String username) {
+    final var authorizationRecord =
+        new AuthorizationRecord()
+            .setAction(PermissionAction.ADD)
+            .setOwnerKey(key)
+            .setOwnerType(AuthorizationOwnerType.USER)
+            .setResourceType(AuthorizationResourceType.USER)
+            .addPermission(
+                new Permission().setPermissionType(PermissionType.READ).addResourceId(username))
+            .addPermission(
+                new Permission().setPermissionType(PermissionType.UPDATE).addResourceId(username));
+    commandWriter.appendFollowUpCommand(
+        key, AuthorizationIntent.ADD_PERMISSION, authorizationRecord);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -56,7 +57,13 @@ public class AddEntityRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.ROLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == RoleIntent.ADD_ENTITY)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,
@@ -111,7 +118,7 @@ public class AddEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -144,10 +151,11 @@ public class AddEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -64,7 +64,13 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.AUTHORIZATION
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == AuthorizationIntent.ADD_PERMISSION)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,
@@ -125,7 +131,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -164,10 +170,11 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(2))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateRoleMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -121,10 +122,12 @@ public class CreateRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(2))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
-            tuple(ValueType.USER, UserIntent.CREATE), tuple(ValueType.ROLE, RoleIntent.CREATE));
+            tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
+            tuple(ValueType.ROLE, RoleIntent.CREATE));
   }
 
   private void interceptUserCreateForPartition(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/DeleteRoleMultiPartitionTest.java
@@ -47,7 +47,13 @@ public class DeleteRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.ROLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == RoleIntent.DELETE)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -62,7 +63,13 @@ public class RemoveEntityRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.ROLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == RoleIntent.REMOVE_ENTITY)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,
@@ -123,7 +130,7 @@ public class RemoveEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -162,10 +169,11 @@ public class RemoveEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(5))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY),
             tuple(ValueType.ROLE, RoleIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/UpdateRoleMultiPartitionTest.java
@@ -47,7 +47,13 @@ public class UpdateRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.ROLE
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == RoleIntent.UPDATE)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -57,7 +58,13 @@ public class AddEntityGroupMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.GROUP
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == GroupIntent.ADD_ENTITY)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,
@@ -112,7 +119,7 @@ public class AddEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -145,10 +152,11 @@ public class AddEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.GROUP, GroupIntent.CREATE),
             tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -61,7 +62,13 @@ public class RemoveEntityGroupMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.GROUP
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == GroupIntent.REMOVE_ENTITY)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,
@@ -122,7 +129,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -161,10 +168,11 @@ public class RemoveEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(5))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.GROUP, GroupIntent.CREATE),
             tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY),
             tuple(ValueType.GROUP, GroupIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/UpdateGroupMultiPartitionTest.java
@@ -49,7 +49,13 @@ public class UpdateGroupMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.GROUP
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == GroupIntent.UPDATE)))
         .extracting(
             io.camunda.zeebe.protocol.record.Record::getIntent,
             io.camunda.zeebe.protocol.record.Record::getRecordType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -63,7 +64,7 @@ public class AddEntityTenantMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.TENANT
@@ -127,7 +128,7 @@ public class AddEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -167,10 +168,11 @@ public class AddEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
@@ -104,12 +104,12 @@ public class CreateTenantMultiPartitionTest {
       interceptTenantCreateForPartition(partitionId);
     }
 
-    // when creating a tenant
-    engine.tenant().newTenant().withTenantId("tenant-queue").withName("Queued Tenant").create();
-
     // Create a role to ensure proper order
     final var roleName = UUID.randomUUID().toString();
     engine.role().newRole(roleName).create();
+
+    // when creating a tenant
+    engine.tenant().newTenant().withTenantId("tenant-queue").withName("Queued Tenant").create();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));
@@ -120,7 +120,7 @@ public class CreateTenantMultiPartitionTest {
                 .limit(2))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
-            tuple(ValueType.TENANT, TenantIntent.CREATE), tuple(ValueType.ROLE, RoleIntent.CREATE));
+            tuple(ValueType.ROLE, RoleIntent.CREATE), tuple(ValueType.TENANT, TenantIntent.CREATE));
   }
 
   private void interceptTenantCreateForPartition(final int partitionId) {
@@ -131,7 +131,7 @@ public class CreateTenantMultiPartitionTest {
             return true;
           }
           hasInterceptedPartition.set(true);
-          return !(receiverPartitionId == partitionId && intent == TenantIntent.CREATE);
+          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
         });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -70,7 +71,7 @@ public class RemoveEntityTenantMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.TENANT
@@ -117,7 +118,7 @@ public class RemoveEntityTenantMultiPartitionTest {
     setupTenantWithUserAndRemoveEntity();
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -136,10 +137,11 @@ public class RemoveEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(5))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.ADD_ENTITY),
             tuple(ValueType.TENANT, TenantIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/UpdateTenantMultiPartitionTest.java
@@ -64,7 +64,13 @@ public class UpdateTenantMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.TENANT
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == TenantIntent.UPDATE)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -48,7 +49,14 @@ public class CreateUserMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limit(record -> record.getIntent().equals(CommandDistributionIntent.FINISHED)))
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.USER
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == UserIntent.CREATE)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserTest.java
@@ -18,7 +18,6 @@ import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.jupiter.api.DisplayName;
 
 public class CreateUserTest {
 
@@ -28,7 +27,6 @@ public class CreateUserTest {
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  @DisplayName("should create user if no user with given username exists")
   @Test
   public void shouldCreateUser() {
     // when
@@ -52,9 +50,8 @@ public class CreateUserTest {
         .hasFieldOrPropertyWithValue("password", "password");
   }
 
-  @DisplayName("should reject user create command when username already exists")
   @Test
-  public void shouldNotDuplicate() {
+  public void shouldRejectIfUsernameAlreadyExists() {
     // given
     final var username = UUID.randomUUID().toString();
     final var createdUserRecord =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -66,7 +67,13 @@ public class DeleteUserMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2))
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .filter(
+                    record ->
+                        record.getValueType() == ValueType.USER
+                            || (record.getValueType() == ValueType.COMMAND_DISTRIBUTION
+                                && ((CommandDistributionRecordValue) record.getValue()).getIntent()
+                                    == UserIntent.DELETE)))
         .extracting(
             Record::getIntent,
             Record::getRecordType,
@@ -127,7 +134,7 @@ public class DeleteUserMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -164,10 +171,11 @@ public class DeleteUserMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(2))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             Assertions.tuple(ValueType.USER, UserIntent.CREATE),
+            Assertions.tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             Assertions.tuple(ValueType.USER, UserIntent.DELETE));
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -62,8 +62,8 @@ public class AddPermissionsTest {
     final var recordValue =
         RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)
             .withOwnerKey(ownerKey)
-            .limit(1)
-            .getFirst()
+            .limit(2)
+            .getLast()
             .getValue();
     assertThat(recordValue.getAction()).isEqualTo(PermissionAction.ADD);
     assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Gives the user default READ and UPDATE permissions for its own username.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24060
