### PR TITLE
feat: export Job-based User Tasks

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskEntity.java
@@ -54,6 +54,9 @@ public class TaskEntity extends TasklistEntity<TaskEntity> {
   private String formKey;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  private boolean isFormEmbedded;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
   private OffsetDateTime followUpDate;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -79,6 +82,9 @@ public class TaskEntity extends TasklistEntity<TaskEntity> {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   private TaskJoinRelationship join;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private TaskImplementation implementation;
 
   public TaskEntity() {}
 
@@ -248,6 +254,15 @@ public class TaskEntity extends TasklistEntity<TaskEntity> {
     return this;
   }
 
+  public Boolean getIsFormEmbedded() {
+    return isFormEmbedded;
+  }
+
+  public TaskEntity setIsFormEmbedded(final Boolean isFormEmbedded) {
+    this.isFormEmbedded = isFormEmbedded;
+    return this;
+  }
+
   public OffsetDateTime getFollowUpDate() {
     return followUpDate;
   }
@@ -329,7 +344,17 @@ public class TaskEntity extends TasklistEntity<TaskEntity> {
     return this;
   }
 
-  public String getImplementation() {
-    return "ZEEBE_USER_TASK";
+  public TaskImplementation getImplementation() {
+    return implementation;
+  }
+
+  public TaskEntity setImplementation(final TaskImplementation implementation) {
+    this.implementation = implementation;
+    return this;
+  }
+
+  public enum TaskImplementation {
+    JOB_WORKER,
+    ZEEBE_USER_TASK
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -40,6 +40,7 @@ import io.camunda.exporter.handlers.UserCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.UserDeletedHandler;
 import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler;
 import io.camunda.exporter.handlers.UserTaskHandler;
+import io.camunda.exporter.handlers.UserTaskJobBasedHandler;
 import io.camunda.exporter.handlers.UserTaskProcessInstanceHandler;
 import io.camunda.exporter.handlers.UserTaskVariableHandler;
 import io.camunda.exporter.handlers.VariableHandler;
@@ -201,6 +202,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new EventFromProcessMessageSubscriptionHandler(
                 templateDescriptorsMap.get(EventTemplate.class).getFullQualifiedName(), false),
             new UserTaskHandler(
+                templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName()),
+            new UserTaskJobBasedHandler(
                 templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName()),
             new UserTaskProcessInstanceHandler(
                 templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskHandler.java
@@ -11,6 +11,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
@@ -193,6 +194,7 @@ public class UserTaskHandler implements ExportHandler<TaskEntity, UserTaskRecord
 
   private void createTaskEntity(final TaskEntity entity, final Record<UserTaskRecordValue> record) {
     entity
+        .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
         .setId(String.valueOf(record.getValue().getElementInstanceKey()))
         .setKey(record.getKey())
         .setState(TaskState.CREATED)

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.zeebe.protocol.Protocol.USER_TASK_ASSIGNEE_HEADER_NAME;
+import static io.camunda.zeebe.protocol.Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME;
+import static io.camunda.zeebe.protocol.Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.tasklist.TaskState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRecordValue> {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserTaskJobBasedHandler.class);
+  private static final Pattern EMBEDDED_FORMS_PATTERN = Pattern.compile("^camunda-forms:bpmn:.*");
+  private static final Set<JobIntent> SUPPORTED_INTENTS =
+      EnumSet.of(
+          JobIntent.CREATED,
+          JobIntent.COMPLETED,
+          JobIntent.CANCELED,
+          JobIntent.MIGRATED,
+          JobIntent.RECURRED_AFTER_BACKOFF,
+          JobIntent.FAILED);
+
+  private final String indexName;
+
+  public UserTaskJobBasedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.JOB;
+  }
+
+  @Override
+  public Class<TaskEntity> getEntityType() {
+    return TaskEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<JobRecordValue> record) {
+    return SUPPORTED_INTENTS.contains(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<JobRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public TaskEntity createNewEntity(final String id) {
+    return new TaskEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<JobRecordValue> record, final TaskEntity entity) {
+    entity.setProcessInstanceId(String.valueOf(record.getValue().getProcessInstanceKey()));
+    switch (record.getIntent()) {
+      case JobIntent.CREATED -> createTaskEntity(entity, record);
+      case JobIntent.COMPLETED, JobIntent.CANCELED ->
+          entity
+              .setState(
+                  record.getIntent().equals(JobIntent.COMPLETED)
+                      ? TaskState.COMPLETED
+                      : TaskState.CANCELED)
+              .setCompletionTime(
+                  ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+      case JobIntent.MIGRATED ->
+          entity
+              .setFlowNodeBpmnId(record.getValue().getElementId())
+              .setBpmnProcessId(record.getValue().getBpmnProcessId())
+              .setProcessDefinitionId(String.valueOf(record.getValue().getProcessDefinitionKey()))
+              .setState(TaskState.CREATED);
+      case JobIntent.RECURRED_AFTER_BACKOFF -> entity.setState(TaskState.CREATED);
+      case JobIntent.FAILED -> {
+        final var recordValue = record.getValue();
+        if (recordValue.getRetries() > 0 && recordValue.getRetryBackoff() <= 0) {
+          entity.setState(TaskState.CREATED);
+        } else {
+          entity.setState(TaskState.FAILED);
+        }
+      }
+      default -> {}
+    }
+
+    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
+    joinRelation.setName(TaskJoinRelationshipType.TASK.getType());
+    joinRelation.setParent(Long.valueOf(entity.getProcessInstanceId()));
+    entity.setJoin(joinRelation);
+  }
+
+  @Override
+  public void flush(final TaskEntity entity, final BatchRequest batchRequest) {
+    final var updateFields = getUpdatedFields(entity);
+    final var taskEntityId = entity.getId();
+    final var processInstanceKey = entity.getProcessInstanceId();
+    batchRequest.upsertWithRouting(
+        indexName, taskEntityId, entity, updateFields, processInstanceKey);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private Map<String, Object> getUpdatedFields(final TaskEntity entity) {
+    final var updateFields = new HashMap<String, Object>();
+
+    if (entity.getCompletionTime() != null) {
+      updateFields.put(TaskTemplate.COMPLETION_TIME, entity.getCompletionTime());
+    }
+    if (entity.getState() != null) {
+      updateFields.put(TaskTemplate.STATE, entity.getState());
+    }
+    if (entity.getFlowNodeBpmnId() != null) {
+      updateFields.put(TaskTemplate.FLOW_NODE_BPMN_ID, entity.getFlowNodeBpmnId());
+    }
+    if (entity.getProcessDefinitionId() != null) {
+      updateFields.put(TaskTemplate.PROCESS_DEFINITION_ID, entity.getProcessDefinitionId());
+    }
+    if (entity.getBpmnProcessId() != null) {
+      updateFields.put(TaskTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
+    }
+
+    return updateFields;
+  }
+
+  private void createTaskEntity(final TaskEntity entity, final Record<JobRecordValue> record) {
+    final var recordValue = record.getValue();
+    final var customHeaders = recordValue.getCustomHeaders();
+
+    final var dueDate = customHeaders.get(Protocol.USER_TASK_DUE_DATE_HEADER_NAME);
+    final var followUpDate = customHeaders.get(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME);
+    final var assignee = customHeaders.get(USER_TASK_ASSIGNEE_HEADER_NAME);
+    final var candidateGroups =
+        toStringArray(customHeaders.get(USER_TASK_CANDIDATE_GROUPS_HEADER_NAME));
+    final var candidateUsers =
+        toStringArray(customHeaders.get(USER_TASK_CANDIDATE_USERS_HEADER_NAME));
+    final var formKey = customHeaders.get(Protocol.USER_TASK_FORM_KEY_HEADER_NAME);
+
+    entity
+        .setImplementation(TaskImplementation.JOB_WORKER)
+        .setKey(record.getKey())
+        .setState(TaskState.CREATED)
+        .setAssignee(ExporterUtil.isEmpty(assignee) ? null : assignee)
+        .setDueDate(ExporterUtil.toOffsetDateTime(dueDate))
+        .setFollowUpDate(ExporterUtil.toOffsetDateTime(followUpDate))
+        .setFlowNodeInstanceId(String.valueOf(recordValue.getElementInstanceKey()))
+        .setProcessInstanceId(String.valueOf(recordValue.getProcessInstanceKey()))
+        .setFlowNodeBpmnId(recordValue.getElementId())
+        .setBpmnProcessId(recordValue.getBpmnProcessId())
+        .setProcessDefinitionId(String.valueOf(recordValue.getProcessDefinitionKey()))
+        .setProcessDefinitionVersion(recordValue.getProcessDefinitionVersion())
+        .setPartitionId(record.getPartitionId())
+        .setTenantId(recordValue.getTenantId())
+        .setPosition(record.getPosition())
+        .setCreationTime(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+
+    if (candidateUsers != null && candidateUsers.length > 0) {
+      entity.setCandidateUsers(candidateUsers);
+    }
+
+    if (candidateGroups != null && candidateGroups.length > 0) {
+      entity.setCandidateGroups(candidateGroups);
+    }
+
+    if (!ExporterUtil.isEmpty(formKey)) {
+      final var isEmbeddedForm = EMBEDDED_FORMS_PATTERN.matcher(formKey).matches();
+      entity.setFormKey(formKey);
+      entity.setIsFormEmbedded(isEmbeddedForm);
+    }
+  }
+
+  private String[] toStringArray(final String value) {
+    if (!ExporterUtil.isEmpty(value)) {
+      try {
+        return MAPPER.readValue(value, String[].class);
+      } catch (final JsonProcessingException e) {
+        LOGGER.warn(String.format("Failed to parse value %s: %s", value, e.getMessage()), e);
+      }
+    }
+    return null;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskHandlerTest.java
@@ -16,6 +16,7 @@ import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.utils.ExporterUtil;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskState;
 import io.camunda.zeebe.protocol.record.Record;
@@ -198,6 +199,7 @@ public class UserTaskHandlerTest {
     assertThat(taskEntity.getCreationTime())
         .isEqualTo(
             ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(taskRecord.getTimestamp())));
+    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.ZEEBE_USER_TASK);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -1,0 +1,623 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.ExporterUtil;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
+import io.camunda.webapps.schema.entities.tasklist.TaskEntity.TaskImplementation;
+import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
+import io.camunda.webapps.schema.entities.tasklist.TaskState;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class UserTaskJobBasedHandlerTest {
+  private static final Set<JobIntent> SUPPORTED_INTENTS =
+      EnumSet.of(
+          JobIntent.CREATED,
+          JobIntent.COMPLETED,
+          JobIntent.CANCELED,
+          JobIntent.MIGRATED,
+          JobIntent.RECURRED_AFTER_BACKOFF,
+          JobIntent.FAILED);
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-tasklist-task";
+  private final UserTaskJobBasedHandler underTest = new UserTaskJobBasedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.JOB);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(TaskEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    SUPPORTED_INTENTS.forEach(
+        intent -> {
+          final Record<JobRecordValue> jobRecord =
+              factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+          // when - then
+          assertThat(underTest.handlesRecord(jobRecord)).isTrue();
+        });
+  }
+
+  @Test
+  void shouldNotHandleRecord() {
+    // given
+    Arrays.stream(JobIntent.values())
+        .filter(intent -> !SUPPORTED_INTENTS.contains(intent))
+        .forEach(
+            intent -> {
+              final Record<JobRecordValue> jobRecord =
+                  factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+              // when - then
+              assertThat(underTest.handlesRecord(jobRecord)).isFalse();
+            });
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final long expectedId = 123;
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB, r -> r.withIntent(JobIntent.CREATED).withKey(expectedId));
+
+    // when
+    final var idList = underTest.generateIds(jobRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(expectedId));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldAddEntityOnFlush() {
+    // given
+    final TaskEntity inputEntity = new TaskEntity().setProcessInstanceId("111");
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    final Map<String, Object> updateFieldsMap = new HashMap<>();
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            inputEntity.getId(),
+            inputEntity,
+            updateFieldsMap,
+            inputEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecord() {
+    // given
+    final var dateTime = OffsetDateTime.now().format(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+    final long processInstanceKey = 123;
+    final long jobKey = 456;
+    final var assignee = "foo";
+    final var formKey = "my-local-form-key";
+
+    final var customerHeaders = new HashMap<String, String>();
+    customerHeaders.put(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, assignee);
+    customerHeaders.put(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, dateTime);
+    customerHeaders.put(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, dateTime);
+    customerHeaders.put(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"user1\", \"user2\"]");
+    customerHeaders.put(
+        Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"group1\", \"group2\"]");
+    customerHeaders.put(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, formKey);
+
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withCustomHeaders(customerHeaders)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withKey(jobKey)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId(String.valueOf(jobKey));
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getId()).isEqualTo(String.valueOf(jobKey));
+    assertThat(taskEntity.getKey()).isEqualTo(jobRecord.getKey());
+    assertThat(taskEntity.getTenantId()).isEqualTo(jobRecordValue.getTenantId());
+    assertThat(taskEntity.getPartitionId()).isEqualTo(jobRecord.getPartitionId());
+    assertThat(taskEntity.getPosition()).isEqualTo(jobRecord.getPosition());
+    assertThat(taskEntity.getProcessInstanceId()).isEqualTo(String.valueOf(processInstanceKey));
+    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo(jobRecordValue.getElementId());
+    assertThat(taskEntity.getBpmnProcessId()).isEqualTo(jobRecordValue.getBpmnProcessId());
+    assertThat(taskEntity.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(jobRecordValue.getProcessDefinitionKey()));
+    assertThat(taskEntity.getProcessDefinitionVersion())
+        .isEqualTo(jobRecordValue.getProcessDefinitionVersion());
+    assertThat(taskEntity.getFormKey()).isEqualTo(formKey);
+    assertThat(taskEntity.getExternalFormReference()).isNull();
+    assertThat(taskEntity.getCustomHeaders()).isNull();
+    assertThat(taskEntity.getPriority()).isNull();
+    assertThat(taskEntity.getAction()).isNull();
+    assertThat(taskEntity.getDueDate()).isEqualTo(dateTime);
+    assertThat(taskEntity.getFollowUpDate()).isEqualTo(dateTime);
+    assertThat(Arrays.stream(taskEntity.getCandidateGroups()).toList())
+        .contains("group1", "group1");
+    assertThat(Arrays.stream(taskEntity.getCandidateUsers()).toList()).contains("user1", "user2");
+    assertThat(taskEntity.getAssignee()).isEqualTo(assignee);
+    assertThat(taskEntity.getJoin()).isNotNull();
+    assertThat(taskEntity.getJoin().getParent()).isEqualTo(jobRecordValue.getProcessInstanceKey());
+    assertThat(taskEntity.getJoin().getName()).isEqualTo(TaskJoinRelationshipType.TASK.getType());
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+    assertThat(taskEntity.getCreationTime())
+        .isEqualTo(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(jobRecord.getTimestamp())));
+    assertThat(taskEntity.getImplementation()).isEqualTo(TaskImplementation.JOB_WORKER);
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForCanceledIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CANCELED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CANCELED);
+    assertThat(taskEntity.getCompletionTime())
+        .isEqualTo(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(jobRecord.getTimestamp())));
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForCompletedIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.COMPLETED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.COMPLETED);
+    assertThat(taskEntity.getCompletionTime())
+        .isEqualTo(
+            ExporterUtil.toZonedOffsetDateTime(Instant.ofEpochMilli(jobRecord.getTimestamp())));
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForMigratedIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder().withProcessInstanceKey(processInstanceKey).build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.MIGRATED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+  }
+
+  @Test
+  void flushedEntityShouldContainMigratedData() {
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withProcessDefinitionKey(456L)
+            .withElementId("elementId")
+            .withBpmnProcessId("bpmnProcessId")
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.MIGRATED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.PROCESS_DEFINITION_ID, taskEntity.getProcessDefinitionId());
+    expectedUpdates.put(TaskTemplate.BPMN_PROCESS_ID, taskEntity.getBpmnProcessId());
+    expectedUpdates.put(TaskTemplate.FLOW_NODE_BPMN_ID, taskEntity.getFlowNodeBpmnId());
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+
+    // then
+    assertThat(taskEntity.getProcessDefinitionId())
+        .isEqualTo(String.valueOf(jobRecordValue.getProcessDefinitionKey()));
+    assertThat(taskEntity.getFlowNodeBpmnId()).isEqualTo(jobRecordValue.getElementId());
+    assertThat(taskEntity.getBpmnProcessId()).isEqualTo(jobRecordValue.getBpmnProcessId());
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void flushedEntityShouldContainCompletionUpdate() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder().withProcessInstanceKey(processInstanceKey).build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.COMPLETED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.COMPLETED);
+    expectedUpdates.put(TaskTemplate.COMPLETION_TIME, taskEntity.getCompletionTime());
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForFailedWithoutRetriesIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(0)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.FAILED);
+  }
+
+  @Test
+  void flushedEntityShouldContainFailedWithoutRetriesUpdate() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(0)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.FAILED);
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForFailedWithRetryBackoffIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(1)
+            .withRetryBackoff(100L)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.FAILED);
+  }
+
+  @Test
+  void flushedEntityShouldContainFailedWithRetryBackoffUpdate() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(1)
+            .withRetryBackoff(100L)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.FAILED);
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForFailedWithoutRetryBackoffIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(1)
+            .withRetryBackoff(0L)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+  }
+
+  @Test
+  void flushedEntityShouldContainFailedWithoutRetryBackoffUpdate() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .withRetries(1)
+            .withRetryBackoff(0L)
+            .withProcessInstanceKey(processInstanceKey)
+            .build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+
+  @Test
+  void shouldUpdateEntityFromRecordForRecurredAfterBackoffIntent() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder().withProcessInstanceKey(processInstanceKey).build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.RECURRED_AFTER_BACKOFF)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    // then
+    assertThat(taskEntity.getState()).isEqualTo(TaskState.CREATED);
+  }
+
+  @Test
+  void flushedEntityShouldContainRecurredAfterBackoffUpdate() {
+    // given
+    final long processInstanceKey = 123;
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder().withProcessInstanceKey(processInstanceKey).build();
+
+    final Record<JobRecordValue> jobRecord =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.RECURRED_AFTER_BACKOFF)
+                    .withValue(jobRecordValue)
+                    .withTimestamp(System.currentTimeMillis()));
+
+    // when
+    final TaskEntity taskEntity = new TaskEntity().setId("id");
+    underTest.updateEntity(jobRecord, taskEntity);
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(taskEntity, mockRequest);
+    final Map<String, Object> expectedUpdates = new HashMap<>();
+    expectedUpdates.put(TaskTemplate.STATE, TaskState.CREATED);
+
+    verify(mockRequest, times(1))
+        .upsertWithRouting(
+            indexName,
+            taskEntity.getId(),
+            taskEntity,
+            expectedUpdates,
+            taskEntity.getProcessInstanceId());
+  }
+}


### PR DESCRIPTION
## Description

Re-introduces the Job-based User Tasks in the new `camunda-exporter` to continue supporting the Tasklist (v1) API.

Please Note: The correct form handling will be implemented with a separate PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24665
