### PR TITLE
support DMN entities in RDBMS search client

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms;
 
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
@@ -21,6 +22,7 @@ public class RdbmsService {
 
   private final RdbmsWriterFactory rdbmsWriterFactory;
   private final DecisionDefinitionReader decisionDefinitionReader;
+  private final DecisionRequirementsReader decisionRequirementsReader;
   private final FlowNodeInstanceReader flowNodeInstanceReader;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessInstanceReader processInstanceReader;
@@ -30,12 +32,14 @@ public class RdbmsService {
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
       final DecisionDefinitionReader decisionDefinitionReader,
+      final DecisionRequirementsReader decisionRequirementsReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceReader processInstanceReader,
       final VariableReader variableReader,
       final UserTaskReader userTaskReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
+    this.decisionRequirementsReader = decisionRequirementsReader;
     this.decisionDefinitionReader = decisionDefinitionReader;
     this.flowNodeInstanceReader = flowNodeInstanceReader;
     this.processDefinitionReader = processDefinitionReader;
@@ -46,6 +50,10 @@ public class RdbmsService {
 
   public DecisionDefinitionReader getDecisionDefinitionReader() {
     return decisionDefinitionReader;
+  }
+
+  public DecisionRequirementsReader getDecisionRequirementsReader() {
+    return decisionRequirementsReader;
   }
 
   public FlowNodeInstanceReader getFlowNodeInstanceReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.db.rdbms;
 
+import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
@@ -19,6 +20,7 @@ import io.camunda.db.rdbms.write.RdbmsWriterFactory;
 public class RdbmsService {
 
   private final RdbmsWriterFactory rdbmsWriterFactory;
+  private final DecisionDefinitionReader decisionDefinitionReader;
   private final FlowNodeInstanceReader flowNodeInstanceReader;
   private final ProcessDefinitionReader processDefinitionReader;
   private final ProcessInstanceReader processInstanceReader;
@@ -27,17 +29,23 @@ public class RdbmsService {
 
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
+      final DecisionDefinitionReader decisionDefinitionReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceReader processInstanceReader,
       final VariableReader variableReader,
       final UserTaskReader userTaskReader) {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
+    this.decisionDefinitionReader = decisionDefinitionReader;
     this.flowNodeInstanceReader = flowNodeInstanceReader;
     this.processDefinitionReader = processDefinitionReader;
     this.processInstanceReader = processInstanceReader;
     this.variableReader = variableReader;
     this.userTaskReader = userTaskReader;
+  }
+
+  public DecisionDefinitionReader getDecisionDefinitionReader() {
+    return decisionDefinitionReader;
   }
 
   public FlowNodeInstanceReader getFlowNodeInstanceReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DbQuerySorting.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.db.rdbms.read.domain;
 
-import io.camunda.db.rdbms.sql.SearchColumn;
+import io.camunda.db.rdbms.sql.columns.SearchColumn;
 import io.camunda.search.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionDefinitionDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionDefinitionDbQuery.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.filter.DecisionDefinitionFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record DecisionDefinitionDbQuery(
+    DecisionDefinitionFilter filter,
+    DbQuerySorting<DecisionDefinitionEntity> sort,
+    DbQueryPage page) {
+
+  public static DecisionDefinitionDbQuery of(
+      final Function<Builder, ObjectBuilder<DecisionDefinitionDbQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<DecisionDefinitionDbQuery> {
+
+    private static final DecisionDefinitionFilter EMPTY_FILTER =
+        FilterBuilders.decisionDefinition().build();
+
+    private DecisionDefinitionFilter filter;
+    private DbQuerySorting<DecisionDefinitionEntity> sort;
+    private DbQueryPage page;
+
+    public DecisionDefinitionDbQuery.Builder filter(final DecisionDefinitionFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public DecisionDefinitionDbQuery.Builder sort(
+        final DbQuerySorting<DecisionDefinitionEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public DecisionDefinitionDbQuery.Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public DecisionDefinitionDbQuery.Builder filter(
+        final Function<DecisionDefinitionFilter.Builder, ObjectBuilder<DecisionDefinitionFilter>>
+            fn) {
+      return filter(FilterBuilders.decisionDefinition(fn));
+    }
+
+    public DecisionDefinitionDbQuery.Builder sort(
+        final Function<
+                DbQuerySorting.Builder<DecisionDefinitionEntity>,
+                ObjectBuilder<DbQuerySorting<DecisionDefinitionEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public DecisionDefinitionDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new DecisionDefinitionDbQuery(filter, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionRequirementsDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionRequirementsDbQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.filter.DecisionRequirementsFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record DecisionRequirementsDbQuery(
+    DecisionRequirementsFilter filter,
+    DbQuerySorting<DecisionRequirementsEntity> sort,
+    DbQueryPage page,
+    DecisionRequirementsQueryResultConfig resultConfig) {
+
+  public static DecisionRequirementsDbQuery of(
+      final Function<Builder, ObjectBuilder<DecisionRequirementsDbQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<DecisionRequirementsDbQuery> {
+
+    private static final DecisionRequirementsFilter DEFAULT_FILTER =
+        FilterBuilders.decisionRequirements().build();
+    private static final DecisionRequirementsQueryResultConfig DEFAULT_RESULT_CONFIG =
+        DecisionRequirementsQueryResultConfig.of(b -> b);
+
+    private DecisionRequirementsFilter filter;
+    private DbQuerySorting<DecisionRequirementsEntity> sort;
+    private DbQueryPage page;
+    private DecisionRequirementsQueryResultConfig resultConfig;
+
+    public DecisionRequirementsDbQuery.Builder filter(final DecisionRequirementsFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbQuery.Builder sort(
+        final DbQuerySorting<DecisionRequirementsEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbQuery.Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbQuery.Builder resultConfig(
+        final DecisionRequirementsQueryResultConfig resultConfig) {
+      this.resultConfig = resultConfig;
+      return this;
+    }
+
+    @Override
+    public DecisionRequirementsDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, DEFAULT_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      resultConfig = Objects.requireNonNullElse(resultConfig, DEFAULT_RESULT_CONFIG);
+      return new DecisionRequirementsDbQuery(filter, sort, page, resultConfig);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -15,7 +15,7 @@ import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
-import io.camunda.db.rdbms.sql.SearchColumn;
+import io.camunda.db.rdbms.sql.columns.SearchColumn;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOption.FieldSorting;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper.DecisionDefinitionSearchColumn;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DecisionDefinitionReader extends AbstractEntityReader<DecisionDefinitionEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DecisionDefinitionReader.class);
+
+  private final DecisionDefinitionMapper decisionDefinitionMapper;
+
+  public DecisionDefinitionReader(final DecisionDefinitionMapper decisionDefinitionMapper) {
+    super(DecisionDefinitionSearchColumn::findByProperty);
+    this.decisionDefinitionMapper = decisionDefinitionMapper;
+  }
+
+  public Optional<DecisionDefinitionEntity> findOne(final long decisionDefinitionKey) {
+    final var result =
+        search(
+            DecisionDefinitionQuery.of(
+                b -> b.filter(f -> f.decisionDefinitionKeys(decisionDefinitionKey))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionDefinitionEntity> search(final DecisionDefinitionQuery query) {
+    final var dbSort =
+        convertSort(query.sort(), DecisionDefinitionSearchColumn.DECISION_DEFINITION_KEY);
+    final var dbQuery =
+        DecisionDefinitionDbQuery.of(
+            b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
+
+    LOG.trace("[RDBMS DB] Search for decision definition with filter {}", dbQuery);
+    final var totalHits = decisionDefinitionMapper.count(dbQuery);
+    final var hits = decisionDefinitionMapper.search(dbQuery);
+    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
@@ -9,7 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
-import io.camunda.db.rdbms.sql.DecisionDefinitionMapper.DecisionDefinitionSearchColumn;
+import io.camunda.db.rdbms.sql.columns.DecisionDefinitionSearchColumn;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
@@ -9,7 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
-import io.camunda.db.rdbms.sql.DecisionRequirementsMapper.DecisionRequirementsSearchColumn;
+import io.camunda.db.rdbms.sql.columns.DecisionRequirementsSearchColumn;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.SearchQueryResult;

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper.DecisionRequirementsSearchColumn;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.query.SearchQueryResult;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DecisionRequirementsReader extends AbstractEntityReader<DecisionRequirementsEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DecisionRequirementsReader.class);
+
+  private final DecisionRequirementsMapper decisionRequirementsMapper;
+
+  public DecisionRequirementsReader(final DecisionRequirementsMapper decisionRequirementsMapper) {
+    super(DecisionRequirementsSearchColumn::findByProperty);
+    this.decisionRequirementsMapper = decisionRequirementsMapper;
+  }
+
+  public Optional<DecisionRequirementsEntity> findOne(final long decisionRequirementsKey) {
+    final var result =
+        search(
+            DecisionRequirementsQuery.of(
+                b ->
+                    b.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
+                        .resultConfig(c -> c.includeXml(true))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionRequirementsEntity> search(
+      final DecisionRequirementsQuery query) {
+    final var dbSort =
+        convertSort(query.sort(), DecisionRequirementsSearchColumn.DECISION_REQUIREMENTS_KEY);
+    final var dbQuery =
+        DecisionRequirementsDbQuery.of(
+            b ->
+                b.filter(query.filter())
+                    .sort(dbSort)
+                    .page(convertPaging(dbSort, query.page()))
+                    .resultConfig(query.resultConfig()));
+
+    LOG.trace("[RDBMS DB] Search for decision requirements with filter {}", dbQuery);
+    final var totalHits = decisionRequirementsMapper.count(dbQuery);
+    final var hits = decisionRequirementsMapper.search(dbQuery);
+    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
@@ -9,7 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
-import io.camunda.db.rdbms.sql.ProcessDefinitionMapper.ProcessDefinitionSearchColumn;
+import io.camunda.db.rdbms.sql.columns.ProcessDefinitionSearchColumn;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -24,7 +24,7 @@ public class ProcessDefinitionReader extends AbstractEntityReader<ProcessDefinit
   private final ProcessDefinitionMapper processDefinitionMapper;
 
   public ProcessDefinitionReader(final ProcessDefinitionMapper processDefinitionMapper) {
-    super(ProcessDefinitionMapper.ProcessDefinitionSearchColumn::findByProperty);
+    super(ProcessDefinitionSearchColumn::findByProperty);
     this.processDefinitionMapper = processDefinitionMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
@@ -9,7 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.sql.ProcessInstanceMapper;
-import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceSearchColumn;
+import io.camunda.db.rdbms.sql.columns.ProcessInstanceSearchColumn;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryResult;
@@ -24,7 +24,7 @@ public class ProcessInstanceReader extends AbstractEntityReader<ProcessInstanceE
   private final ProcessInstanceMapper processInstanceMapper;
 
   public ProcessInstanceReader(final ProcessInstanceMapper processInstanceMapper) {
-    super(ProcessInstanceMapper.ProcessInstanceSearchColumn::findByProperty);
+    super(ProcessInstanceSearchColumn::findByProperty);
     this.processInstanceMapper = processInstanceMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SearchColumnFinder.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/SearchColumnFinder.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.db.rdbms.read.service;
 
-import io.camunda.db.rdbms.sql.SearchColumn;
+import io.camunda.db.rdbms.sql.columns.SearchColumn;
 
 public interface SearchColumnFinder<T> {
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
@@ -9,7 +9,7 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.VariableDbQuery;
 import io.camunda.db.rdbms.sql.VariableMapper;
-import io.camunda.db.rdbms.sql.VariableMapper.VariableSearchColumn;
+import io.camunda.db.rdbms.sql.columns.VariableSearchColumn;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.page.SearchQueryPage;
@@ -27,7 +27,7 @@ public class VariableReader extends AbstractEntityReader<VariableEntity> {
   private final VariableMapper variableMapper;
 
   public VariableReader(final VariableMapper variableMapper) {
-    super(VariableMapper.VariableSearchColumn::findByProperty);
+    super(VariableSearchColumn::findByProperty);
     this.variableMapper = variableMapper;
   }
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionDefinitionMapper.java
@@ -11,7 +11,6 @@ import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
 import io.camunda.search.entities.DecisionDefinitionEntity;
 import java.util.List;
-import java.util.function.Function;
 
 public interface DecisionDefinitionMapper {
 
@@ -20,59 +19,4 @@ public interface DecisionDefinitionMapper {
   Long count(DecisionDefinitionDbQuery filter);
 
   List<DecisionDefinitionEntity> search(DecisionDefinitionDbQuery filter);
-
-  enum DecisionDefinitionSearchColumn implements SearchColumn<DecisionDefinitionEntity> {
-    DECISION_DEFINITION_KEY(
-        "decisionDefinitionKey", DecisionDefinitionEntity::decisionDefinitionKey),
-    DECISION_DEFINITION_ID("decisionDefinitionId", DecisionDefinitionEntity::decisionDefinitionId),
-    NAME("name", DecisionDefinitionEntity::name),
-    VERSION("version", DecisionDefinitionEntity::version),
-    TENANT_ID("tenantId", DecisionDefinitionEntity::tenantId),
-    DECISION_REQUIREMENTS_KEY(
-        "decisionRequirementsKey", DecisionDefinitionEntity::decisionRequirementsKey),
-    DECISION_REQUIREMENTS_ID(
-        "decisionRequirementsId", DecisionDefinitionEntity::decisionRequirementsId);
-
-    private final String property;
-    private final Function<DecisionDefinitionEntity, Object> propertyReader;
-    private final Function<Object, Object> sortOptionConverter;
-
-    DecisionDefinitionSearchColumn(
-        final String property, final Function<DecisionDefinitionEntity, Object> propertyReader) {
-      this(property, propertyReader, Function.identity());
-    }
-
-    DecisionDefinitionSearchColumn(
-        final String property,
-        final Function<DecisionDefinitionEntity, Object> propertyReader,
-        final Function<Object, Object> sortOptionConverter) {
-      this.property = property;
-      this.propertyReader = propertyReader;
-      this.sortOptionConverter = sortOptionConverter;
-    }
-
-    @Override
-    public Object getPropertyValue(final DecisionDefinitionEntity entity) {
-      return propertyReader.apply(entity);
-    }
-
-    @Override
-    public Object convertSortOption(final Object object) {
-      if (object == null) {
-        return null;
-      }
-
-      return sortOptionConverter.apply(object);
-    }
-
-    public static DecisionDefinitionSearchColumn findByProperty(final String property) {
-      for (final DecisionDefinitionSearchColumn column : DecisionDefinitionSearchColumn.values()) {
-        if (column.property.equals(property)) {
-          return column;
-        }
-      }
-
-      return null;
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionDefinitionMapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery;
+import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import java.util.List;
+import java.util.function.Function;
+
+public interface DecisionDefinitionMapper {
+
+  void insert(DecisionDefinitionDbModel processDeployment);
+
+  Long count(DecisionDefinitionDbQuery filter);
+
+  List<DecisionDefinitionEntity> search(DecisionDefinitionDbQuery filter);
+
+  enum DecisionDefinitionSearchColumn implements SearchColumn<DecisionDefinitionEntity> {
+    DECISION_DEFINITION_KEY(
+        "decisionDefinitionKey", DecisionDefinitionEntity::decisionDefinitionKey),
+    DECISION_DEFINITION_ID("decisionDefinitionId", DecisionDefinitionEntity::decisionDefinitionId),
+    NAME("name", DecisionDefinitionEntity::name),
+    VERSION("version", DecisionDefinitionEntity::version),
+    TENANT_ID("tenantId", DecisionDefinitionEntity::tenantId),
+    DECISION_REQUIREMENTS_KEY(
+        "decisionRequirementsKey", DecisionDefinitionEntity::decisionRequirementsKey),
+    DECISION_REQUIREMENTS_ID(
+        "decisionRequirementsId", DecisionDefinitionEntity::decisionRequirementsId);
+
+    private final String property;
+    private final Function<DecisionDefinitionEntity, Object> propertyReader;
+    private final Function<Object, Object> sortOptionConverter;
+
+    DecisionDefinitionSearchColumn(
+        final String property, final Function<DecisionDefinitionEntity, Object> propertyReader) {
+      this(property, propertyReader, Function.identity());
+    }
+
+    DecisionDefinitionSearchColumn(
+        final String property,
+        final Function<DecisionDefinitionEntity, Object> propertyReader,
+        final Function<Object, Object> sortOptionConverter) {
+      this.property = property;
+      this.propertyReader = propertyReader;
+      this.sortOptionConverter = sortOptionConverter;
+    }
+
+    @Override
+    public Object getPropertyValue(final DecisionDefinitionEntity entity) {
+      return propertyReader.apply(entity);
+    }
+
+    @Override
+    public Object convertSortOption(final Object object) {
+      if (object == null) {
+        return null;
+      }
+
+      return sortOptionConverter.apply(object);
+    }
+
+    public static DecisionDefinitionSearchColumn findByProperty(final String property) {
+      for (final DecisionDefinitionSearchColumn column : DecisionDefinitionSearchColumn.values()) {
+        if (column.property.equals(property)) {
+          return column;
+        }
+      }
+
+      return null;
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionRequirementsMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionRequirementsMapper.java
@@ -11,7 +11,6 @@ import io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery;
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import java.util.List;
-import java.util.function.Function;
 
 public interface DecisionRequirementsMapper {
 
@@ -20,59 +19,4 @@ public interface DecisionRequirementsMapper {
   Long count(DecisionRequirementsDbQuery filter);
 
   List<DecisionRequirementsEntity> search(DecisionRequirementsDbQuery filter);
-
-  enum DecisionRequirementsSearchColumn implements SearchColumn<DecisionRequirementsEntity> {
-    DECISION_REQUIREMENTS_KEY(
-        "decisionRequirementsKey", DecisionRequirementsEntity::decisionRequirementsKey),
-    DECISION_REQUIREMENTS_ID(
-        "decisionRequirementsId", DecisionRequirementsEntity::decisionRequirementsId),
-    NAME("name", DecisionRequirementsEntity::name),
-    VERSION("version", DecisionRequirementsEntity::version),
-    TENANT_ID("tenantId", DecisionRequirementsEntity::tenantId),
-    RESOURCE_NAME("resourceName", DecisionRequirementsEntity::resourceName),
-    XML("xml", DecisionRequirementsEntity::xml);
-
-    private final String property;
-    private final Function<DecisionRequirementsEntity, Object> propertyReader;
-    private final Function<Object, Object> sortOptionConverter;
-
-    DecisionRequirementsSearchColumn(
-        final String property, final Function<DecisionRequirementsEntity, Object> propertyReader) {
-      this(property, propertyReader, Function.identity());
-    }
-
-    DecisionRequirementsSearchColumn(
-        final String property,
-        final Function<DecisionRequirementsEntity, Object> propertyReader,
-        final Function<Object, Object> sortOptionConverter) {
-      this.property = property;
-      this.propertyReader = propertyReader;
-      this.sortOptionConverter = sortOptionConverter;
-    }
-
-    @Override
-    public Object getPropertyValue(final DecisionRequirementsEntity entity) {
-      return propertyReader.apply(entity);
-    }
-
-    @Override
-    public Object convertSortOption(final Object object) {
-      if (object == null) {
-        return null;
-      }
-
-      return sortOptionConverter.apply(object);
-    }
-
-    public static DecisionRequirementsSearchColumn findByProperty(final String property) {
-      for (final DecisionRequirementsSearchColumn column :
-          DecisionRequirementsSearchColumn.values()) {
-        if (column.property.equals(property)) {
-          return column;
-        }
-      }
-
-      return null;
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionRequirementsMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionRequirementsMapper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery;
+import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import java.util.List;
+import java.util.function.Function;
+
+public interface DecisionRequirementsMapper {
+
+  void insert(DecisionRequirementsDbModel processDeployment);
+
+  Long count(DecisionRequirementsDbQuery filter);
+
+  List<DecisionRequirementsEntity> search(DecisionRequirementsDbQuery filter);
+
+  enum DecisionRequirementsSearchColumn implements SearchColumn<DecisionRequirementsEntity> {
+    DECISION_REQUIREMENTS_KEY(
+        "decisionRequirementsKey", DecisionRequirementsEntity::decisionRequirementsKey),
+    DECISION_REQUIREMENTS_ID(
+        "decisionRequirementsId", DecisionRequirementsEntity::decisionRequirementsId),
+    NAME("name", DecisionRequirementsEntity::name),
+    VERSION("version", DecisionRequirementsEntity::version),
+    TENANT_ID("tenantId", DecisionRequirementsEntity::tenantId),
+    RESOURCE_NAME("resourceName", DecisionRequirementsEntity::resourceName),
+    XML("xml", DecisionRequirementsEntity::xml);
+
+    private final String property;
+    private final Function<DecisionRequirementsEntity, Object> propertyReader;
+    private final Function<Object, Object> sortOptionConverter;
+
+    DecisionRequirementsSearchColumn(
+        final String property, final Function<DecisionRequirementsEntity, Object> propertyReader) {
+      this(property, propertyReader, Function.identity());
+    }
+
+    DecisionRequirementsSearchColumn(
+        final String property,
+        final Function<DecisionRequirementsEntity, Object> propertyReader,
+        final Function<Object, Object> sortOptionConverter) {
+      this.property = property;
+      this.propertyReader = propertyReader;
+      this.sortOptionConverter = sortOptionConverter;
+    }
+
+    @Override
+    public Object getPropertyValue(final DecisionRequirementsEntity entity) {
+      return propertyReader.apply(entity);
+    }
+
+    @Override
+    public Object convertSortOption(final Object object) {
+      if (object == null) {
+        return null;
+      }
+
+      return sortOptionConverter.apply(object);
+    }
+
+    public static DecisionRequirementsSearchColumn findByProperty(final String property) {
+      for (final DecisionRequirementsSearchColumn column :
+          DecisionRequirementsSearchColumn.values()) {
+        if (column.property.equals(property)) {
+          return column;
+        }
+      }
+
+      return null;
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessDefinitionMapper.java
@@ -11,7 +11,6 @@ import io.camunda.db.rdbms.read.domain.ProcessDefinitionDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import java.util.List;
-import java.util.function.Function;
 
 public interface ProcessDefinitionMapper {
 
@@ -20,58 +19,4 @@ public interface ProcessDefinitionMapper {
   Long count(ProcessDefinitionDbQuery filter);
 
   List<ProcessDefinitionEntity> search(ProcessDefinitionDbQuery filter);
-
-  enum ProcessDefinitionSearchColumn implements SearchColumn<ProcessDefinitionEntity> {
-    PROCESS_DEFINITION_KEY("processDefinitionKey", ProcessDefinitionEntity::processDefinitionKey),
-    PROCESS_DEFINITION_ID("processDefinitionId", ProcessDefinitionEntity::processDefinitionId),
-    NAME("name", ProcessDefinitionEntity::name),
-    VERSION("version", ProcessDefinitionEntity::version),
-    VERSION_TAG("versionTag", ProcessDefinitionEntity::versionTag),
-    TENANT_ID("tenantId", ProcessDefinitionEntity::tenantId),
-    FORM_ID("formId", ProcessDefinitionEntity::formId),
-    RESOURCE_NAME("resourceName", ProcessDefinitionEntity::resourceName),
-    BPMN_XML("bpmnXml", ProcessDefinitionEntity::bpmnXml);
-
-    private final String property;
-    private final Function<ProcessDefinitionEntity, Object> propertyReader;
-    private final Function<Object, Object> sortOptionConverter;
-
-    ProcessDefinitionSearchColumn(
-        final String property, final Function<ProcessDefinitionEntity, Object> propertyReader) {
-      this(property, propertyReader, Function.identity());
-    }
-
-    ProcessDefinitionSearchColumn(
-        final String property,
-        final Function<ProcessDefinitionEntity, Object> propertyReader,
-        final Function<Object, Object> sortOptionConverter) {
-      this.property = property;
-      this.propertyReader = propertyReader;
-      this.sortOptionConverter = sortOptionConverter;
-    }
-
-    @Override
-    public Object getPropertyValue(final ProcessDefinitionEntity entity) {
-      return propertyReader.apply(entity);
-    }
-
-    @Override
-    public Object convertSortOption(final Object object) {
-      if (object == null) {
-        return null;
-      }
-
-      return sortOptionConverter.apply(object);
-    }
-
-    public static ProcessDefinitionSearchColumn findByProperty(final String property) {
-      for (final ProcessDefinitionSearchColumn column : ProcessDefinitionSearchColumn.values()) {
-        if (column.property.equals(property)) {
-          return column;
-        }
-      }
-
-      return null;
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/ProcessInstanceMapper.java
@@ -10,10 +10,8 @@ package io.camunda.db.rdbms.sql;
 import io.camunda.db.rdbms.read.domain.ProcessInstanceDbQuery;
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.search.entities.ProcessInstanceEntity;
-import io.camunda.zeebe.util.DateUtil;
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.function.Function;
 
 public interface ProcessInstanceMapper {
 
@@ -31,67 +29,4 @@ public interface ProcessInstanceMapper {
       long processInstanceKey,
       ProcessInstanceEntity.ProcessInstanceState state,
       OffsetDateTime endDate) {}
-
-  enum ProcessInstanceSearchColumn implements SearchColumn<ProcessInstanceEntity> {
-    PROCESS_INSTANCE_KEY("processInstanceKey", ProcessInstanceEntity::processInstanceKey),
-    PROCESS_DEFINITION_KEY("processDefinitionKey", ProcessInstanceEntity::processDefinitionKey),
-    PROCESS_DEFINITION_ID("processDefinitionId", ProcessInstanceEntity::processDefinitionId),
-    PROCESS_DEFINITION_NAME("processDefinitionName", ProcessInstanceEntity::processDefinitionName),
-    PROCESS_DEFINITION_VERSION(
-        "processDefinitionVersion", ProcessInstanceEntity::processDefinitionVersion),
-    PROCESS_DEFINITION_VERSION_TAG(
-        "processDefinitionVersionTag", ProcessInstanceEntity::processDefinitionVersionTag),
-    START_DATE("startDate", ProcessInstanceEntity::startDate, DateUtil::fuzzyToOffsetDateTime),
-    END_DATE("endDate", ProcessInstanceEntity::endDate, DateUtil::fuzzyToOffsetDateTime),
-    STATE("state", ProcessInstanceEntity::state),
-    TENANT_ID("tenantId", ProcessInstanceEntity::tenantId),
-    PARENT_PROCESS_INSTANCE_KEY(
-        "parentProcessInstanceKey", ProcessInstanceEntity::parentProcessInstanceKey),
-    PARENT_FLOW_NODE_INSTANCE_KEY(
-        "parentFlowNodeInstanceKey", ProcessInstanceEntity::parentFlowNodeInstanceKey),
-    TREE_PATH("treePath", ProcessInstanceEntity::treePath),
-    INCIDENT("hasIncident", ProcessInstanceEntity::hasIncident);
-
-    private final String property;
-    private final Function<ProcessInstanceEntity, Object> propertyReader;
-    private final Function<Object, Object> sortOptionConverter;
-
-    ProcessInstanceSearchColumn(
-        final String property, final Function<ProcessInstanceEntity, Object> propertyReader) {
-      this(property, propertyReader, Function.identity());
-    }
-
-    ProcessInstanceSearchColumn(
-        final String property,
-        final Function<ProcessInstanceEntity, Object> propertyReader,
-        final Function<Object, Object> sortOptionConverter) {
-      this.property = property;
-      this.propertyReader = propertyReader;
-      this.sortOptionConverter = sortOptionConverter;
-    }
-
-    @Override
-    public Object getPropertyValue(final ProcessInstanceEntity entity) {
-      return propertyReader.apply(entity);
-    }
-
-    @Override
-    public Object convertSortOption(final Object object) {
-      if (object == null) {
-        return null;
-      }
-
-      return sortOptionConverter.apply(object);
-    }
-
-    public static ProcessInstanceSearchColumn findByProperty(final String property) {
-      for (final ProcessInstanceSearchColumn column : ProcessInstanceSearchColumn.values()) {
-        if (column.property.equals(property)) {
-          return column;
-        }
-      }
-
-      return null;
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/VariableMapper.java
@@ -11,7 +11,6 @@ import io.camunda.db.rdbms.read.domain.VariableDbQuery;
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.search.entities.VariableEntity;
 import java.util.List;
-import java.util.function.Function;
 
 public interface VariableMapper {
 
@@ -22,57 +21,4 @@ public interface VariableMapper {
   Long count(VariableDbQuery filter);
 
   List<VariableEntity> search(VariableDbQuery filter);
-
-  enum VariableSearchColumn implements SearchColumn<VariableEntity> {
-    VAR_KEY("variableKey", VariableEntity::variableKey),
-    PROCESS_INSTANCE_KEY("processInstanceKey", VariableEntity::processInstanceKey),
-    SCOPE_KEY("scopeKey", VariableEntity::scopeKey),
-    VAR_NAME("name", VariableEntity::name),
-    VAR_VALUE("value", VariableEntity::value),
-    VAR_FULL_VALUE("fullValue", VariableEntity::fullValue),
-    TENANT_ID("tenantId", VariableEntity::tenantId),
-    IS_PREVIEW("isPreview", VariableEntity::isPreview),
-    PROCESS_DEFINITION_ID("processDefinitionId", VariableEntity::processDefinitionId);
-
-    private final String property;
-    private final Function<VariableEntity, Object> propertyReader;
-    private final Function<Object, Object> sortOptionConverter;
-
-    VariableSearchColumn(
-        final String property, final Function<VariableEntity, Object> propertyReader) {
-      this(property, propertyReader, Function.identity());
-    }
-
-    VariableSearchColumn(
-        final String property,
-        final Function<VariableEntity, Object> propertyReader,
-        final Function<Object, Object> sortOptionConverter) {
-      this.property = property;
-      this.propertyReader = propertyReader;
-      this.sortOptionConverter = sortOptionConverter;
-    }
-
-    @Override
-    public Object getPropertyValue(final VariableEntity entity) {
-      return propertyReader.apply(entity);
-    }
-
-    @Override
-    public Object convertSortOption(final Object object) {
-      if (object == null) {
-        return null;
-      }
-
-      return sortOptionConverter.apply(object);
-    }
-
-    public static VariableSearchColumn findByProperty(final String property) {
-      for (final VariableSearchColumn column : VariableSearchColumn.values()) {
-        if (column.property.equals(property)) {
-          return column;
-        }
-      }
-      return null;
-    }
-  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionDefinitionSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionDefinitionSearchColumn.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import java.util.function.Function;
+
+public enum DecisionDefinitionSearchColumn implements SearchColumn<DecisionDefinitionEntity> {
+  DECISION_DEFINITION_KEY("decisionDefinitionKey", DecisionDefinitionEntity::decisionDefinitionKey),
+  DECISION_DEFINITION_ID("decisionDefinitionId", DecisionDefinitionEntity::decisionDefinitionId),
+  NAME("name", DecisionDefinitionEntity::name),
+  VERSION("version", DecisionDefinitionEntity::version),
+  TENANT_ID("tenantId", DecisionDefinitionEntity::tenantId),
+  DECISION_REQUIREMENTS_KEY(
+      "decisionRequirementsKey", DecisionDefinitionEntity::decisionRequirementsKey),
+  DECISION_REQUIREMENTS_ID(
+      "decisionRequirementsId", DecisionDefinitionEntity::decisionRequirementsId);
+
+  private final String property;
+  private final Function<DecisionDefinitionEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  DecisionDefinitionSearchColumn(
+      final String property, final Function<DecisionDefinitionEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  DecisionDefinitionSearchColumn(
+      final String property,
+      final Function<DecisionDefinitionEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final DecisionDefinitionEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static DecisionDefinitionSearchColumn findByProperty(final String property) {
+    for (final DecisionDefinitionSearchColumn column : DecisionDefinitionSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionRequirementsSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionRequirementsSearchColumn.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import java.util.function.Function;
+
+public enum DecisionRequirementsSearchColumn implements SearchColumn<DecisionRequirementsEntity> {
+  DECISION_REQUIREMENTS_KEY(
+      "decisionRequirementsKey", DecisionRequirementsEntity::decisionRequirementsKey),
+  DECISION_REQUIREMENTS_ID(
+      "decisionRequirementsId", DecisionRequirementsEntity::decisionRequirementsId),
+  NAME("name", DecisionRequirementsEntity::name),
+  VERSION("version", DecisionRequirementsEntity::version),
+  TENANT_ID("tenantId", DecisionRequirementsEntity::tenantId),
+  RESOURCE_NAME("resourceName", DecisionRequirementsEntity::resourceName),
+  XML("xml", DecisionRequirementsEntity::xml);
+
+  private final String property;
+  private final Function<DecisionRequirementsEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  DecisionRequirementsSearchColumn(
+      final String property, final Function<DecisionRequirementsEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  DecisionRequirementsSearchColumn(
+      final String property,
+      final Function<DecisionRequirementsEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final DecisionRequirementsEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static DecisionRequirementsSearchColumn findByProperty(final String property) {
+    for (final DecisionRequirementsSearchColumn column :
+        DecisionRequirementsSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessDefinitionSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessDefinitionSearchColumn.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import java.util.function.Function;
+
+public enum ProcessDefinitionSearchColumn implements SearchColumn<ProcessDefinitionEntity> {
+  PROCESS_DEFINITION_KEY("processDefinitionKey", ProcessDefinitionEntity::processDefinitionKey),
+  PROCESS_DEFINITION_ID("processDefinitionId", ProcessDefinitionEntity::processDefinitionId),
+  NAME("name", ProcessDefinitionEntity::name),
+  VERSION("version", ProcessDefinitionEntity::version),
+  VERSION_TAG("versionTag", ProcessDefinitionEntity::versionTag),
+  TENANT_ID("tenantId", ProcessDefinitionEntity::tenantId),
+  FORM_ID("formId", ProcessDefinitionEntity::formId),
+  RESOURCE_NAME("resourceName", ProcessDefinitionEntity::resourceName),
+  BPMN_XML("bpmnXml", ProcessDefinitionEntity::bpmnXml);
+
+  private final String property;
+  private final Function<ProcessDefinitionEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  ProcessDefinitionSearchColumn(
+      final String property, final Function<ProcessDefinitionEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  ProcessDefinitionSearchColumn(
+      final String property,
+      final Function<ProcessDefinitionEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final ProcessDefinitionEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static ProcessDefinitionSearchColumn findByProperty(final String property) {
+    for (final ProcessDefinitionSearchColumn column : ProcessDefinitionSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/ProcessInstanceSearchColumn.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.ProcessInstanceEntity;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.function.Function;
+
+public enum ProcessInstanceSearchColumn implements SearchColumn<ProcessInstanceEntity> {
+  PROCESS_INSTANCE_KEY("processInstanceKey", ProcessInstanceEntity::processInstanceKey),
+  PROCESS_DEFINITION_KEY("processDefinitionKey", ProcessInstanceEntity::processDefinitionKey),
+  PROCESS_DEFINITION_ID("processDefinitionId", ProcessInstanceEntity::processDefinitionId),
+  PROCESS_DEFINITION_NAME("processDefinitionName", ProcessInstanceEntity::processDefinitionName),
+  PROCESS_DEFINITION_VERSION(
+      "processDefinitionVersion", ProcessInstanceEntity::processDefinitionVersion),
+  PROCESS_DEFINITION_VERSION_TAG(
+      "processDefinitionVersionTag", ProcessInstanceEntity::processDefinitionVersionTag),
+  START_DATE("startDate", ProcessInstanceEntity::startDate, DateUtil::fuzzyToOffsetDateTime),
+  END_DATE("endDate", ProcessInstanceEntity::endDate, DateUtil::fuzzyToOffsetDateTime),
+  STATE("state", ProcessInstanceEntity::state),
+  TENANT_ID("tenantId", ProcessInstanceEntity::tenantId),
+  PARENT_PROCESS_INSTANCE_KEY(
+      "parentProcessInstanceKey", ProcessInstanceEntity::parentProcessInstanceKey),
+  PARENT_FLOW_NODE_INSTANCE_KEY(
+      "parentFlowNodeInstanceKey", ProcessInstanceEntity::parentFlowNodeInstanceKey),
+  TREE_PATH("treePath", ProcessInstanceEntity::treePath),
+  INCIDENT("hasIncident", ProcessInstanceEntity::hasIncident);
+
+  private final String property;
+  private final Function<ProcessInstanceEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  ProcessInstanceSearchColumn(
+      final String property, final Function<ProcessInstanceEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  ProcessInstanceSearchColumn(
+      final String property,
+      final Function<ProcessInstanceEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final ProcessInstanceEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static ProcessInstanceSearchColumn findByProperty(final String property) {
+    for (final ProcessInstanceSearchColumn column : ProcessInstanceSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/SearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/SearchColumn.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.db.rdbms.sql;
+package io.camunda.db.rdbms.sql.columns;
 
 public interface SearchColumn<T> {
 

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/VariableSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/VariableSearchColumn.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.VariableEntity;
+import java.util.function.Function;
+
+public enum VariableSearchColumn implements SearchColumn<VariableEntity> {
+  VAR_KEY("variableKey", VariableEntity::variableKey),
+  PROCESS_INSTANCE_KEY("processInstanceKey", VariableEntity::processInstanceKey),
+  SCOPE_KEY("scopeKey", VariableEntity::scopeKey),
+  VAR_NAME("name", VariableEntity::name),
+  VAR_VALUE("value", VariableEntity::value),
+  VAR_FULL_VALUE("fullValue", VariableEntity::fullValue),
+  TENANT_ID("tenantId", VariableEntity::tenantId),
+  IS_PREVIEW("isPreview", VariableEntity::isPreview),
+  PROCESS_DEFINITION_ID("processDefinitionId", VariableEntity::processDefinitionId);
+
+  private final String property;
+  private final Function<VariableEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  VariableSearchColumn(
+      final String property, final Function<VariableEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  VariableSearchColumn(
+      final String property,
+      final Function<VariableEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final VariableEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static VariableSearchColumn findByProperty(final String property) {
+    for (final VariableSearchColumn column : VariableSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
+import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
@@ -20,6 +21,7 @@ public class RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final DecisionDefinitionWriter decisionDefinitionWriter;
+  private final DecisionRequirementsWriter decisionRequirementsWriter;
   private final ExporterPositionService exporterPositionService;
   private final FlowNodeInstanceWriter flowNodeInstanceWriter;
   private final ProcessDefinitionWriter processDefinitionWriter;
@@ -32,6 +34,7 @@ public class RdbmsWriter {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     decisionDefinitionWriter = new DecisionDefinitionWriter(executionQueue);
+    decisionRequirementsWriter = new DecisionRequirementsWriter(executionQueue);
     flowNodeInstanceWriter = new FlowNodeInstanceWriter(executionQueue);
     processDefinitionWriter = new ProcessDefinitionWriter(executionQueue);
     processInstanceWriter = new ProcessInstanceWriter(executionQueue);
@@ -41,6 +44,10 @@ public class RdbmsWriter {
 
   public DecisionDefinitionWriter getDecisionDefinitionWriter() {
     return decisionDefinitionWriter;
+  }
+
+  public DecisionRequirementsWriter getDecisionRequirementsWriter() {
+    return decisionRequirementsWriter;
   }
 
   public FlowNodeInstanceWriter getFlowNodeInstanceWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
@@ -18,6 +19,7 @@ import io.camunda.db.rdbms.write.service.VariableWriter;
 public class RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
+  private final DecisionDefinitionWriter decisionDefinitionWriter;
   private final ExporterPositionService exporterPositionService;
   private final FlowNodeInstanceWriter flowNodeInstanceWriter;
   private final ProcessDefinitionWriter processDefinitionWriter;
@@ -29,11 +31,16 @@ public class RdbmsWriter {
       final ExecutionQueue executionQueue, final ExporterPositionService exporterPositionService) {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
+    decisionDefinitionWriter = new DecisionDefinitionWriter(executionQueue);
     flowNodeInstanceWriter = new FlowNodeInstanceWriter(executionQueue);
     processDefinitionWriter = new ProcessDefinitionWriter(executionQueue);
     processInstanceWriter = new ProcessInstanceWriter(executionQueue);
     variableWriter = new VariableWriter(executionQueue);
     userTaskWriter = new UserTaskWriter(executionQueue);
+  }
+
+  public DecisionDefinitionWriter getDecisionDefinitionWriter() {
+    return decisionDefinitionWriter;
   }
 
   public FlowNodeInstanceWriter getFlowNodeInstanceWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionDefinitionDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionDefinitionDbModel.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+
+public record DecisionDefinitionDbModel(
+    Long decisionDefinitionKey,
+    String name,
+    String decisionDefinitionId,
+    String tenantId,
+    int version,
+    String decisionRequirementsId,
+    Long decisionRequirementsKey) {
+
+  // create a builder for this record extending ObjectBuilder
+  public static class DecisionDefinitionDbModelBuilder
+      implements ObjectBuilder<DecisionDefinitionDbModel> {
+
+    private Long decisionDefinitionKey;
+    private String name;
+    private String decisionDefinitionId;
+    private String tenantId;
+    private int version;
+    private String decisionRequirementsId;
+    private Long decisionRequirementsKey;
+
+    public DecisionDefinitionDbModelBuilder decisionDefinitionKey(
+        final Long decisionDefinitionKey) {
+      this.decisionDefinitionKey = decisionDefinitionKey;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder name(final String name) {
+      this.name = name;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder decisionDefinitionId(
+        final String decisionDefinitionId) {
+      this.decisionDefinitionId = decisionDefinitionId;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder tenantId(final String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder version(final int version) {
+      this.version = version;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder decisionRequirementsId(
+        final String decisionRequirementsId) {
+      this.decisionRequirementsId = decisionRequirementsId;
+      return this;
+    }
+
+    public DecisionDefinitionDbModelBuilder decisionRequirementsKey(
+        final Long decisionRequirementsKey) {
+      this.decisionRequirementsKey = decisionRequirementsKey;
+      return this;
+    }
+
+    @Override
+    public DecisionDefinitionDbModel build() {
+      return new DecisionDefinitionDbModel(
+          decisionDefinitionKey,
+          name,
+          decisionDefinitionId,
+          tenantId,
+          version,
+          decisionRequirementsId,
+          decisionRequirementsKey);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionRequirementsDbModel.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.util.ObjectBuilder;
+
+public record DecisionRequirementsDbModel(
+    Long decisionRequirementsKey,
+    String decisionRequirementsId,
+    String name,
+    String resourceName,
+    Integer version,
+    String xml,
+    String tenantId) {
+
+  public static final class Builder implements ObjectBuilder<DecisionRequirementsDbModel> {
+
+    private Long decisionRequirementsKey;
+    private String decisionRequirementsId;
+    private String name;
+    private String resourceName;
+    private Integer version;
+    private String xml;
+    private String tenantId;
+
+    public DecisionRequirementsDbModel.Builder decisionRequirementsKey(final Long value) {
+      decisionRequirementsKey = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder decisionRequirementsId(final String value) {
+      decisionRequirementsId = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder name(final String value) {
+      name = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder resourceName(final String value) {
+      resourceName = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder version(final Integer value) {
+      version = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder xml(final String value) {
+      xml = value;
+      return this;
+    }
+
+    public DecisionRequirementsDbModel.Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
+    @Override
+    public DecisionRequirementsDbModel build() {
+      return new DecisionRequirementsDbModel(
+          decisionRequirementsKey,
+          decisionRequirementsId,
+          name,
+          resourceName,
+          version,
+          xml,
+          tenantId);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write.queue;
 
 public enum ContextType {
   EXPORTER_POSITION,
+  DECISION_DEFINITION,
   PROCESS_DEFINITION,
   PROCESS_INSTANCE,
   FLOW_NODE,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionDefinitionWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionDefinitionWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+
+public class DecisionDefinitionWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public DecisionDefinitionWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final DecisionDefinitionDbModel decisionDefinition) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.DECISION_DEFINITION,
+            decisionDefinition.decisionDefinitionKey(),
+            "io.camunda.db.rdbms.sql.DecisionDefinitionMapper.insert",
+            decisionDefinition));
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionRequirementsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionRequirementsWriter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+
+public class DecisionRequirementsWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public DecisionRequirementsWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final DecisionRequirementsDbModel decisionRequirements) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.DECISION_DEFINITION,
+            decisionRequirements.decisionRequirementsKey(),
+            "io.camunda.db.rdbms.sql.DecisionRequirementsMapper.insert",
+            decisionRequirements));
+  }
+}

--- a/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
+++ b/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
@@ -160,4 +160,22 @@
   </changeSet>
 
 
+  <changeSet id="create_decision_definition_table" author="cthiel">
+    <createTable tableName="DECISION_DEFINITION">
+      <column name="DECISION_DEFINITION_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="NAME" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="VERSION" type="SMALLINT" />
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT" />
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(255)" />
+    </createTable>
+
+    <createIndex tableName="DECISION_DEFINITION" indexName="IDX_DECISION_DEFINITION_ID">
+      <column name="DECISION_DEFINITION_ID" />
+    </createIndex>
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
+++ b/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
@@ -165,7 +165,7 @@
       <column name="DECISION_DEFINITION_KEY" type="BIGINT">
         <constraints primaryKey="true"/>
       </column>
-      <column name="DECISION_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="DECISION_DEFINITION_ID" type="VARCHAR(200)" />
       <column name="NAME" type="VARCHAR(200)" />
       <column name="TENANT_ID" type="VARCHAR(255)" />
       <column name="VERSION" type="SMALLINT" />
@@ -175,6 +175,24 @@
 
     <createIndex tableName="DECISION_DEFINITION" indexName="IDX_DECISION_DEFINITION_ID">
       <column name="DECISION_DEFINITION_ID" />
+    </createIndex>
+  </changeSet>
+
+  <changeSet id="create_decision_requirements_table" author="cthiel">
+    <createTable tableName="DECISION_REQUIREMENTS">
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(200)" />
+      <column name="NAME" type="VARCHAR(200)" />
+      <column name="TENANT_ID" type="VARCHAR(255)" />
+      <column name="VERSION" type="SMALLINT" />
+      <column name="RESOURCE_NAME" type="VARCHAR(4000)" />
+      <column name="XML" type="CLOB" />
+    </createTable>
+
+    <createIndex tableName="DECISION_REQUIREMENTS" indexName="IDX_DECISION_REQUIREMENTS_ID">
+      <column name="DECISION_REQUIREMENTS_ID" />
     </createIndex>
   </changeSet>
 

--- a/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionDefinitionMapper.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.DecisionDefinitionMapper">
+
+  <select id="count" parameterType="io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery">
+    SELECT COUNT(*)
+    FROM DECISION_DEFINITION
+    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
+  </select>
+
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.DecisionDefinitionDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchResultMap">
+    SELECT * FROM (
+    SELECT DECISION_DEFINITION_KEY,
+    DECISION_DEFINITION_ID,
+    NAME,
+    TENANT_ID,
+    VERSION,
+    DECISION_REQUIREMENTS_KEY,
+    DECISION_REQUIREMENTS_ID
+    FROM DECISION_DEFINITION
+    <include refid="io.camunda.db.rdbms.sql.DecisionDefinitionMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="searchFilter">
+    WHERE 1 = 1
+    <!-- basic filters -->
+    <if test="filter.decisionDefinitionKeys != null and !filter.decisionDefinitionKeys.isEmpty()">
+      AND DECISION_DEFINITION_KEY IN
+      <foreach collection="filter.decisionDefinitionKeys" item="value" open="(" separator=", "
+        close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionDefinitionIds != null and !filter.decisionDefinitionIds.isEmpty()">
+      AND DECISION_DEFINITION_ID IN
+      <foreach collection="filter.decisionDefinitionIds" item="value" open="(" separator=", "
+        close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.names != null and !filter.names.isEmpty()">
+      AND name IN
+      <foreach collection="filter.names" item="value" open="(" separator=", " close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.versions != null and !filter.versions.isEmpty()">
+      AND VERSION IN
+      <foreach collection="filter.versions" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionRequirementsIds != null and !filter.decisionRequirementsIds.isEmpty()">
+      AND DECISION_REQUIREMENTS_ID IN
+      <foreach collection="filter.decisionRequirementsIds" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionRequirementsKeys != null and !filter.decisionRequirementsKeys.isEmpty()">
+      AND DECISION_REQUIREMENTS_KEY IN
+      <foreach collection="filter.decisionRequirementsKeys" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+  </sql>
+
+  <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionDefinitionEntity">
+    <constructor>
+      <idArg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="NAME" javaType="java.lang.String"/>
+      <arg column="VERSION" javaType="java.lang.Integer"/>
+      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"/>
+      <arg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+    </constructor>
+  </resultMap>
+
+  <insert
+    id="insert"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel"
+    flushCache="true">
+    INSERT INTO DECISION_DEFINITION (DECISION_DEFINITION_KEY, DECISION_DEFINITION_ID, NAME, TENANT_ID, VERSION, DECISION_REQUIREMENTS_ID, DECISION_REQUIREMENTS_KEY)
+    VALUES (#{decisionDefinitionKey}, #{decisionDefinitionId}, #{name},
+            #{tenantId}, #{version}, #{decisionRequirementsId}, #{decisionRequirementsKey})
+  </insert>
+</mapper>

--- a/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionRequirementsMapper.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.DecisionRequirementsMapper">
+
+  <select id="count" parameterType="io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery">
+    SELECT COUNT(*)
+    FROM DECISION_REQUIREMENTS
+    <include refid="io.camunda.db.rdbms.sql.DecisionRequirementsMapper.searchFilter"/>
+  </select>
+
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.DecisionRequirementsDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.DecisionRequirementsMapper.searchResultMap">
+    SELECT * FROM (
+    SELECT DECISION_REQUIREMENTS_KEY,
+    DECISION_REQUIREMENTS_ID,
+    NAME,
+    TENANT_ID,
+    VERSION,
+    <if test="resultConfig.includeXml">XML,</if>
+    <if test="!resultConfig.includeXml">NULL AS XML,</if>
+    RESOURCE_NAME
+    FROM DECISION_REQUIREMENTS
+    <include refid="io.camunda.db.rdbms.sql.DecisionRequirementsMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="searchFilter">
+    WHERE 1 = 1
+    <!-- basic filters -->
+    <if test="filter.decisionRequirementsKeys != null and !filter.decisionRequirementsKeys.isEmpty()">
+      AND DECISION_REQUIREMENTS_KEY IN
+      <foreach collection="filter.decisionRequirementsKeys" item="value" open="(" separator=", "
+        close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionRequirementsIds != null and !filter.decisionRequirementsIds.isEmpty()">
+      AND DECISION_REQUIREMENTS_ID IN
+      <foreach collection="filter.decisionRequirementsIds" item="value" open="(" separator=", "
+        close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.names != null and !filter.names.isEmpty()">
+      AND name IN
+      <foreach collection="filter.names" item="value" open="(" separator=", " close=")">#{value}
+      </foreach>
+    </if>
+    <if test="filter.versions != null and !filter.versions.isEmpty()">
+      AND VERSION IN
+      <foreach collection="filter.versions" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
+      AND TENANT_ID IN
+      <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">
+        #{value}
+      </foreach>
+    </if>
+  </sql>
+
+  <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionRequirementsEntity">
+    <constructor>
+      <idArg column="DECISION_REQUIREMENTS_KEY" javaType="java.lang.Long"/>
+      <arg column="DECISION_REQUIREMENTS_ID" javaType="java.lang.String"/>
+      <arg column="NAME" javaType="java.lang.String"/>
+      <arg column="VERSION" javaType="java.lang.Integer"/>
+      <arg column="RESOURCE_NAME" javaType="java.lang.String"/>
+      <arg column="XML" javaType="java.lang.String"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+    </constructor>
+  </resultMap>
+
+  <insert
+    id="insert"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel"
+    flushCache="true">
+    INSERT INTO DECISION_REQUIREMENTS (DECISION_REQUIREMENTS_KEY, DECISION_REQUIREMENTS_ID, NAME, TENANT_ID, VERSION, RESOURCE_NAME, XML)
+    VALUES (#{decisionRequirementsKey}, #{decisionRequirementsId}, #{name},
+            #{tenantId}, #{version}, #{resourceName}, #{xml})
+  </insert>
+</mapper>

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -16,7 +16,7 @@ import io.camunda.db.rdbms.read.domain.DbQueryPage.KeySetPaginationFieldEntry;
 import io.camunda.db.rdbms.read.domain.DbQueryPage.Operator;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
-import io.camunda.db.rdbms.sql.ProcessInstanceMapper.ProcessInstanceSearchColumn;
+import io.camunda.db.rdbms.sql.columns.ProcessInstanceSearchColumn;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.sort.ProcessInstanceSort;

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.commons.rdbms;
 
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
@@ -75,6 +76,12 @@ public class MyBatisConfiguration {
 
     factoryBean.setConfigurationProperties(p);
     return factoryBean.getObject();
+  }
+
+  @Bean
+  public MapperFactoryBean<DecisionDefinitionMapper> decisionDefinitionMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, DecisionDefinitionMapper.class);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.rdbms;
 
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
@@ -82,6 +83,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<DecisionDefinitionMapper> decisionDefinitionMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, DecisionDefinitionMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<DecisionRequirementsMapper> decisionRequirementsMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, DecisionRequirementsMapper.class);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -9,12 +9,14 @@ package io.camunda.application.commons.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.read.service.VariableReader;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
@@ -42,6 +44,12 @@ public class RdbmsConfiguration {
   public DecisionDefinitionReader decisionDefinitionReader(
       final DecisionDefinitionMapper decisionDefinitionMapper) {
     return new DecisionDefinitionReader(decisionDefinitionMapper);
+  }
+
+  @Bean
+  public DecisionRequirementsReader decisionRequirementsReader(
+      final DecisionRequirementsMapper decisionRequirementsMapper) {
+    return new DecisionRequirementsReader(decisionRequirementsMapper);
   }
 
   @Bean
@@ -79,6 +87,7 @@ public class RdbmsConfiguration {
       final RdbmsWriterFactory rdbmsWriterFactory,
       final VariableReader variableReader,
       final DecisionDefinitionReader decisionDefinitionReader,
+      final DecisionRequirementsReader decisionRequirementsReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceReader processInstanceReader,
@@ -86,6 +95,7 @@ public class RdbmsConfiguration {
     return new RdbmsService(
         rdbmsWriterFactory,
         decisionDefinitionReader,
+        decisionRequirementsReader,
         flowNodeInstanceReader,
         processDefinitionReader,
         processInstanceReader,

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -8,11 +8,13 @@
 package io.camunda.application.commons.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
 import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.read.service.VariableReader;
+import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.sql.ProcessDefinitionMapper;
@@ -34,6 +36,12 @@ public class RdbmsConfiguration {
   @Bean
   public VariableReader variableRdbmsReader(final VariableMapper variableMapper) {
     return new VariableReader(variableMapper);
+  }
+
+  @Bean
+  public DecisionDefinitionReader decisionDefinitionReader(
+      final DecisionDefinitionMapper decisionDefinitionMapper) {
+    return new DecisionDefinitionReader(decisionDefinitionMapper);
   }
 
   @Bean
@@ -70,12 +78,14 @@ public class RdbmsConfiguration {
   public RdbmsService rdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
       final VariableReader variableReader,
+      final DecisionDefinitionReader decisionDefinitionReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
       final ProcessInstanceReader processInstanceReader,
       final UserTaskReader userTaskReader) {
     return new RdbmsService(
         rdbmsWriterFactory,
+        decisionDefinitionReader,
         flowNodeInstanceReader,
         processDefinitionReader,
         processInstanceReader,

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisiondefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
+import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.filter.DecisionDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.sort.DecisionDefinitionSort;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionDefinitionIT {
+
+  public static final Long PARTITION_ID = 0L;
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @TestTemplate
+  public void shouldSaveAndFindByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
+    createAndSaveDecisionDefinition(rdbmsWriter, decisionDefinition);
+
+    final var instance =
+        decisionDefinitionReader.findOne(decisionDefinition.decisionDefinitionKey()).orElse(null);
+    assertThat(instance).isNotNull();
+    assertThat(instance.decisionDefinitionKey())
+        .isEqualTo(decisionDefinition.decisionDefinitionKey());
+    assertThat(instance.version()).isEqualTo(decisionDefinition.version());
+    assertThat(instance.name()).isEqualTo(decisionDefinition.name());
+    assertThat(instance.decisionDefinitionId())
+        .isEqualTo(decisionDefinition.decisionDefinitionId());
+    assertThat(instance.decisionRequirementsId())
+        .isEqualTo(decisionDefinition.decisionRequirementsId());
+    assertThat(instance.decisionRequirementsKey())
+        .isEqualTo(decisionDefinition.decisionRequirementsKey());
+  }
+
+  @TestTemplate
+  public void shouldFindByBpmnProcessId(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createRandomized(
+            b -> b.decisionDefinitionId("test-process-unique"));
+    createAndSaveDecisionDefinition(rdbmsWriter, decisionDefinition);
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                new DecisionDefinitionFilter.Builder()
+                    .decisionDefinitionIds("test-process-unique")
+                    .build(),
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(10))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+
+    final var instance = searchResult.items().getFirst();
+
+    assertThat(instance.decisionDefinitionKey())
+        .isEqualTo(decisionDefinition.decisionDefinitionKey());
+    assertThat(instance.version()).isEqualTo(decisionDefinition.version());
+    assertThat(instance.name()).isEqualTo(decisionDefinition.name());
+    assertThat(instance.decisionDefinitionId())
+        .isEqualTo(decisionDefinition.decisionDefinitionId());
+    assertThat(instance.decisionRequirementsId())
+        .isEqualTo(decisionDefinition.decisionRequirementsId());
+    assertThat(instance.decisionRequirementsKey())
+        .isEqualTo(decisionDefinition.decisionRequirementsKey());
+  }
+
+  @TestTemplate
+  public void shouldFindAllPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    final String decisionDefinitionId = DecisionDefinitionFixtures.nextStringId();
+    createAndSaveRandomDecisionDefinitions(
+        rdbmsWriter, b -> b.decisionDefinitionId(decisionDefinitionId));
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                new DecisionDefinitionFilter.Builder()
+                    .decisionDefinitionIds(decisionDefinitionId)
+                    .build(),
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+  }
+
+  @TestTemplate
+  public void shouldFindAllPageValuesAreNull(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    createAndSaveRandomDecisionDefinitions(rdbmsWriter);
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                new DecisionDefinitionFilter.Builder().build(),
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(null).size(null))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isGreaterThanOrEqualTo(20);
+    assertThat(searchResult.items()).hasSizeGreaterThanOrEqualTo(20);
+  }
+
+  @TestTemplate
+  public void shouldFindWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    final var decisionDefinition = DecisionDefinitionFixtures.createRandomized(b -> b);
+    createAndSaveRandomDecisionDefinitions(rdbmsWriter);
+    createAndSaveDecisionDefinition(rdbmsWriter, decisionDefinition);
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                new DecisionDefinitionFilter.Builder()
+                    .decisionDefinitionKeys(decisionDefinition.decisionDefinitionKey())
+                    .decisionDefinitionIds(decisionDefinition.decisionDefinitionId())
+                    .names(decisionDefinition.name())
+                    .versions(decisionDefinition.version())
+                    .tenantIds(decisionDefinition.tenantId())
+                    .decisionRequirementsIds(decisionDefinition.decisionRequirementsId())
+                    .decisionRequirementsKeys(decisionDefinition.decisionRequirementsKey())
+                    .build(),
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionDefinitionKey())
+        .isEqualTo(decisionDefinition.decisionDefinitionKey());
+  }
+
+  @TestTemplate
+  public void shouldFindWithSearchAfter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader decisionDefinitionReader =
+        rdbmsService.getDecisionDefinitionReader();
+
+    createAndSaveRandomDecisionDefinitions(rdbmsWriter, b -> b.tenantId("search-after-123456"));
+    final var sort =
+        DecisionDefinitionSort.of(s -> s.name().asc().version().asc().tenantId().desc());
+    final var searchResult =
+        decisionDefinitionReader.search(
+            DecisionDefinitionQuery.of(
+                b ->
+                    b.filter(f -> f.tenantIds("search-after-123456"))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var instanceAfter = searchResult.items().get(9);
+    final var nextPage =
+        decisionDefinitionReader.search(
+            DecisionDefinitionQuery.of(
+                b ->
+                    b.filter(f -> f.tenantIds("search-after-123456"))
+                        .sort(sort)
+                        .page(
+                            p ->
+                                p.size(5)
+                                    .searchAfter(
+                                        new Object[]{
+                                            instanceAfter.name(),
+                                            instanceAfter.version(),
+                                            instanceAfter.tenantId(),
+                                            instanceAfter.decisionDefinitionKey()
+                                        }))));
+
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(5);
+    assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(10, 15));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionIT.java
@@ -34,8 +34,7 @@ public class DecisionDefinitionIT {
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
   @TestTemplate
-  public void shouldSaveAndFindByKey(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -60,8 +59,7 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
-  public void shouldFindByBpmnProcessId(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindByBpmnProcessId(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -100,8 +98,7 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
-  public void shouldFindAllPaged(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -126,8 +123,7 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
-  public void shouldFindAllPageValuesAreNull(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindAllPageValuesAreNull(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -148,8 +144,7 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
-  public void shouldFindWithFullFilter(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -181,8 +176,7 @@ public class DecisionDefinitionIT {
   }
 
   @TestTemplate
-  public void shouldFindWithSearchAfter(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionDefinitionReader decisionDefinitionReader =
@@ -210,11 +204,11 @@ public class DecisionDefinitionIT {
                             p ->
                                 p.size(5)
                                     .searchAfter(
-                                        new Object[]{
-                                            instanceAfter.name(),
-                                            instanceAfter.version(),
-                                            instanceAfter.tenantId(),
-                                            instanceAfter.decisionDefinitionKey()
+                                        new Object[] {
+                                          instanceAfter.name(),
+                                          instanceAfter.version(),
+                                          instanceAfter.tenantId(),
+                                          instanceAfter.decisionDefinitionKey()
                                         }))));
 
     assertThat(nextPage.total()).isEqualTo(20);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSortIT.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisiondefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.DecisionDefinitionEntity;
+import io.camunda.search.filter.DecisionDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.sort.DecisionDefinitionSort;
+import io.camunda.search.sort.DecisionDefinitionSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionDefinitionSortIT {
+
+  public static final Long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionIdAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionId().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionId));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionIdDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionId().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionKey().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionKey().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionDefinitionKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::name));
+  }
+
+  @TestTemplate
+  public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::name).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByRequirementsIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsId().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsId));
+  }
+
+  @TestTemplate
+  public void shouldSortByRequirementsIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsId().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::decisionRequirementsId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::version));
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::version).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().asc(),
+        Comparator.comparing(DecisionDefinitionEntity::tenantId));
+  }
+
+  @TestTemplate
+  public void shouldSortByTenantIdDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.tenantId().desc(),
+        Comparator.comparing(DecisionDefinitionEntity::tenantId).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<DecisionDefinitionSort>> sortBuilder,
+      final Comparator<DecisionDefinitionEntity> comparator) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionDefinitionReader reader = rdbmsService.getDecisionDefinitionReader();
+
+    final var requirementsKey = nextKey();
+    createAndSaveRandomDecisionDefinitions(
+        rdbmsWriter, b -> b.decisionRequirementsKey(requirementsKey));
+
+    final var searchResult =
+        reader
+            .search(
+                new DecisionDefinitionQuery(
+                    new DecisionDefinitionFilter.Builder()
+                        .decisionRequirementsKeys(requirementsKey)
+                        .build(),
+                    DecisionDefinitionSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b)))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -39,11 +39,9 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
 public class DecisionDefinitionSpecificFilterIT {
 
-  @Autowired
-  private RdbmsService rdbmsService;
+  @Autowired private RdbmsService rdbmsService;
 
-  @Autowired
-  private DecisionDefinitionReader decisionDefinitionReader;
+  @Autowired private DecisionDefinitionReader decisionDefinitionReader;
 
   private RdbmsWriter rdbmsWriter;
 
@@ -54,8 +52,7 @@ public class DecisionDefinitionSpecificFilterIT {
 
   @ParameterizedTest
   @MethodSource("shouldFindWithSpecificFilterParameters")
-  public void shouldFindWithSpecificFilter(
-      final DecisionDefinitionFilter filter) {
+  public void shouldFindWithSpecificFilter(final DecisionDefinitionFilter filter) {
     createAndSaveRandomDecisionDefinitions(rdbmsWriter);
     createAndSaveDecisionDefinition(
         rdbmsWriter,

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisiondefinition/DecisionDefinitionSpecificFilterIT.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisiondefinition;
+
+import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveDecisionDefinition;
+import static io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinitions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.filter.DecisionDefinitionFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionDefinitionQuery;
+import io.camunda.search.sort.DecisionDefinitionSort;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@Tag("rdbms")
+@DataJdbcTest
+@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
+@AutoConfigurationPackage
+@TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
+public class DecisionDefinitionSpecificFilterIT {
+
+  @Autowired
+  private RdbmsService rdbmsService;
+
+  @Autowired
+  private DecisionDefinitionReader decisionDefinitionReader;
+
+  private RdbmsWriter rdbmsWriter;
+
+  @BeforeEach
+  public void beforeAll() {
+    rdbmsWriter = rdbmsService.createWriter(0L);
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldFindWithSpecificFilterParameters")
+  public void shouldFindWithSpecificFilter(
+      final DecisionDefinitionFilter filter) {
+    createAndSaveRandomDecisionDefinitions(rdbmsWriter);
+    createAndSaveDecisionDefinition(
+        rdbmsWriter,
+        DecisionDefinitionFixtures.createRandomized(
+            b ->
+                b.decisionDefinitionKey(1337L)
+                    .decisionDefinitionId("sorting-test-process")
+                    .name("Sorting Test Process")
+                    .version(1337)
+                    .decisionRequirementsKey(1338L)
+                    .decisionRequirementsId("requirements-1338")
+                    .tenantId("sorting-tenant1")));
+
+    final var searchResult =
+        decisionDefinitionReader.search(
+            new DecisionDefinitionQuery(
+                filter,
+                DecisionDefinitionSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionDefinitionKey()).isEqualTo(1337L);
+  }
+
+  static List<DecisionDefinitionFilter> shouldFindWithSpecificFilterParameters() {
+    return List.of(
+        new DecisionDefinitionFilter.Builder().decisionDefinitionKeys(1337L).build(),
+        new DecisionDefinitionFilter.Builder()
+            .decisionDefinitionIds("sorting-test-process")
+            .build(),
+        new DecisionDefinitionFilter.Builder().names("Sorting Test Process").build(),
+        new DecisionDefinitionFilter.Builder().decisionRequirementsIds("requirements-1338").build(),
+        new DecisionDefinitionFilter.Builder().decisionRequirementsKeys(1338L).build(),
+        new DecisionDefinitionFilter.Builder().versions(1337).build(),
+        new DecisionDefinitionFilter.Builder().tenantIds("sorting-tenant1").build());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -35,8 +35,7 @@ public class DecisionRequirementsIT {
   public static final OffsetDateTime NOW = OffsetDateTime.now();
 
   @TestTemplate
-  public void shouldSaveAndFindByKey(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldSaveAndFindByKey(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsReader decisionRequirementsReader =
@@ -62,8 +61,7 @@ public class DecisionRequirementsIT {
   }
 
   @TestTemplate
-  public void shouldFindById(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindById(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsReader decisionRequirementsReader =
@@ -101,8 +99,7 @@ public class DecisionRequirementsIT {
   }
 
   @TestTemplate
-  public void shouldFindAllPaged(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindAllPaged(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsReader decisionRequirementsReader =
@@ -135,8 +132,7 @@ public class DecisionRequirementsIT {
   }
 
   @TestTemplate
-  public void shouldFindWithFullFilter(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindWithFullFilter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsReader decisionRequirementsReader =
@@ -169,8 +165,7 @@ public class DecisionRequirementsIT {
   }
 
   @TestTemplate
-  public void shouldFindWithSearchAfter(
-      final CamundaRdbmsTestApplication testApplication) {
+  public void shouldFindWithSearchAfter(final CamundaRdbmsTestApplication testApplication) {
     final RdbmsService rdbmsService = testApplication.getRdbmsService();
     final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
     final DecisionRequirementsReader decisionRequirementsReader =
@@ -198,11 +193,11 @@ public class DecisionRequirementsIT {
                             p ->
                                 p.size(5)
                                     .searchAfter(
-                                        new Object[]{
-                                            instanceAfter.name(),
-                                            instanceAfter.version(),
-                                            instanceAfter.tenantId(),
-                                            instanceAfter.decisionRequirementsKey()
+                                        new Object[] {
+                                          instanceAfter.name(),
+                                          instanceAfter.version(),
+                                          instanceAfter.tenantId(),
+                                          instanceAfter.decisionRequirementsKey()
                                         }))));
 
     assertThat(nextPage.total()).isEqualTo(20);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsIT.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisionrequirements;
+
+import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
+import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.filter.DecisionRequirementsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
+import io.camunda.search.sort.DecisionRequirementsSort;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionRequirementsIT {
+
+  public static final Long PARTITION_ID = 0L;
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @TestTemplate
+  public void shouldSaveAndFindByKey(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
+    createAndSaveDecisionRequirement(rdbmsWriter, decisionRequirements);
+
+    final var instance =
+        decisionRequirementsReader
+            .findOne(decisionRequirements.decisionRequirementsKey())
+            .orElse(null);
+
+    assertThat(instance).isNotNull();
+    assertThat(instance.decisionRequirementsKey())
+        .isEqualTo(decisionRequirements.decisionRequirementsKey());
+    assertThat(instance.version()).isEqualTo(decisionRequirements.version());
+    assertThat(instance.name()).isEqualTo(decisionRequirements.name());
+    assertThat(instance.decisionRequirementsId())
+        .isEqualTo(decisionRequirements.decisionRequirementsId());
+    assertThat(instance.resourceName()).isEqualTo(decisionRequirements.resourceName());
+    assertThat(instance.xml()).isEqualTo(decisionRequirements.xml());
+  }
+
+  @TestTemplate
+  public void shouldFindById(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    final var decisionRequirements =
+        DecisionRequirementsFixtures.createRandomized(
+            b -> b.decisionRequirementsId("test-process-unique"));
+    createAndSaveDecisionRequirement(rdbmsWriter, decisionRequirements);
+
+    final var searchResult =
+        decisionRequirementsReader.search(
+            new DecisionRequirementsQuery(
+                new DecisionRequirementsFilter.Builder()
+                    .decisionRequirementsIds("test-process-unique")
+                    .build(),
+                DecisionRequirementsSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(10)),
+                DecisionRequirementsQueryResultConfig.of(b -> b.includeXml(true))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+
+    final var instance = searchResult.items().getFirst();
+
+    assertThat(instance.decisionRequirementsKey())
+        .isEqualTo(decisionRequirements.decisionRequirementsKey());
+    assertThat(instance.version()).isEqualTo(decisionRequirements.version());
+    assertThat(instance.name()).isEqualTo(decisionRequirements.name());
+    assertThat(instance.decisionRequirementsId())
+        .isEqualTo(decisionRequirements.decisionRequirementsId());
+    assertThat(instance.resourceName()).isEqualTo(decisionRequirements.resourceName());
+    assertThat(instance.xml()).isEqualTo(decisionRequirements.xml());
+  }
+
+  @TestTemplate
+  public void shouldFindAllPaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    final String decisionRequirementsId = DecisionRequirementsFixtures.nextStringId();
+    createAndSaveRandomDecisionRequirements(
+        rdbmsWriter, b -> b.decisionRequirementsId(decisionRequirementsId));
+
+    final var searchResult =
+        decisionRequirementsReader.search(
+            new DecisionRequirementsQuery(
+                new DecisionRequirementsFilter.Builder()
+                    .decisionRequirementsIds(decisionRequirementsId)
+                    .build(),
+                DecisionRequirementsSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5)),
+                null));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+
+    // by default XML is not filled
+    assertThat(searchResult.items())
+        .allSatisfy(
+            item -> {
+              assertThat(item.xml()).isNull();
+            });
+  }
+
+  @TestTemplate
+  public void shouldFindWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    final var decisionRequirements = DecisionRequirementsFixtures.createRandomized(b -> b);
+    createAndSaveRandomDecisionRequirements(rdbmsWriter);
+    createAndSaveDecisionRequirement(rdbmsWriter, decisionRequirements);
+
+    final var searchResult =
+        decisionRequirementsReader.search(
+            new DecisionRequirementsQuery(
+                new DecisionRequirementsFilter.Builder()
+                    .decisionRequirementsKeys(decisionRequirements.decisionRequirementsKey())
+                    .decisionRequirementsIds(decisionRequirements.decisionRequirementsId())
+                    .names(decisionRequirements.name())
+                    .versions(decisionRequirements.version())
+                    .tenantIds(decisionRequirements.tenantId())
+                    .decisionRequirementsIds(decisionRequirements.decisionRequirementsId())
+                    .decisionRequirementsKeys(decisionRequirements.decisionRequirementsKey())
+                    .build(),
+                DecisionRequirementsSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5)),
+                null));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionRequirementsKey())
+        .isEqualTo(decisionRequirements.decisionRequirementsKey());
+  }
+
+  @TestTemplate
+  public void shouldFindWithSearchAfter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader decisionRequirementsReader =
+        rdbmsService.getDecisionRequirementsReader();
+
+    createAndSaveRandomDecisionRequirements(rdbmsWriter, b -> b.tenantId("search-after-123456"));
+    final var sort =
+        DecisionRequirementsSort.of(s -> s.name().asc().version().asc().tenantId().desc());
+    final var searchResult =
+        decisionRequirementsReader.search(
+            DecisionRequirementsQuery.of(
+                b ->
+                    b.filter(f -> f.tenantIds("search-after-123456"))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var instanceAfter = searchResult.items().get(9);
+    final var nextPage =
+        decisionRequirementsReader.search(
+            DecisionRequirementsQuery.of(
+                b ->
+                    b.filter(f -> f.tenantIds("search-after-123456"))
+                        .sort(sort)
+                        .page(
+                            p ->
+                                p.size(5)
+                                    .searchAfter(
+                                        new Object[]{
+                                            instanceAfter.name(),
+                                            instanceAfter.version(),
+                                            instanceAfter.tenantId(),
+                                            instanceAfter.decisionRequirementsKey()
+                                        }))));
+
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(5);
+    assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(10, 15));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSortIT.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisionrequirements;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextStringId;
+import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.DecisionRequirementsEntity;
+import io.camunda.search.filter.DecisionRequirementsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.sort.DecisionRequirementsSort;
+import io.camunda.search.sort.DecisionRequirementsSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionRequirementsSortIT {
+
+  public static final Long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByDecisionRequirementsIdAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsId().asc(),
+        Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsId));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionRequirementsIdDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsId().desc(),
+        Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionRequirementsKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsKey().asc(),
+        Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionRequirementsKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionRequirementsKey().desc(),
+        Comparator.comparing(DecisionRequirementsEntity::decisionRequirementsKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByNameAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().asc(),
+        Comparator.comparing(DecisionRequirementsEntity::name));
+  }
+
+  @TestTemplate
+  public void shouldSortByNameDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.name().desc(),
+        Comparator.comparing(DecisionRequirementsEntity::name).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().asc(),
+        Comparator.comparing(DecisionRequirementsEntity::version));
+  }
+
+  @TestTemplate
+  public void shouldSortByVersionDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.version().desc(),
+        Comparator.comparing(DecisionRequirementsEntity::version).reversed());
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<DecisionRequirementsSort>> sortBuilder,
+      final Comparator<DecisionRequirementsEntity> comparator) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionRequirementsReader reader = rdbmsService.getDecisionRequirementsReader();
+
+    final var tenantId = nextStringId();
+    createAndSaveRandomDecisionRequirements(rdbmsWriter, b -> b.tenantId(tenantId));
+
+    final var searchResult =
+        reader
+            .search(
+                new DecisionRequirementsQuery(
+                    new DecisionRequirementsFilter.Builder().tenantIds(tenantId).build(),
+                    DecisionRequirementsSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b),
+                    null))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
@@ -39,11 +39,9 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
 public class DecisionRequirementsSpecificFilterIT {
 
-  @Autowired
-  private RdbmsService rdbmsService;
+  @Autowired private RdbmsService rdbmsService;
 
-  @Autowired
-  private DecisionRequirementsReader decisionRequirementsReader;
+  @Autowired private DecisionRequirementsReader decisionRequirementsReader;
 
   private RdbmsWriter rdbmsWriter;
 
@@ -54,8 +52,7 @@ public class DecisionRequirementsSpecificFilterIT {
 
   @ParameterizedTest
   @MethodSource("shouldFindWithSpecificFilterParameters")
-  public void shouldFindWithSpecificFilter(
-      final DecisionRequirementsFilter filter) {
+  public void shouldFindWithSpecificFilter(final DecisionRequirementsFilter filter) {
     createAndSaveRandomDecisionRequirements(rdbmsWriter);
     createAndSaveDecisionRequirement(
         rdbmsWriter,
@@ -80,8 +77,7 @@ public class DecisionRequirementsSpecificFilterIT {
     assertThat(searchResult.items().getFirst().decisionRequirementsKey()).isEqualTo(1337L);
   }
 
-  static List<DecisionRequirementsFilter>
-  shouldFindWithSpecificFilterParameters() {
+  static List<DecisionRequirementsFilter> shouldFindWithSpecificFilterParameters() {
     return List.of(
         new DecisionRequirementsFilter.Builder().decisionRequirementsKeys(1337L).build(),
         new DecisionRequirementsFilter.Builder()

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisionrequirements/DecisionRequirementsSpecificFilterIT.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisionrequirements;
+
+import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveDecisionRequirement;
+import static io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures.createAndSaveRandomDecisionRequirements;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionRequirementsFixtures;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.filter.DecisionRequirementsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionRequirementsQuery;
+import io.camunda.search.sort.DecisionRequirementsSort;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@Tag("rdbms")
+@DataJdbcTest
+@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
+@AutoConfigurationPackage
+@TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
+public class DecisionRequirementsSpecificFilterIT {
+
+  @Autowired
+  private RdbmsService rdbmsService;
+
+  @Autowired
+  private DecisionRequirementsReader decisionRequirementsReader;
+
+  private RdbmsWriter rdbmsWriter;
+
+  @BeforeEach
+  public void beforeAll() {
+    rdbmsWriter = rdbmsService.createWriter(0L);
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldFindWithSpecificFilterParameters")
+  public void shouldFindWithSpecificFilter(
+      final DecisionRequirementsFilter filter) {
+    createAndSaveRandomDecisionRequirements(rdbmsWriter);
+    createAndSaveDecisionRequirement(
+        rdbmsWriter,
+        DecisionRequirementsFixtures.createRandomized(
+            b ->
+                b.decisionRequirementsKey(1337L)
+                    .decisionRequirementsId("sorting-test-requirement")
+                    .name("Sorting Test Requirement")
+                    .version(1337)
+                    .tenantId("sorting-tenant1")));
+
+    final var searchResult =
+        decisionRequirementsReader.search(
+            new DecisionRequirementsQuery(
+                filter,
+                DecisionRequirementsSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5)),
+                null));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionRequirementsKey()).isEqualTo(1337L);
+  }
+
+  static List<DecisionRequirementsFilter>
+  shouldFindWithSpecificFilterParameters() {
+    return List.of(
+        new DecisionRequirementsFilter.Builder().decisionRequirementsKeys(1337L).build(),
+        new DecisionRequirementsFilter.Builder()
+            .decisionRequirementsIds("sorting-test-requirement")
+            .build(),
+        new DecisionRequirementsFilter.Builder().names("Sorting Test Requirement").build(),
+        new DecisionRequirementsFilter.Builder().versions(1337).build(),
+        new DecisionRequirementsFilter.Builder().tenantIds("sorting-tenant1").build());
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
+import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel.DecisionDefinitionDbModelBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final class DecisionDefinitionFixtures extends CommonFixtures {
+
+  private DecisionDefinitionFixtures() {}
+
+  public static DecisionDefinitionDbModel createRandomized(
+      final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
+          builderFunction) {
+    final var decisionDefinitionKey = nextKey();
+    final var decisionRequirementsKey = nextKey();
+    final var version = RANDOM.nextInt(1000);
+    final var builder =
+        new DecisionDefinitionDbModelBuilder()
+            .decisionDefinitionKey(decisionDefinitionKey)
+            .decisionDefinitionId("process-" + decisionDefinitionKey)
+            .name("Process " + decisionDefinitionKey)
+            .version(version)
+            .decisionRequirementsKey(decisionRequirementsKey)
+            .decisionRequirementsId("decision-requirements-" + decisionRequirementsKey)
+            .tenantId("tenant-" + RANDOM.nextInt(1000));
+
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveRandomDecisionDefinitions(final RdbmsWriter rdbmsWriter) {
+    createAndSaveRandomDecisionDefinitions(
+        rdbmsWriter, b -> b.decisionDefinitionId(nextStringId()));
+  }
+
+  public static void createAndSaveRandomDecisionDefinitions(
+      final RdbmsWriter rdbmsWriter,
+      final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
+          builderFunction) {
+    for (int i = 0; i < 20; i++) {
+      rdbmsWriter
+          .getDecisionDefinitionWriter()
+          .create(DecisionDefinitionFixtures.createRandomized(builderFunction));
+    }
+
+    rdbmsWriter.flush();
+  }
+
+  public static DecisionDefinitionDbModel createAndSaveDecisionDefinition(
+      final RdbmsWriter rdbmsWriter,
+      final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
+          builderFunction) {
+    final var definition = createRandomized(builderFunction);
+    createAndSaveDecisionDefinitions(rdbmsWriter, List.of(definition));
+    return definition;
+  }
+
+  public static void createAndSaveDecisionDefinition(
+      final RdbmsWriter rdbmsWriter, final DecisionDefinitionDbModel decisionDefinition) {
+    createAndSaveDecisionDefinitions(rdbmsWriter, List.of(decisionDefinition));
+  }
+
+  public static void createAndSaveDecisionDefinitions(
+      final RdbmsWriter rdbmsWriter, final List<DecisionDefinitionDbModel> decisionDefinitionList) {
+    for (final DecisionDefinitionDbModel decisionDefinition : decisionDefinitionList) {
+      rdbmsWriter.getDecisionDefinitionWriter().create(decisionDefinition);
+    }
+    rdbmsWriter.flush();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionRequirementsFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionRequirementsFixtures.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
+import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel.Builder;
+import java.util.List;
+import java.util.function.Function;
+
+public final class DecisionRequirementsFixtures extends CommonFixtures {
+
+  private DecisionRequirementsFixtures() {}
+
+  public static DecisionRequirementsDbModel createRandomized(
+      final Function<Builder, Builder> builderFunction) {
+    final var decisionRequirementsKey = nextKey();
+    final var version = RANDOM.nextInt(1000);
+    final var builder =
+        new Builder()
+            .decisionRequirementsKey(decisionRequirementsKey)
+            .decisionRequirementsId("requirement-" + decisionRequirementsKey)
+            .name("requirement " + decisionRequirementsKey)
+            .version(version)
+            .tenantId("tenant-" + RANDOM.nextInt(1000))
+            .resourceName("requirement-" + decisionRequirementsKey + ".xml")
+            .xml("<xml>" + decisionRequirementsKey + "</xml>");
+
+    return builderFunction.apply(builder).build();
+  }
+
+  public static void createAndSaveRandomDecisionRequirements(final RdbmsWriter rdbmsWriter) {
+    createAndSaveRandomDecisionRequirements(
+        rdbmsWriter, b -> b.decisionRequirementsId(nextStringId()));
+  }
+
+  public static void createAndSaveRandomDecisionRequirements(
+      final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
+    for (int i = 0; i < 20; i++) {
+      rdbmsWriter
+          .getDecisionRequirementsWriter()
+          .create(DecisionRequirementsFixtures.createRandomized(builderFunction));
+    }
+
+    rdbmsWriter.flush();
+  }
+
+  public static DecisionRequirementsDbModel createAndSaveDecisionRequirement(
+      final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
+    final var definition = createRandomized(builderFunction);
+    createAndSaveDecisionRequirements(rdbmsWriter, List.of(definition));
+    return definition;
+  }
+
+  public static void createAndSaveDecisionRequirement(
+      final RdbmsWriter rdbmsWriter, final DecisionRequirementsDbModel decisionRequirements) {
+    createAndSaveDecisionRequirements(rdbmsWriter, List.of(decisionRequirements));
+  }
+
+  public static void createAndSaveDecisionRequirements(
+      final RdbmsWriter rdbmsWriter,
+      final List<DecisionRequirementsDbModel> decisionRequirementsList) {
+    for (final DecisionRequirementsDbModel decisionRequirements : decisionRequirementsList) {
+      rdbmsWriter.getDecisionRequirementsWriter().create(decisionRequirements);
+    }
+    rdbmsWriter.flush();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -32,7 +33,9 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ImmutableDecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.ImmutableProcess;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
@@ -213,6 +216,23 @@ class RdbmsExporterIT {
   }
 
   @Test
+  public void shouldExportDecisionRequirements() {
+    // given
+    final var record = getDecisionRequirementsCreatedRecord(1L);
+
+    // when
+    exporter.export(record);
+    // and we do a manual flush
+    exporter.flushExecutionQueue();
+
+    // then
+    final var key =
+        ((DecisionRequirementsRecordValue) record.getValue()).getDecisionRequirementsKey();
+    final var entity = rdbmsService.getDecisionRequirementsReader().findOne(key);
+    assertThat(entity).isNotEmpty();
+  }
+
+  @Test
   public void shouldExportDecisionDefinition() {
     // given
     final var decisionDefinitionRecord = getDecisionDefinitionCreatedRecord(1L);
@@ -278,6 +298,24 @@ class RdbmsExporterIT {
             ImmutableProcess.builder()
                 .from((Process) recordValueRecord.getValue())
                 .withVersion(1)
+                .build())
+        .build();
+  }
+
+  private ImmutableRecord<RecordValue> getDecisionRequirementsCreatedRecord(final Long position) {
+    final Record<RecordValue> recordValueRecord =
+        factory.generateRecord(ValueType.DECISION_REQUIREMENTS);
+
+    return ImmutableRecord.builder()
+        .from(recordValueRecord)
+        .withIntent(DecisionRequirementsIntent.CREATED)
+        .withPosition(position)
+        .withTimestamp(System.currentTimeMillis())
+        .withPartitionId(1)
+        .withValue(
+            ImmutableDecisionRequirementsRecordValue.builder()
+                .from((DecisionRequirementsRecordValue) recordValueRecord.getValue())
+                .withDecisionRequirementsVersion(1)
                 .build())
         .build();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -58,8 +58,7 @@ class RdbmsExporterIT {
 
   private final ProtocolFactory factory = new ProtocolFactory(System.nanoTime());
 
-  @Autowired
-  private RdbmsService rdbmsService;
+  @Autowired private RdbmsService rdbmsService;
 
   private RdbmsExporter exporter;
 

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -60,19 +60,19 @@ import org.slf4j.LoggerFactory;
 
 public class RdbmsSearchClient
     implements AuthorizationSearchClient,
-    DecisionDefinitionSearchClient,
-    DecisionInstanceSearchClient,
-    DecisionRequirementSearchClient,
-    FlowNodeInstanceSearchClient,
-    FormSearchClient,
-    IncidentSearchClient,
-    ProcessInstanceSearchClient,
-    ProcessDefinitionSearchClient,
-    UserTaskSearchClient,
-    UserSearchClient,
-    VariableSearchClient,
-    RoleSearchClient,
-    TenantSearchClient {
+        DecisionDefinitionSearchClient,
+        DecisionInstanceSearchClient,
+        DecisionRequirementSearchClient,
+        FlowNodeInstanceSearchClient,
+        FormSearchClient,
+        IncidentSearchClient,
+        ProcessInstanceSearchClient,
+        ProcessDefinitionSearchClient,
+        UserTaskSearchClient,
+        UserSearchClient,
+        VariableSearchClient,
+        RoleSearchClient,
+        TenantSearchClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSearchClient.class);
 

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -60,19 +60,19 @@ import org.slf4j.LoggerFactory;
 
 public class RdbmsSearchClient
     implements AuthorizationSearchClient,
-        DecisionDefinitionSearchClient,
-        DecisionInstanceSearchClient,
-        DecisionRequirementSearchClient,
-        FlowNodeInstanceSearchClient,
-        FormSearchClient,
-        IncidentSearchClient,
-        ProcessInstanceSearchClient,
-        ProcessDefinitionSearchClient,
-        UserTaskSearchClient,
-        UserSearchClient,
-        VariableSearchClient,
-        RoleSearchClient,
-        TenantSearchClient {
+    DecisionDefinitionSearchClient,
+    DecisionInstanceSearchClient,
+    DecisionRequirementSearchClient,
+    FlowNodeInstanceSearchClient,
+    FormSearchClient,
+    IncidentSearchClient,
+    ProcessInstanceSearchClient,
+    ProcessDefinitionSearchClient,
+    UserTaskSearchClient,
+    UserSearchClient,
+    VariableSearchClient,
+    RoleSearchClient,
+    TenantSearchClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSearchClient.class);
 
@@ -108,8 +108,10 @@ public class RdbmsSearchClient
 
   @Override
   public SearchQueryResult<DecisionDefinitionEntity> searchDecisionDefinitions(
-      final DecisionDefinitionQuery filter) {
-    return null;
+      final DecisionDefinitionQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for decisionDefinition: {}", query);
+
+    return rdbmsService.getDecisionDefinitionReader().search(query);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionDefinitionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionDefinitionExportHandler.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
+import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DecisionDefinitionExportHandler implements RdbmsExportHandler<DecisionRecordValue> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DecisionDefinitionExportHandler.class);
+
+  private final DecisionDefinitionWriter decisionDefinitionWriter;
+
+  public DecisionDefinitionExportHandler(final DecisionDefinitionWriter decisionDefinitionWriter) {
+    this.decisionDefinitionWriter = decisionDefinitionWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<DecisionRecordValue> record) {
+    // do not react on DecisionIntent.DELETED to keep historic data
+    return record.getValueType() == ValueType.DECISION
+        && record.getIntent() == DecisionIntent.CREATED;
+  }
+
+  @Override
+  public void export(final Record<DecisionRecordValue> record) {
+    final DecisionRecordValue value = record.getValue();
+    decisionDefinitionWriter.create(map(value));
+  }
+
+  private DecisionDefinitionDbModel map(final DecisionRecordValue decision) {
+    return new DecisionDefinitionDbModel.DecisionDefinitionDbModelBuilder()
+        .decisionDefinitionId(decision.getDecisionId())
+        .decisionDefinitionKey(decision.getDecisionKey())
+        .name(decision.getDecisionName())
+        .version(decision.getVersion())
+        .decisionRequirementsId(decision.getDecisionRequirementsId())
+        .decisionRequirementsKey(decision.getDecisionRequirementsKey())
+        .tenantId(decision.getTenantId())
+        .build();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionRequirementsExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionRequirementsExportHandler.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
+import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
+import java.nio.charset.StandardCharsets;
+
+public class DecisionRequirementsExportHandler
+    implements RdbmsExportHandler<DecisionRequirementsRecordValue> {
+
+  private final DecisionRequirementsWriter decisionRequirementsWriter;
+
+  public DecisionRequirementsExportHandler(
+      final DecisionRequirementsWriter decisionRequirementsWriter) {
+    this.decisionRequirementsWriter = decisionRequirementsWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<DecisionRequirementsRecordValue> record) {
+    // do not react on DecisionRequirementsIntent.DELETED to keep historic data
+    return record.getValueType() == ValueType.DECISION_REQUIREMENTS
+        && record.getIntent() == DecisionRequirementsIntent.CREATED;
+  }
+
+  @Override
+  public void export(final Record<DecisionRequirementsRecordValue> record) {
+    final DecisionRequirementsRecordValue value = record.getValue();
+    decisionRequirementsWriter.create(map(value));
+  }
+
+  private DecisionRequirementsDbModel map(final DecisionRequirementsRecordValue value) {
+    return new DecisionRequirementsDbModel.Builder()
+        .decisionRequirementsKey(value.getDecisionRequirementsKey())
+        .decisionRequirementsId(value.getDecisionRequirementsId())
+        .name(value.getDecisionRequirementsName())
+        .version(value.getDecisionRequirementsVersion())
+        .resourceName(value.getResourceName())
+        .xml(new String(value.getResource(), StandardCharsets.UTF_8))
+        .tenantId(value.getTenantId())
+        .build();
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -23,10 +23,14 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
+/**
+ * https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/
+ */
 public class RdbmsExporter implements Exporter {
 
-  /** The partition on which all process deployments are published */
+  /**
+   * The partition on which all process deployments are published
+   */
   public static final long PROCESS_DEFINITION_PARTITION = 1L;
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsExporter.class);
@@ -124,6 +128,10 @@ public class RdbmsExporter implements Exporter {
           ValueType.PROCESS,
           List.of(new ProcessExportHandler(rdbmsWriter.getProcessDefinitionWriter())));
     }
+    registeredHandlers.put(
+        ValueType.DECISION,
+        List.of(
+            new DecisionDefinitionExportHandler(rdbmsWriter.getDecisionDefinitionWriter())));
     registeredHandlers.put(
         ValueType.PROCESS_INSTANCE,
         List.of(

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -23,14 +23,10 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/
- */
+/** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
 public class RdbmsExporter implements Exporter {
 
-  /**
-   * The partition on which all process deployments are published
-   */
+  /** The partition on which all process deployments are published */
   public static final long PROCESS_DEFINITION_PARTITION = 1L;
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsExporter.class);
@@ -130,8 +126,11 @@ public class RdbmsExporter implements Exporter {
     }
     registeredHandlers.put(
         ValueType.DECISION,
+        List.of(new DecisionDefinitionExportHandler(rdbmsWriter.getDecisionDefinitionWriter())));
+    registeredHandlers.put(
+        ValueType.DECISION_REQUIREMENTS,
         List.of(
-            new DecisionDefinitionExportHandler(rdbmsWriter.getDecisionDefinitionWriter())));
+            new DecisionRequirementsExportHandler(rdbmsWriter.getDecisionRequirementsWriter())));
     registeredHandlers.put(
         ValueType.PROCESS_INSTANCE,
         List.of(


### PR DESCRIPTION
## Description
Enabled the Rdbms to store and search for DMN entities like DecisionDefinitions, DecisionRequirements and DecisionInstances


closes #23265 #23267 
