### PR TITLE
feat: apply authorization check on GET decision definition endpoints

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -81,7 +81,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedDecisionDefinitions(
+  void searchShouldReturnAuthorizedDecisionDefinitions(
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // when
     final var decisionDefinitions = userClient.newDecisionDefinitionQuery().send().join().items();
@@ -93,7 +93,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnForbiddenForUnauthorizedDecisionDefinition(
+  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionDefinition(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
@@ -112,7 +112,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedDecisionDefinition(
+  void getByKeyShouldReturnAuthorizedDecisionDefinition(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
@@ -129,7 +129,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedDecisionRequirements(
+  void searchShouldReturnAuthorizedDecisionRequirements(
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // when
     final var decisionRequirements =
@@ -142,7 +142,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnForbiddenForUnauthorizedDecisionRequirements(
+  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionRequirements(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
@@ -162,7 +162,7 @@ class DecisionAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedDecisionRequirements(
+  void getByKeyShouldReturnAuthorizedDecisionRequirements(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionAuthorizationIT.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.application.Profile;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
+import io.camunda.it.utils.ZeebeClientTestFactory.Authenticated;
+import io.camunda.it.utils.ZeebeClientTestFactory.Permissions;
+import io.camunda.it.utils.ZeebeClientTestFactory.User;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class DecisionAuthorizationIT {
+
+  private static final String DECISION_DEFINITION_ID_1 = "decision_1";
+  private static final String DECISION_REQUIREMENTS_ID_1 = "definitions_1";
+  private static final String DECISION_DEFINITION_ID_2 = "test_qa";
+  private static final String DECISION_REQUIREMENTS_ID_2 = "definitions_test";
+  private static final String ADMIN = "admin";
+  private static final String RESTRICTED = "restricted-user";
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(DECISION_DEFINITION, READ, List.of("*")),
+              new Permissions(DECISION_REQUIREMENTS_DEFINITION, READ, List.of("*"))));
+  private static final User RESTRICTED_USER =
+      new User(
+          RESTRICTED,
+          "password",
+          List.of(
+              new Permissions(DECISION_DEFINITION, READ, List.of(DECISION_DEFINITION_ID_1)),
+              new Permissions(
+                  DECISION_REQUIREMENTS_DEFINITION, READ, List.of(DECISION_REQUIREMENTS_ID_1))));
+
+  @RegisterExtension
+  static final BrokerWithCamundaExporterITInvocationProvider PROVIDER =
+      new BrokerWithCamundaExporterITInvocationProvider()
+          .withAdditionalProfiles(Profile.AUTH_BASIC)
+          .withAuthorizationsEnabled()
+          .withUsers(ADMIN_USER, RESTRICTED_USER);
+
+  private boolean initialized;
+
+  @BeforeEach
+  void setUp(@Authenticated(ADMIN) final ZeebeClient adminClient) {
+    if (!initialized) {
+      final List<String> decisions = List.of("decision_model.dmn", "decision_model_1.dmn");
+      decisions.forEach(
+          decision -> deployResource(adminClient, String.format("decisions/%s", decision)));
+      waitForDecisionDefinitionsToBeDeployed(adminClient, decisions.size());
+      waitForDecisionRequirementsToBeDeployed(adminClient, decisions.size());
+      initialized = true;
+    }
+  }
+
+  @TestTemplate
+  void shouldReturnAuthorizedDecisionDefinitions(
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // when
+    final var decisionDefinitions = userClient.newDecisionDefinitionQuery().send().join().items();
+
+    // then
+    assertThat(decisionDefinitions).hasSize(1);
+    assertThat(decisionDefinitions.stream().map(p -> p.getDmnDecisionId()).toList())
+        .containsOnly(DECISION_DEFINITION_ID_1);
+  }
+
+  @TestTemplate
+  void shouldReturnForbiddenForUnauthorizedDecisionDefinition(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionDefinitionKey =
+        getDecisionDefinitionKey(adminClient, DECISION_DEFINITION_ID_2);
+
+    // when
+    final Executable executeGet =
+        () -> userClient.newDecisionDefinitionGetRequest(decisionDefinitionKey).send().join();
+
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo("Unauthorized to perform operation 'READ' on resource 'DECISION_DEFINITION'");
+  }
+
+  @TestTemplate
+  void shouldReturnAuthorizedDecisionDefinition(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionDefinitionKey =
+        getDecisionDefinitionKey(adminClient, DECISION_DEFINITION_ID_1);
+
+    // when
+    final var decisionDefinition =
+        userClient.newDecisionDefinitionGetRequest(decisionDefinitionKey).send().join();
+
+    // then
+    assertThat(decisionDefinition).isNotNull();
+    assertThat(decisionDefinition.getDmnDecisionId()).isEqualTo(DECISION_DEFINITION_ID_1);
+  }
+
+  @TestTemplate
+  void shouldReturnAuthorizedDecisionRequirements(
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // when
+    final var decisionRequirements =
+        userClient.newDecisionRequirementsQuery().send().join().items();
+
+    // then
+    assertThat(decisionRequirements).hasSize(1);
+    assertThat(decisionRequirements.stream().map(p -> p.getDmnDecisionRequirementsId()).toList())
+        .containsOnly(DECISION_REQUIREMENTS_ID_1);
+  }
+
+  @TestTemplate
+  void shouldReturnForbiddenForUnauthorizedDecisionRequirements(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionRequirementsKey =
+        getDecisionRequirementsKey(adminClient, DECISION_REQUIREMENTS_ID_2);
+
+    // when
+    final Executable executeGet =
+        () -> userClient.newDecisionRequirementsGetRequest(decisionRequirementsKey).send().join();
+
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'");
+  }
+
+  @TestTemplate
+  void shouldReturnAuthorizedDecisionRequirements(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionRequirementsKey =
+        getDecisionRequirementsKey(adminClient, DECISION_REQUIREMENTS_ID_1);
+
+    // when
+    final var decisionRequirements =
+        userClient.newDecisionRequirementsGetRequest(decisionRequirementsKey).send().join();
+
+    // then
+    assertThat(decisionRequirements).isNotNull();
+    assertThat(decisionRequirements.getDmnDecisionRequirementsId())
+        .isEqualTo(DECISION_REQUIREMENTS_ID_1);
+  }
+
+  private long getDecisionDefinitionKey(
+      final ZeebeClient client, final String decisionDefinitionId) {
+    return client
+        .newDecisionDefinitionQuery()
+        .filter(f -> f.decisionDefinitionId(decisionDefinitionId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getDecisionKey();
+  }
+
+  private long getDecisionRequirementsKey(
+      final ZeebeClient client, final String decisionRequirementsId) {
+    return client
+        .newDecisionRequirementsQuery()
+        .filter(f -> f.decisionRequirementsId(decisionRequirementsId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getDecisionRequirementsKey();
+  }
+
+  private DeploymentEvent deployResource(final ZeebeClient zeebeClient, final String resourceName) {
+    return zeebeClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .send()
+        .join();
+  }
+
+  private void waitForDecisionDefinitionsToBeDeployed(
+      final ZeebeClient zeebeClient, final int expectedCount) {
+    Awaitility.await("should deploy decision definitions and import in Operate")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = zeebeClient.newDecisionDefinitionQuery().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+
+  private void waitForDecisionRequirementsToBeDeployed(
+      final ZeebeClient zeebeClient, final int expectedCount) {
+    Awaitility.await("should deploy decision requirements and import in Operate")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = zeebeClient.newDecisionRequirementsQuery().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -74,7 +74,7 @@ class ProcessAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedProcessDefinitions(
+  void searchShouldReturnAuthorizedProcessDefinitions(
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // when
     final var processDefinitions = userClient.newProcessDefinitionQuery().send().join().items();
@@ -86,7 +86,7 @@ class ProcessAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnForbiddenForUnauthorizedProcessDefinition(
+  void getByKeyShouldReturnForbiddenForUnauthorizedProcessDefinition(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
@@ -104,7 +104,7 @@ class ProcessAuthorizationIT {
   }
 
   @TestTemplate
-  void shouldReturnAuthorizedProcessDefinition(
+  void getByKeShouldReturnAuthorizedProcessDefinition(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessAuthorizationIT.java
@@ -67,8 +67,7 @@ class ProcessAuthorizationIT {
       final List<String> processes =
           List.of("service_tasks_v1.bpmn", "service_tasks_v2.bpmn", "incident_process_v1.bpmn");
       processes.forEach(
-          process ->
-              deployResource(adminClient, String.format("process/%s", process)).getProcesses());
+          process -> deployResource(adminClient, String.format("process/%s", process)));
       waitForProcessesToBeDeployed(adminClient, processes.size());
       initialized = true;
     }

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -207,7 +207,7 @@ class DecisionQueryTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision Definition with decisionKey=%d not found".formatted(decisionKey));
+        .isEqualTo("Decision definition with key %d not found".formatted(decisionKey));
   }
 
   @Test
@@ -231,7 +231,7 @@ class DecisionQueryTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision Definition with decisionKey=%d not found".formatted(decisionKey));
+        .isEqualTo("Decision definition with key %d not found".formatted(decisionKey));
   }
 
   @Test
@@ -693,8 +693,7 @@ class DecisionQueryTest {
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Decision requirements with decisionRequirementsKey=%d not found"
-                .formatted(decisionRequirementsKey));
+            "Decision requirements with key %d not found".formatted(decisionRequirementsKey));
   }
 
   @Test

--- a/search/search-domain/src/main/java/io/camunda/search/query/DecisionRequirementsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/DecisionRequirementsQuery.java
@@ -41,8 +41,6 @@ public record DecisionRequirementsQuery(
         FilterBuilders.decisionRequirements().build();
     private static final DecisionRequirementsSort EMPTY_SORT =
         SortOptionBuilders.decisionRequirements().build();
-    private static final DecisionRequirementsQueryResultConfig EXCLUDE_XML_RESULT_CONFIG =
-        QueryResultConfigBuilders.decisionRequirements(r -> r.xml().exclude());
 
     private DecisionRequirementsFilter filter;
     private DecisionRequirementsSort sort;
@@ -95,7 +93,6 @@ public record DecisionRequirementsQuery(
     public DecisionRequirementsQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
       sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
-      resultConfig = Objects.requireNonNullElse(resultConfig, EXCLUDE_XML_RESULT_CONFIG);
       return new DecisionRequirementsQuery(filter, sort, page(), resultConfig);
     }
   }

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -13,13 +13,11 @@ import static io.camunda.search.query.SearchQueryBuilders.decisionRequirementsSe
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionDefinitionEntity;
-import io.camunda.search.entities.DecisionRequirementsEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.util.ObjectBuilder;
@@ -79,37 +77,32 @@ public final class DecisionDefinitionServices
     final Long decisionRequirementsKey = decisionDefinition.decisionRequirementsKey();
     final var decisionRequirementsQuery =
         decisionRequirementsSearchQuery(
-            q ->
-                q.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
-                    .resultConfig(r -> r.xml().include()));
-    return decisionRequirementSearchClient
-        .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
-        .searchDecisionRequirements(decisionRequirementsQuery)
-        .items()
-        .stream()
-        .findFirst()
-        .map(DecisionRequirementsEntity::xml)
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    "DecisionRequirements with decisionRequirementsKey=%d cannot be found"
-                        .formatted(decisionRequirementsKey)));
+            q -> q.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey)));
+    final var decisionRequirements =
+        getSingleResultOrThrow(
+            decisionRequirementSearchClient
+                .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+                .searchDecisionRequirements(decisionRequirementsQuery),
+            decisionRequirementsKey,
+            "Decision requirements");
+    return decisionRequirements.xml();
   }
 
   public DecisionDefinitionEntity getByKey(final long decisionKey) {
     final var result =
-        search(
-            decisionDefinitionSearchQuery(
-                q -> q.filter(f -> f.decisionDefinitionKeys(decisionKey))));
-    if (result.total() < 1) {
-      throw new NotFoundException(
-          "Decision Definition with decisionKey=%d not found".formatted(decisionKey));
-    } else if (result.total() > 1) {
-      throw new CamundaSearchException(
-          String.format("Found Decision Definition with key %d more than once", decisionKey));
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
+        decisionDefinitionSearchClient
+            .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+            .searchDecisionDefinitions(
+                decisionDefinitionSearchQuery(
+                    q -> q.filter(f -> f.decisionDefinitionKeys(decisionKey))));
+    final var decisionDefinitionEntity =
+        getSingleResultOrThrow(result, decisionKey, "Decision definition");
+    final var authorization = Authorization.of(a -> a.decisionDefinition().read());
+    if (!securityContextProvider.isAuthorized(
+        decisionDefinitionEntity.decisionId(), authentication, authorization)) {
+      throw new ForbiddenException(authorization);
     }
+    return decisionDefinitionEntity;
   }
 
   public CompletableFuture<BrokerResponse<DecisionEvaluationRecord>> evaluateDecision(

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -8,15 +8,16 @@
 package io.camunda.service;
 
 import static io.camunda.search.query.SearchQueryBuilders.decisionRequirementsSearchQuery;
+import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.entities.DecisionRequirementsEntity;
-import io.camunda.search.exception.CamundaSearchException;
-import io.camunda.search.exception.NotFoundException;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.util.ObjectBuilder;
@@ -51,22 +52,40 @@ public final class DecisionRequirementsServices
         .withSecurityContext(
             securityContextProvider.provideSecurityContext(
                 authentication, Authorization.of(a -> a.decisionRequirementsDefinition().read())))
-        .searchDecisionRequirements(query);
+        .searchDecisionRequirements(
+            decisionRequirementsSearchQuery(
+                q ->
+                    q.filter(query.filter())
+                        .sort(query.sort())
+                        .page(query.page())
+                        .resultConfig(
+                            ofNullable(query.resultConfig())
+                                .orElseGet(() -> defaultSearchResultConfig()))));
+  }
+
+  /**
+   * Default search result configuration excluding XML field to reduce the size of the response
+   * fetched from the database.
+   */
+  private DecisionRequirementsQueryResultConfig defaultSearchResultConfig() {
+    return DecisionRequirementsQueryResultConfig.of(r -> r.xml().exclude());
   }
 
   public DecisionRequirementsEntity getByKey(final Long key) {
-    final SearchQueryResult<DecisionRequirementsEntity> result =
-        search(
-            decisionRequirementsSearchQuery().filter(f -> f.decisionRequirementsKeys(key)).build());
-    if (result.total() < 1) {
-      throw new NotFoundException(
-          String.format("Decision requirements with decisionRequirementsKey=%d not found", key));
-    } else if (result.total() > 1) {
-      throw new CamundaSearchException(
-          String.format("Found decision requirements with key %d more than once", key));
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
+    final var result =
+        decisionRequirementSearchClient
+            .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+            .searchDecisionRequirements(
+                decisionRequirementsSearchQuery(
+                    q -> q.filter(f -> f.decisionRequirementsKeys(key))));
+    final var decisionRequirementsEntity =
+        getSingleResultOrThrow(result, key, "Decision requirements");
+    final var authorization = Authorization.of(a -> a.decisionRequirementsDefinition().read());
+    if (!securityContextProvider.isAuthorized(
+        decisionRequirementsEntity.decisionRequirementsId(), authentication, authorization)) {
+      throw new ForbiddenException(authorization);
     }
+    return decisionRequirementsEntity;
   }
 
   public SearchQueryResult<DecisionRequirementsEntity> search(
@@ -76,18 +95,6 @@ public final class DecisionRequirementsServices
   }
 
   public String getDecisionRequirementsXml(final Long decisionRequirementsKey) {
-    final var decisionRequirementsQuery =
-        decisionRequirementsSearchQuery(
-            q ->
-                q.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
-                    .resultConfig(r -> r.xml().include()));
-    return search(decisionRequirementsQuery).items().stream()
-        .findFirst()
-        .map(DecisionRequirementsEntity::xml)
-        .orElseThrow(
-            () ->
-                new NotFoundException(
-                    "Decision Requirements with decisionRequirementsKey=%d cannot be found"
-                        .formatted(decisionRequirementsKey)));
+    return getByKey(decisionRequirementsKey).xml();
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -24,32 +24,39 @@ import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public final class DecisionDefinitionServiceTest {
 
   private DecisionDefinitionServices services;
   private DecisionDefinitionSearchClient client;
   private DecisionRequirementSearchClient decisionRequirementSearchClient;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(DecisionDefinitionSearchClient.class);
     decisionRequirementSearchClient = mock(DecisionRequirementSearchClient.class);
+    securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
     when(decisionRequirementSearchClient.withSecurityContext(any()))
         .thenReturn(decisionRequirementSearchClient);
     services =
         new DecisionDefinitionServices(
             mock(BrokerClient.class),
-            mock(SecurityContextProvider.class),
+            securityContextProvider,
             client,
             decisionRequirementSearchClient,
-            null);
+            authentication);
   }
 
   @Test
@@ -74,6 +81,7 @@ public final class DecisionDefinitionServiceTest {
     // given
     final var definitionEntity = mock(DecisionDefinitionEntity.class);
     when(definitionEntity.decisionRequirementsKey()).thenReturn(42L);
+    when(definitionEntity.decisionId()).thenReturn("decId");
     when(client.searchDecisionDefinitions(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null));
 
@@ -81,6 +89,9 @@ public final class DecisionDefinitionServiceTest {
     when(requirementEntity.xml()).thenReturn("<foo>bar</foo>");
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(requirementEntity), null));
+    when(securityContextProvider.isAuthorized(
+            "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
+        .thenReturn(true);
 
     // when
     final var xml = services.getDecisionDefinitionXml(42L);
@@ -98,8 +109,7 @@ public final class DecisionDefinitionServiceTest {
     // then
     final var exception =
         assertThrows(NotFoundException.class, () -> services.getDecisionDefinitionXml(1L));
-    assertThat(exception.getMessage())
-        .isEqualTo("Decision Definition with decisionKey=1 not found");
+    assertThat(exception.getMessage()).isEqualTo("Decision definition with key 1 not found");
     verify(client).searchDecisionDefinitions(any(DecisionDefinitionQuery.class));
     verify(decisionRequirementSearchClient, never())
         .searchDecisionRequirements(any(DecisionRequirementsQuery.class));
@@ -110,18 +120,21 @@ public final class DecisionDefinitionServiceTest {
     // given
     final var definitionEntity = mock(DecisionDefinitionEntity.class);
     when(definitionEntity.decisionRequirementsKey()).thenReturn(1L);
+    when(definitionEntity.decisionId()).thenReturn("decId");
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
         .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null));
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
         .thenReturn(new SearchQueryResult<>(0, List.of(), null));
+    when(securityContextProvider.isAuthorized(
+            "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
+        .thenReturn(true);
 
     // then
     final var exception =
         assertThrows(NotFoundException.class, () -> services.getDecisionDefinitionXml(1L));
-    assertThat(exception.getMessage())
-        .isEqualTo("DecisionRequirements with decisionRequirementsKey=1 cannot be found");
+    assertThat(exception.getMessage()).isEqualTo("Decision requirements with key 1 not found");
   }
 
   @Test
@@ -129,15 +142,65 @@ public final class DecisionDefinitionServiceTest {
     // given
     final var definitionEntity = mock(DecisionDefinitionEntity.class);
     when(definitionEntity.key()).thenReturn(42L);
+    when(definitionEntity.decisionId()).thenReturn("decId");
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
         .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+    when(securityContextProvider.isAuthorized(
+            "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
+        .thenReturn(true);
 
     // when
     final DecisionDefinitionEntity decisionDefinition = services.getByKey(42L);
 
     // then
     assertThat(decisionDefinition.key()).isEqualTo(42L);
+  }
+
+  @Test
+  void shouldGetByKeyThrowForbiddenExceptionOnUnauthorizedDecisionKey() {
+    // given
+    final var definitionEntity = mock(DecisionDefinitionEntity.class);
+    when(definitionEntity.decisionId()).thenReturn("decId");
+    final var definitionResult = mock(SearchQueryResult.class);
+    when(definitionResult.items()).thenReturn(List.of(definitionEntity));
+    when(client.searchDecisionDefinitions(any()))
+        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+    when(securityContextProvider.isAuthorized(
+            "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
+        .thenReturn(false);
+
+    // when
+    final Executable executable = () -> services.getByKey(1L);
+
+    // then
+    final var exception = assertThrows(ForbiddenException.class, executable);
+    assertThat(exception.getMessage())
+        .isEqualTo("Unauthorized to perform operation 'READ' on resource 'DECISION_DEFINITION'");
+  }
+
+  @Test
+  void shouldGetXmlThrowForbiddenExceptionOnUnauthorizedDecisionKey() {
+    // given
+    final var definitionEntity = mock(DecisionDefinitionEntity.class);
+    when(definitionEntity.decisionId()).thenReturn("decId");
+    final var definitionResult = mock(SearchQueryResult.class);
+    when(definitionResult.items()).thenReturn(List.of(definitionEntity));
+    when(client.searchDecisionDefinitions(any()))
+        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+    when(securityContextProvider.isAuthorized(
+            "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
+        .thenReturn(false);
+
+    // when
+    final Executable executable = () -> services.getDecisionDefinitionXml(1L);
+
+    // then
+    final var exception = assertThrows(ForbiddenException.class, executable);
+    assertThat(exception.getMessage())
+        .isEqualTo("Unauthorized to perform operation 'READ' on resource 'DECISION_DEFINITION'");
+    verify(decisionRequirementSearchClient, never())
+        .searchDecisionRequirements(any(DecisionRequirementsQuery.class));
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -17,6 +18,9 @@ import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
@@ -27,14 +31,17 @@ public final class DecisionRequirementsServiceTest {
 
   private DecisionRequirementsServices services;
   private DecisionRequirementSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(DecisionRequirementSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
     services =
         new DecisionRequirementsServices(
-            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
   }
 
   @Test
@@ -58,8 +65,14 @@ public final class DecisionRequirementsServiceTest {
     // given
     final var decisionRequirementEntity = mock(DecisionRequirementsEntity.class);
     when(decisionRequirementEntity.key()).thenReturn(124L);
+    when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
     when(client.searchDecisionRequirements(any()))
         .thenReturn(new SearchQueryResult(1, List.of(decisionRequirementEntity), null));
+    when(securityContextProvider.isAuthorized(
+            "decReqId",
+            authentication,
+            Authorization.of(a -> a.decisionRequirementsDefinition().read())))
+        .thenReturn(true);
 
     // when
     final var searchQueryResult = services.getByKey(124L);
@@ -74,10 +87,17 @@ public final class DecisionRequirementsServiceTest {
     // given
     final var decisionRequirementEntity = mock(DecisionRequirementsEntity.class);
     when(decisionRequirementEntity.key()).thenReturn(124L);
+    when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
     when(decisionRequirementEntity.xml()).thenReturn("<xml/>");
     final var decisionRequirementResult = mock(SearchQueryResult.class);
     when(decisionRequirementResult.items()).thenReturn(List.of(decisionRequirementEntity));
+    when(decisionRequirementResult.total()).thenReturn(1L);
     when(client.searchDecisionRequirements(any())).thenReturn(decisionRequirementResult);
+    when(securityContextProvider.isAuthorized(
+            "decReqId",
+            authentication,
+            Authorization.of(a -> a.decisionRequirementsDefinition().read())))
+        .thenReturn(true);
 
     // when
     final String expectedXml = "<xml/>";
@@ -85,5 +105,52 @@ public final class DecisionRequirementsServiceTest {
 
     // then
     assertThat(searchQueryResult).isEqualTo(expectedXml);
+  }
+
+  @Test
+  void shouldGetByKeyThrowForbiddenExceptionForUnauthorizedDecisionReq() {
+    // given
+    final var decisionRequirementEntity = mock(DecisionRequirementsEntity.class);
+    when(decisionRequirementEntity.key()).thenReturn(124L);
+    when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
+    final var decisionRequirementResult = mock(SearchQueryResult.class);
+    when(decisionRequirementResult.items()).thenReturn(List.of(decisionRequirementEntity));
+    when(decisionRequirementResult.total()).thenReturn(1L);
+    when(client.searchDecisionRequirements(any())).thenReturn(decisionRequirementResult);
+    when(securityContextProvider.isAuthorized(
+            "decReqId",
+            authentication,
+            Authorization.of(a -> a.decisionRequirementsDefinition().read())))
+        .thenReturn(false);
+
+    // then
+    final var exception = assertThrows(ForbiddenException.class, () -> services.getByKey(124L));
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'");
+  }
+
+  @Test
+  void shouldGetXmlThrowForbiddenExceptionForUnauthorizedDecisionReq() {
+    // given
+    final var decisionRequirementEntity = mock(DecisionRequirementsEntity.class);
+    when(decisionRequirementEntity.key()).thenReturn(124L);
+    when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
+    final var decisionRequirementResult = mock(SearchQueryResult.class);
+    when(decisionRequirementResult.items()).thenReturn(List.of(decisionRequirementEntity));
+    when(decisionRequirementResult.total()).thenReturn(1L);
+    when(client.searchDecisionRequirements(any())).thenReturn(decisionRequirementResult);
+    when(securityContextProvider.isAuthorized(
+            "decReqId",
+            authentication,
+            Authorization.of(a -> a.decisionRequirementsDefinition().read())))
+        .thenReturn(false);
+
+    // then
+    final var exception =
+        assertThrows(ForbiddenException.class, () -> services.getDecisionRequirementsXml(124L));
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ' on resource 'DECISION_REQUIREMENTS_DEFINITION'");
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
@@ -69,7 +69,9 @@ public class DecisionRequirementsQueryController {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toDecisionRequirements(
-                  decisionRequirementsServices.getByKey(decisionRequirementsKey)));
+                  decisionRequirementsServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getByKey(decisionRequirementsKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -83,7 +85,10 @@ public class DecisionRequirementsQueryController {
     try {
       return ResponseEntity.ok()
           .contentType(new MediaType(MediaType.TEXT_XML, StandardCharsets.UTF_8))
-          .body(decisionRequirementsServices.getDecisionRequirementsXml(decisionRequirementsKey));
+          .body(
+              decisionRequirementsServices
+                  .withAuthentication(RequestMapper.getAuthentication())
+                  .getDecisionRequirementsXml(decisionRequirementsKey));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding `DECISION_DEFINITION.READ` permission check on the following endpoints

```
GET /decision-definitions/{decisionDefinitionKey}
GET /decision-definitions/{decisionDefinitionKey}/xml
```

Adding `DECISION_REQUIREMENTS_DEFINITION.READ` permission check on the following endpoints
```
GET /decision-requirements/{decisionRequirementsKey}
GET /decision-requirements/{decisionRequirementsKey}/xml
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23180
