### PR TITLE
Add group remove entity processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupProcessors.java
@@ -52,5 +52,16 @@ public class GroupProcessors {
             keyGenerator,
             writers,
             commandDistributionBehavior));
+    typedRecordProcessors.onCommand(
+        ValueType.GROUP,
+        GroupIntent.REMOVE_ENTITY,
+        new GroupRemoveEntityProcessor(
+            processingState.getGroupState(),
+            processingState.getUserState(),
+            processingState.getMappingState(),
+            authCheckBehavior,
+            keyGenerator,
+            writers,
+            commandDistributionBehavior));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -90,7 +90,7 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
     final var entityType = record.getEntityType();
     if (!isEntityPresent(entityKey, entityType)) {
       final var errorMessage =
-          "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity doesn't exist."
+          "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity does not exist."
               .formatted(entityKey, entityType, groupKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.UNAUTHORIZED_ERROR_MESSAGE;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.AuthorizationRequest;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.GroupState;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
+
+  private final GroupState groupState;
+  private final UserState userState;
+  private final MappingState mappingState;
+  private final AuthorizationCheckBehavior authCheckBehavior;
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+
+  public GroupRemoveEntityProcessor(
+      final GroupState groupState,
+      final UserState userState,
+      final MappingState mappingState,
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final KeyGenerator keyGenerator,
+      final Writers writers,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    this.groupState = groupState;
+    this.userState = userState;
+    this.mappingState = mappingState;
+    this.authCheckBehavior = authCheckBehavior;
+    this.keyGenerator = keyGenerator;
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<GroupRecord> command) {
+    final var record = command.getValue();
+    final var groupKey = record.getGroupKey();
+    final var persistedRecord = groupState.get(groupKey);
+    if (persistedRecord.isEmpty()) {
+      final var errorMessage =
+          "Expected to update group with key '%s', but a group with this key does not exist."
+              .formatted(groupKey);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      return;
+    }
+
+    final var authorizationRequest =
+        new AuthorizationRequest(command, AuthorizationResourceType.GROUP, PermissionType.UPDATE)
+            .addResourceId(persistedRecord.get().getName());
+    if (!authCheckBehavior.isAuthorized(authorizationRequest)) {
+      final var errorMessage =
+          UNAUTHORIZED_ERROR_MESSAGE.formatted(
+              authorizationRequest.getPermissionType(), authorizationRequest.getResourceType());
+      rejectionWriter.appendRejection(command, RejectionType.UNAUTHORIZED, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.UNAUTHORIZED, errorMessage);
+      return;
+    }
+
+    final var entityKey = record.getEntityKey();
+    final var entityType = record.getEntityType();
+    if (!isEntityPresent(entityKey, entityType)) {
+      final var errorMessage =
+          "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity doesn't exist."
+              .formatted(entityKey, entityType, groupKey);
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
+      return;
+    }
+
+    stateWriter.appendFollowUpEvent(groupKey, GroupIntent.ENTITY_REMOVED, record);
+    responseWriter.writeEventOnCommand(groupKey, GroupIntent.ENTITY_REMOVED, record, command);
+
+    final long distributionKey = keyGenerator.nextKey();
+    commandDistributionBehavior
+        .withKey(distributionKey)
+        .inQueue(DistributionQueue.IDENTITY.getQueueId())
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue());
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private boolean isEntityPresent(final long entityKey, final EntityType entityType) {
+    return switch (entityType) {
+      case USER -> userState.getUser(entityKey).isPresent();
+      case MAPPING -> mappingState.get(entityKey).isPresent();
+      default -> false;
+    };
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupEntityRemovedApplier.java
@@ -30,15 +30,21 @@ public class GroupEntityRemovedApplier implements TypedEventApplier<GroupIntent,
   @Override
   public void applyState(final long key, final GroupRecord value) {
     final var entityKey = value.getEntityKey();
-    groupState.removeEntity(key, entityKey);
-    switch (value.getEntityType()) {
+    final var entityType = value.getEntityType();
+
+    // get the record key from the GroupRecord, as the key argument
+    // may belong to the distribution command
+    final var groupKey = value.getGroupKey();
+    groupState.removeEntity(groupKey, entityKey);
+
+    switch (entityType) {
       case USER -> userState.removeGroup(entityKey, key);
       case MAPPING -> mappingState.removeGroup(entityKey, key);
       default ->
           throw new IllegalStateException(
               String.format(
                   "Expected to remove entity '%d' from group '%d', but entities of type '%s' cannot be removed from groups.",
-                  entityKey, key, value.getEntityType()));
+                  entityKey, groupKey, entityType));
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -172,4 +172,83 @@ public class GroupTest {
             "Expected to add an entity with key '%s' and type '%s' to group with key '%s', but the entity does not exist."
                 .formatted(1L, EntityType.USER, groupKey));
   }
+
+  @Test
+  public void shouldRemoveEntityToGroup() {
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    final var removedEntity =
+        engine
+            .group()
+            .removeEntity(groupKey)
+            .withEntityKey(userKey)
+            .withEntityType(EntityType.USER)
+            .remove()
+            .getValue();
+
+    Assertions.assertThat(removedEntity)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("groupKey", groupKey)
+        .hasFieldOrPropertyWithValue("entityKey", userKey)
+        .hasFieldOrPropertyWithValue("entityType", EntityType.USER);
+  }
+
+  @Test
+  public void shouldRejectIfGroupIsNotPresentEntityRemoval() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var groupRecord = engine.group().newGroup(name).create();
+
+    // when
+    final var notPresentGroupKey = 1L;
+    final var notPresentUpdateRecord =
+        engine.group().addEntity(notPresentGroupKey).expectRejection().add();
+
+    final var createdGroup = groupRecord.getValue();
+    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
+
+    assertThat(notPresentUpdateRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to update group with key '"
+                + notPresentGroupKey
+                + "', but a group with this key does not exist.");
+  }
+
+  @Test
+  public void shouldRejectIfEntityIsNotPresentEntityRemoval() {
+    // given
+    final var name = UUID.randomUUID().toString();
+    final var groupRecord = engine.group().newGroup(name).create();
+
+    // when
+    final var createdGroup = groupRecord.getValue();
+    final var groupKey = createdGroup.getGroupKey();
+    final var notPresentUpdateRecord =
+        engine
+            .group()
+            .removeEntity(groupKey)
+            .withEntityKey(1L)
+            .withEntityType(EntityType.USER)
+            .expectRejection()
+            .remove();
+
+    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
+
+    assertThat(notPresentUpdateRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity doesn't exist."
+                .formatted(1L, EntityType.USER, groupKey));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -205,24 +205,16 @@ public class GroupTest {
 
   @Test
   public void shouldRejectIfGroupIsNotPresentEntityRemoval() {
-    // given
-    final var name = UUID.randomUUID().toString();
-    final var groupRecord = engine.group().newGroup(name).create();
-
     // when
     final var notPresentGroupKey = 1L;
     final var notPresentUpdateRecord =
         engine.group().addEntity(notPresentGroupKey).expectRejection().add();
 
-    final var createdGroup = groupRecord.getValue();
-    Assertions.assertThat(createdGroup).isNotNull().hasFieldOrPropertyWithValue("name", name);
-
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to update group with key '"
-                + notPresentGroupKey
-                + "', but a group with this key does not exist.");
+            "Expected to update group with key '%d', but a group with this key does not exist."
+                .formatted(notPresentGroupKey));
   }
 
   @Test
@@ -248,7 +240,7 @@ public class GroupTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity doesn't exist."
+            "Expected to remove an entity with key '%s' and type '%s' from group with key '%s', but the entity does not exist."
                 .formatted(1L, EntityType.USER, groupKey));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -122,7 +122,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.group;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class RemoveEntityGroupMultiPartitionTest {
+  private static final int PARTITION_COUNT = 3;
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher testWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldDistributeGroupRemoveEntityCommand() {
+    // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .removeEntity(groupKey)
+        .withEntityKey(userKey)
+        .withEntityType(EntityType.USER)
+        .remove();
+
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limitByCount(
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4))
+        .extracting(
+            io.camunda.zeebe.protocol.record.Record::getIntent,
+            io.camunda.zeebe.protocol.record.Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the creation was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(GroupIntent.REMOVE_ENTITY, RecordType.COMMAND, 1),
+            tuple(GroupIntent.ENTITY_REMOVED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.groupRecords()
+                  .withPartitionId(partitionId)
+                  .limit(record -> record.getIntent().equals(GroupIntent.ENTITY_REMOVED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(GroupIntent.REMOVE_ENTITY, GroupIntent.ENTITY_REMOVED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    // when
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .removeEntity(groupKey)
+        .withEntityKey(userKey)
+        .withEntityType(EntityType.USER)
+        .remove();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+
+  @Test
+  public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
+    // given the user creation distribution is intercepted
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      interceptUserCreateForPartition(partitionId);
+    }
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+
+    // when
+    final var name = UUID.randomUUID().toString();
+    final var groupKey = engine.group().newGroup(name).create().getValue().getGroupKey();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+    engine
+        .group()
+        .removeEntity(groupKey)
+        .withEntityKey(userKey)
+        .withEntityType(EntityType.USER)
+        .remove();
+
+    // Increase time to trigger a redistribution
+    engine.increaseTime(Duration.ofMinutes(1));
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .limit(4))
+        .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(ValueType.USER, UserIntent.CREATE),
+            tuple(ValueType.GROUP, GroupIntent.CREATE),
+            tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY),
+            tuple(ValueType.GROUP, GroupIntent.REMOVE_ENTITY));
+  }
+
+  private void interceptUserCreateForPartition(final int partitionId) {
+    final var hasInterceptedPartition = new AtomicBoolean(false);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (hasInterceptedPartition.get()) {
+            return true;
+          }
+          hasInterceptedPartition.set(true);
+          return !(receiverPartitionId == partitionId && intent == UserIntent.CREATE);
+        });
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add a processor for GroupIntent.REMOVE_ENTITY commands.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23549
