### PR TITLE
fix: handle flush error when leader tries to commit

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/RaftException.java
@@ -16,6 +16,8 @@
  */
 package io.atomix.raft;
 
+import io.atomix.raft.RaftError.Type;
+
 /**
  * Base Raft protocol exception.
  *
@@ -82,6 +84,13 @@ public abstract class RaftException extends RuntimeException {
     public ConfigurationException(
         final Throwable throwable, final String message, final Object... args) {
       super(RaftError.Type.CONFIGURATION_ERROR, throwable, message, args);
+    }
+  }
+
+  public static class CommitFailedException extends RaftException {
+
+    public CommitFailedException(final String message, final Object... args) {
+      super(Type.COMMAND_FAILURE, message, args);
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/DelayedFlusher.java
@@ -9,6 +9,7 @@ package io.atomix.raft.storage.log;
 
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalException;
 import java.io.UncheckedIOException;
@@ -89,7 +90,7 @@ public final class DelayedFlusher implements RaftLogFlusher {
 
     try {
       journal.flush();
-    } catch (final JournalException | UncheckedIOException e) {
+    } catch (final CheckedJournalException | JournalException | UncheckedIOException e) {
       LOGGER.warn("Failed to flush journal, operation will be retried after {}", delayTime, e);
       scheduleFlush(journal);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLog.java
@@ -24,6 +24,7 @@ import io.atomix.raft.storage.log.RaftLogFlusher.Factory;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.serializer.RaftEntrySBESerializer;
 import io.atomix.raft.storage.serializer.RaftEntrySerializer;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalRecord;
 import java.io.Closeable;
@@ -183,7 +184,7 @@ public final class RaftLog implements Closeable {
     lastAppendedEntry = null;
   }
 
-  public void deleteAfter(final long index) {
+  public void deleteAfter(final long index) throws FlushException {
     if (index < commitIndex) {
       throw new IllegalStateException(
           String.format(
@@ -205,7 +206,7 @@ public final class RaftLog implements Closeable {
    * Flushes the underlying journal using the configured flushing strategy. For guarantees, refer to
    * the configured {@link RaftLogFlusher}.
    */
