### PR TITLE
[Backport stable/8.6] feature: when a follower fails to flush respond with error to leader

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -735,7 +735,14 @@ public class PassiveRole extends InactiveRole {
 
         final boolean failedToAppend = tryToAppend(future, entry, index, lastEntry);
         if (failedToAppend) {
-          flush(lastLogIndex - 1, request.prevLogIndex());
+          try {
+            flush(lastLogIndex - 1, request.prevLogIndex());
+          } catch (final Exception e) {
+            log.warn(
+                "Failed to flush when append failed: lastFlushedIndex={}, prevEntryIndex={}",
+                lastLogIndex - 1,
+                request.prevLogIndex());
+          }
           return;
         }
 
@@ -756,8 +763,18 @@ public class PassiveRole extends InactiveRole {
       log.trace("Committed entries up to index {}", commitIndex);
     }
 
-    // Make sure all entries are flushed before ack to ensure we have persisted what we acknowledge
-    flush(lastLogIndex, request.prevLogIndex());
+    try {
+      //     Make sure all entries are flushed before ack to ensure we have persisted what we
+      //     acknowledge
+      flush(lastLogIndex, request.prevLogIndex());
+    } catch (final Exception e) {
+      log.warn(
+          "Failed to flush appended entries to the log, cannot guarantee durability; leader will retry the append operation",
+          e);
+      // Flush failed, return error to the leader so we can retry.
+      failAppend(request.prevLogIndex(), future);
+      return;
+    }
 
     // Return a successful append response.
     succeedAppend(lastLogIndex, future);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftFlushErrorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftFlushErrorTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule.Configurator;
+import io.atomix.raft.RaftServer.Builder;
+import io.atomix.raft.RaftServer.Role;
+import io.atomix.raft.partition.RaftElectionConfig;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.RaftLogFlusher;
+import io.camunda.zeebe.journal.Journal;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RaftFlushErrorTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RaftFlushErrorTest.class);
+  private static final int MEMBERS = 3;
+  public AtomicBoolean isFaulty = new AtomicBoolean(false);
+  public AtomicInteger flushFailedCount = new AtomicInteger(0);
+
+  @Rule
+  public RaftRule raftRule =
+      RaftRule.withBootstrappedNodes(
+          MEMBERS,
+          new FaultyFlusherConfigurator(
+              (MEMBERS - 1) / 2, isFaulty::get, flushFailedCount::incrementAndGet));
+
+  @Test
+  public void shouldAppendEntryOnAllNodesWhenFollowerFailsFlush() throws Throwable {
+    final var leader = raftRule.getLeader().get();
+    // The number of failing nodes is less than the majority: (N - 1)/2;
+    final var failingNodes = (MEMBERS - 1) / 2;
+    // the leader must not be one of the failing nodes,
+    // the priority election config should avoid this happening.
+    assertThat(Integer.parseInt(leader.name())).isGreaterThan(failingNodes);
+
+    raftRule.appendEntry();
+
+    // when
+    // faulty nodes can't flush anymore
+    isFaulty.set(true);
+
+    // then
+    final var commitListener = raftRule.appendEntryAsync();
+    final var index = commitListener.awaitCommit(Duration.ofSeconds(5));
+
+    Awaitility.await("Flush failed for all faulty nodes at least once")
+        .until(
+            () -> {
+              System.out.println(flushFailedCount.get());
+              return flushFailedCount.get() > failingNodes;
+            });
+
+    // when
+    // the faulty nodes can flush again successfully
+    isFaulty.set(false);
+
+    // then
+    // all logs eventually converge
+    raftRule.awaitSameLogSizeOnAllNodes(index);
+
+    // all members are still registered
+    assertThat(raftRule.getMemberLogs().size()).isEqualTo(MEMBERS);
+    // all members are either LEADER or FOLLOWER
+    assertThat(
+            raftRule.getServers().stream()
+                .filter(s -> s.getRole() == Role.FOLLOWER || s.getRole() == Role.LEADER)
+                .count())
+        .isEqualTo(MEMBERS);
+  }
+
+  private static RaftLogFlusher.Factory faultyFlusher(
+      final Supplier<Boolean> faultyWhen, final Runnable notifyFaultyFlush) {
+    return (ignored) ->
+        new RaftLogFlusher() {
+          @Override
+          public void flush(final Journal journal) {
+            if (faultyWhen.get()) {
+              notifyFaultyFlush.run();
+              throw new RuntimeException(new IOException("Failed sync"));
+            } else {
+              journal.flush();
+            }
+          }
+        };
+  }
+
+  /**
+   * Set the first faultyFlusherNumber nodes with a faulty flusher, when the supplier returns true
+   */
+  private record FaultyFlusherConfigurator(
+      int faultyFlusherNumber, Supplier<Boolean> faultyWhen, Runnable notifyFaultyFlush)
+      implements Configurator {
+
+    @Override
+    public void configure(final MemberId id, final Builder builder) {
+      final var numericId = Integer.parseInt(id.id());
+      // Node priority is used to avoid the faulty nodes to become leaders
+      final int nodePriority;
+      if (numericId <= faultyFlusherNumber) {
+        LOG.trace("failing flusher for member {}", id);
+        final var storage = builder.storage;
+        Objects.requireNonNull(storage);
+        builder.withStorage(
+            RaftStorage.builder()
+                .withDirectory(storage.directory())
+                .withSnapshotStore(storage.getPersistedSnapshotStore())
+                .withFlusherFactory(faultyFlusher(faultyWhen, notifyFaultyFlush))
+                .build());
+        nodePriority = 1;
+      } else {
+        LOG.trace("not failing flusher for member {} ", id);
+        nodePriority = 5;
+      }
+      builder.withElectionConfig(RaftElectionConfig.ofPriorityElection(5, nodePriority));
+    }
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -487,6 +487,10 @@ public final class RaftRule extends ExternalResource {
   }
 
   public void awaitCommit(final long commitIndex) throws Exception {
+    awaitCommit(commitIndex, Duration.ofSeconds(30));
+  }
+
+  public void awaitCommit(final long commitIndex, final Duration timeout) throws Exception {
     if (highestCommit >= commitIndex) {
       return;
     }
@@ -494,7 +498,7 @@ public final class RaftRule extends ExternalResource {
     final var commitAwaiter = new CommitAwaiter(commitIndex);
     commitAwaiterRef.set(commitAwaiter);
 
-    commitAwaiter.awaitCommit();
+    commitAwaiter.awaitCommit(timeout);
   }
 
   private RaftServer createServer(final MemberId memberId, final Configurator configurator) {
@@ -530,7 +534,6 @@ public final class RaftRule extends ExternalResource {
             .withMaxSegmentSize(1024 * 10)
             .withFreeDiskSpace(100)
             .withSnapshotStore(snapshotStore);
-
     return builder.build();
   }
 
@@ -558,6 +561,15 @@ public final class RaftRule extends ExternalResource {
     final var leader = getLeader().orElseThrow();
 
     return appendEntry(leader, 1024);
+  }
+
+  public TestAppendListener appendEntryAsync() throws Exception {
+    final var raftRole = getLeader().orElseThrow().getContext().getRaftRole();
+    if (raftRole instanceof LeaderRole) {
+      return appendEntry(1024, (LeaderRole) raftRole);
+    } else {
+      throw new IllegalStateException("Expected Leader to be a LeaderRole, was: " + raftRole);
+    }
   }
 
   private long appendEntry(final RaftServer leader, final int entrySize) throws Exception {
@@ -641,29 +653,7 @@ public final class RaftRule extends ExternalResource {
     protocolFactory.heal(follower.cluster().getLocalMember().memberId());
   }
 
-  private static final class CommitAwaiter {
-
-    private final long awaitedIndex;
-    private final CountDownLatch latch = new CountDownLatch(1);
-
-    public CommitAwaiter(final long index) {
-      awaitedIndex = index;
-    }
-
-    public boolean reachedCommit(final long currentIndex) {
-      if (awaitedIndex <= currentIndex) {
-        latch.countDown();
-        return true;
-      }
-      return false;
-    }
-
-    public void awaitCommit() throws Exception {
-      latch.await(30, TimeUnit.SECONDS);
-    }
-  }
-
-  private static final class TestAppendListener implements ZeebeLogAppender.AppendListener {
+  public static final class TestAppendListener implements ZeebeLogAppender.AppendListener {
 
     private final CompletableFuture<Long> commitFuture = new CompletableFuture<>();
 
@@ -684,6 +674,36 @@ public final class RaftRule extends ExternalResource {
 
     public long awaitCommit() throws Exception {
       return commitFuture.get(30, TimeUnit.SECONDS);
+    }
+
+    public long awaitCommit(final Duration duration) throws Exception {
+      return commitFuture.get(duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private static final class CommitAwaiter {
+
+    private final long awaitedIndex;
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    public CommitAwaiter(final long index) {
+      awaitedIndex = index;
+    }
+
+    public boolean reachedCommit(final long currentIndex) {
+      if (awaitedIndex <= currentIndex) {
+        latch.countDown();
+        return true;
+      }
+      return false;
+    }
+
+    public void awaitCommit(final Duration timeout) throws Exception {
+      latch.await(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    public void awaitCommit() throws Exception {
+      latch.await(30, TimeUnit.SECONDS);
     }
   }
 


### PR DESCRIPTION
# Description
Backport of #24378 to `stable/8.6`.

relates to #14867
original author: @entangled90