### PR TITLE
Add group add entity processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.UNAUTHORIZED_ERROR_MESSAGE;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.GroupState;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
+
+  private final GroupState groupState;
+  private final UserState userState;
+  private final MappingState mappingState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+
+  public GroupAddEntityProcessor(
+      final GroupState groupState,
+      final UserState userState,
+      final MappingState mappingState,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    this.commandDistributionBehavior = commandDistributionBehavior;
+    this.keyGenerator = keyGenerator;
+    this.authCheckBehavior = authCheckBehavior;
+    this.groupState = groupState;
+    this.userState = userState;
+    this.mappingState = mappingState;
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<GroupRecord> command) {
+    final var record = command.getValue();
+    final var persistedRecord = groupState.get(record.getGroupKey());
+    final var groupKey = record.getGroupKey();
+    if (persistedRecord.isEmpty()) {
+      final var errorMessage =
+          "Expected to update group with key '%s', but a group with this key does not exist."
+              .formatted(groupKey);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      return;
+    }
+
+    final var authorizationRequest =
+        new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
+            .addResourceId(record.getName());
+    if (!authCheckBehavior.isAuthorized(authorizationRequest)) {
+      final var errorMessage =
+          UNAUTHORIZED_ERROR_MESSAGE.formatted(
+              authorizationRequest.getPermissionType(), authorizationRequest.getResourceType());
+      rejectionWriter.appendRejection(command, RejectionType.UNAUTHORIZED, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.UNAUTHORIZED, errorMessage);
+      return;
+    }
+
+    final var entityKey = record.getEntityKey();
+    final var entityType = record.getEntityType();
+    if (!isEntityPresent(entityKey, entityType)) {
+      final var errorMessage =
+          "Expected to add an entity with key '%s' and type '%s' to group with key '%d', but the entity doesn't exist."
+              .formatted(entityKey, entityType, groupKey);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      return;
+    }
+
+    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_ADDED, record);
+    responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_ADDED, record, command);
+
+    final long distributionKey = keyGenerator.nextKey();
+    commandDistributionBehavior
+        .withKey(distributionKey)
+        .inQueue(DistributionQueue.IDENTITY.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
+    stateWriter.appendFollowUpEvent(command.getKey(), GroupIntent.ENTITY_ADDED, command.getValue());
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
+    return switch (entityType) {
+      case EntityType.USER -> userState.getUser(entityKey).isPresent();
+      case EntityType.MAPPING -> mappingState.get(entityKey).isPresent();
+      default -> false;
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -90,7 +90,7 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
     final var entityType = record.getEntityType();
     if (!isEntityPresent(entityKey, entityType)) {
       final var errorMessage =
-          "Expected to add an entity with key '%s' and type '%s' to group with key '%d', but the entity doesn't exist."
+          "Expected to add an entity with key '%s' and type '%s' to group with key '%d', but the entity does not exist."
               .formatted(entityKey, entityType, groupKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupAddEntityProcessor.java
@@ -63,8 +63,8 @@ public class GroupAddEntityProcessor implements DistributedTypedRecordProcessor<
   @Override
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
-    final var persistedRecord = groupState.get(record.getGroupKey());
     final var groupKey = record.getGroupKey();
+    final var persistedRecord = groupState.get(groupKey);
     if (persistedRecord.isEmpty()) {
       final var errorMessage =
           "Expected to update group with key '%s', but a group with this key does not exist."

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupCreateProcessor.java
@@ -65,11 +65,12 @@ public class GroupCreateProcessor implements DistributedTypedRecordProcessor<Gro
     }
 
     final var record = command.getValue();
-    final var groupKey = groupState.getGroupKeyByName(record.getName());
+    final var groupName = record.getName();
+    final var groupKey = groupState.getGroupKeyByName(groupName);
     if (groupKey.isPresent()) {
       final var errorMessage =
           "Expected to create group with name '%s', but a group with this name already exists."
-              .formatted(record.getName());
+              .formatted(groupName);
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -41,5 +41,16 @@ public class GroupProcessors {
             authCheckBehavior,
             writers,
             commandDistributionBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.GROUP,
+        GroupIntent.ADD_ENTITY,
+        new GroupAddEntityProcessor(
+            processingState.getGroupState(),
+            processingState.getUserState(),
+            processingState.getMappingState(),
+            authCheckBehavior,
+            keyGenerator,
+            writers,
+            commandDistributionBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -54,11 +54,12 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
   @Override
   public void processNewCommand(final TypedRecord<GroupRecord> command) {
     final var record = command.getValue();
-    final var persistedRecord = groupState.get(record.getGroupKey());
+    final var groupKey = record.getGroupKey();
+    final var persistedRecord = groupState.get(groupKey);
     if (persistedRecord.isEmpty()) {
       final var errorMessage =
           "Expected to update group with key '%s', but a group with this key does not exist."
-              .formatted(record.getGroupKey());
+              .formatted(groupKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
@@ -86,8 +87,8 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
       return;
     }
 
-    stateWriter.appendFollowUpEvent(record.getGroupKey(), GroupIntent.UPDATED, record);
-    responseWriter.writeEventOnCommand(record.getGroupKey(), GroupIntent.UPDATED, record, command);
+    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.UPDATED, record);
+    responseWriter.writeEventOnCommand(groupKey, GroupIntent.UPDATED, record, command);
 
     final long distributionKey = keyGenerator.nextKey();
     commandDistributionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityAddedApplier.java
@@ -29,15 +29,21 @@ public class GroupEntityAddedApplier implements TypedEventApplier<GroupIntent, G
 
   @Override
   public void applyState(final long key, final GroupRecord value) {
-    groupState.addEntity(key, value);
-    switch (value.getEntityType()) {
-      case USER -> userState.addGroup(value.getEntityKey(), key);
-      case MAPPING -> mappingState.addGroup(value.getEntityKey(), key);
+    // get the record key from the GroupRecord, as the key argument
+    // may belong to the distribution command
+    final var groupKey = value.getGroupKey();
+    groupState.addEntity(groupKey, value);
+
+    final var entityKey = value.getEntityKey();
+    final var entityType = value.getEntityType();
+    switch (entityType) {
+      case USER -> userState.addGroup(entityKey, groupKey);
+      case MAPPING -> mappingState.addGroup(entityKey, groupKey);
       default ->
           throw new IllegalStateException(
               String.format(
                   "Expected to add entity '%d' to group '%d', but entities of type '%s' cannot be added to groups.",
-                  value.getEntityKey(), key, value.getEntityType()));
+                  entityKey, groupKey, entityType));
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -112,7 +112,7 @@ public class AddEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -122,7 +122,7 @@ public class AddEntityGroupMultiPartitionTest {
   public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
     // given the group creation distribution is intercepted
     for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
-      interceptGroupCommandForPartition(partitionId, UserIntent.CREATE);
+      interceptGroupCommandForPartition(partitionId, GroupIntent.CREATE);
     }
     final var userKey =
         engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class AddEntityGroupMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDistributeGroupAddEntityCommand() {
+    // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3))
+        .extracting(
+            io.camunda.zeebe.protocol.record.Record::getIntent,
+            io.camunda.zeebe.protocol.record.Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the creation was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(GroupIntent.ADD_ENTITY, RecordType.COMMAND, 1),
+            tuple(GroupIntent.ENTITY_ADDED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.groupRecords()
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(GroupIntent.ENTITY_ADDED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(GroupIntent.ADD_ENTITY, GroupIntent.ENTITY_ADDED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+
+  @Test
+  public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
+    // given the group creation distribution is intercepted
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      interceptGroupCommandForPartition(partitionId, UserIntent.CREATE);
+    }
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+
+    // when
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // Increase time to trigger a redistribution
+    engine.increaseTime(Duration.ofMinutes(1));
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .limit(3))
+        .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.GROUP, GroupIntent.CREATE),
+            tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY));
+  }
+
+  private void interceptGroupCommandForPartition(
+      final int partitionId, final Intent commandIntent) {
+    final var hasInterceptedPartition = new AtomicBoolean(false);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (hasInterceptedPartition.get()) {
+            return true;
+          }
+          hasInterceptedPartition.set(true);
+          return !(receiverPartitionId == partitionId && intent == commandIntent);
+        });
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -134,24 +134,16 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfGroupIsNotPresentWhileAddingEntity() {
-    // given
-    final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
-
     // when
     final var notPresentGroupKey = 1L;
     final var notPresentUpdateRecord =
         engine.group().addEntity(notPresentGroupKey).expectRejection().add();
 
-    final var createdGroup = groupRecord.getValue();
-    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
-
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to update group with key '"
-                + notPresentGroupKey
-                + "', but a group with this key does not exist.");
+            "Expected to update group with key '%d', but a group with this key does not exist."
+                .formatted(notPresentGroupKey));
   }
 
   @Test
@@ -177,7 +169,7 @@ public class GroupTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add an entity with key '%s' and type '%s' to group with key '%s', but the entity doesn't exist."
+            "Expected to add an entity with key '%s' and type '%s' to group with key '%s', but the entity does not exist."
                 .formatted(1L, EntityType.USER, groupKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -101,5 +102,82 @@ public class GroupTest {
         .hasRejectionReason(
             "Expected to update group with name '%s', but a group with this name already exists."
                 .formatted(updatedName));
+  }
+
+  @Test
+  public void shouldAddEntityToGroup() {
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    final var updatedGroup =
+        engine
+            .group()
+            .addEntity(groupKey)
+            .withEntityKey(userKey)
+            .withEntityType(EntityType.USER)
+            .add()
+            .getValue();
+
+    Assertions.assertThat(updatedGroup)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("entityKey", userKey)
+        .hasFieldOrPropertyWithValue("entityType", EntityType.USER);
+  }
+
+  @Test
+  public void shouldRejectIfGroupIsNotPresentWhileAddingEntity() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var groupRecord = engine.group().newGroup(name).create();
+
+    // when
+    final var notPresentGroupKey = 1L;
+    final var notPresentUpdateRecord =
+        engine.group().addEntity(notPresentGroupKey).expectRejection().add();
+
+    final var createdGroup = groupRecord.getValue();
+    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
+
+    assertThat(notPresentUpdateRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to update group with key '"
+                + notPresentGroupKey
+                + "', but a group with this key does not exist.");
+  }
+
+  @Test
+  public void shouldRejectIfEntityIsNotPresent() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var groupRecord = engine.group().newGroup(name).create();
+
+    // when
+    final var createdGroup = groupRecord.getValue();
+    final var groupKey = createdGroup.getGroupKey();
+    final var notPresentUpdateRecord =
+        engine
+            .group()
+            .addEntity(groupKey)
+            .withEntityKey(1L)
+            .withEntityType(EntityType.USER)
+            .expectRejection()
+            .add();
+
+    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
+
+    assertThat(notPresentUpdateRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to add an entity with key '%s' and type '%s' to group with key '%s', but the entity doesn't exist."
+                .formatted(1L, EntityType.USER, groupKey));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add a `GroupAddEntityProcessor` to process `GroupIntent.ADD_ENTITY` commands.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23547
closes #23874
