### PR TITLE
fix: rework java_home handling in c8run

### DIFF
--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -161,6 +161,7 @@ if [ "$1" = "start" ] ; then
 
   # limit the java heapspace used by ElasticSearch to 1GB
   export ES_JAVA_OPTS="-Xms1g -Xmx1g"
+  export ES_JAVA_HOME="$JAVA_HOME"
 
   echo
   echo "Starting Elasticsearch ${ELASTICSEARCH_VERSION}...";

--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -126,7 +126,7 @@ if [ "$1" = "start" ] ; then
       JAVA="java"
     fi
     # We want to set JAVA_HOME so that we can set elasticsearch to use JAVA_HOME
-    export JAVA_HOME=$(which $JAVA | xargs dirname | xargs dirname)
+    export JAVA_HOME=$(which "$JAVA" | xargs dirname | xargs dirname)
   fi
 
   if [ "x$JAVA_OPTS" != "x" ]; then
@@ -166,8 +166,8 @@ if [ "$1" = "start" ] ; then
   echo "(Hint: you can find the log output in the 'elasticsearch.log' file in the 'log' folder of your distribution.)"
   echo
   ELASTICSEARCH_LOG_FILE=$PARENTDIR/log/elasticsearch.log
-  $PARENTDIR/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch -E xpack.ml.enabled=false -E xpack.security.enabled=false </dev/null > "$ELASTICSEARCH_LOG_FILE" 2>&1 &
-  echo $! > $ELASTIC_PID_PATH
+  "$PARENTDIR/elasticsearch-${ELASTICSEARCH_VERSION}/bin/elasticsearch" -E xpack.ml.enabled=false -E xpack.security.enabled=false </dev/null > "$ELASTICSEARCH_LOG_FILE" 2>&1 &
+  echo $! > "$ELASTIC_PID_PATH"
 
 
   function checkStartup {
@@ -215,25 +215,25 @@ Please stop it or remove the file $PID_PATH."
       exit 1
     fi
 
-    pushd $PARENTDIR/camunda-zeebe-$CAMUNDA_VERSION/
-    echo ./bin/camunda $extraArgs >> $PARENTDIR/log/camunda.log 2>> $PARENTDIR/log/camunda.log &
-    ./bin/camunda $extraArgs >> $PARENTDIR/log/camunda.log 2>> $PARENTDIR/log/camunda.log &
+    pushd "$PARENTDIR/camunda-zeebe-$CAMUNDA_VERSION/"
+    echo ./bin/camunda $extraArgs >> "$PARENTDIR/log/camunda.log" 2>> "$PARENTDIR/log/camunda.log" &
+    ./bin/camunda $extraArgs >> "$PARENTDIR/log/camunda.log" 2>> "$PARENTDIR/log/camunda.log" &
     echo $! > "$PID_PATH"
     popd
 
-    $JAVA -cp "$PARENTDIR/*:$PARENTDIR/custom_connectors/*:./camunda-zeebe-$CAMUNDA_VERSION/lib/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication" --spring.config.location=./connectors-application.properties >> $PARENTDIR/log/connectors.log 2>> $PARENTDIR/log/connectors.log &
+    "$JAVA" -cp "$PARENTDIR/*:$PARENTDIR/custom_connectors/*:./camunda-zeebe-$CAMUNDA_VERSION/lib/*" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication" --spring.config.location=./connectors-application.properties >> "$PARENTDIR/log/connectors.log" 2>> "$PARENTDIR/log/connectors.log" &
     echo $! > "$CONNECTORS_PID_PATH"
     if [ -s "$POLLING_CAMUNDA_PID_PATH" ]; then
       wait $(cat "$POLLING_CAMUNDA_PID_PATH")
     fi
     cat endpoints.txt
   else
-    $JAVA -cp "$PARENTDIR/*:$PARENTDIR/custom_connectors/*:./camunda-zeebe-$CAMUNDA_VERSION/lib/*'" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication" --spring.config.location=./connectors-application.properties >> $PARENTDIR/log/connectors.log 2>> $PARENTDIR/log/connectors.log &
+    "$JAVA" -cp "$PARENTDIR/*:$PARENTDIR/custom_connectors/*:./camunda-zeebe-$CAMUNDA_VERSION/lib/*'" "io.camunda.connector.runtime.app.ConnectorRuntimeApplication" --spring.config.location=./connectors-application.properties >> "$PARENTDIR/log/connectors.log" 2>> "$PARENTDIR/log/connectors.log" &
     echo $! > "$CONNECTORS_PID_PATH"
 
-    pushd $PARENTDIR/camunda-zeebe-$CAMUNDA_VERSION/
-    echo ./bin/camunda $extraArgs 2>&1 | tee $PARENTDIR/log/camunda.log
-    ./bin/camunda $extraArgs 2>&1 | tee $PARENTDIR/log/camunda.log
+    pushd "$PARENTDIR/camunda-zeebe-$CAMUNDA_VERSION/"
+    echo ./bin/camunda $extraArgs 2>&1 | tee "$PARENTDIR/log/camunda.log"
+    ./bin/camunda $extraArgs 2>&1 | tee "$PARENTDIR/log/camunda.log"
     popd
   fi
 #   wait $(cat "$CONNECTORS_PID_PATH")

--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -112,23 +112,21 @@ trap childExitHandler SIGCHLD
 if [ "$1" = "start" ] ; then
   shift
   # setup the JVM
-  if [ "x$JAVA" = "x" ]; then
-    if [ "x$JAVA_HOME" != "x" ]; then
-      echo Setting JAVA property to "$JAVA_HOME/bin/java"
-      JAVA="$JAVA_HOME/bin/java"
-    else
-      echo JAVA_HOME is not set. Unexpected results may occur.
-      echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
+  if [ "x$JAVA_HOME" != "x" ]; then
+
+    # turns out not all java installations put the binary in bin/java . so this should be a find command.
+    if [ "x$JAVA" == "x" ]; then
+      JAVA=$(find "$JAVA_HOME" -name "java" | head -n 1)
+      echo Setting JAVA property to "$JAVA" in "$JAVA_HOME"
+    fi
+  else
+    echo JAVA_HOME is not set. Unexpected results may occur.
+    echo Set JAVA_HOME to the directory of your local JDK to avoid this message.
+    if [ "x$JAVA" == "x" ]; then
       JAVA="java"
     fi
-  fi
-
-  JAVA_VERSION=$("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^0\./s///' | cut -d'.' -f1)
-  echo Java version is $("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2)
-  if [[ "$JAVA_VERSION" -lt "$EXPECTED_JAVA_VERSION" ]]; then
-    echo "You must use at least JDK $EXPECTED_JAVA_VERSION to start Camunda Platform Run."
-    childExitHandler $$ 1
-    exit 1
+    # We want to set JAVA_HOME so that we can set elasticsearch to use JAVA_HOME
+    export JAVA_HOME=$(which $JAVA | xargs dirname | xargs dirname)
   fi
 
   if [ "x$JAVA_OPTS" != "x" ]; then

--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -129,6 +129,15 @@ if [ "$1" = "start" ] ; then
     export JAVA_HOME=$(which "$JAVA" | xargs dirname | xargs dirname)
   fi
 
+  JAVA_VERSION=$("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2 | sed '/^0\./s///' | cut -d'.' -f1)
+  echo Java version is $("$JAVA" -version 2>&1 | head -1 | cut -d'"' -f2)
+
+  if [[ "$JAVA_VERSION" -lt "$EXPECTED_JAVA_VERSION" ]]; then
+    echo "You must use at least JDK $EXPECTED_JAVA_VERSION to start Camunda Platform Run."
+    childExitHandler $$ 1
+    exit 1
+  fi
+
   if [ "x$JAVA_OPTS" != "x" ]; then
     echo JAVA_OPTS: $JAVA_OPTS
   fi

--- a/c8run/internal/run.sh
+++ b/c8run/internal/run.sh
@@ -116,7 +116,7 @@ if [ "$1" = "start" ] ; then
 
     # turns out not all java installations put the binary in bin/java . so this should be a find command.
     if [ "x$JAVA" == "x" ]; then
-      JAVA=$(find "$JAVA_HOME" -name "java" | head -n 1)
+      JAVA=$(find -L "$JAVA_HOME" -name "java" | head -n 1)
       echo Setting JAVA property to "$JAVA" in "$JAVA_HOME"
     fi
   else

--- a/c8run/start.sh
+++ b/c8run/start.sh
@@ -86,10 +86,10 @@ if [ $# -eq 0 ]; then
   fi
 
   # start Camunda Run in the foreground
-  exec $runScript start
+  exec "$runScript" start
 
 else
   # start Camunda Run with the passed arguments
-  exec $runScript start "$@"
+  exec "$runScript" start "$@"
 fi
 

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -171,6 +171,12 @@ func main() {
 
         javaHome := os.Getenv("JAVA_HOME")
 	javaBinary := "java"
+        javaHomeAfterSymlink, err := filepath.EvalSymlinks(javaHome)
+        if err != nil {
+                fmt.Println("Failed to check if filepath is a symlink")
+                os.Exit(1)
+        }
+        javaHome = javaHomeAfterSymlink
         if javaHome != "" {
                 filepath.Walk(javaHome, func(path string, info os.FileInfo, err error) error {
                         _, filename := filepath.Split(path)

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -251,8 +251,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		elasticsearchCmdString := filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat") + " -E xpack.ml.enabled=false -E xpack.security.enabled=false"
-		elasticsearchCmd := exec.Command("cmd", "/C", elasticsearchCmdString)
+		elasticsearchCmd := exec.Command(filepath.Join(parentDir, "elasticsearch-"+elasticsearchVersion, "bin", "elasticsearch.bat"), "-E", "xpack.ml.enabled=false", "-E", "xpack.security.enabled=false")
 
 		elasticsearchCmd.SysProcAttr = &syscall.SysProcAttr{
 			CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
@@ -300,9 +299,7 @@ func main() {
 		} else {
 			extraArgs = "--spring.config.location=" + filepath.Join(parentDir, "configuration")
 		}
-		camundaCmdString := parentDir + "\\camunda-zeebe-" + camundaVersion + "\\bin\\camunda " + extraArgs
-		fmt.Println(camundaCmdString)
-		camundaCmd := exec.Command("cmd", "/C", camundaCmdString)
+		camundaCmd := exec.Command(parentDir + "\\camunda-zeebe-" + camundaVersion + "\\bin\\camunda", extraArgs)
 		camundaLogPath := filepath.Join(parentDir, "log", "camunda.log")
 		camundaLogFile, err := os.OpenFile(camundaLogPath, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -185,6 +185,15 @@ func main() {
                 if javaBinary == "" {
 	                javaBinary = filepath.Join(javaHome, "bin", "java.exe")
                 }
+        } else {
+                path, err := exec.LookPath("java")
+                if err == nil {
+                        fmt.Println("Failed to find JAVA_HOME or java program.")
+                        os.Exit(1)
+                }
+
+                // go up 2 directories since it's not guaranteed that java is in a bin folder
+                javaHome = filepath.Dir(filepath.Dir(path))
         }
         os.Setenv("ES_JAVA_HOME", javaHome)
 

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -271,7 +271,7 @@ func main() {
 		elasticsearchPidFile.Write([]byte(strconv.Itoa(elasticsearchCmd.Process.Pid)))
 		queryElasticsearchHealth("Elasticsearch", "http://localhost:9200/_cluster/health?wait_for_status=green&wait_for_active_shards=all&wait_for_no_initializing_shards=true&timeout=120s")
 
-		connectorsCmd := exec.Command(javaBinary, "-classpath", parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\*", "io.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.location=" + parentDir + "\\connectors-application.properties")
+		connectorsCmd := exec.Command(javaBinary, "-classpath", parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\*", "io.camunda.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.location=" + parentDir + "\\connectors-application.properties")
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		connectorsLogFile, err := os.OpenFile(connectorsLogPath, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -201,7 +201,7 @@ func main() {
 	if baseCommand == "start" {
 		javaVersion := os.Getenv("JAVA_VERSION")
 		if javaVersion == "" {
-			javaVersionCmd := exec.Command("cmd", "/C", "\"" + javaBinary + "\"" + " --version")
+			javaVersionCmd := exec.Command(javaBinary, "--version")
 			var out strings.Builder
                         var stderr strings.Builder
 			javaVersionCmd.Stdout = &out
@@ -272,8 +272,7 @@ func main() {
 		elasticsearchPidFile.Write([]byte(strconv.Itoa(elasticsearchCmd.Process.Pid)))
 		queryElasticsearchHealth("Elasticsearch", "http://localhost:9200/_cluster/health?wait_for_status=green&wait_for_active_shards=all&wait_for_no_initializing_shards=true&timeout=120s")
 
-		connectorsCmdString := "\"" + javaBinary + "\"" + " -classpath " + parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\* io.camunda.connector.runtime.app.ConnectorRuntimeApplication --spring.config.location=" + parentDir + "\\connectors-application.properties"
-		connectorsCmd := exec.Command("cmd", "/C", connectorsCmdString)
+		connectorsCmd := exec.Command(javaBinary, "-classpath", parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\*", "io.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.location=" + parentDir + "\\connectors-application.properties")
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		connectorsLogFile, err := os.OpenFile(connectorsLogPath, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -172,43 +172,24 @@ func main() {
         javaHome := os.Getenv("JAVA_HOME")
 	javaBinary := "java"
         if javaHome != "" {
-	        javaBinary = filepath.Join(javaHome, "bin", "java")
+                var javaBinary string
+                filepath.Walk(javaHome, func(path string, info os.FileInfo, err error) error {
+                        _, filename := filepath.Split(path)
+                        if strings.Compare(filename, "java.exe") == 0 || strings.Compare(filename, "java") == 0 {
+                                javaBinary = path
+                                return filepath.SkipAll
+                        }
+                        return nil
+
+                })
+                // fallback to bin/java.exe
+                if javaBinary == "" {
+	                javaBinary = filepath.Join(javaHome, "bin", "java.exe")
+                }
         }
+        os.Setenv("ES_JAVA_HOME", javaHome)
 
 	if baseCommand == "start" {
-		javaVersion := os.Getenv("JAVA_VERSION")
-		if javaVersion == "" {
-			javaVersionCmd := exec.Command("cmd", "/C", javaBinary + " --version")
-			var out strings.Builder
-                        var stderr strings.Builder
-			javaVersionCmd.Stdout = &out
-			javaVersionCmd.Stderr = &stderr
-			javaVersionCmd.Run()
-                        javaVersionOutput := out.String()
-			javaVersionOutputSplit := strings.Split(javaVersionOutput, " ")
-			if len(javaVersionOutputSplit) < 2 {
-				fmt.Println("Java needs to be installed. Please install JDK " + strconv.Itoa(expectedJavaVersion) + " or newer.")
-				fmt.Println("If java is already installed, try explicitly setting JAVA_HOME and JAVA_VERSION")
-				os.Exit(1)
-			}
-			output := javaVersionOutputSplit[1]
-			os.Setenv("JAVA_VERSION", output)
-			javaVersion = output
-		}
-		fmt.Print("Java version is " + javaVersion + "\n")
-
-		versionSplit := strings.Split(javaVersion, ".")
-		if len(versionSplit) == 0 {
-			fmt.Println("Java needs to be installed. Please install JDK " + strconv.Itoa(expectedJavaVersion) + " or newer.")
-			os.Exit(1)
-		}
-		javaMajorVersion := versionSplit[0]
-		javaMajorVersionInt, _ := strconv.Atoi(javaMajorVersion)
-		if javaMajorVersionInt < expectedJavaVersion {
-			fmt.Print("You must use at least JDK " + strconv.Itoa(expectedJavaVersion) + " to start Camunda Platform Run.\n")
-			os.Exit(1)
-		}
-
 		javaOpts := os.Getenv("JAVA_OPTS")
 		if javaOpts != "" {
 			fmt.Print("JAVA_OPTS: " + javaOpts + "\n")

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -138,7 +138,6 @@ func main() {
 	// deploymentDir := filepath.Join(parentDir, "configuration", "resources")
 	elasticsearchVersion := "8.13.4"
 	camundaVersion := "8.6.2"
-	expectedJavaVersion := 21
 
 	elasticsearchPidPath := filepath.Join(baseDir, "elasticsearch.pid")
 	connectorsPidPath := filepath.Join(baseDir, "connectors.pid")

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -175,7 +175,6 @@ func main() {
                 filepath.Walk(javaHome, func(path string, info os.FileInfo, err error) error {
                         _, filename := filepath.Split(path)
                         if strings.Compare(filename, "java.exe") == 0 || strings.Compare(filename, "java") == 0 {
-                                fmt.Println("found file " + path)
                                 javaBinary = path
                                 return filepath.SkipAll
                         }
@@ -184,7 +183,6 @@ func main() {
                 })
                 // fallback to bin/java.exe
                 if javaBinary == "" {
-                        fmt.Println("using default filepath")
 	                javaBinary = filepath.Join(javaHome, "bin", "java.exe")
                 }
         }

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -299,7 +299,7 @@ func main() {
 		} else {
 			extraArgs = "--spring.config.location=" + filepath.Join(parentDir, "configuration")
 		}
-		camundaCmd := exec.Command(parentDir + "\\camunda-zeebe-" + camundaVersion + "\\bin\\camunda", extraArgs)
+		camundaCmd := exec.Command(".\\camunda-zeebe-" + camundaVersion + "\\bin\\camunda.bat", extraArgs)
 		camundaLogPath := filepath.Join(parentDir, "log", "camunda.log")
 		camundaLogFile, err := os.OpenFile(camundaLogPath, os.O_RDWR|os.O_CREATE, 0644)
 		if err != nil {

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -175,6 +175,7 @@ func main() {
                 filepath.Walk(javaHome, func(path string, info os.FileInfo, err error) error {
                         _, filename := filepath.Split(path)
                         if strings.Compare(filename, "java.exe") == 0 || strings.Compare(filename, "java") == 0 {
+                                fmt.Println("found file " + path)
                                 javaBinary = path
                                 return filepath.SkipAll
                         }
@@ -183,6 +184,7 @@ func main() {
                 })
                 // fallback to bin/java.exe
                 if javaBinary == "" {
+                        fmt.Println("using default filepath")
 	                javaBinary = filepath.Join(javaHome, "bin", "java.exe")
                 }
         }

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -172,7 +172,6 @@ func main() {
         javaHome := os.Getenv("JAVA_HOME")
 	javaBinary := "java"
         if javaHome != "" {
-                var javaBinary string
                 filepath.Walk(javaHome, func(path string, info os.FileInfo, err error) error {
                         _, filename := filepath.Split(path)
                         if strings.Compare(filename, "java.exe") == 0 || strings.Compare(filename, "java") == 0 {
@@ -195,13 +194,14 @@ func main() {
 
                 // go up 2 directories since it's not guaranteed that java is in a bin folder
                 javaHome = filepath.Dir(filepath.Dir(path))
+                javaBinary = path
         }
         os.Setenv("ES_JAVA_HOME", javaHome)
 
 	if baseCommand == "start" {
 		javaVersion := os.Getenv("JAVA_VERSION")
 		if javaVersion == "" {
-			javaVersionCmd := exec.Command("cmd", "/C", javaBinary + " --version")
+			javaVersionCmd := exec.Command("cmd", "/C", "\"" + javaBinary + "\"" + " --version")
 			var out strings.Builder
                         var stderr strings.Builder
 			javaVersionCmd.Stdout = &out
@@ -272,7 +272,7 @@ func main() {
 		elasticsearchPidFile.Write([]byte(strconv.Itoa(elasticsearchCmd.Process.Pid)))
 		queryElasticsearchHealth("Elasticsearch", "http://localhost:9200/_cluster/health?wait_for_status=green&wait_for_active_shards=all&wait_for_no_initializing_shards=true&timeout=120s")
 
-		connectorsCmdString := javaBinary + " -classpath " + parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\* io.camunda.connector.runtime.app.ConnectorRuntimeApplication --spring.config.location=" + parentDir + "\\connectors-application.properties"
+		connectorsCmdString := "\"" + javaBinary + "\"" + " -classpath " + parentDir + "\\*;" + parentDir + "\\custom_connectors\\*;" + parentDir + "\\camunda-zeebe-" + camundaVersion + "\\lib\\* io.camunda.connector.runtime.app.ConnectorRuntimeApplication --spring.config.location=" + parentDir + "\\connectors-application.properties"
 		connectorsCmd := exec.Command("cmd", "/C", connectorsCmdString)
 		connectorsLogPath := filepath.Join(parentDir, "log", "connectors.log")
 		connectorsLogFile, err := os.OpenFile(connectorsLogPath, os.O_RDWR|os.O_CREATE, 0644)

--- a/c8run/windows/c8run_windows.go
+++ b/c8run/windows/c8run_windows.go
@@ -188,7 +188,7 @@ func main() {
                 }
         } else {
                 path, err := exec.LookPath("java")
-                if err == nil {
+                if err != nil {
                         fmt.Println("Failed to find JAVA_HOME or java program.")
                         os.Exit(1)
                 }


### PR DESCRIPTION
## Description

related to https://github.com/camunda/camunda/issues/23126

There's been quite a few issues with different setups and JAVA_HOME .  Some people do not set JAVA_HOME, some JDKs install without a bin folder. Some people put spaces in their directory names. This PR hopes to reduce those errors by being stricter about quoting references to filepaths, and searching folders in JAVA_HOME for a java binary instead of assuming `./bin/java` will be there . previously windows required `JAVA_HOME` to be set. Now it works a bit better in cases where it's not set.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/24314
