### PR TITLE
feat: multi-store config for document module

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.service;
 
+import io.camunda.document.store.EnvironmentConfigurationLoader;
 import io.camunda.document.store.SimpleDocumentStoreRegistry;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
@@ -190,7 +191,10 @@ public class CamundaServicesConfiguration {
   public DocumentServices documentServices(
       final BrokerClient brokerClient, final SecurityContextProvider securityContextProvider) {
     return new DocumentServices(
-        brokerClient, securityContextProvider, null, new SimpleDocumentStoreRegistry());
+        brokerClient,
+        securityContextProvider,
+        null,
+        new SimpleDocumentStoreRegistry(new EnvironmentConfigurationLoader()));
   }
 
   @Bean

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreConfiguration.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.document.api;
 
-public interface DocumentStoreRegistry {
+import java.util.List;
+import java.util.Map;
 
-  DocumentStoreConfiguration getConfiguration();
+public record DocumentStoreConfiguration(
+    String defaultDocumentStoreId, List<DocumentStoreConfigurationRecord> documentStores) {
 
-  DocumentStoreRecord getDocumentStore(final String id);
-
-  DocumentStoreRecord getDefaultDocumentStore();
+  public record DocumentStoreConfigurationRecord(
+      String id,
+      Class<? extends DocumentStoreProvider> providerClass,
+      Map<String, String> properties) {}
 }

--- a/document/api/src/main/java/io/camunda/document/api/DocumentStoreProvider.java
+++ b/document/api/src/main/java/io/camunda/document/api/DocumentStoreProvider.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.document.api;
 
-public interface DocumentStoreRegistry {
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 
-  DocumentStoreConfiguration getConfiguration();
+public interface DocumentStoreProvider {
 
-  DocumentStoreRecord getDocumentStore(final String id);
-
-  DocumentStoreRecord getDefaultDocumentStore();
+  DocumentStore createDocumentStore(DocumentStoreConfigurationRecord configuration);
 }

--- a/document/store/src/main/java/io/camunda/document/store/DocumentStoreConfigurationLoader.java
+++ b/document/store/src/main/java/io/camunda/document/store/DocumentStoreConfigurationLoader.java
@@ -5,13 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.document.api;
+package io.camunda.document.store;
 
-public interface DocumentStoreRegistry {
+import io.camunda.document.api.DocumentStoreConfiguration;
 
-  DocumentStoreConfiguration getConfiguration();
+@FunctionalInterface
+public interface DocumentStoreConfigurationLoader {
 
-  DocumentStoreRecord getDocumentStore(final String id);
-
-  DocumentStoreRecord getDefaultDocumentStore();
+  DocumentStoreConfiguration loadConfiguration();
 }

--- a/document/store/src/main/java/io/camunda/document/store/EnvironmentConfigurationLoader.java
+++ b/document/store/src/main/java/io/camunda/document/store/EnvironmentConfigurationLoader.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store;
+
+import io.camunda.document.api.DocumentStoreConfiguration;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * DOCUMENT_HASH_VERIFICATION_ENABLED=true
+ * DOCUMENT_STORE_GCP_CLASS=io.camunda.document.store.gcp.GcpDocumentStoreProvider
+ * DOCUMENT_STORE_GCP_BUCKET=my-bucket
+ * DOCUMENT_STORE_INMEMORY_CLASS=io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider
+ */
+public class EnvironmentConfigurationLoader implements DocumentStoreConfigurationLoader {
+
+  private static final String CONFIGURATION_PREFIX = "DOCUMENT_";
+  private static final String STORE_PREFIX = "DOCUMENT_STORE_";
+  private static final String DEFAULT_DOCUMENT_STORE_ID = "DEFAULT_STORE_ID";
+
+  private static final Pattern DOCUMENT_STORE_PROPERTY_PATTERN =
+      Pattern.compile("^" + STORE_PREFIX + "(?<id>[^_]+)_(?<property>.+)$");
+  private static final String STORE_CLASS = "CLASS";
+
+  private final Map<String, String> environmentVariableOverrides = new HashMap<>();
+
+  @Override
+  public DocumentStoreConfiguration loadConfiguration() {
+    return new DocumentStoreConfiguration(
+        getRootLevelProperty(DEFAULT_DOCUMENT_STORE_ID).map(String::toLowerCase).orElse(null),
+        loadDocumentStoreProperties());
+  }
+
+  // For testing purposes
+  void addEnvironmentVariableOverride(final String key, final String value) {
+    environmentVariableOverrides.put(key, value);
+  }
+
+  private List<DocumentStoreConfigurationRecord> loadDocumentStoreProperties() {
+    final var envVars = new HashSet<>(environmentVariableOverrides.keySet());
+    envVars.addAll(System.getenv().keySet());
+    final var matches =
+        envVars.stream().map(DOCUMENT_STORE_PROPERTY_PATTERN::matcher).filter(Matcher::matches);
+    final Map<String, Map<String, String>> storeProperties = new HashMap<>();
+    matches.forEach(
+        matcher -> {
+          final var id = matcher.group("id");
+          final var property = matcher.group("property");
+          final var value = getEnvVariable(matcher.group()).orElse(null);
+          storeProperties.computeIfAbsent(id, __ -> new HashMap<>()).put(property, value);
+        });
+    return storeProperties.entrySet().stream()
+        .map(
+            entry -> {
+              final var id = entry.getKey();
+              final Map<String, String> properties = entry.getValue();
+              final var storeClass = properties.get(STORE_CLASS);
+              if (storeClass == null) {
+                throw new IllegalArgumentException(
+                    "Document store class not defined for document store: "
+                        + id
+                        + ". Please define the class in the environment variable: "
+                        + STORE_PREFIX
+                        + id
+                        + "_"
+                        + STORE_CLASS);
+              }
+              properties.remove(STORE_CLASS);
+              final Class<? extends DocumentStoreProvider> storeClassInstance;
+              try {
+                storeClassInstance =
+                    (Class<? extends DocumentStoreProvider>) Class.forName(storeClass);
+              } catch (final ClassNotFoundException e) {
+                throw new IllegalArgumentException(
+                    "Document store class not found: " + storeClass, e);
+              }
+              return new DocumentStoreConfigurationRecord(
+                  id.toLowerCase(), storeClassInstance, properties);
+            })
+        .toList();
+  }
+
+  private Optional<String> getRootLevelProperty(final String name) {
+    return getEnvVariable(CONFIGURATION_PREFIX + name);
+  }
+
+  private Optional<String> getEnvVariable(final String name) {
+    return Optional.ofNullable(environmentVariableOverrides.get(name))
+        .or(() -> Optional.ofNullable(System.getenv().get(name)));
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStore.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.document.store;
+package io.camunda.document.store.gcp;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/gcp/GcpDocumentStoreProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.gcp;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
+import java.util.Optional;
+
+public class GcpDocumentStoreProvider implements DocumentStoreProvider {
+
+  private static final String BUCKET_NAME_PROPERTY = "BUCKET";
+
+  @Override
+  public DocumentStore createDocumentStore(final DocumentStoreConfigurationRecord configuration) {
+    final String bucketName =
+        Optional.ofNullable(configuration.properties().get(BUCKET_NAME_PROPERTY))
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Failed to configure document store with id '"
+                            + configuration.id()
+                            + "': missing required property '"
+                            + BUCKET_NAME_PROPERTY
+                            + "'"));
+    return new GcpDocumentStore(bucketName);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStore.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.document.store;
+package io.camunda.document.store.inmemory;
 
 import io.camunda.document.api.DocumentCreationRequest;
 import io.camunda.document.api.DocumentError;

--- a/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.inmemory;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
+
+public class InMemoryDocumentStoreProvider implements DocumentStoreProvider {
+
+  @Override
+  public DocumentStore createDocumentStore(final DocumentStoreConfigurationRecord configuration) {
+    return new InMemoryDocumentStore();
+  }
+}

--- a/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
+++ b/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
@@ -1,0 +1,9 @@
+#
+# Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+# one or more contributor license agreements. See the NOTICE file distributed
+# with this work for additional information regarding copyright ownership.
+# Licensed under the Camunda License 1.0. You may not use this file
+# except in compliance with the Camunda License 1.0.
+#
+io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider
+io.camunda.document.store.gcp.GcpDocumentStoreProvider

--- a/document/store/src/test/java/io/camunda/document/store/EnvironmentConfigurationLoaderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/EnvironmentConfigurationLoaderTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.document.store.gcp.GcpDocumentStoreProvider;
+import io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider;
+import org.junit.jupiter.api.Test;
+
+public class EnvironmentConfigurationLoaderTest {
+
+  @Test
+  public void shouldLoadConfiguration() {
+    // given
+    final EnvironmentConfigurationLoader loader = new EnvironmentConfigurationLoader();
+    loader.addEnvironmentVariableOverride("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
+    loader.addEnvironmentVariableOverride(
+        "DOCUMENT_STORE_MYGCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
+    loader.addEnvironmentVariableOverride("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
+
+    // when
+    final var configuration = loader.loadConfiguration();
+
+    // then
+    assertThat(configuration.defaultDocumentStoreId()).isEqualTo("mygcp");
+    assertThat(configuration.documentStores()).hasSize(1);
+    final var store = configuration.documentStores().get(0);
+    assertThat(store.id()).isEqualTo("mygcp");
+    assertThat(store.providerClass()).isEqualTo(GcpDocumentStoreProvider.class);
+    assertThat(store.properties()).containsEntry("BUCKET", "my-bucket");
+  }
+
+  @Test
+  public void shouldLoadConfigurationWithMultipleStores() {
+    // given
+    final EnvironmentConfigurationLoader loader = new EnvironmentConfigurationLoader();
+    loader.addEnvironmentVariableOverride("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
+    loader.addEnvironmentVariableOverride("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
+    loader.addEnvironmentVariableOverride(
+        "DOCUMENT_STORE_MYGCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
+    loader.addEnvironmentVariableOverride(
+        "DOCUMENT_STORE_MYINMEMORY_CLASS",
+        "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider");
+
+    // when
+    final var configuration = loader.loadConfiguration();
+
+    // then
+    assertThat(configuration.defaultDocumentStoreId()).isEqualTo("mygcp");
+    assertThat(configuration.documentStores()).hasSize(2);
+    final var gcpStore =
+        configuration.documentStores().stream()
+            .filter(s -> s.id().equals("mygcp"))
+            .findFirst()
+            .get();
+    assertThat(gcpStore.providerClass()).isEqualTo(GcpDocumentStoreProvider.class);
+    assertThat(gcpStore.properties()).containsEntry("BUCKET", "my-bucket");
+    final var inMemoryStore =
+        configuration.documentStores().stream()
+            .filter(s -> s.id().equals("myinmemory"))
+            .findFirst()
+            .get();
+    assertThat(inMemoryStore.providerClass()).isEqualTo(InMemoryDocumentStoreProvider.class);
+    assertThat(inMemoryStore.properties()).isEmpty();
+  }
+
+  @Test
+  public void shouldLoadWhenNoStores() {
+    // given
+    final EnvironmentConfigurationLoader loader = new EnvironmentConfigurationLoader();
+
+    // when
+    final var configuration = loader.loadConfiguration();
+
+    // then
+    assertThat(configuration.defaultDocumentStoreId()).isNull();
+    assertThat(configuration.documentStores()).isEmpty();
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/EnvironmentConfigurationLoaderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/EnvironmentConfigurationLoaderTest.java
@@ -19,10 +19,10 @@ public class EnvironmentConfigurationLoaderTest {
   public void shouldLoadConfiguration() {
     // given
     final EnvironmentConfigurationLoader loader = new EnvironmentConfigurationLoader();
-    loader.addEnvironmentVariableOverride("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
-    loader.addEnvironmentVariableOverride(
+    System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
+    System.setProperty(
         "DOCUMENT_STORE_MYGCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
-    loader.addEnvironmentVariableOverride("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
+    System.setProperty("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
 
     // when
     final var configuration = loader.loadConfiguration();
@@ -34,17 +34,21 @@ public class EnvironmentConfigurationLoaderTest {
     assertThat(store.id()).isEqualTo("mygcp");
     assertThat(store.providerClass()).isEqualTo(GcpDocumentStoreProvider.class);
     assertThat(store.properties()).containsEntry("BUCKET", "my-bucket");
+
+    System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
+    System.clearProperty("DOCUMENT_STORE_MYGCP_CLASS");
+    System.clearProperty("DOCUMENT_STORE_MYGCP_BUCKET");
   }
 
   @Test
   public void shouldLoadConfigurationWithMultipleStores() {
     // given
     final EnvironmentConfigurationLoader loader = new EnvironmentConfigurationLoader();
-    loader.addEnvironmentVariableOverride("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
-    loader.addEnvironmentVariableOverride("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
-    loader.addEnvironmentVariableOverride(
+    System.setProperty("DOCUMENT_DEFAULT_STORE_ID", "MYGCP");
+    System.setProperty(
         "DOCUMENT_STORE_MYGCP_CLASS", "io.camunda.document.store.gcp.GcpDocumentStoreProvider");
-    loader.addEnvironmentVariableOverride(
+    System.setProperty("DOCUMENT_STORE_MYGCP_BUCKET", "my-bucket");
+    System.setProperty(
         "DOCUMENT_STORE_MYINMEMORY_CLASS",
         "io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider");
 
@@ -68,6 +72,11 @@ public class EnvironmentConfigurationLoaderTest {
             .get();
     assertThat(inMemoryStore.providerClass()).isEqualTo(InMemoryDocumentStoreProvider.class);
     assertThat(inMemoryStore.properties()).isEmpty();
+
+    System.clearProperty("DOCUMENT_DEFAULT_STORE_ID");
+    System.clearProperty("DOCUMENT_STORE_MYGCP_CLASS");
+    System.clearProperty("DOCUMENT_STORE_MYGCP_BUCKET");
+    System.clearProperty("DOCUMENT_STORE_MYINMEMORY_CLASS");
   }
 
   @Test

--- a/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/SimpleDocumentStoreRegistryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.document.api.DocumentStoreConfiguration;
+import io.camunda.document.store.inmemory.InMemoryDocumentStore;
+import io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SimpleDocumentStoreRegistryTest {
+
+  @Test
+  public void shouldRegisterDocumentStore() {
+    // given
+    final DocumentStoreConfiguration.DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfiguration.DocumentStoreConfigurationRecord(
+            "custom-in-memory", InMemoryDocumentStoreProvider.class, Map.of());
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("custom-in-memory", List.of(configurationRecord));
+
+    // when
+    final var registry = new SimpleDocumentStoreRegistry(() -> configuration);
+
+    // then
+    final var storeRecord = registry.getDocumentStore("custom-in-memory");
+    assertThat(storeRecord.instance()).isInstanceOf(InMemoryDocumentStore.class);
+    assertThat(storeRecord.storeId()).isEqualTo("custom-in-memory");
+    assertThat(registry.getDefaultDocumentStore()).isEqualTo(storeRecord);
+    assertThat(registry.getConfiguration()).isEqualTo(configuration);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenDocumentStoreNotFound() {
+    // given
+    final DocumentStoreConfiguration.DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfiguration.DocumentStoreConfigurationRecord(
+            "custom-in-memory", InMemoryDocumentStoreProvider.class, Map.of());
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("custom-in-memory", List.of(configurationRecord));
+
+    // when
+    final var registry = new SimpleDocumentStoreRegistry(() -> configuration);
+
+    // then
+    assertThatThrownBy(() -> registry.getDocumentStore("custom-in-memory-1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No such document store: custom-in-memory-1");
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenDefaultDocumentStoreNotFound() {
+    // given
+    final DocumentStoreConfiguration.DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfiguration.DocumentStoreConfigurationRecord(
+            "custom-in-memory", InMemoryDocumentStoreProvider.class, Map.of());
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration("custom-in-memory", List.of(configurationRecord));
+
+    // when
+    final var registry = new SimpleDocumentStoreRegistry(() -> configuration);
+
+    // then
+    assertThatThrownBy(() -> registry.getDocumentStore("custom-in-memory-1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No such document store: custom-in-memory-1");
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenDefaultDocumentStoreIdNotConfigured() {
+    // given
+    final DocumentStoreConfiguration.DocumentStoreConfigurationRecord configurationRecord =
+        new DocumentStoreConfiguration.DocumentStoreConfigurationRecord(
+            "custom-in-memory", InMemoryDocumentStoreProvider.class, Map.of());
+    final DocumentStoreConfiguration configuration =
+        new DocumentStoreConfiguration(null, List.of(configurationRecord));
+
+    // when
+    // then
+    assertThatThrownBy(() -> new SimpleDocumentStoreRegistry(() -> configuration))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("No default document store ID configured.");
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.gcp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+public class GcpDocumentStoreProviderTest {
+
+  @Test
+  public void shouldCreateDocumentStore() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when
+    final DocumentStore documentStore = provider.createDocumentStore(configuration);
+
+    // then
+    assertNotNull(documentStore);
+  }
+
+  @Test
+  public void shouldThrowIfBucketNameIsMissing() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-gcp", GcpDocumentStoreProvider.class, new HashMap<>());
+    final GcpDocumentStoreProvider provider = new GcpDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> provider.createDocumentStore(configuration));
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'my-gcp': missing required property 'BUCKET'");
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/gcp/GcpDocumentStoreTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.document.store;
+package io.camunda.document.store.gcp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/inmemory/InMemoryDocumentStoreTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.inmemory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentError;
+import io.camunda.document.api.DocumentLink;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentReference;
+import io.camunda.zeebe.util.Either;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.OffsetDateTime;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class InMemoryDocumentStoreTest {
+
+  @Test
+  public void createDocumentKeyExistsShouldFail() {
+    // given
+    final InMemoryDocumentStore store = new InMemoryDocumentStore();
+    final String key = "key";
+    final var content = "content".getBytes();
+
+    // when
+    final var request = new DocumentCreationRequest(key, new ByteArrayInputStream(content), null);
+    final var result = store.createDocument(request).join();
+
+    assertThat(result).isInstanceOf(Either.Right.class);
+
+    // when
+    final var result2 = store.createDocument(request).join();
+
+    // then
+    assertThat(result2).isInstanceOf(Either.Left.class);
+    assertThat(((Either.Left<DocumentError, DocumentReference>) result2).value())
+        .isInstanceOf(DocumentError.DocumentAlreadyExists.class);
+  }
+
+  @Test
+  public void createDocumentShouldSucceed() {
+    // given
+    final InMemoryDocumentStore store = new InMemoryDocumentStore();
+    final String key = "key";
+    final var metadata =
+        new DocumentMetadataModel(
+            "application/json", "hello.json", OffsetDateTime.now(), 10L, Map.of("key", "value"));
+
+    // when
+    final var request =
+        new DocumentCreationRequest(key, new ByteArrayInputStream("content".getBytes()), metadata);
+    final var result = store.createDocument(request).join();
+
+    // then
+    assertThat(result).isInstanceOf(Either.Right.class);
+    final var reference = ((Either.Right<DocumentError, DocumentReference>) result).value();
+    assertThat(reference).isNotNull();
+    assertThat(reference.documentId()).isEqualTo(key);
+    assertThat(reference.metadata()).isEqualTo(metadata);
+  }
+
+  @Test
+  public void deleteDocumentShouldSucceedOnlyIfDocumentExists() {
+    // given
+    final InMemoryDocumentStore store = new InMemoryDocumentStore();
+    final String id = "key";
+
+    // when
+    final var request =
+        new DocumentCreationRequest(id, new ByteArrayInputStream("content".getBytes()), null);
+    final var result = store.createDocument(request).join();
+
+    // then
+    assertThat(result).isInstanceOf(Either.Right.class);
+
+    // when
+    final var result2 = store.deleteDocument(id).join();
+
+    // then
+    assertThat(result2).isInstanceOf(Either.Right.class);
+
+    // when
+    final var result3 = store.deleteDocument(id).join();
+
+    // then
+    assertThat(result3).isInstanceOf(Either.Left.class);
+    assertThat(((Either.Left<DocumentError, Void>) result3).value())
+        .isInstanceOf(DocumentError.DocumentNotFound.class);
+  }
+
+  @Test
+  public void getDocumentShouldSucceedOnlyIfDocumentExists() throws IOException {
+    // given
+    final InMemoryDocumentStore store = new InMemoryDocumentStore();
+    final String id = "key";
+
+    // when
+    final var request =
+        new DocumentCreationRequest(id, new ByteArrayInputStream("content".getBytes()), null);
+
+    final var result = store.createDocument(request).join();
+
+    // then
+    assertThat(result).isInstanceOf(Either.Right.class);
+
+    // when
+    final var result2 = store.getDocument(id).join();
+
+    // then
+    assertThat(result2).isInstanceOf(Either.Right.class);
+    final var stream = ((Either.Right<DocumentError, InputStream>) result2).value();
+    assertThat(stream).isNotNull();
+    final var content = new String(stream.readAllBytes());
+    assertThat(content).isEqualTo("content");
+
+    // when
+    final var result3 = store.getDocument("non-existing").join();
+
+    // then
+    assertThat(result3).isInstanceOf(Either.Left.class);
+    assertThat(((Either.Left<DocumentError, InputStream>) result3).value())
+        .isInstanceOf(DocumentError.DocumentNotFound.class);
+  }
+
+  @Test
+  public void createLinkShouldFail() {
+    // given
+    final InMemoryDocumentStore store = new InMemoryDocumentStore();
+    final String id = "key";
+
+    // when
+    final var result = store.createLink(id, 1000L).join();
+
+    // then
+    assertThat(result).isInstanceOf(Either.Left.class);
+    assertThat(((Either.Left<DocumentError, DocumentLink>) result).value())
+        .isInstanceOf(DocumentError.OperationNotSupported.class);
+  }
+}

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -27,11 +27,6 @@ public class DocumentServices extends ApiServices<DocumentServices> {
   private final SimpleDocumentStoreRegistry registry;
 
   public DocumentServices(
-      final BrokerClient brokerClient, final SecurityContextProvider securityContextProvider) {
-    this(brokerClient, securityContextProvider, null, new SimpleDocumentStoreRegistry());
-  }
-
-  public DocumentServices(
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final Authentication authentication,


### PR DESCRIPTION
## Description

This PR will introduce the basic configuration for the document module that would allow defining document store properties as environment variables.

**Goals:**
* Custom document stores can be plugged into Camunda without modifying the document module
* Users can associate IDs with document store implementations arbitrarily
  * e.g. this should be possible: there is only one implementation for the GCP document store, but logically there are multiple store instances of the GCP store with different IDs, each connecting to its own bucket
* If no document store is configured, an instance of the in-memory document store is used (in the future can be replaced with local file system store)

**Example configuration:**
```
DOCUMENT_DEFAULT_STORE_ID=gcp-first

DOCUMENT_STORE_GCP-FIRST_CLASS=io.camunda.document.store.gcp.GcpDocumentStoreProvider
DOCUMENT_STORE_GCP-FIRST_BUCKET=first-bucket-name

DOCUMENT_STORE_GCP-SECOND_CLASS=io.camunda.document.store.gcp.GcpDocumentStoreProvider
DOCUMENT_STORE_GCP-SECOND_BUCKET=second-bucket-name
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/24508