-  public void flush() {
+  public void flush() throws FlushException {
     flusher.flush(journal);
   }
 
@@ -216,7 +217,7 @@ public final class RaftLog implements Closeable {
    * <p>NOTE: this bypasses the configured flushing strategy, and is meant to be used when certain
    * guarantees are required.
    */
-  public void forceFlush() {
+  public void forceFlush() throws FlushException {
     Factory.DIRECT.flush(journal);
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/storage/log/RaftLogFlusher.java
@@ -8,6 +8,7 @@
 package io.atomix.raft.storage.log;
 
 import io.atomix.utils.concurrent.ThreadContextFactory;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.util.CloseableSilently;
 
@@ -37,7 +38,7 @@ public interface RaftLogFlusher extends CloseableSilently {
    *
    * @param journal the journal to flush
    */
-  void flush(final Journal journal);
+  void flush(final Journal journal) throws FlushException;
 
   /**
    * If this returns true, then any calls to {@link #flush(Journal)} are synchronous and immediate,
@@ -69,7 +70,7 @@ public interface RaftLogFlusher extends CloseableSilently {
   final class DirectFlusher implements RaftLogFlusher {
 
     @Override
-    public void flush(final Journal journal) {
+    public void flush(final Journal journal) throws FlushException {
       journal.flush();
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/FaultyFlusherConfigurator.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftRule.Configurator;
+import io.atomix.raft.RaftServer.Builder;
+import io.atomix.raft.partition.RaftElectionConfig;
+import io.atomix.raft.storage.RaftStorage;
+import io.atomix.raft.storage.log.RaftLogFlusher;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.Journal;
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Set the first faultyFlusherNumber nodes with a faulty flusher, when the supplier returns true */
+public record FaultyFlusherConfigurator(
+    int faultyFlusherNumber,
+    Supplier<Boolean> faultyWhen,
+    Runnable notifyFaultyFlush,
+    boolean leaderFaulty,
+    boolean withDataLoss)
+    implements Configurator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FaultyFlusherConfigurator.class);
+
+  private RaftLogFlusher.Factory faultyFlusher(
+      final Supplier<Boolean> faultyWhen, final Runnable notifyFaultyFlush) {
+    return (ignored) ->
+        new RaftLogFlusher() {
+          @Override
+          public void flush(final Journal journal) throws FlushException {
+            if (faultyWhen.get()) {
+              notifyFaultyFlush.run();
+              if (withDataLoss) {
+                journal.deleteAfter(journal.getLastIndex() - 1);
+              }
+              throw new FlushException(new IOException("Failed sync"));
+            } else {
+              journal.flush();
+            }
+          }
+        };
+  }
+
+  @Override
+  public void configure(final MemberId id, final Builder builder) {
+    final var numericId = Integer.parseInt(id.id());
+    // Node priority is used to avoid the faulty nodes to become leaders
+    final int nodePriority;
+    if (numericId <= faultyFlusherNumber) {
+      LOG.trace("failing flusher for member {}", id);
+      final var storage = builder.storage;
+      Objects.requireNonNull(storage);
+      builder.withStorage(
+          RaftStorage.builder()
+              .withDirectory(storage.directory())
+              .withSnapshotStore(storage.getPersistedSnapshotStore())
+              .withFlusherFactory(faultyFlusher(faultyWhen, notifyFaultyFlush))
+              .build());
+      nodePriority = leaderFaulty ? Math.max(5 - numericId, 2) : numericId;
+    } else {
+      LOG.trace("not failing flusher for member {} ", id);
+      nodePriority = leaderFaulty ? numericId : Math.max(5 - numericId, 2);
+    }
+    builder.withElectionConfig(RaftElectionConfig.ofPriorityElection(5, nodePriority));
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -579,7 +579,7 @@ public final class RaftRule extends ExternalResource {
     return appendEntry(leader, 1024);
   }
 
-  public TestAppendListener appendEntryAsync() throws Exception {
+  public TestAppendListener appendEntryAsync() {
     final var raftRole = getLeader().orElseThrow().getContext().getRaftRole();
     if (raftRole instanceof LeaderRole) {
       return appendEntry(1024, (LeaderRole) raftRole);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -35,6 +35,7 @@ import io.atomix.raft.protocol.VersionedAppendRequest;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -106,7 +107,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldFlushAfterAppendRequest() {
+  public void shouldFlushAfterAppendRequest() throws CheckedJournalException {
     // given
     final var entries =
         List.of(
@@ -136,7 +137,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldFlushAfterPartiallyAppendedRequest() {
+  public void shouldFlushAfterPartiallyAppendedRequest() throws CheckedJournalException {
     // given
     final var entries =
         List.of(
@@ -166,7 +167,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldNotFlushIfNoEntryIsAppended() {
+  public void shouldNotFlushIfNoEntryIsAppended() throws CheckedJournalException {
     // given
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 1, new byte[1]));
     final VersionedAppendRequest request =
@@ -192,7 +193,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldFlushEventWithFailure() {
+  public void shouldFlushEventWithFailure() throws CheckedJournalException {
     // given
     final var entries =
         List.of(
@@ -223,7 +224,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldAppendOldVersion() {
+  public void shouldAppendOldVersion() throws CheckedJournalException {
     // given
     final var entries = List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
     final var request = new AppendRequest(2, "a", 0, 0, entries, 1);
@@ -239,7 +240,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldCompleteFutureWithErrorIfAppendFails() {
+  public void shouldCompleteFutureWithErrorIfAppendFails() throws CheckedJournalException {
     // given
     final var entries = List.of(new PersistedRaftRecord(1, 1, 1, 1, new byte[1]));
     final var request = new AppendRequest(2, "a", 0, 0, entries, 1);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/RaftLeaderFlushErrorTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.atomix.raft.roles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.atomix.raft.FaultyFlusherConfigurator;
+import io.atomix.raft.RaftRule;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class RaftLeaderFlushErrorTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RaftLeaderFlushErrorTest.class);
+  private static final int MEMBERS = 3;
+
+  @Parameter public boolean withDataLoss;
+
+  @Rule
+  @Parameter(1)
+  public RaftRule raftRule; // =
+
+  @Parameter(2)
+  public AtomicBoolean isFaulty;
+
+  @Parameter(3)
+  public AtomicInteger flushFailedCount;
+
+  @Parameters(name = "{index}: withDataLoss = {0}")
+  public static Collection<Object[]> parameters() {
+    return Stream.of(true, false)
+        .map(
+            withDataLoss -> {
+              final var isFaulty = new AtomicBoolean(false);
+              final var flushFailedCount = new AtomicInteger(0);
+              return new Object[] {
+                withDataLoss,
+                RaftRule.withBootstrappedNodes(
+                    MEMBERS,
+                    new FaultyFlusherConfigurator(
+                        (MEMBERS - 1) / 2,
+                        isFaulty::get,
+                        flushFailedCount::incrementAndGet,
+                        true,
+                        withDataLoss)),
+                isFaulty,
+                flushFailedCount
+              };
+            })
+        .toList();
+  }
+
+  @Test
+  public void shouldTransitionToFollowerWhenLeaderFailsToFlush() throws Exception {
+    // given
+    final var leader = raftRule.getLeader().get();
+    // check that the leader has a faulty flusher
+    assertThat(leader.name()).isEqualTo("1");
+
+    // get last index
+    raftRule.appendEntry();
+
+    // flusher fails to flush
+    isFaulty.set(true);
+
+    LOG.info("Leader flusher set to faulty");
+    // when
+    final var commitListener = raftRule.appendEntryAsync();
+
+    // then
+    assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
+        .isExactlyInstanceOf(TimeoutException.class);
+
+    // when
+    isFaulty.set(false);
+    LOG.info("Leader flusher is not faulty anymore");
+
+    assertThatThrownBy(() -> commitListener.awaitCommit(Duration.ofSeconds(2)))
+        .isExactlyInstanceOf(TimeoutException.class);
+
+    // then
+    // await new leader
+    raftRule.awaitNewLeader();
+    LOG.debug("appending a new entry after leader change");
+    // appending a new entry succeeds
+    final var finalIndex = raftRule.appendEntry();
+    // all nodes have the same entry
+    raftRule.awaitSameLogSizeOnAllNodes(finalIndex);
+  }
+}

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.Scheduler;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.Journal;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -32,7 +33,7 @@ final class DelayedFlusherTest {
   }
 
   @Test
-  void shouldDelayFlushByInterval() {
+  void shouldDelayFlushByInterval() throws CheckedJournalException {
     // given
     final var journal = Mockito.mock(Journal.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
@@ -51,7 +52,7 @@ final class DelayedFlusherTest {
   }
 
   @Test
-  void shouldFlushWhenScheduledTaskIsRun() {
+  void shouldFlushWhenScheduledTaskIsRun() throws CheckedJournalException {
     // given
     final var journal = Mockito.mock(Journal.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
@@ -99,7 +100,7 @@ final class DelayedFlusherTest {
   }
 
   @Test
-  void shouldNotScheduleFlushWhenClosed() {
+  void shouldNotScheduleFlushWhenClosed() throws CheckedJournalException {
     // given
     final var journal = Mockito.mock(Journal.class);
     Mockito.when(journal.isOpen()).thenReturn(true);
@@ -113,7 +114,7 @@ final class DelayedFlusherTest {
   }
 
   @Test
-  void shouldRescheduleOnFlushError() {
+  void shouldRescheduleOnFlushError() throws CheckedJournalException {
     // given
     final var journal = Mockito.mock(Journal.class);
     Mockito.doThrow(new UncheckedIOException(new IOException("Cannot allocate memory")))
@@ -131,7 +132,7 @@ final class DelayedFlusherTest {
   }
 
   @Test
-  void shouldNotRescheduleOnFlushErrorIfClosed() {
+  void shouldNotRescheduleOnFlushErrorIfClosed() throws CheckedJournalException {
     // given
     final var journal = Mockito.mock(Journal.class);
     Mockito.doThrow(new UncheckedIOException(new IOException("Cannot allocate memory")))

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -34,6 +34,7 @@ import io.atomix.raft.storage.log.entry.ConfigurationEntry;
 import io.atomix.raft.storage.log.entry.InitialEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
@@ -172,7 +173,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldDeleteAfter() {
+  void shouldDeleteAfter() throws CheckedJournalException {
     // given
     raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
     final var secondEntry =
@@ -249,7 +250,7 @@ class RaftLogTest {
   @Nested
   final class FlushTest {
     @Test
-    void shouldUseFlusher() {
+    void shouldUseFlusher() throws CheckedJournalException {
       // given
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
@@ -263,7 +264,7 @@ class RaftLogTest {
     }
 
     @Test
-    void shouldForceFlush() {
+    void shouldForceFlush() throws CheckedJournalException {
       final var journal = mock(Journal.class);
       final var flusher = mock(RaftLogFlusher.class);
       final var log = new RaftLog(journal, flusher);
@@ -277,7 +278,7 @@ class RaftLogTest {
     }
 
     @Test
-    void shouldFlushDirectly() {
+    void shouldFlushDirectly() throws CheckedJournalException {
       // given
       final var journal = mock(Journal.class);
       final var log = new RaftLog(journal, new DirectFlusher());
@@ -291,7 +292,7 @@ class RaftLogTest {
     }
 
     @Test
-    void shouldDisableFlush() {
+    void shouldDisableFlush() throws CheckedJournalException {
       // given
       final var journal = mock(Journal.class);
       final var flusher = spy(new NoopFlusher());

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.raft.storage.log.entry.ApplicationEntry;
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -85,7 +86,7 @@ class RaftLogUncommittedReaderTest {
   }
 
   @Test
-  void shouldSeekToIndexAfterTruncate() {
+  void shouldSeekToIndexAfterTruncate() throws CheckedJournalException {
     // given
     appendEntries(6);
     uncommittedReader.seek(5);

--- a/zeebe/atomix/utils/pom.xml
+++ b/zeebe/atomix/utils/pom.xml
@@ -94,5 +94,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/SingleThreadContextTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/SingleThreadContextTest.java
@@ -16,21 +16,64 @@
 package io.atomix.utils.concurrent;
 
 import static io.atomix.utils.concurrent.Threads.namedThreads;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import io.camunda.zeebe.util.CheckedRunnable;
+import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
+import io.camunda.zeebe.util.RetryDelayStrategy;
+import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
-import org.junit.Test;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SingleThreadContextTest {
 
+  private static final int NUM_RETRIES = 10;
+  private static final Duration MAX_DELAY = Duration.ofMillis(10);
+  private CheckedRunnable taskToRetry;
+  private RetryDelayStrategy delayStrategy;
   private final Logger log = LoggerFactory.getLogger("thread");
   private Consumer<Throwable> exceptionHandler;
-  private final SingleThreadContext threadContext =
-      new SingleThreadContext(namedThreads("test", log), e -> exceptionHandler.accept(e));
+  private CountDownLatch latch;
+  private SingleThreadContext threadContext;
+
+  private AtomicInteger retryCount;
+
+  @BeforeEach
+  public void setup() {
+    retryCount = new AtomicInteger(0);
+    latch = new CountDownLatch(1);
+    delayStrategy = new ExponentialBackoffRetryDelay(MAX_DELAY, Duration.ofMillis(1));
+    threadContext =
+        new SingleThreadContext(namedThreads("test", log), e -> exceptionHandler.accept(e));
+    taskToRetry =
+        () -> {
+          // retry until NUM_RETRIES is reached, then wait for the latch
+          if (retryCount.incrementAndGet() < NUM_RETRIES) {
+            throw new IllegalArgumentException("Expected");
+          } else {
+            try {
+              latch.await();
+            } catch (final InterruptedException e) {
+              throw new RuntimeException(e);
+            }
+          }
+        };
+  }
+
+  @AfterEach
+  public void cleanUp() {
+    threadContext.close();
+  }
 
   @Test
   public void shouldInvokeHandlerOnException() throws InterruptedException {
@@ -44,9 +87,63 @@ public class SingleThreadContextTest {
           throw new RuntimeException();
         });
 
-    latch.await(2, TimeUnit.SECONDS);
+    assertTrue(latch.await(2, TimeUnit.SECONDS));
 
     // then
     assertEquals(0, latch.getCount());
+  }
+
+  @Test
+  public void shouldRetryCallableUntilSuccessful() {
+    // when
+    final var result =
+        threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> true);
+
+    // then
+    assertFalse(result.isDone());
+    Awaitility.await("Await 10 retries").until(() -> retryCount.get() >= NUM_RETRIES);
+
+    // when
+    latch.countDown();
+
+    // then
+    Awaitility.await("the futures succeeds").until(result::isDone);
+  }
+
+  @Test
+  public void shouldNotRetryWhenPredicateIsFalse() {
+    // when
+    final var result =
+        threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> false);
+
+    // then
+    Awaitility.await("Await 1 retry ").until(() -> retryCount.get() == 1);
+    assertTrue(result.isCompletedExceptionally());
+  }
+
+  @Test
+  public void shouldNotContinueIfFutureIsCancelled() throws InterruptedException {
+    // given
+    final var result =
+        threadContext.retryUntilSuccessful(
+            () -> {
+              throw new RuntimeException("expected");
+            },
+            delayStrategy,
+            (ignored) -> true);
+
+    // when
+    result.cancel(false);
+
+    // submit a task after the cancellation with MAX_DELAY so that it will be executed after
+    // the first task checks for cancellation
+    final var scheduled = threadContext.schedule(MAX_DELAY, () -> {});
+    Awaitility.await("task is completed").until(scheduled::isDone);
+
+    // then - no tasks are scheduled
+    final var scheduledTasks = threadContext.executor.shutdownNow();
+    assertTrue(scheduledTasks.isEmpty());
+    // executor terminates gracefully if no task is scheduled
+    assertTrue(threadContext.executor.awaitTermination(1, TimeUnit.SECONDS));
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.journal;
+
+import java.io.IOException;
+
+public sealed class CheckedJournalException extends Exception {
+
+  public CheckedJournalException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public static final class FlushException extends CheckedJournalException {
+    public FlushException(final IOException cause) {
+      super("Error when flushing", cause);
+    }
+  }
+}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.journal;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalException.InvalidChecksum;
 import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -121,7 +122,7 @@ public interface Journal extends AutoCloseable {
    * persistent storage. A call to this method guarantees that all records written are safely
    * flushed to the persistent storage.
    */
-  void flush();
+  void flush() throws FlushException;
 
   /**
    * Opens a new {@link JournalReader}

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/JournalException.java
@@ -17,7 +17,7 @@
 package io.camunda.zeebe.journal;
 
 /** Defines exceptions thrown by the Journal */
-public class JournalException extends RuntimeException {
+public sealed class JournalException extends RuntimeException {
 
   public JournalException(final String message) {
     super(message);
@@ -32,21 +32,21 @@ public class JournalException extends RuntimeException {
   }
 
   /** Exception thrown when storage runs out of disk space. */
-  public static class OutOfDiskSpace extends JournalException {
+  public static final class OutOfDiskSpace extends JournalException {
     public OutOfDiskSpace(final String message) {
       super(message);
     }
   }
 
   /** Exception thrown when an entry has an invalid checksum. */
-  public static class InvalidChecksum extends JournalException {
+  public static final class InvalidChecksum extends JournalException {
     public InvalidChecksum(final String message) {
       super(message);
     }
   }
 
   /** Exception thrown when an entry's index is not the expected one. */
-  public static class InvalidIndex extends JournalException {
+  public static final class InvalidIndex extends JournalException {
     public InvalidIndex(final String message) {
       super(message);
     }
@@ -55,21 +55,21 @@ public class JournalException extends RuntimeException {
   /**
    * Exception thrown when an entry's application sequence number lower than the previous record.
    */
-  public static class InvalidAsqn extends JournalException {
+  public static final class InvalidAsqn extends JournalException {
     public InvalidAsqn(final String message) {
       super(message);
     }
   }
 
   /** Exception thrown when the segment is full and no records can be appended */
-  public static class SegmentFull extends JournalException {
+  public static final class SegmentFull extends JournalException {
     public SegmentFull(final String message) {
       super(message);
     }
   }
 
   /** Exception thrown when the segment is too small to fit even one record */
-  public static class SegmentSizeTooSmall extends JournalException {
+  public static final class SegmentSizeTooSmall extends JournalException {
     public SegmentSizeTooSmall(final String message) {
       super(message);
     }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/FlushableSegment.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/FlushableSegment.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+
 /** The minimum API a segment has to implement to be flush-able. */
 interface FlushableSegment {
 
@@ -22,7 +24,7 @@ interface FlushableSegment {
    * <p>If the method returns true, then it is guaranteed that the modified pages for this segment *
    * have been flushed to disk (according to the underlying file system).
    *
-   * @return true if the segment flushed successfully, false otherwise
+   * @throws FlushException if for any reason the flush failed
    */
-  boolean flush();
+  void flush() throws FlushException;
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournal.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.journal.file;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.Sets;
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.Journal;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.JournalRecord;
@@ -154,7 +155,7 @@ public final class SegmentedJournal implements Journal {
   }
 
   @Override
-  public void flush() {
+  public void flush() throws FlushException {
     if (!isOpen() || isEmpty()) {
       LOGGER.debug("Skipped journal flush as it is either closed or empty");
       return;
@@ -210,7 +211,11 @@ public final class SegmentedJournal implements Journal {
 
   @Override
   public void close() {
-    flush();
+    try {
+      flush();
+    } catch (final FlushException e) {
+      LOGGER.warn("Failed to flush when closing", e);
+    }
     segments.close();
     open = false;
   }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentedJournalWriter.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalException.SegmentFull;
 import io.camunda.zeebe.journal.JournalException.SegmentSizeTooSmall;
 import io.camunda.zeebe.journal.JournalRecord;
@@ -118,7 +119,7 @@ final class SegmentedJournalWriter {
     currentWriter.truncate(index);
   }
 
-  void flush() {
+  void flush() throws FlushException {
     // even if the next flush index has not been written, this will always flush at least the last
     // segment if only to cover cases such as truncating the log, where the next flush index may not
     // have been written yet but we still want to flush that segment after modifying it

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsFlusher.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import java.util.Collection;
 import java.util.Objects;
@@ -42,7 +43,7 @@ final class SegmentsFlusher {
    *
    * @param dirtySegments the list of segments which need to be flushed
    */
-  void flush(final Collection<? extends FlushableSegment> dirtySegments) {
+  void flush(final Collection<? extends FlushableSegment> dirtySegments) throws FlushException {
     final var segmentsCount = dirtySegments.size();
     long flushedIndex = -1;
 
@@ -55,9 +56,8 @@ final class SegmentsFlusher {
     try {
       for (final var segment : dirtySegments) {
         final long lastSegmentIndex = segment.lastIndex();
-        if (segment.flush()) {
-          flushedIndex = lastSegmentIndex;
-        }
+        segment.flush(); // throws FlushException
+        flushedIndex = lastSegmentIndex;
       }
     } finally {
       // store whatever we managed to flush to avoid doing it again

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.journal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.file.LogCorrupter;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
@@ -540,7 +541,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldUpdateMetastoreAfterFlush() {
+  void shouldUpdateMetastoreAfterFlush() throws FlushException {
     journal = openJournal();
     journal.append(1, recordDataWriter);
     final var lastWrittenIndex = journal.append(2, recordDataWriter).index();
@@ -557,7 +558,7 @@ final class JournalTest {
     final RecordData data =
         new RecordData(record.index(), record.asqn(), BufferUtil.cloneBuffer(record.data()));
 
-    if (record instanceof PersistedJournalRecord p) {
+    if (record instanceof final PersistedJournalRecord p) {
       return new PersistedJournalRecord(
           p.metadata(), data, BufferUtil.cloneBuffer(p.serializedRecord()));
     }

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalTest.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.journal.record.PersistedJournalRecord;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.util.MockJournalMetastore;
 import io.camunda.zeebe.journal.util.PosixPathAssert;
+import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.buffer.DirectBufferWriter;
 import java.io.File;
@@ -888,7 +889,7 @@ class SegmentedJournalTest {
               barrier.arriveAndAwaitAdvance();
               barrier.arriveAndAwaitAdvance();
             });
-    final var flushed = CompletableFuture.runAsync(journal::flush);
+    final var flushed = CompletableFuture.runAsync(CheckedRunnable.toUnchecked(journal::flush));
 
     // then
     barrier.arriveAndAwaitAdvance();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
@@ -52,7 +53,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldResetLastFlushedIndexOnDeleteAfter() {
+  void shouldResetLastFlushedIndexOnDeleteAfter() throws FlushException {
     // given
     writer.append(1, journalFactory.entry());
     writer.append(2, journalFactory.entry());
@@ -69,7 +70,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldResetLastFlushedIndexOnReset() {
+  void shouldResetLastFlushedIndexOnReset() throws FlushException {
     // given
     writer.append(1, journalFactory.entry());
     writer.append(2, journalFactory.entry());

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/CheckedRunnable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/CheckedRunnable.java
@@ -7,10 +7,30 @@
  */
 package io.camunda.zeebe.util;
 
+import java.util.concurrent.Callable;
+import org.agrona.LangUtil;
+
 /** A simple extension of runnable which allows for exceptions to be thrown. */
 @FunctionalInterface
 // ignore generic exception warning here as we want to allow for any exception to be thrown
 @SuppressWarnings("java:S112")
 public interface CheckedRunnable {
   void run() throws Exception;
+
+  static java.lang.Runnable toUnchecked(final CheckedRunnable runnable) {
+    return () -> {
+      try {
+        runnable.run();
+      } catch (final Exception e) {
+        LangUtil.rethrowUnchecked(e);
+      }
+    };
+  }
+
+  static Callable<Void> toCallable(final CheckedRunnable runnable) {
+    return () -> {
+      runnable.run();
+      return null;
+    };
+  }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SubClassOf.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SubClassOf.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.function.Predicate;
+
+/**
+ * Predicate to test if a object is a subclass of some types. Usage:
+ *
+ * <pre>{@code
+ * final var subClassOf = SubClassOf.make(
+ *   IllegalArgumentException.class,
+ *   IllegalStateException.class
+ *   );
+ * subclassOf.test(new Exception("Error"));
+ *
+ * }</pre>
+ *
+ * @param classes
+ * @param <A>
+ */
+public record SubClassOf<A>(Class<? extends A>[] classes) implements Predicate<A> {
+
+  @Override
+  public boolean test(final A a) {
+    for (final var clzz : classes) {
+      if (clzz.isAssignableFrom(a.getClass())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @SafeVarargs
+  public static <A> SubClassOf<A> make(final Class<? extends A>... classes) {
+    return new SubClassOf<>(classes);
+  }
+}

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class SubClassOfTest {
+  @Test
+  public void shouldReturnCorrectSubclass() {
+    final var subclass =
+        SubClassOf.make(IllegalArgumentException.class, IllegalStateException.class);
+
+    assertTrue(subclass.test(new IllegalArgumentException("")));
+    assertTrue(subclass.test(new IllegalStateException("")));
+    assertTrue(subclass.test(new MyIllegalArgumentException()));
+    assertFalse(subclass.test(new RuntimeException("")));
+  }
+
+  @Test
+  public void shouldNotReturnTrueIfEmpty() {
+    final var subclass = SubClassOf.make();
+    final var objects = new Object[] {"", 1, 1.0, new Object[] {}};
+
+    for (final var obj : objects) {
+      assertFalse(subclass.test(obj));
+    }
+  }
+
+  public static final class MyIllegalArgumentException extends IllegalArgumentException {}
+}


### PR DESCRIPTION
## Description
All flush() commands in the journal module now can throw a checked exception FlushException, in order to make sure that all possible exceptions thrown when flushing are handled.
A new class `CheckedJournalException` has been created, since `JournalException` extends `RuntimeException`, thus it would not be a checked exception.

Using `Either<Throwable,Void>` was also taken into consideration as a first approach, but I was afraid that it was likely that a left either value could be easily discarded as a return value by mistake, while this is not possible with checked exception.
This also means that using checked exception "pollutes" a lot the code so the idea is to use them only in critical parts of the code when we must ensure that exceptions are handled properly. 


When the leader fails to flush, it resets its commitIndex to the previous value and transitions to the Follower role.

<!-- Describe the goal and purpose of this PR. -->

## Related issues
closes #15463 