### PR TITLE
ci: use 8.6 Helm chart for preview envs

### DIFF
--- a/.ci/preview-environments/charts/c8sm/Chart.yaml
+++ b/.ci/preview-environments/charts/c8sm/Chart.yaml
@@ -11,4 +11,4 @@ version: 0.1.0
 dependencies:
 - name: camunda-platform
   repository: oci://ghcr.io/camunda/helm
-  version: 0.0.0-snapshot-alpha
+  version: 0.0.0-snapshot-8.6

--- a/.ci/preview-environments/charts/c8sm/values.yaml
+++ b/.ci/preview-environments/charts/c8sm/values.yaml
@@ -169,6 +169,8 @@ global:
       optimize:
         # will be replaced by the preview-env-deploy workflow
         redirectUrl: "https://test.camunda.camunda.cloud/optimize"
+        existingSecret:
+          name: identity-secret-for-components
       webModeler:
         # will be replaced by the preview-env-deploy workflow
         redirectUrl: "https:/test.camunda.camunda.cloud/modeler"
@@ -451,8 +453,6 @@ camunda-platform:
         effect: "NoSchedule"
 
   connectors:
-    # temporarily disabled until solution for problem from https://github.com/camunda/camunda/pull/24253 is found
-    enabled: false
     contextPath: "/connectors"
     nodeSelector:
       cloud.google.com/gke-nodepool: previews


### PR DESCRIPTION
## Description

Before the 8.6 release in October, we had to use the alpha Helm chart to support features around architecture streamlining to get working preview environments. The alpha Helm chart got stabilized into the v11 Helm chart with the 8.6 release (see [version matrix](https://helm.camunda.io/camunda-platform/version-matrix/)).

This PR proposes switching to use the v11 Helm chart (8.6) since that should be still compatible + currently there are problems when using the alpha Helm chart (together with our configuration). This way we can re-enable connectors and all components are accessible again in preview environments.

I also discovered that the secret used between Identity and Optimize was not hard-coded (we do that for all other components already) and thus would break on subsequent pushes. Fix also included in this PR.

### Notes from my debugging

The things I observed and problems I noticed with the alpha Helm chart (see also https://github.com/camunda/camunda/pull/24253):

1. Connectors cannot authenticate successfully with Operate
    - this makes the deployment unhealthy since Connectors wants to import process definitions at startup
2. no `demo` user existing in Keycloak/Identity
    - probably explains why 1. is happening
    - prevents login into any* other component like Tasklist/Optimize
3. *but login to Operate using `demo/demo` works even without a `demo` user in Keycloak/Identity, which is unexpected
    - Operate login happens on `/operate/operate/login` while all other components redirect to Identity login page (and have SSO)
    - this made troubleshooting more difficult because Operate is the default landing app but `demo/demo` working in Operate doesn't mean Identity is configured correctly (?)

Re 1+2 I compared changes between [8.6 Helm chart](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform-8.6) and [alpha](https://github.com/camunda/camunda-platform-helm/tree/main/charts/camunda-platform-alpha):
Most likely this problem comes from some incompatibility between changes related to how Identity is configured (https://github.com/camunda/camunda-platform-helm/pull/2400 + https://github.com/camunda/camunda-platform-helm/pull/2512) and our configuration. No `demo` user being created is similar to the bug https://github.com/camunda/camunda-platform-helm/issues/2339 which Andrea encountered in September.

Re 3 I will reach out to the Operate team to understand the situation around Operate authentication and whether Identity is used there better.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/655