### PR TITLE
Migrate compensation boundary event subscriptions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -114,7 +114,7 @@ public class BpmnCompensationSubscriptionBehaviour {
             subscription -> subscription.getRecord().getCompensableActivityScopeKey() == scopeKey);
   }
 
-  private Optional<String> getCompensationHandlerId(final ExecutableActivity element) {
+  public Optional<String> getCompensationHandlerId(final ExecutableActivity element) {
     return element.getBoundaryEvents().stream()
         .map(ExecutableBoundaryEvent::getCompensation)
         .filter(Objects::nonNull)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -420,6 +420,18 @@ public class BpmnCompensationSubscriptionBehaviour {
             });
   }
 
+  public void deleteSubscriptionsOfProcessInstanceFilter(
+      final BpmnElementContext context,
+      final Predicate<CompensationSubscription> compensationSubscriptionFilter) {
+    // delete all compensation subscriptions of the process instance matching the filter
+    compensationSubscriptionState
+        .findSubscriptionsByProcessInstanceKey(
+            context.getTenantId(), context.getProcessInstanceKey())
+        .stream()
+        .filter(compensationSubscriptionFilter)
+        .forEach(this::appendCompensationSubscriptionDeleteEvent);
+  }
+
   public void deleteSubscriptionsOfProcessInstance(final BpmnElementContext context) {
     // delete all compensation subscriptions of the process instance
     compensationSubscriptionState

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
@@ -174,6 +174,20 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
           recordCopy.setProcessDefinitionKey(targetProcessDefinition.getKey());
           recordCopy.setCompensableActivityId(targetActivityId);
 
+          // set the compensation handler id if subscription belongs to an activity with a boundary
+          targetProcessDefinition
+              .getProcess()
+              .getElementById(targetActivityId, ExecutableActivity.class)
+              .getBoundaryEvents()
+              .stream()
+              .filter(event -> event.getEventType() == BpmnEventType.COMPENSATION)
+              .findFirst()
+              .ifPresent(
+                  boundary ->
+                      recordCopy.setCompensationHandlerId(
+                          BufferUtil.bufferAsString(
+                              boundary.getCompensation().getCompensationHandler().getId())));
+
           stateWriter.appendFollowUpEvent(
               subscription.getKey(), CompensationSubscriptionIntent.MIGRATED, recordCopy);
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationCatchEventBehaviour.java
@@ -10,12 +10,15 @@ package io.camunda.zeebe.engine.processing.processinstance;
 import static io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.requireNoPendingMsgSubMigrationDistribution;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnCompensationSubscriptionBehaviour;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.ProcessInstanceMigrationPreconditionFailedException;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.DistributionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessMessageSubscriptionState;
@@ -24,16 +27,20 @@ import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.engine.state.routing.RoutingInfo;
 import io.camunda.zeebe.engine.state.signal.SignalSubscription;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,6 +52,7 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
 
   private final ProcessMessageSubscriptionState processMessageSubscriptionState;
   private final CatchEventBehavior catchEventBehavior;
+  private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
   private final TypedCommandWriter commandWriter;
   private final CommandDistributionBehavior commandDistributionBehavior;
   private final DistributionState distributionState;
@@ -55,6 +63,7 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
   public ProcessInstanceMigrationCatchEventBehaviour(
       final ProcessMessageSubscriptionState processMessageSubscriptionState,
       final CatchEventBehavior catchEventBehavior,
+      final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour,
       final TypedCommandWriter commandWriter,
       final CommandDistributionBehavior commandDistributionBehavior,
       final DistributionState distributionState,
@@ -63,6 +72,7 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
       final RoutingInfo routingInfo) {
     this.processMessageSubscriptionState = processMessageSubscriptionState;
     this.catchEventBehavior = catchEventBehavior;
+    this.compensationSubscriptionBehaviour = compensationSubscriptionBehaviour;
     this.commandWriter = commandWriter;
     this.commandDistributionBehavior = commandDistributionBehavior;
     this.distributionState = distributionState;
@@ -80,6 +90,7 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
   public void handleCatchEvents(
       final ElementInstance elementInstance,
       final DeployedProcess targetProcessDefinition,
+      final DeployedProcess sourceProcessDefinition,
       final Map<String, String> sourceElementIdToTargetElementId,
       final ProcessInstanceRecord elementInstanceRecord,
       final String targetElementId,
@@ -91,6 +102,14 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
         targetProcessDefinition
             .getProcess()
             .getElementById(targetElementId, ExecutableCatchEventSupplier.class);
+
+    if (elementInstanceRecord.getBpmnElementType() == BpmnElementType.PROCESS) {
+      handleCompensationCatchEvents(
+          targetProcessDefinition,
+          sourceProcessDefinition,
+          sourceElementIdToTargetElementId,
+          context);
+    }
 
     // UNSUBSCRIBE FROM CATCH EVENTS
     final List<ProcessMessageSubscription> processMessageSubscriptionsToMigrate =
@@ -123,6 +142,103 @@ public class ProcessInstanceMigrationCatchEventBehaviour {
         targetProcessDefinition, sourceElementIdToTargetElementId, timerInstancesToMigrate);
     migrateSignalEvents(
         targetProcessDefinition, sourceElementIdToTargetElementId, signalSubscriptionsToMigrate);
+  }
+
+  private void handleCompensationCatchEvents(
+      final DeployedProcess targetProcessDefinition,
+      final DeployedProcess sourceProcessDefinition,
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final BpmnElementContextImpl context) {
+    final List<CompensationSubscription> compensationSubscriptionsToMigrate =
+        unsubscribeFromCompensationEvents(
+            sourceProcessDefinition, sourceElementIdToTargetElementId, context);
+    // DO NOT SUBSCRIBE TO UNMAPPED COMPENSATION EVENTS AS THEY ARE CREATED ON ELEMENT COMPLETION
+    migrateCompensationEvents(
+        targetProcessDefinition,
+        sourceElementIdToTargetElementId,
+        compensationSubscriptionsToMigrate);
+  }
+
+  private void migrateCompensationEvents(
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final List<CompensationSubscription> compensationSubscriptionsToMigrate) {
+    compensationSubscriptionsToMigrate.forEach(
+        subscription -> {
+          final var sourceActivityId = subscription.getRecord().getCompensableActivityId();
+          final var targetActivityId = sourceElementIdToTargetElementId.get(sourceActivityId);
+
+          final var compensationSubscriptionRecord = subscription.getRecord();
+          final var recordCopy = new CompensationSubscriptionRecord();
+          recordCopy.wrap(compensationSubscriptionRecord);
+          recordCopy.setProcessDefinitionKey(targetProcessDefinition.getKey());
+          recordCopy.setCompensableActivityId(targetActivityId);
+
+          stateWriter.appendFollowUpEvent(
+              subscription.getKey(), CompensationSubscriptionIntent.MIGRATED, recordCopy);
+        });
+  }
+
+  private List<CompensationSubscription> unsubscribeFromCompensationEvents(
+      final DeployedProcess sourceProcessDefinition,
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final BpmnElementContextImpl context) {
+    final List<CompensationSubscription> compensationSubscriptionsToMigrate = new ArrayList<>();
+    compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstanceFilter(
+        context,
+        compensationSubscription -> {
+          final String compensableActivityId =
+              compensationSubscription.getRecord().getCompensableActivityId();
+          final ExecutableActivity compensableActivity =
+              sourceProcessDefinition
+                  .getProcess()
+                  .getElementById(compensableActivityId, ExecutableActivity.class);
+
+          final boolean shouldBeMigrated =
+              shouldCompensationBeMigrated(
+                  sourceElementIdToTargetElementId, compensableActivity, compensableActivityId);
+
+          if (shouldBeMigrated) {
+            // We will migrate this mapped catch event, so we don't want to unsubscribe from it.
+            // Avoid reusing the subscription directly as any access to the state (e.g. #get) will
+            // overwrite it
+            final var copy = new CompensationSubscription();
+            copy.copyFrom(compensationSubscription);
+            compensationSubscriptionsToMigrate.add(copy);
+
+            return false;
+          }
+
+          return true;
+        });
+
+    return compensationSubscriptionsToMigrate;
+  }
+
+  private static boolean shouldCompensationBeMigrated(
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final ExecutableActivity compensableActivity,
+      final String compensableActivityId) {
+    if (compensableActivity.getElementType() == BpmnElementType.SUB_PROCESS) {
+      return sourceElementIdToTargetElementId.containsKey(
+          BufferUtil.bufferAsString(compensableActivity.getId()));
+    } else {
+      // compensable activity is a task
+      final var compensationBoundaryEvent =
+          compensableActivity.getEvents().stream()
+              .filter(event -> event.getEventType() == BpmnEventType.COMPENSATION)
+              .findFirst()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          String.format(
+                              "Expected to find a compensation event for activity '%s' but not found.",
+                              compensableActivityId)));
+      return sourceElementIdToTargetElementId.containsKey(
+              BufferUtil.bufferAsString(compensableActivity.getId()))
+          && sourceElementIdToTargetElementId.containsKey(
+              BufferUtil.bufferAsString(compensationBoundaryEvent.getId()));
+    }
   }
 
   private void migrateSignalEvents(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -100,6 +100,7 @@ public class ProcessInstanceMigrationMigrateProcessor
         new ProcessInstanceMigrationCatchEventBehaviour(
             processingState.getProcessMessageSubscriptionState(),
             bpmnBehaviors.catchEventBehavior(),
+            bpmnBehaviors.compensationSubscriptionBehaviour(),
             writers.command(),
             commandDistributionBehavior,
             processingState.getDistributionState(),
@@ -251,7 +252,8 @@ public class ProcessInstanceMigrationMigrateProcessor
             BpmnEventType.TIMER,
             BpmnEventType.SIGNAL,
             BpmnEventType.ERROR,
-            BpmnEventType.ESCALATION));
+            BpmnEventType.ESCALATION,
+            BpmnEventType.COMPENSATION));
     requireNoBoundaryEventInTarget(
         targetProcessDefinition,
         targetElementId,
@@ -261,7 +263,8 @@ public class ProcessInstanceMigrationMigrateProcessor
             BpmnEventType.TIMER,
             BpmnEventType.SIGNAL,
             BpmnEventType.ERROR,
-            BpmnEventType.ESCALATION));
+            BpmnEventType.ESCALATION,
+            BpmnEventType.COMPENSATION));
     requireMappedCatchEventsToStayAttachedToSameElement(
         processInstanceKey,
         sourceProcessDefinition,
@@ -372,6 +375,7 @@ public class ProcessInstanceMigrationMigrateProcessor
       migrationCatchEventBehaviour.handleCatchEvents(
           elementInstance,
           targetProcessDefinition,
+          sourceProcessDefinition,
           sourceElementIdToTargetElementId,
           elementInstanceRecord,
           targetElementId,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionMigratedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+
+public class CompensationSubscriptionMigratedApplier
+    implements TypedEventApplier<CompensationSubscriptionIntent, CompensationSubscriptionRecord> {
+
+  private final MutableCompensationSubscriptionState compensationState;
+
+  public CompensationSubscriptionMigratedApplier(
+      final MutableCompensationSubscriptionState compensationState) {
+    this.compensationState = compensationState;
+  }
+
+  @Override
+  public void applyState(final long key, final CompensationSubscriptionRecord value) {
+    compensationState.update(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -423,6 +423,10 @@ public final class EventAppliers implements EventApplier {
         CompensationSubscriptionIntent.DELETED,
         new CompensationSubscriptionDeletedApplier(
             processingState.getCompensationSubscriptionState()));
+    register(
+        CompensationSubscriptionIntent.MIGRATED,
+        new CompensationSubscriptionMigratedApplier(
+            processingState.getCompensationSubscriptionState()));
   }
 
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCompensationSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCompensationSubscriptionTest.java
@@ -94,7 +94,6 @@ public class MigrateCompensationSubscriptionTest {
         .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
         .addMappingInstruction("B", "D")
         .addMappingInstruction("A", "C")
-        .addMappingInstruction("boundary1", "boundary2")
         .migrate();
 
     // then
@@ -196,7 +195,6 @@ public class MigrateCompensationSubscriptionTest {
         .addMappingInstruction("B", "D")
         .addMappingInstruction("subProcess1", "subProcess2")
         .addMappingInstruction("A", "C")
-        .addMappingInstruction("boundary1", "boundary2")
         .migrate();
 
     // then

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCompensationSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCompensationSubscriptionTest.java
@@ -1,0 +1,520 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateCompensationSubscriptionTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteCompensationMigratedEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoA", t -> t.zeebeJobType("undoA"))))
+                    .moveToActivity("A")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("C", t -> t.zeebeJobType("C"))
+                    .boundaryEvent(
+                        "boundary2",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoC", t -> t.zeebeJobType("undoC"))))
+                    .moveToActivity("C")
+                    .serviceTask("D", t -> t.zeebeJobType("D"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("C"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    RecordingExporter.compensationSubscriptionRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(CompensationSubscriptionIntent.CREATED)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B", "D")
+        .addMappingInstruction("A", "C")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the process instance is migrated")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("C")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoA");
+
+    engine.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.TRIGGERED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst())
+        .describedAs("Expect that the compensation boundary event in the source is deleted")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldWriteCompensationMigratedEventForCompensationInsideSubprocess() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .subProcess("subProcess1")
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoA", t -> t.zeebeJobType("undoA"))))
+                    .moveToActivity("A")
+                    .endEvent()
+                    .subProcessDone()
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", AbstractThrowEventBuilder::compensateEventDefinition)
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess("subProcess2")
+                    .embeddedSubProcess()
+                    .startEvent()
+                    .serviceTask("C", t -> t.zeebeJobType("C"))
+                    .boundaryEvent(
+                        "boundary2",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoC", t -> t.zeebeJobType("undoC"))))
+                    .moveToActivity("C")
+                    .endEvent()
+                    .subProcessDone()
+                    .serviceTask("D", t -> t.zeebeJobType("D"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", AbstractThrowEventBuilder::compensateEventDefinition)
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    RecordingExporter.compensationSubscriptionRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(CompensationSubscriptionIntent.CREATED)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B", "D")
+        .addMappingInstruction("subProcess1", "subProcess2")
+        .addMappingInstruction("A", "C")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the process instance is migrated")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("C")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoA");
+
+    engine.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.TRIGGERED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(CompensationSubscriptionRecordValue::getCompensableActivityId)
+        .hasSize(2)
+        .containsExactly("subProcess2", "C");
+  }
+
+  @Test
+  public void shouldUnsubscribeFromCompensationEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoA", t -> t.zeebeJobType("undoA"))))
+                    .moveToActivity("A")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("C", t -> t.zeebeJobType("C"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final long sourceProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    RecordingExporter.compensationSubscriptionRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(CompensationSubscriptionIntent.CREATED)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B", "C")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the process instance is migrated")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(sourceProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("A")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoA")
+        .describedAs("Expect that the compensation boundary event in the source is deleted")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldSubscribeToCompensationEventAfterMigration() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoB", t -> t.zeebeJobType("undoB"))))
+                    .moveToActivity("B")
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the process instance is migrated")
+        .isNotNull();
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("B")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoB")
+        .describedAs("Expect that the compensation boundary event in the source is created")
+        .isNotNull();
+
+    engine.job().ofInstance(processInstanceKey).withType("undoB").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the compensation boundary event in the target is completed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("B")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoB")
+        .describedAs("Expect that the compensation boundary event in the source is created")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldNotSubscribeToUnMappedCompensationEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoA", t -> t.zeebeJobType("undoA"))))
+                    .moveToActivity("A")
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("C", t -> t.zeebeJobType("C"))
+                    .boundaryEvent(
+                        "boundary2",
+                        b ->
+                            b.compensation(
+                                c -> c.serviceTask("undoC", t -> t.zeebeJobType("undoC"))))
+                    .moveToActivity("C")
+                    .serviceTask("D", t -> t.zeebeJobType("D"))
+                    .intermediateThrowEvent(
+                        "boundary_throw", ic -> ic.compensateEventDefinition().activityRef("C"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final long sourceProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    engine.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    RecordingExporter.compensationSubscriptionRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .withIntent(CompensationSubscriptionIntent.CREATED)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B", "D")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the process instance is migrated")
+        .isNotNull();
+
+    Assertions.assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withIntent(CompensationSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(sourceProcessDefinitionKey)
+        .describedAs("Expect that the compensable activity is updated")
+        .hasCompensableActivityId("A")
+        .describedAs("Expect that the compensation handler id is unchanged")
+        .hasCompensationHandlerId("undoA")
+        .describedAs("Expect that the compensation boundary event in the source is deleted")
+        .isNotNull();
+
+    engine.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("boundary_throw")
+                .exists())
+        .describedAs("Expect that the compensation throw event is completed")
+        .isTrue();
+
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .withIntent(CompensationSubscriptionIntent.CREATED)
+                .skip(1) // skip the first one, which is created for the source process
+                .exists())
+        .describedAs("Expect that the compensation boundary event in the target is not created")
+        .isFalse();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CompensationSubscriptionIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CompensationSubscriptionIntent.java
@@ -19,7 +19,8 @@ public enum CompensationSubscriptionIntent implements Intent {
   CREATED((short) 0),
   TRIGGERED((short) 1),
   COMPLETED((short) 2),
-  DELETED((short) 3);
+  DELETED((short) 3),
+  MIGRATED((short) 4);
 
   private final short value;
 
@@ -37,6 +38,8 @@ public enum CompensationSubscriptionIntent implements Intent {
         return COMPLETED;
       case 3:
         return DELETED;
+      case 4:
+        return MIGRATED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Check related issue #24377 and commit messages for details.

Please note that there is no validation for compensation subscription mappings. Those rejection cases will be implemented in a separate PR.

## Related issues

closes #24377 
