### PR TITLE
ci: do not auto-merge release PRs

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -439,7 +439,7 @@ jobs:
     if: |
       github.repository == 'camunda/camunda' &&
       github.event_name == 'pull_request' &&
-      (github.actor == 'backport-action' || github.actor == 'camundait')
+      (github.actor == 'backport-action')
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
## Description

As in that case author equals approver and approval will thus fail.

See e.g. https://github.com/camunda/camunda/actions/runs/11711592864/job/32620917786?pr=24437
```
failed to create review: GraphQL: Can not approve your own pull request (addPullRequestReview)
```

The failure also blocks merge as the `Auto-merge backport and release PRs` step is part of the zeebe ci.
I would thus disable auto-merge for release PRs for now until we have separate access tokens for creating and approving the release PRs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates #20675
