### PR TITLE
refactor: rename FormEntity.bpmnId to formId

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/FormEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/FormEntity.java
@@ -7,10 +7,14 @@
  */
 package io.camunda.webapps.schema.entities.tasklist;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 
 public class FormEntity extends TasklistEntity<FormEntity> {
+
+  @JsonProperty("bpmnId")
   private String formId;
+
   private String schema;
   private Long version;
   private Boolean isDeleted;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/FormEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/FormEntity.java
@@ -10,7 +10,7 @@ package io.camunda.webapps.schema.entities.tasklist;
 import java.util.Objects;
 
 public class FormEntity extends TasklistEntity<FormEntity> {
-  private String bpmnId;
+  private String formId;
   private String schema;
   private Long version;
   private Boolean isDeleted;
@@ -20,23 +20,23 @@ public class FormEntity extends TasklistEntity<FormEntity> {
   public FormEntity(
       final long key,
       final String tenantId,
-      final String bpmnId,
+      final String formId,
       final String schema,
       final Long version,
       final Boolean isDeleted) {
     super(String.valueOf(key), key, tenantId);
-    this.bpmnId = bpmnId;
+    this.formId = formId;
     this.schema = schema;
     this.version = version;
     this.isDeleted = isDeleted;
   }
 
-  public String getBpmnId() {
-    return bpmnId;
+  public String getFormId() {
+    return formId;
   }
 
-  public FormEntity setBpmnId(final String bpmnId) {
-    this.bpmnId = bpmnId;
+  public FormEntity setFormId(final String formId) {
+    this.formId = formId;
     return this;
   }
 
@@ -69,7 +69,7 @@ public class FormEntity extends TasklistEntity<FormEntity> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), bpmnId, schema, version, isDeleted);
+    return Objects.hash(super.hashCode(), formId, schema, version, isDeleted);
   }
 
   @Override
@@ -84,7 +84,7 @@ public class FormEntity extends TasklistEntity<FormEntity> {
       return false;
     }
     final FormEntity that = (FormEntity) o;
-    return Objects.equals(bpmnId, that.bpmnId)
+    return Objects.equals(formId, that.formId)
         && Objects.equals(schema, that.schema)
         && Objects.equals(version, that.version)
         && Objects.equals(isDeleted, that.isDeleted);
@@ -93,8 +93,8 @@ public class FormEntity extends TasklistEntity<FormEntity> {
   @Override
   public String toString() {
     return "FormEntity{"
-        + "bpmnId='"
-        + bpmnId
+        + "formId='"
+        + formId
         + '\''
         + ", schema='"
         + schema

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FormHandler.java
@@ -55,7 +55,7 @@ public class FormHandler implements ExportHandler<FormEntity, Form> {
     entity
         .setVersion((long) value.getVersion())
         .setKey(value.getFormKey())
-        .setBpmnId(value.getFormId())
+        .setFormId(value.getFormId())
         .setSchema(new String(value.getResource(), StandardCharsets.UTF_8))
         .setTenantId(value.getTenantId())
         .setIsDeleted(record.getIntent().name().equals(FormIntent.DELETED.name()));

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FormHandlerTest.java
@@ -114,7 +114,7 @@ public class FormHandlerTest {
     // then
     assertThat(formEntity.getKey()).isEqualTo(formKey);
     assertThat(formEntity.getVersion()).isEqualTo(formValue.getVersion());
-    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getFormId());
+    assertThat(formEntity.getFormId()).isEqualTo(formValue.getFormId());
     assertThat(formEntity.getSchema())
         .isEqualTo(new String(formValue.getResource(), StandardCharsets.UTF_8));
     assertThat(formEntity.getTenantId()).isEqualTo(formValue.getTenantId());
@@ -144,7 +144,7 @@ public class FormHandlerTest {
     assertThat(formEntity.getKey()).isEqualTo(formKey);
     assertThat(formEntity.getIsDeleted()).isTrue();
     assertThat(formEntity.getVersion()).isEqualTo(formValue.getVersion());
-    assertThat(formEntity.getBpmnId()).isEqualTo(formValue.getFormId());
+    assertThat(formEntity.getFormId()).isEqualTo(formValue.getFormId());
     assertThat(formEntity.getSchema())
         .isEqualTo(new String(formValue.getResource(), StandardCharsets.UTF_8));
     assertThat(formEntity.getTenantId()).isEqualTo(formValue.getTenantId());


### PR DESCRIPTION
## Description
Rename confusing FormEntity `bpmnId` to `formId`for the CamundaExporter.

Ref [thread](https://camunda.slack.com/archives/C06F0GLJNFM/p1730914284411179?thread_ts=1730888941.382889&cid=C06F0GLJNFM)
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
