### PR TITLE
deps: bump spring to fix CVE-2024-38821

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -97,7 +97,7 @@
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.1.14</version.spring>
-    <version.spring-security>6.2.4</version.spring-security>
+    <version.spring-security>6.2.7</version.spring-security>
     <version.spring-boot>3.2.7</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.6.2</version.kryo>


### PR DESCRIPTION
## Description

Bumps Spring Security to fix https://spring.io/security/cve-2024-38821

Note that this doesn't affect Zeebe as we don't use static resources, but nevertheless, doesn't cost anything to bump it.
