### PR TITLE
ES/OS Exporter writes to correct versioned indices

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -164,15 +164,7 @@ class ElasticsearchClient implements AutoCloseable {
    * @return true if request was acknowledged
    */
   public boolean putIndexTemplate(final ValueType valueType) {
-    final String templateName =
-        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
-    final Template template =
-        templateReader.readIndexTemplate(
-            valueType,
-            indexRouter.searchPatternForValueType(valueType),
-            indexRouter.aliasNameForValueType(valueType));
-
-    return putIndexTemplate(templateName, template);
+    return putIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
   }
 
   public boolean putIndexTemplate(final ValueType valueType, final String version) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.exporter.dto.PutIndexTemplateResponse;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer.Sample;
 import java.io.IOException;
@@ -163,7 +164,8 @@ class ElasticsearchClient implements AutoCloseable {
    * @return true if request was acknowledged
    */
   public boolean putIndexTemplate(final ValueType valueType) {
-    final String templateName = indexRouter.indexPrefixForValueType(valueType);
+    final String templateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
     final Template template =
         templateReader.readIndexTemplate(
             valueType,

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -175,6 +175,17 @@ class ElasticsearchClient implements AutoCloseable {
     return putIndexTemplate(templateName, template);
   }
 
+  public boolean putIndexTemplate(final ValueType valueType, final String version) {
+    final String templateName = indexRouter.indexPrefixForValueType(valueType, version);
+    final Template template =
+        templateReader.readIndexTemplate(
+            valueType,
+            indexRouter.searchPatternForValueType(valueType, version),
+            indexRouter.aliasNameForValueType(valueType));
+
+    return putIndexTemplate(templateName, template);
+  }
+
   /**
    * Creates or updates the component template on the target Elasticsearch. The template is read
    * from {@link TemplateReader#readComponentTemplate()}.

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -57,7 +59,7 @@ public class ElasticsearchExporter implements Exporter {
   private MeterRegistry registry;
 
   private long lastPosition = -1;
-  private boolean indexTemplatesCreated;
+  private Map<String, Boolean> indexTemplatesCreated;
 
   @Override
   public void configure(final Context context) {
@@ -70,7 +72,7 @@ public class ElasticsearchExporter implements Exporter {
     pluginRepository.load(configuration.getInterceptorPlugins());
 
     context.setFilter(new ElasticsearchRecordFilter(configuration));
-    indexTemplatesCreated = false;
+    indexTemplatesCreated = new HashMap<>();
     registry = context.getMeterRegistry();
   }
 
@@ -118,8 +120,8 @@ public class ElasticsearchExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    if (!indexTemplatesCreated) {
-      createIndexTemplates();
+    if (!indexTemplatesCreated.containsKey(record.getBrokerVersion())) {
+      createIndexTemplates(record.getBrokerVersion());
 
       updateRetentionPolicyForExistingIndices();
     }
@@ -234,7 +236,7 @@ public class ElasticsearchExporter implements Exporter {
     }
   }
 
-  private void createIndexTemplates() {
+  private void createIndexTemplates(final String version) {
     if (configuration.retention.isEnabled()) {
       createIndexLifecycleManagementPolicy();
     }
@@ -245,117 +247,117 @@ public class ElasticsearchExporter implements Exporter {
       createComponentTemplate();
 
       if (index.deployment) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT);
+        createValueIndexTemplate(ValueType.DEPLOYMENT, version);
       }
       if (index.process) {
-        createValueIndexTemplate(ValueType.PROCESS);
+        createValueIndexTemplate(ValueType.PROCESS, version);
       }
       if (index.error) {
-        createValueIndexTemplate(ValueType.ERROR);
+        createValueIndexTemplate(ValueType.ERROR, version);
       }
       if (index.incident) {
-        createValueIndexTemplate(ValueType.INCIDENT);
+        createValueIndexTemplate(ValueType.INCIDENT, version);
       }
       if (index.job) {
-        createValueIndexTemplate(ValueType.JOB);
+        createValueIndexTemplate(ValueType.JOB, version);
       }
       if (index.jobBatch) {
-        createValueIndexTemplate(ValueType.JOB_BATCH);
+        createValueIndexTemplate(ValueType.JOB_BATCH, version);
       }
       if (index.message) {
-        createValueIndexTemplate(ValueType.MESSAGE);
+        createValueIndexTemplate(ValueType.MESSAGE, version);
       }
       if (index.messageBatch) {
-        createValueIndexTemplate(ValueType.MESSAGE_BATCH);
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH, version);
       }
       if (index.messageSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION, version);
       }
       if (index.variable) {
-        createValueIndexTemplate(ValueType.VARIABLE);
+        createValueIndexTemplate(ValueType.VARIABLE, version);
       }
       if (index.variableDocument) {
-        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT);
+        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT, version);
       }
       if (index.processInstance) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE, version);
       }
       if (index.processInstanceBatch) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH, version);
       }
       if (index.processInstanceCreation) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION, version);
       }
       if (index.processInstanceModification) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
       }
       if (index.processMessageSubscription) {
-        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
       if (index.decisionRequirements) {
-        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS);
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }
       if (index.decision) {
-        createValueIndexTemplate(ValueType.DECISION);
+        createValueIndexTemplate(ValueType.DECISION, version);
       }
       if (index.decisionEvaluation) {
-        createValueIndexTemplate(ValueType.DECISION_EVALUATION);
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION, version);
       }
       if (index.checkpoint) {
-        createValueIndexTemplate(ValueType.CHECKPOINT);
+        createValueIndexTemplate(ValueType.CHECKPOINT, version);
       }
       if (index.timer) {
-        createValueIndexTemplate(ValueType.TIMER);
+        createValueIndexTemplate(ValueType.TIMER, version);
       }
       if (index.messageStartEventSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, version);
       }
       if (index.processEvent) {
-        createValueIndexTemplate(ValueType.PROCESS_EVENT);
+        createValueIndexTemplate(ValueType.PROCESS_EVENT, version);
       }
       if (index.deploymentDistribution) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION);
+        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION, version);
       }
       if (index.escalation) {
-        createValueIndexTemplate(ValueType.ESCALATION);
+        createValueIndexTemplate(ValueType.ESCALATION, version);
       }
       if (index.signal) {
-        createValueIndexTemplate(ValueType.SIGNAL);
+        createValueIndexTemplate(ValueType.SIGNAL, version);
       }
       if (index.signalSubscription) {
-        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION, version);
       }
       if (index.resourceDeletion) {
-        createValueIndexTemplate(ValueType.RESOURCE_DELETION);
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION, version);
       }
       if (index.commandDistribution) {
-        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION, version);
       }
       if (index.form) {
-        createValueIndexTemplate(ValueType.FORM);
+        createValueIndexTemplate(ValueType.FORM, version);
       }
       if (index.userTask) {
-        createValueIndexTemplate(ValueType.USER_TASK);
+        createValueIndexTemplate(ValueType.USER_TASK, version);
       }
       if (index.processInstanceMigration) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION, version);
       }
       if (index.compensationSubscription) {
-        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION, version);
       }
       if (index.messageCorrelation) {
-        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION, version);
       }
       if (index.user) {
-        createValueIndexTemplate(ValueType.USER);
+        createValueIndexTemplate(ValueType.USER, version);
       }
 
       if (index.authorization) {
-        createValueIndexTemplate(ValueType.AUTHORIZATION);
+        createValueIndexTemplate(ValueType.AUTHORIZATION, version);
       }
     }
 
-    indexTemplatesCreated = true;
+    indexTemplatesCreated.put(version, true);
   }
 
   private void createIndexLifecycleManagementPolicy() {
@@ -373,6 +375,14 @@ public class ElasticsearchExporter implements Exporter {
 
   private void createValueIndexTemplate(final ValueType valueType) {
     if (!client.putIndexTemplate(valueType)) {
+      log.warn(
+          "Failed to acknowledge the creation or update of the index template for value type {}",
+          valueType);
+    }
+  }
+
+  private void createValueIndexTemplate(final ValueType valueType, final String version) {
+    if (!client.putIndexTemplate(valueType, version)) {
       log.warn(
           "Failed to acknowledge the creation or update of the index template for value type {}",
           valueType);

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -79,6 +79,10 @@ final class RecordIndexRouter {
         + "*";
   }
 
+  String searchPatternForValueType(final ValueType valueType, final String version) {
+    return indexPrefixForValueType(valueType, version) + INDEX_DELIMITER + "*";
+  }
+
   /**
    * Returns the routing for this record. The routing field of a document controls to which shard it
    * will be assigned.

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -73,12 +72,6 @@ final class RecordIndexRouter {
    * separator and a wildcard, without the date. This allows one to search for this pattern and get
    * all indices regardless of their date.
    */
-  String searchPatternForValueType(final ValueType valueType) {
-    return indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase())
-        + INDEX_DELIMITER
-        + "*";
-  }
-
   String searchPatternForValueType(final ValueType valueType, final String version) {
     return indexPrefixForValueType(valueType, version) + INDEX_DELIMITER + "*";
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -40,7 +40,8 @@ final class RecordIndexRouter {
    */
   String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-    return (indexPrefixForValueType(record.getValueType()) + INDEX_DELIMITER)
+    return (indexPrefixForValueType(record.getValueType(), record.getBrokerVersion())
+            + INDEX_DELIMITER)
         + formatter.format(timestamp);
   }
 
@@ -61,6 +62,10 @@ final class RecordIndexRouter {
   /** Returns the index for this value type, minus the current date. */
   String indexPrefixForValueType(final ValueType valueType) {
     final String version = VersionUtil.getVersionLowerCase();
+    return indexPrefixForValueType(valueType, version);
+  }
+
+  String indexPrefixForValueType(final ValueType valueType, final String version) {
     return config.prefix
         + INDEX_DELIMITER
         + valueTypeToString(valueType)

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter;
 import io.camunda.zeebe.exporter.ElasticsearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -41,17 +40,7 @@ final class RecordIndexRouter {
    */
   String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-
-    final var recordVersion = SemanticVersion.parse(record.getBrokerVersion());
-    var indexVersion = SemanticVersion.parse(VersionUtil.getVersionLowerCase()).orElseThrow();
-
-    // if the record version is less than the current version use that as the record should be
-    // written to old versioned index.
-    if (recordVersion.isPresent() && recordVersion.get().compareTo(indexVersion) < 0) {
-      indexVersion = recordVersion.get();
-    }
-
-    return (indexPrefixForValueType(record.getValueType(), indexVersion.toString().toLowerCase())
+    return (indexPrefixForValueType(record.getValueType(), record.getBrokerVersion())
             + INDEX_DELIMITER)
         + formatter.format(timestamp);
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -60,11 +60,6 @@ final class RecordIndexRouter {
   }
 
   /** Returns the index for this value type, minus the current date. */
-  String indexPrefixForValueType(final ValueType valueType) {
-    final String version = VersionUtil.getVersionLowerCase();
-    return indexPrefixForValueType(valueType, version);
-  }
-
   String indexPrefixForValueType(final ValueType valueType, final String version) {
     return config.prefix
         + INDEX_DELIMITER
@@ -79,7 +74,9 @@ final class RecordIndexRouter {
    * all indices regardless of their date.
    */
   String searchPatternForValueType(final ValueType valueType) {
-    return indexPrefixForValueType(valueType) + INDEX_DELIMITER + "*";
+    return indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase())
+        + INDEX_DELIMITER
+        + "*";
   }
 
   /**

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -86,7 +86,11 @@ final class ElasticsearchClientIT {
     // given - a record with a negative timestamp will not be indexed because its field in ES is a
     // date, which must be a positive number of milliseconds since the UNIX epoch
     final var invalidRecord =
-        recordFactory.generateRecord(ValueType.VARIABLE, b -> b.withTimestamp(Long.MIN_VALUE));
+        recordFactory.generateRecord(
+            ValueType.VARIABLE,
+            b ->
+                b.withTimestamp(Long.MIN_VALUE)
+                    .withBrokerVersion(VersionUtil.getVersionLowerCase()));
     client.index(invalidRecord, new RecordSequence(PARTITION_ID, 1));
     client.putComponentTemplate();
     client.putIndexTemplate(ValueType.VARIABLE);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
@@ -101,7 +102,8 @@ final class ElasticsearchClientIT {
   void shouldPutIndexTemplate() {
     // given
     final var valueType = ValueType.VARIABLE;
-    final String indexTemplateName = indexRouter.indexPrefixForValueType(valueType);
+    final String indexTemplateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
     final String indexTemplateAlias = indexRouter.aliasNameForValueType(valueType);
     final Template expectedTemplate =
         templateReader.readIndexTemplate(

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -111,7 +111,9 @@ final class ElasticsearchClientIT {
     final String indexTemplateAlias = indexRouter.aliasNameForValueType(valueType);
     final Template expectedTemplate =
         templateReader.readIndexTemplate(
-            valueType, indexRouter.searchPatternForValueType(valueType), indexTemplateAlias);
+            valueType,
+            indexRouter.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase()),
+            indexTemplateAlias);
 
     // required since all index templates are composed with it
     client.putComponentTemplate();

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -74,7 +75,7 @@ final class ElasticsearchClientTest {
     final Template expectedTemplate =
         templateReader.readIndexTemplate(
             valueType,
-            indexRouter.searchPatternForValueType(valueType),
+            indexRouter.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase()),
             indexRouter.aliasNameForValueType(valueType));
     final ArgumentCaptor<Request> requestCaptor =
         mockClientResponse(new PutIndexTemplateResponse(true));

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -109,7 +109,9 @@ final class ElasticsearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
   void shouldExportRecord(final ValueType valueType) {
     // given
-    final var record = factory.generateRecord(valueType);
+    final var record =
+        factory.generateRecord(
+            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -139,7 +141,10 @@ final class ElasticsearchExporterIT {
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
             .build();
     final Record<JobRecordValue> record =
-        factory.generateRecord(ValueType.JOB, builder -> builder.withValue(value));
+        factory.generateRecord(
+            ValueType.JOB,
+            builder ->
+                builder.withValue(value).withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -165,7 +170,10 @@ final class ElasticsearchExporterIT {
             .withJobKeys(Collections.singleton(1L))
             .build();
     final Record<JobBatchRecordValue> record =
-        factory.generateRecord(ValueType.JOB_BATCH, builder -> builder.withValue(value));
+        factory.generateRecord(
+            ValueType.JOB_BATCH,
+            builder ->
+                builder.withValue(value).withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -184,7 +192,9 @@ final class ElasticsearchExporterIT {
         "no template is created because the exporter is configured filter out records of this type");
 
     // given
-    final var record = factory.generateRecord(valueType);
+    final var record =
+        factory.generateRecord(
+            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
     final var expectedIndexTemplateName =
         indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
@@ -204,7 +214,8 @@ final class ElasticsearchExporterIT {
   @Test
   void shouldPutComponentTemplate() {
     // given
-    final var record = factory.generateRecord();
+    final var record =
+        factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when - export a single record to enforce installing all index templatesWrapper
     export(record);
@@ -230,7 +241,9 @@ final class ElasticsearchExporterIT {
     void shouldAddIndexLifecycleSettingsToExistingIndicesOnRerunWhenRetentionIsEnabled() {
       // given
       configureExporter(false);
-      final var record1 = factory.generateRecord(ValueType.JOB);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record1);
@@ -244,7 +257,9 @@ final class ElasticsearchExporterIT {
       /* Tests when retention is later enabled all indices should have lifecycle policy */
       // given
       configureExporter(true);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record2);
@@ -262,7 +277,9 @@ final class ElasticsearchExporterIT {
     void shouldRemoveIndexLifecycleSettingsFromExistingIndicesOnRerunWhenRetentionIsDisabled() {
       // given
       configureExporter(true);
-      final var record1 = factory.generateRecord(ValueType.JOB);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record1);
@@ -275,7 +292,9 @@ final class ElasticsearchExporterIT {
       /* Tests when retention is later disabled all indices should not have a lifecycle policy */
       // given
       configureExporter(false);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record2);
@@ -303,13 +322,17 @@ final class ElasticsearchExporterIT {
       // using 498 here as we will export one more record after (1 main shard, 1 replica)
       final int limit = 498;
       for (int i = 0; i < limit; i++) {
-        final var record = factory.generateRecord(ValueType.JOB);
+        final var record =
+            factory.generateRecord(
+                ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
         records.add(record);
         export(record);
       }
       // when
       configureExporter(true);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
       // when
       await("New record is exported, and existing indices are updated")
           .atMost(Duration.ofSeconds(30))

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -185,7 +185,8 @@ final class ElasticsearchExporterIT {
 
     // given
     final var record = factory.generateRecord(valueType);
-    final var expectedIndexTemplateName = indexRouter.indexPrefixForValueType(valueType);
+    final var expectedIndexTemplateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // when - export a single record to enforce installing all index templatesWrapper
     export(record);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -113,9 +113,7 @@ final class ElasticsearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")
   void shouldExportRecord(final ValueType valueType) {
     // given
-    final var record =
-        factory.generateRecord(
-            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+    final var record = generateRecord(valueType);
 
     // when
     export(record);
@@ -196,9 +194,7 @@ final class ElasticsearchExporterIT {
         "no template is created because the exporter is configured filter out records of this type");
 
     // given
-    final var record =
-        factory.generateRecord(
-            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+    final var record = generateRecord(valueType);
     final var expectedIndexTemplateName =
         indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
@@ -239,15 +235,18 @@ final class ElasticsearchExporterIT {
     return true;
   }
 
+  private <T extends RecordValue> Record<T> generateRecord(final ValueType valueType) {
+    return factory.generateRecord(
+        valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+  }
+
   @Nested
   final class IndexSettingsTest {
     @Test
     void shouldAddIndexLifecycleSettingsToExistingIndicesOnRerunWhenRetentionIsEnabled() {
       // given
       configureExporter(false);
-      final var record1 =
-          factory.generateRecord(
-              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+      final var record1 = generateRecord(ValueType.JOB);
 
       // when
       export(record1);
@@ -261,9 +260,7 @@ final class ElasticsearchExporterIT {
       /* Tests when retention is later enabled all indices should have lifecycle policy */
       // given
       configureExporter(true);
-      final var record2 =
-          factory.generateRecord(
-              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+      final var record2 = generateRecord(ValueType.JOB);
 
       // when
       export(record2);
@@ -281,9 +278,7 @@ final class ElasticsearchExporterIT {
     void shouldRemoveIndexLifecycleSettingsFromExistingIndicesOnRerunWhenRetentionIsDisabled() {
       // given
       configureExporter(true);
-      final var record1 =
-          factory.generateRecord(
-              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+      final var record1 = generateRecord(ValueType.JOB);
 
       // when
       export(record1);
@@ -296,9 +291,7 @@ final class ElasticsearchExporterIT {
       /* Tests when retention is later disabled all indices should not have a lifecycle policy */
       // given
       configureExporter(false);
-      final var record2 =
-          factory.generateRecord(
-              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+      final var record2 = generateRecord(ValueType.JOB);
 
       // when
       export(record2);
@@ -326,17 +319,13 @@ final class ElasticsearchExporterIT {
       // using 498 here as we will export one more record after (1 main shard, 1 replica)
       final int limit = 498;
       for (int i = 0; i < limit; i++) {
-        final var record =
-            factory.generateRecord(
-                ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+        final var record = generateRecord(ValueType.JOB);
         records.add(record);
         export(record);
       }
       // when
       configureExporter(true);
-      final var record2 =
-          factory.generateRecord(
-              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
+      final var record2 = generateRecord(ValueType.JOB);
       // when
       await("New record is exported, and existing indices are updated")
           .atMost(Duration.ofSeconds(30))

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -428,6 +428,7 @@ final class ElasticsearchExporterIT {
               .get(firstRecordIndexName)
               .aliases();
       assertThat(firstRecordIndexAliases.size()).isEqualTo(1);
+      assertThat(firstRecordIndexName).contains("8.6.0");
 
       final var secondRecordIndexName = indexRouter.indexFor(record2);
       final var secondRecordIndexAliases =
@@ -439,6 +440,7 @@ final class ElasticsearchExporterIT {
               .get(secondRecordIndexName)
               .aliases();
       assertThat(secondRecordIndexAliases.size()).isEqualTo(1);
+      assertThat(secondRecordIndexName).contains("8.7.0");
     }
 
     private void assertIndexSettingsHasLifecyclePolicy(

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -204,10 +205,11 @@ final class ElasticsearchExporterTest {
       // when
       final var recordMock = mock(Record.class);
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
 
       // then
-      verify(client, times(1)).putIndexTemplate(valueType);
+      verify(client, times(1)).putIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/FaultToleranceIT.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
@@ -37,7 +38,9 @@ final class FaultToleranceIT {
   @Test
   void shouldExportEvenIfElasticNotInitiallyReachable() {
     // given
-    final var record = factory.generateRecord(ValueType.VARIABLE);
+    final var record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
     config.bulk.size = 1; // force flushing after a single record
     config.index.variable = true;
     config.index.createTemplate = true;

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
@@ -100,7 +100,7 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS;
 
     // when
-    final var prefix = router.indexPrefixForValueType(valueType);
+    final var prefix = router.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase());
@@ -113,7 +113,7 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 
     // when
-    final var prefix = router.indexPrefixForValueType(valueType);
+    final var prefix = router.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix)

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
@@ -147,13 +147,13 @@ final class RecordIndexRouterTest {
     // given
     config.prefix = "foo-bar";
     final var valueType = ValueType.PROCESS;
+    final var version = "8.6.0";
 
     // when
-    final var prefix =
-        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
+    final var prefix = router.searchPatternForValueType(valueType, version);
 
     // then
-    assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase() + "_*");
+    assertThat(prefix).isEqualTo("foo-bar_process_" + version + "_*");
   }
 
   @Test

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
@@ -40,7 +40,10 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.VARIABLE;
     final var record =
         recordFactory.generateRecord(
-            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
+            b ->
+                b.withValueType(valueType)
+                    .withTimestamp(timestamp.toEpochMilli())
+                    .withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     final var index = router.indexFor(record);
@@ -60,7 +63,10 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.VARIABLE;
     final var record =
         recordFactory.generateRecord(
-            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
+            b ->
+                b.withValueType(valueType)
+                    .withTimestamp(timestamp.toEpochMilli())
+                    .withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     final var index = router.indexFor(record);

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/RecordIndexRouterTest.java
@@ -133,7 +133,8 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 
     // when
-    final var prefix = router.searchPatternForValueType(valueType);
+    final var prefix =
+        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix)
@@ -148,7 +149,8 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS;
 
     // when
-    final var prefix = router.searchPatternForValueType(valueType);
+    final var prefix =
+        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase() + "_*");

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
@@ -82,7 +83,11 @@ final class TestClient implements CloseableSilently {
   Optional<IndexTemplateWrapper> getIndexTemplate(final ValueType valueType) {
     try {
       final var request =
-          new Request("GET", "/_index_template/" + indexRouter.indexPrefixForValueType(valueType));
+          new Request(
+              "GET",
+              "/_index_template/"
+                  + indexRouter.indexPrefixForValueType(
+                      valueType, VersionUtil.getVersionLowerCase()));
       final var response = restClient.performRequest(request);
       final var templates =
           MAPPER.readValue(response.getEntity().getContent(), IndexTemplatesDto.class);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.PutIndexTemplateResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -153,7 +154,8 @@ public class OpensearchClient implements AutoCloseable {
    * @return true if request was acknowledged
    */
   public boolean putIndexTemplate(final ValueType valueType) {
-    final String templateName = indexRouter.indexPrefixForValueType(valueType);
+    final String templateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
     final Template template =
         templateReader.readIndexTemplate(
             valueType,

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -154,12 +154,15 @@ public class OpensearchClient implements AutoCloseable {
    * @return true if request was acknowledged
    */
   public boolean putIndexTemplate(final ValueType valueType) {
-    final String templateName =
-        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
+    return putIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
+  }
+
+  public boolean putIndexTemplate(final ValueType valueType, final String version) {
+    final String templateName = indexRouter.indexPrefixForValueType(valueType, version);
     final Template template =
         templateReader.readIndexTemplate(
             valueType,
-            indexRouter.searchPatternForValueType(valueType),
+            indexRouter.searchPatternForValueType(valueType, version),
             indexRouter.aliasNameForValueType(valueType));
 
     return putIndexTemplate(templateName, template);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.HashSet;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +44,7 @@ public class OpensearchExporter implements Exporter {
   private MeterRegistry meterRegistry;
 
   private long lastPosition = -1;
-  private boolean indexTemplatesCreated;
+  private Set<String> indexTemplatesCreated;
 
   @Override
   public void configure(final Context context) {
@@ -54,7 +56,7 @@ public class OpensearchExporter implements Exporter {
     pluginRepository.load(configuration.getInterceptorPlugins());
 
     context.setFilter(new OpensearchRecordFilter(configuration));
-    indexTemplatesCreated = false;
+    indexTemplatesCreated = new HashSet<>();
     meterRegistry = context.getMeterRegistry();
   }
 
@@ -102,8 +104,8 @@ public class OpensearchExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    if (!indexTemplatesCreated) {
-      createIndexTemplates();
+    if (!indexTemplatesCreated.contains(record.getBrokerVersion())) {
+      createIndexTemplates(record.getBrokerVersion());
 
       updateRetentionPolicyForExistingIndices();
     }
@@ -199,7 +201,7 @@ public class OpensearchExporter implements Exporter {
     }
   }
 
-  private void createIndexTemplates() {
+  private void createIndexTemplates(final String version) {
     if (configuration.retention.isEnabled()) {
       createIndexStateManagementPolicy();
     } else {
@@ -212,117 +214,117 @@ public class OpensearchExporter implements Exporter {
       createComponentTemplate();
 
       if (index.deployment) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT);
+        createValueIndexTemplate(ValueType.DEPLOYMENT, version);
       }
       if (index.process) {
-        createValueIndexTemplate(ValueType.PROCESS);
+        createValueIndexTemplate(ValueType.PROCESS, version);
       }
       if (index.error) {
-        createValueIndexTemplate(ValueType.ERROR);
+        createValueIndexTemplate(ValueType.ERROR, version);
       }
       if (index.incident) {
-        createValueIndexTemplate(ValueType.INCIDENT);
+        createValueIndexTemplate(ValueType.INCIDENT, version);
       }
       if (index.job) {
-        createValueIndexTemplate(ValueType.JOB);
+        createValueIndexTemplate(ValueType.JOB, version);
       }
       if (index.jobBatch) {
-        createValueIndexTemplate(ValueType.JOB_BATCH);
+        createValueIndexTemplate(ValueType.JOB_BATCH, version);
       }
       if (index.message) {
-        createValueIndexTemplate(ValueType.MESSAGE);
+        createValueIndexTemplate(ValueType.MESSAGE, version);
       }
       if (index.messageBatch) {
-        createValueIndexTemplate(ValueType.MESSAGE_BATCH);
+        createValueIndexTemplate(ValueType.MESSAGE_BATCH, version);
       }
       if (index.messageSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.MESSAGE_SUBSCRIPTION, version);
       }
       if (index.variable) {
-        createValueIndexTemplate(ValueType.VARIABLE);
+        createValueIndexTemplate(ValueType.VARIABLE, version);
       }
       if (index.variableDocument) {
-        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT);
+        createValueIndexTemplate(ValueType.VARIABLE_DOCUMENT, version);
       }
       if (index.processInstance) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE, version);
       }
       if (index.processInstanceBatch) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_BATCH, version);
       }
       if (index.processInstanceCreation) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_CREATION, version);
       }
       if (index.processInstanceMigration) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MIGRATION, version);
       }
       if (index.processInstanceModification) {
-        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION);
+        createValueIndexTemplate(ValueType.PROCESS_INSTANCE_MODIFICATION, version);
       }
       if (index.processMessageSubscription) {
-        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.PROCESS_MESSAGE_SUBSCRIPTION, version);
       }
       if (index.decisionRequirements) {
-        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS);
+        createValueIndexTemplate(ValueType.DECISION_REQUIREMENTS, version);
       }
       if (index.decision) {
-        createValueIndexTemplate(ValueType.DECISION);
+        createValueIndexTemplate(ValueType.DECISION, version);
       }
       if (index.decisionEvaluation) {
-        createValueIndexTemplate(ValueType.DECISION_EVALUATION);
+        createValueIndexTemplate(ValueType.DECISION_EVALUATION, version);
       }
       if (index.checkpoint) {
-        createValueIndexTemplate(ValueType.CHECKPOINT);
+        createValueIndexTemplate(ValueType.CHECKPOINT, version);
       }
       if (index.timer) {
-        createValueIndexTemplate(ValueType.TIMER);
+        createValueIndexTemplate(ValueType.TIMER, version);
       }
       if (index.messageStartEventSubscription) {
-        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.MESSAGE_START_EVENT_SUBSCRIPTION, version);
       }
       if (index.processEvent) {
-        createValueIndexTemplate(ValueType.PROCESS_EVENT);
+        createValueIndexTemplate(ValueType.PROCESS_EVENT, version);
       }
       if (index.deploymentDistribution) {
-        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION);
+        createValueIndexTemplate(ValueType.DEPLOYMENT_DISTRIBUTION, version);
       }
       if (index.escalation) {
-        createValueIndexTemplate(ValueType.ESCALATION);
+        createValueIndexTemplate(ValueType.ESCALATION, version);
       }
       if (index.signal) {
-        createValueIndexTemplate(ValueType.SIGNAL);
+        createValueIndexTemplate(ValueType.SIGNAL, version);
       }
       if (index.signalSubscription) {
-        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.SIGNAL_SUBSCRIPTION, version);
       }
       if (index.resourceDeletion) {
-        createValueIndexTemplate(ValueType.RESOURCE_DELETION);
+        createValueIndexTemplate(ValueType.RESOURCE_DELETION, version);
       }
       if (index.commandDistribution) {
-        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION);
+        createValueIndexTemplate(ValueType.COMMAND_DISTRIBUTION, version);
       }
       if (index.form) {
-        createValueIndexTemplate(ValueType.FORM);
+        createValueIndexTemplate(ValueType.FORM, version);
       }
       if (index.userTask) {
-        createValueIndexTemplate(ValueType.USER_TASK);
+        createValueIndexTemplate(ValueType.USER_TASK, version);
       }
       if (index.compensationSubscription) {
-        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
+        createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION, version);
       }
       if (index.messageCorrelation) {
-        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION, version);
       }
       if (index.user) {
-        createValueIndexTemplate(ValueType.USER);
+        createValueIndexTemplate(ValueType.USER, version);
       }
 
       if (index.authorization) {
-        createValueIndexTemplate(ValueType.AUTHORIZATION);
+        createValueIndexTemplate(ValueType.AUTHORIZATION, version);
       }
     }
 
-    indexTemplatesCreated = true;
+    indexTemplatesCreated.add(version);
   }
 
   private void createIndexStateManagementPolicy() {
@@ -362,8 +364,8 @@ public class OpensearchExporter implements Exporter {
     }
   }
 
-  private void createValueIndexTemplate(final ValueType valueType) {
-    if (!client.putIndexTemplate(valueType)) {
+  private void createValueIndexTemplate(final ValueType valueType, final String version) {
+    if (!client.putIndexTemplate(valueType, version)) {
       log.warn(
           "Failed to acknowledge the creation or update of the index template for value type {}",
           valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -40,7 +40,8 @@ final class RecordIndexRouter {
    */
   String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-    return (indexPrefixForValueType(record.getValueType()) + INDEX_DELIMITER)
+    return (indexPrefixForValueType(record.getValueType(), record.getBrokerVersion())
+            + INDEX_DELIMITER)
         + formatter.format(timestamp);
   }
 
@@ -61,6 +62,10 @@ final class RecordIndexRouter {
   /** Returns the index for this value type, minus the current date. */
   String indexPrefixForValueType(final ValueType valueType) {
     final String version = VersionUtil.getVersionLowerCase();
+    return indexPrefixForValueType(valueType, version);
+  }
+
+  String indexPrefixForValueType(final ValueType valueType, final String version) {
     return config.prefix
         + INDEX_DELIMITER
         + valueTypeToString(valueType)

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter.opensearch;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -41,16 +40,7 @@ final class RecordIndexRouter {
    */
   String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-
-    final var recordVersion = SemanticVersion.parse(record.getBrokerVersion());
-    var indexVersion = SemanticVersion.parse(VersionUtil.getVersionLowerCase()).orElseThrow();
-
-    // if the record version is less than the current version use that as the record should be
-    // written to old versioned index.
-    if (recordVersion.isPresent() && recordVersion.get().compareTo(indexVersion) < 0) {
-      indexVersion = recordVersion.get();
-    }
-    return (indexPrefixForValueType(record.getValueType(), indexVersion.toString().toLowerCase())
+    return (indexPrefixForValueType(record.getValueType(), record.getBrokerVersion())
             + INDEX_DELIMITER)
         + formatter.format(timestamp);
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.exporter.opensearch;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -73,10 +72,8 @@ final class RecordIndexRouter {
    * separator and a wildcard, without the date. This allows one to search for this pattern and get
    * all indices regardless of their date.
    */
-  String searchPatternForValueType(final ValueType valueType) {
-    return indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase())
-        + INDEX_DELIMITER
-        + "*";
+  String searchPatternForValueType(final ValueType valueType, final String version) {
+    return indexPrefixForValueType(valueType, version) + INDEX_DELIMITER + "*";
   }
 
   /**

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.opensearch;
 import io.camunda.zeebe.exporter.opensearch.OpensearchExporterConfiguration.IndexConfiguration;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -40,7 +41,16 @@ final class RecordIndexRouter {
    */
   String indexFor(final Record<?> record) {
     final Instant timestamp = Instant.ofEpochMilli(record.getTimestamp());
-    return (indexPrefixForValueType(record.getValueType(), record.getBrokerVersion())
+
+    final var recordVersion = SemanticVersion.parse(record.getBrokerVersion());
+    var indexVersion = SemanticVersion.parse(VersionUtil.getVersionLowerCase()).orElseThrow();
+
+    // if the record version is less than the current version use that as the record should be
+    // written to old versioned index.
+    if (recordVersion.isPresent() && recordVersion.get().compareTo(indexVersion) < 0) {
+      indexVersion = recordVersion.get();
+    }
+    return (indexPrefixForValueType(record.getValueType(), indexVersion.toString().toLowerCase())
             + INDEX_DELIMITER)
         + formatter.format(timestamp);
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouter.java
@@ -60,11 +60,6 @@ final class RecordIndexRouter {
   }
 
   /** Returns the index for this value type, minus the current date. */
-  String indexPrefixForValueType(final ValueType valueType) {
-    final String version = VersionUtil.getVersionLowerCase();
-    return indexPrefixForValueType(valueType, version);
-  }
-
   String indexPrefixForValueType(final ValueType valueType, final String version) {
     return config.prefix
         + INDEX_DELIMITER
@@ -79,7 +74,9 @@ final class RecordIndexRouter {
    * all indices regardless of their date.
    */
   String searchPatternForValueType(final ValueType valueType) {
-    return indexPrefixForValueType(valueType) + INDEX_DELIMITER + "*";
+    return indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase())
+        + INDEX_DELIMITER
+        + "*";
   }
 
   /**

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/FaultToleranceIT.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import org.junit.jupiter.api.Test;
 import org.opensearch.testcontainers.OpensearchContainer;
 import org.testcontainers.containers.Network;
@@ -36,7 +37,9 @@ final class FaultToleranceIT {
   @Test
   void shouldExportEvenIfOpensearchNotInitiallyReachable() {
     // given
-    final var record = factory.generateRecord(ValueType.VARIABLE);
+    final var record =
+        factory.generateRecord(
+            ValueType.VARIABLE, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
     config.bulk.size = 1; // force flushing after a single record
     config.index.variable = true;
     config.index.createTemplate = true;

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
 import java.util.Map;
@@ -95,7 +96,8 @@ final class OpensearchClientIT {
   void shouldPutIndexTemplate() {
     // given
     final var valueType = ValueType.VARIABLE;
-    final String indexTemplateName = indexRouter.indexPrefixForValueType(valueType);
+    final String indexTemplateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
     final String indexTemplateAlias = indexRouter.aliasNameForValueType(valueType);
     final Template expectedTemplate =
         templateReader.readIndexTemplate(

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -80,7 +80,11 @@ final class OpensearchClientIT {
     // given - a record with a negative timestamp will not be indexed because its field in ES is a
     // date, which must be a positive number of milliseconds since the UNIX epoch
     final var invalidRecord =
-        recordFactory.generateRecord(ValueType.VARIABLE, b -> b.withTimestamp(Long.MIN_VALUE));
+        recordFactory.generateRecord(
+            ValueType.VARIABLE,
+            b ->
+                b.withTimestamp(Long.MIN_VALUE)
+                    .withBrokerVersion(VersionUtil.getVersionLowerCase()));
     client.index(invalidRecord, new RecordSequence(PARTITION_ID, 1));
     client.putComponentTemplate();
     client.putIndexTemplate(ValueType.VARIABLE);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientIT.java
@@ -105,7 +105,9 @@ final class OpensearchClientIT {
     final String indexTemplateAlias = indexRouter.aliasNameForValueType(valueType);
     final Template expectedTemplate =
         templateReader.readIndexTemplate(
-            valueType, indexRouter.searchPatternForValueType(valueType), indexTemplateAlias);
+            valueType,
+            indexRouter.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase()),
+            indexTemplateAlias);
 
     // required since all index templates are composed with it
     client.putComponentTemplate();

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchClientTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.Template;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.VersionUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -71,7 +72,7 @@ final class OpensearchClientTest {
     final Template expectedTemplate =
         templateReader.readIndexTemplate(
             valueType,
-            indexRouter.searchPatternForValueType(valueType),
+            indexRouter.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase()),
             indexRouter.aliasNameForValueType(valueType));
     final ArgumentCaptor<Request> requestCaptor =
         mockClientResponse(new PutIndexTemplateResponse(true));

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -111,7 +111,9 @@ final class OpensearchExporterIT {
   @MethodSource("io.camunda.zeebe.exporter.opensearch.TestSupport#provideValueTypes")
   void shouldExportRecord(final ValueType valueType) {
     // given
-    final var record = factory.generateRecord(valueType);
+    final var record =
+        factory.generateRecord(
+            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -141,7 +143,10 @@ final class OpensearchExporterIT {
             .withCustomHeaders(Map.of("x", "1", "x.y", "2"))
             .build();
     final Record<JobRecordValue> record =
-        factory.generateRecord(ValueType.JOB, builder -> builder.withValue(value));
+        factory.generateRecord(
+            ValueType.JOB,
+            builder ->
+                builder.withValue(value).withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -167,7 +172,10 @@ final class OpensearchExporterIT {
             .withJobKeys(Collections.singleton(1L))
             .build();
     final Record<JobBatchRecordValue> record =
-        factory.generateRecord(ValueType.JOB_BATCH, builder -> builder.withValue(value));
+        factory.generateRecord(
+            ValueType.JOB_BATCH,
+            builder ->
+                builder.withValue(value).withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when
     export(record);
@@ -186,7 +194,9 @@ final class OpensearchExporterIT {
         "no template is created because the exporter is configured filter out records of this type");
 
     // given
-    final var record = factory.generateRecord(valueType);
+    final var record =
+        factory.generateRecord(
+            valueType, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
     final var expectedIndexTemplateName =
         indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
@@ -206,7 +216,8 @@ final class OpensearchExporterIT {
   @Test
   void shouldPutComponentTemplate() {
     // given
-    final var record = factory.generateRecord();
+    final var record =
+        factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when - export a single record to enforce installing all index templatesWrapper
     export(record);
@@ -224,7 +235,8 @@ final class OpensearchExporterIT {
   @Test
   void shouldCreateIndexStateManagementPolicy() {
     // given
-    final var record = factory.generateRecord();
+    final var record =
+        factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when - export a single record to enforce creating the policy
     export(record);
@@ -270,7 +282,8 @@ final class OpensearchExporterIT {
     final var initialMinimumAge = "100d";
     assertThat(initialMinimumAge).isNotEqualTo(config.retention.getMinimumAge());
     testClient.putIndexStateManagementPolicy(initialMinimumAge);
-    final var record = factory.generateRecord();
+    final var record =
+        factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when - export a single record to enforce creating the policy
     export(record);
@@ -288,7 +301,8 @@ final class OpensearchExporterIT {
     final var initialMinimumAge = "100d";
     assertThat(initialMinimumAge).isNotEqualTo(config.retention.getMinimumAge());
     testClient.putIndexStateManagementPolicy(initialMinimumAge);
-    final var record = factory.generateRecord();
+    final var record =
+        factory.generateRecord(r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
     // when - export a single record to enforce deletion the policy
     configureExporter(false);
@@ -321,7 +335,9 @@ final class OpensearchExporterIT {
     void shouldAddIndexLifecycleSettingsToExistingIndicesOnRerunWhenRetentionIsEnabled() {
       // given
       configureExporter(false);
-      final var record1 = factory.generateRecord(ValueType.JOB);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record1);
@@ -339,7 +355,9 @@ final class OpensearchExporterIT {
       /* Tests when retention is later enabled all indices should have lifecycle policy */
       // given
       configureExporter(true);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record2);
@@ -366,7 +384,9 @@ final class OpensearchExporterIT {
     void shouldRemoveIndexLifecycleSettingsFromExistingIndicesOnRerunWhenRetentionIsDisabled() {
       // given
       configureExporter(true);
-      final var record1 = factory.generateRecord(ValueType.JOB);
+      final var record1 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record1);
@@ -384,7 +404,9 @@ final class OpensearchExporterIT {
       /* Tests when retention is later disabled all indices should not have a lifecycle policy */
       // given
       configureExporter(false);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       // when
       export(record2);
@@ -416,14 +438,18 @@ final class OpensearchExporterIT {
       // using 490 here as we will export one more record after (1 main shard, 1 replica)
       final int limit = 490;
       for (int i = 0; i < limit; i++) {
-        final var record = factory.generateRecord(ValueType.JOB);
+        final var record =
+            factory.generateRecord(
+                ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
         records.add(record);
         export(record);
       }
 
       // when
       configureExporter(true);
-      final var record2 = factory.generateRecord(ValueType.JOB);
+      final var record2 =
+          factory.generateRecord(
+              ValueType.JOB, r -> r.withBrokerVersion(VersionUtil.getVersionLowerCase()));
 
       await("New record is exported, and existing indices are updated")
           .atMost(Duration.ofSeconds(30))

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -187,7 +187,8 @@ final class OpensearchExporterIT {
 
     // given
     final var record = factory.generateRecord(valueType);
-    final var expectedIndexTemplateName = indexRouter.indexPrefixForValueType(valueType);
+    final var expectedIndexTemplateName =
+        indexRouter.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // when - export a single record to enforce installing all index templatesWrapper
     export(record);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 import org.opensearch.client.ResponseException;
 import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.testcontainers.OpensearchContainer;
@@ -442,6 +444,25 @@ final class OpensearchExporterIT {
 
         assertHasISMPolicy(response);
       }
+    }
+
+    @Test
+    void shouldExportRecordToIndexSpecifiedByRecordBrokerVersion() {
+      configureExporter(false);
+      final var oldRecord =
+          factory.generateRecord(ValueType.JOB, r -> r.withBrokerVersion("8.6.0"));
+
+      try (final var mockVersion =
+          Mockito.mockStatic(VersionUtil.class, Mockito.CALLS_REAL_METHODS)) {
+        mockVersion.when(VersionUtil::getVersionLowerCase).thenReturn("8.7.0");
+
+        await("New record is exported, and existing indices are updated")
+            .atMost(Duration.ofSeconds(30))
+            .until(() -> export(oldRecord));
+      }
+
+      final var document = testClient.getExportedDocumentFor(oldRecord);
+      assertThat(document.index().contains(oldRecord.getBrokerVersion())).isTrue();
     }
 
     private void assertHasISMPolicy(final Optional<IndexISMPolicyDto> indexSettings) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.ImmutableRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VersionUtil;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
@@ -259,10 +260,11 @@ final class OpensearchExporterTest {
       // when
       final var recordMock = mock(Record.class);
       when(recordMock.getValueType()).thenReturn(ValueType.PROCESS_INSTANCE);
+      when(recordMock.getBrokerVersion()).thenReturn(VersionUtil.getVersionLowerCase());
       exporter.export(recordMock);
 
       // then
-      verify(client, times(1)).putIndexTemplate(valueType);
+      verify(client, times(1)).putIndexTemplate(valueType, VersionUtil.getVersionLowerCase());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
@@ -112,13 +112,13 @@ final class RecordIndexRouterTest {
     // given
     config.prefix = "foo-bar";
     final var valueType = ValueType.PROCESS;
+    final var version = "8.6.0";
 
     // when
-    final var prefix =
-        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
+    final var prefix = router.searchPatternForValueType(valueType, version);
 
     // then
-    assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase() + "_*");
+    assertThat(prefix).isEqualTo("foo-bar_process_" + version + "_*");
   }
 
   @Test

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
@@ -40,10 +40,7 @@ final class RecordIndexRouterTest {
     final var currentVersion = VersionUtil.getVersionLowerCase();
     final var record =
         recordFactory.generateRecord(
-            b ->
-                b.withValueType(valueType)
-                    .withTimestamp(timestamp.toEpochMilli())
-                    .withBrokerVersion(currentVersion));
+            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
 
     // when
     final var index = router.indexFor(record);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
@@ -98,7 +98,8 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 
     // when
-    final var prefix = router.searchPatternForValueType(valueType);
+    final var prefix =
+        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix)
@@ -113,7 +114,8 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS;
 
     // when
-    final var prefix = router.searchPatternForValueType(valueType);
+    final var prefix =
+        router.searchPatternForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase() + "_*");

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
@@ -40,7 +40,10 @@ final class RecordIndexRouterTest {
     final var currentVersion = VersionUtil.getVersionLowerCase();
     final var record =
         recordFactory.generateRecord(
-            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
+            b ->
+                b.withValueType(valueType)
+                    .withTimestamp(timestamp.toEpochMilli())
+                    .withBrokerVersion(currentVersion));
 
     // when
     final var index = router.indexFor(record);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/RecordIndexRouterTest.java
@@ -37,16 +37,19 @@ final class RecordIndexRouterTest {
     config.prefix = "foo-bar";
     final var timestamp = Instant.parse("2022-04-01T00:00:00Z");
     final var valueType = ValueType.VARIABLE;
+    final var currentVersion = VersionUtil.getVersionLowerCase();
     final var record =
         recordFactory.generateRecord(
-            b -> b.withValueType(valueType).withTimestamp(timestamp.toEpochMilli()));
+            b ->
+                b.withValueType(valueType)
+                    .withTimestamp(timestamp.toEpochMilli())
+                    .withBrokerVersion(currentVersion));
 
     // when
     final var index = router.indexFor(record);
 
     // then
-    assertThat(index)
-        .isEqualTo("foo-bar_variable_" + VersionUtil.getVersionLowerCase() + "_2022-04-01");
+    assertThat(index).isEqualTo("foo-bar_variable_" + currentVersion + "_2022-04-01");
   }
 
   @Test
@@ -68,7 +71,7 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS;
 
     // when
-    final var prefix = router.indexPrefixForValueType(valueType);
+    final var prefix = router.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix).isEqualTo("foo-bar_process_" + VersionUtil.getVersionLowerCase());
@@ -81,7 +84,7 @@ final class RecordIndexRouterTest {
     final var valueType = ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 
     // when
-    final var prefix = router.indexPrefixForValueType(valueType);
+    final var prefix = router.indexPrefixForValueType(valueType, VersionUtil.getVersionLowerCase());
 
     // then
     assertThat(prefix)

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.CloseableSilently;
+import io.camunda.zeebe.util.VersionUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
@@ -96,7 +97,11 @@ final class TestClient implements CloseableSilently {
   Optional<IndexTemplateWrapper> getIndexTemplate(final ValueType valueType) {
     try {
       final var request =
-          new Request("GET", "/_index_template/" + indexRouter.indexPrefixForValueType(valueType));
+          new Request(
+              "GET",
+              "/_index_template/"
+                  + indexRouter.indexPrefixForValueType(
+                      valueType, VersionUtil.getVersionLowerCase()));
       final var response = restClient.performRequest(request);
       final var templates =
           MAPPER.readValue(response.getEntity().getContent(), IndexTemplatesDto.class);


### PR DESCRIPTION
## Description

If the log has records which were generated in an older version of camunda and the brokers (and thus exporters) update, the old records should write to the old versioned zeebe indices instead of the new ones.
e.g.
- log has 8.6 records
- exporter updates to 8.7
- as exporter runs the 8.6 records get written to the 8.6 zeebe indices. (Currently it writes to the 8.7 zeebe indice)

## Related issues

closes #24316 
