### PR TITLE
fix: extract version tag only once

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -87,7 +87,6 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
             entity
                 .setName(processEntity.getName())
                 .setFlowNodes(processEntity.getFlowNodes())
-                .setVersionTag(processEntity.getVersionTag())
                 .setFormId(processEntity.getFormId())
                 .setIsPublic(processEntity.getIsPublic()));
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/utils/XMLUtil.java
@@ -65,7 +65,6 @@ public class XMLUtil {
         return Optional.empty();
       }
       final ProcessEntity processEntity = processEntityOpt.get();
-      processEntity.setVersionTag(handler.versionTag);
       processEntity.setIsPublic(handler.isPublic);
       processEntity.setFormId(handler.formId);
       final Set<String> processChildrenIds = handler.getProcessChildrenIds(bpmnProcessId);
@@ -97,7 +96,6 @@ public class XMLUtil {
     private final Map<String, Set<String>> processChildrenIds = new LinkedHashMap<>();
     private String currentProcessId = null;
     private boolean isStartEvent = false;
-    private String versionTag = null;
     private boolean isPublic = false;
     private String formId = null;
 
@@ -118,8 +116,6 @@ public class XMLUtil {
         isStartEvent = true;
       } else if (currentProcessId != null && elementId != null) {
         processChildrenIds.get(currentProcessId).add(elementId);
-      } else if ("versionTag".equalsIgnoreCase(localName)) {
-        versionTag = attributes.getValue("value");
       } else if (isStartEvent) {
         if (formDefinitionProperty.equalsIgnoreCase(localName)) {
           if (attributes.getValue("formKey") != null) {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ProcessHandlerTest.java
@@ -115,6 +115,7 @@ public class ProcessHandlerTest {
             .from(factory.generateObject(ImmutableProcess.class))
             .withProcessDefinitionKey(expectedId)
             .withBpmnProcessId("testProcessId")
+            .withVersionTag("processTag")
             .withResource(Files.readAllBytes(Path.of(resource.getPath())))
             .build();
 
@@ -154,6 +155,7 @@ public class ProcessHandlerTest {
             .from(factory.generateObject(ImmutableProcess.class))
             .withProcessDefinitionKey(expectedId)
             .withBpmnProcessId("testProcessId")
+            .withVersionTag("processTag")
             .withResource(Files.readAllBytes(Path.of(resource.getPath())))
             .build();
 
@@ -192,6 +194,7 @@ public class ProcessHandlerTest {
             .from(factory.generateObject(ImmutableProcess.class))
             .withProcessDefinitionKey(expectedId)
             .withBpmnProcessId("testProcessId")
+            .withVersionTag("processTag")
             .withResource(Files.readAllBytes(Path.of(resource.getPath())))
             .build();
 


### PR DESCRIPTION
## Description

Previously, the `ProcessHandler` was retrieving the `versionTag` from the ProcessRecord and, in addition, from the BPMN itself. With this PR, the `versionTag` is only read from the ProcessRecord and _not_ from the BPMN.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
