### PR TITLE
fix: allow empty operate index prefix

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateElasticsearchProperties.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class OperateElasticsearchProperties extends ElasticsearchProperties {
 
-  public static final String DEFAULT_INDEX_PREFIX = "operate";
+  public static final String DEFAULT_INDEX_PREFIX = "";
   private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
@@ -27,7 +27,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return indexPrefix;
   }
 
-  public void setIndexPrefix(String indexPrefix) {
+  public void setIndexPrefix(final String indexPrefix) {
     this.indexPrefix = indexPrefix;
   }
 
@@ -55,7 +55,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return refreshInterval;
   }
 
-  public void setRefreshInterval(String refreshInterval) {
+  public void setRefreshInterval(final String refreshInterval) {
     this.refreshInterval = refreshInterval;
   }
 
@@ -63,7 +63,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return numberOfShardsForIndices;
   }
 
-  public void setNumberOfShardsForIndices(Map<String, Integer> numberOfShardsForIndices) {
+  public void setNumberOfShardsForIndices(final Map<String, Integer> numberOfShardsForIndices) {
     this.numberOfShardsForIndices = numberOfShardsForIndices;
   }
 
@@ -71,7 +71,7 @@ public class OperateElasticsearchProperties extends ElasticsearchProperties {
     return numberOfReplicasForIndices;
   }
 
-  public void setNumberOfReplicasForIndices(Map<String, Integer> numberOfReplicasForIndices) {
+  public void setNumberOfReplicasForIndices(final Map<String, Integer> numberOfReplicasForIndices) {
     this.numberOfReplicasForIndices = numberOfReplicasForIndices;
   }
 }

--- a/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OperateOpensearchProperties.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class OperateOpensearchProperties extends OpensearchProperties {
 
-  public static final String DEFAULT_INDEX_PREFIX = "operate";
+  public static final String DEFAULT_INDEX_PREFIX = "";
   private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";
@@ -27,7 +27,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return indexPrefix;
   }
 
-  public void setIndexPrefix(String indexPrefix) {
+  public void setIndexPrefix(final String indexPrefix) {
     this.indexPrefix = indexPrefix;
   }
 
@@ -55,7 +55,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return refreshInterval;
   }
 
-  public void setRefreshInterval(String refreshInterval) {
+  public void setRefreshInterval(final String refreshInterval) {
     this.refreshInterval = refreshInterval;
   }
 
@@ -63,7 +63,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return numberOfShardsForIndices;
   }
 
-  public void setNumberOfShardsForIndices(Map<String, Integer> numberOfShardsForIndices) {
+  public void setNumberOfShardsForIndices(final Map<String, Integer> numberOfShardsForIndices) {
     this.numberOfShardsForIndices = numberOfShardsForIndices;
   }
 
@@ -71,7 +71,7 @@ public class OperateOpensearchProperties extends OpensearchProperties {
     return numberOfReplicasForIndices;
   }
 
-  public void setNumberOfReplicasForIndices(Map<String, Integer> numberOfReplicasForIndices) {
+  public void setNumberOfReplicasForIndices(final Map<String, Integer> numberOfReplicasForIndices) {
     this.numberOfReplicasForIndices = numberOfReplicasForIndices;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
@@ -28,6 +28,8 @@ import io.camunda.operate.store.opensearch.client.sync.OpenSearchIndexOperations
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.util.IndexPrefixHolder;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
+import io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor;
+import io.camunda.webapps.schema.descriptors.ComponentNames;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import java.util.HashSet;
@@ -260,6 +262,11 @@ public class IndexOldSchemaValidatorIT {
   }
 
   private String getFullQualifiedIndexName(final String indexNamePart, final String version) {
-    return String.format("%s-%s-%s_", operatePrefix, indexNamePart, version);
+    return String.format(
+        "%s%s-%s-%s_",
+        AbstractIndexDescriptor.formatIndexPrefix(operatePrefix),
+        ComponentNames.OPERATE,
+        indexNamePart,
+        version);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.operate.schema.elasticsearch;
 
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.formatIndexPrefix;
+import static io.camunda.webapps.schema.descriptors.ComponentNames.OPERATE;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
@@ -280,8 +283,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   }
 
   private String settingsTemplateName() {
-    final OperateElasticsearchProperties elsConfig = operateProperties.getElasticsearch();
-    return String.format("%s_template", elsConfig.getIndexPrefix());
+    return String.format("%s%s_template", formatIndexPrefix(getIndexPrefix()), OPERATE);
   }
 
   private Settings getDefaultIndexSettings() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
@@ -9,6 +9,8 @@ package io.camunda.operate.schema.migration;
 
 import static io.camunda.operate.schema.SchemaManager.*;
 import static io.camunda.operate.util.CollectionUtil.filter;
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.formatIndexPrefix;
+import static io.camunda.webapps.schema.descriptors.ComponentNames.OPERATE;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.exceptions.MigrationException;
@@ -159,7 +161,12 @@ public class Migrator {
               : operateProperties.getElasticsearch().getIndexPrefix();
       if (migrationProperties.isDeleteSrcSchema()) {
         final String olderBaseIndexName =
-            String.format("%s-%s-%s_", indexPrefix, indexDescriptor.getIndexName(), olderVersion);
+            String.format(
+                "%s%s-%s-%s_",
+                formatIndexPrefix(indexPrefix),
+                OPERATE,
+                indexDescriptor.getIndexName(),
+                olderVersion);
         final String deleteIndexPattern = String.format("%s*", olderBaseIndexName);
         LOGGER.info("Deleted previous indices for pattern {}", deleteIndexPattern);
         schemaManager.deleteIndicesFor(deleteIndexPattern);
@@ -258,8 +265,10 @@ public class Migrator {
         DatabaseInfo.isOpensearch()
             ? operateProperties.getOpensearch().getIndexPrefix()
             : operateProperties.getElasticsearch().getIndexPrefix();
-    final String srcIndex = String.format("%s-%s-%s", indexPrefix, indexName, srcVersion);
-    final String dstIndex = String.format("%s-%s-%s", indexPrefix, indexName, dstVersion);
+    final String srcIndex =
+        String.format("%s%s-%s-%s", formatIndexPrefix(indexPrefix), OPERATE, indexName, srcVersion);
+    final String dstIndex =
+        String.format("%s%s-%s-%s", formatIndexPrefix(indexPrefix), OPERATE, indexName, dstVersion);
 
     // forbid migration when migration steps can't be combined
     if (onlyAffectedVersions.stream().anyMatch(s -> s instanceof ProcessorStep)

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
@@ -54,7 +54,7 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
   }
 
   private String formattedIndexPrefix() {
-    return getIndexPrefix() != null && !getIndexPrefix().isBlank() ? getIndexPrefix() + "-" : "";
+    return formatIndexPrefix(getIndexPrefix());
   }
 
   public String getIndexPrefix() {
@@ -62,4 +62,8 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
   }
 
   public abstract String getComponentName();
+
+  public static String formatIndexPrefix(final String indexPrefix) {
+    return indexPrefix != null && !indexPrefix.isBlank() ? indexPrefix + "-" : "";
+  }
 }


### PR DESCRIPTION
## Description

Since a [static component part](https://github.com/camunda/camunda/pull/23865) was introduced to operate index names, all Operate indices were created as `operate-operate-*` by the still present importer instead of just `operate-*` as the default prefix was still set to `operate`.

Setting the prefix to an empty value was not possible as this caused the importer to fail starting as it resulted in an [unsupported template name starting with `_`](https://github.com/camunda/camunda/pull/24512/files#diff-fb8758c4356e435bc7a059595c2042f7b165d7df76e85e4ccc2b57fa2afcd675R283-R286).

See https://camunda.slack.com/archives/C06F0GLJNFM/p1730977896526089?thread_ts=1730410639.126879&cid=C06F0GLJNFM

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates #23972 
