### PR TITLE
[Backport stable/8.6] ci: do not auto-merge release PRs

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -427,7 +427,7 @@ jobs:
     if: |
       github.repository == 'camunda/camunda' &&
       github.event_name == 'pull_request' &&
-      (github.actor == 'backport-action' || github.actor == 'camundait')
+      (github.actor == 'backport-action')
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
# Description
Backport of #24438 to `stable/8.6`.

relates to #20675
original author: @megglos