### PR TITLE
refactor: prepare for different types of background tasks

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -22,7 +22,6 @@ import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 
 import co.elastic.clients.util.VisibleForTesting;
 import io.camunda.exporter.adapters.ClientAdapter;
-import io.camunda.exporter.archiver.Archiver;
 import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -30,6 +29,7 @@ import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.exporter.schema.SchemaManager;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.exporter.store.ExporterBatchWriter;
+import io.camunda.exporter.tasks.BackgroundTaskManager;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.ExporterException;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -56,7 +56,7 @@ public class CamundaExporter implements Exporter {
   private final ExporterResourceProvider provider;
   private CamundaExporterMetrics metrics;
   private Logger logger;
-  private Archiver archiver;
+  private BackgroundTaskManager taskManager;
 
   public CamundaExporter() {
     this(new DefaultExporterResourceProvider());
@@ -102,9 +102,9 @@ public class CamundaExporter implements Exporter {
     // // start archiver after the schema has been created to avoid transient errors
     if (configuration.getArchiver().isRolloverEnabled()) {
       // make sure we create a new one in case open is being retried
-      CloseHelper.quietClose(archiver);
-      archiver =
-          Archiver.create(
+      CloseHelper.quietClose(taskManager);
+      taskManager =
+          BackgroundTaskManager.create(
               context.getPartitionId(),
               context.getConfiguration().getId().toLowerCase(),
               configuration,
@@ -135,7 +135,7 @@ public class CamundaExporter implements Exporter {
       }
     }
 
-    CloseHelper.close(error -> LOG.warn("Failed to close archiver", error), archiver);
+    CloseHelper.close(error -> LOG.warn("Failed to close background tasks", error), taskManager);
     LOG.info("Exporter closed");
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface BackgroundTask {
+  CompletableFuture<Integer> execute();
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -87,7 +87,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
       final String exporterId,
       final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,
-      final io.camunda.exporter.metrics.CamundaExporterMetrics metrics,
+      final CamundaExporterMetrics metrics,
       final Logger logger) {
     final var threadFactory =
         Thread.ofPlatform()
@@ -112,7 +112,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
   }
 
   private static ProcessInstancesArchiverJob createProcessInstanceJob(
-      final io.camunda.exporter.metrics.CamundaExporterMetrics metrics,
+      final CamundaExporterMetrics metrics,
       final Logger logger,
       final ExporterResourceProvider resourceProvider,
       final ArchiverRepository repository,
@@ -139,7 +139,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
   }
 
   private static BatchOperationArchiverJob createBatchOperationJob(
-      final io.camunda.exporter.metrics.CamundaExporterMetrics metrics,
+      final CamundaExporterMetrics metrics,
       final Logger logger,
       final ExporterResourceProvider resourceProvider,
       final ArchiverRepository repository,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiveBatch.java
@@ -5,10 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.List;
 
-public interface ArchiverJob {
-  CompletableFuture<Integer> archiveNextBatch();
-}
+public record ArchiveBatch(String finishDate, List<String> ids) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -5,8 +5,16 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
-import java.util.List;
+import io.camunda.exporter.tasks.BackgroundTask;
+import java.util.concurrent.CompletableFuture;
 
-public record ArchiveBatch(String finishDate, List<String> ids) {}
+public interface ArchiverJob extends BackgroundTask {
+  CompletableFuture<Integer> archiveNextBatch();
+
+  @Override
+  default CompletableFuture<Integer> execute() {
+    return archiveNextBatch();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
 import co.elastic.clients.elasticsearch._types.Conflicts;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
@@ -5,10 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
@@ -46,7 +45,7 @@ import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
 import org.opensearch.client.opensearch.generic.Requests;
 import org.slf4j.Logger;
 
-public final class OpenSearchRepository extends NoopArchiverRepository {
+public final class OpenSearchRepository implements ArchiverRepository {
   private static final String DATES_AGG = "datesAgg";
   private static final String INSTANCES_AGG = "instancesAgg";
   private static final String DATES_SORTED_AGG = "datesSortedAgg";
@@ -189,6 +188,11 @@ public final class OpenSearchRepository extends NoopArchiverRepository {
     return sendRequestAsync(() -> client.reindex(request))
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverReindex(timer), executor)
         .thenApplyAsync(ignored -> null, executor);
+  }
+
+  @Override
+  public void close() throws Exception {
+    client._transport().close();
   }
 
   private SearchRequest createFinishedBatchOperationsSearchRequest(final Aggregation aggregation) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -5,12 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -19,15 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 @AutoCloseResources
-final class ArchiverTest {
+final class BackgroundTaskManagerTest {
   @AutoCloseResource // ensures we always reap the thread no matter what
   private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
 
   @Nested
   final class CloseTest {
     private final CloseableRepository repository = new CloseableRepository();
-    private final Archiver archiver =
-        new Archiver(1, repository, LoggerFactory.getLogger(ArchiverTest.class), executor);
+    private final BackgroundTaskManager archiver =
+        new BackgroundTaskManager(
+            1, repository, LoggerFactory.getLogger(BackgroundTaskManagerTest.class), executor);
 
     @Test
     void shouldCloseExecutorOnClose() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/ReschedulingTaskTest.java
@@ -5,8 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks;
 
+import io.camunda.exporter.tasks.archiver.ArchiverJob;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -5,12 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.archiver.TestRepository.DocumentMove;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
@@ -5,15 +5,23 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.ilm.Phase;
+import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
@@ -30,43 +38,31 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.http.HttpHost;
-import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-import org.opensearch.client.RestClient;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-import org.opensearch.client.opensearch.OpenSearchAsyncClient;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.mapping.Property;
-import org.opensearch.client.opensearch._types.mapping.TypeMapping;
-import org.opensearch.client.opensearch.core.search.Hit;
-import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
-import org.opensearch.client.opensearch.generic.Requests;
-import org.opensearch.client.transport.rest_client.RestClientTransport;
-import org.opensearch.testcontainers.OpensearchContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SuppressWarnings("resource")
 @Testcontainers
 @AutoCloseResources
-final class OpenSearchRepositoryIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchRepositoryIT.class);
+final class ElasticsearchRepositoryIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRepositoryIT.class);
 
   @Container
-  private static final OpensearchContainer<?> OPENSEARCH =
-      TestSearchContainers.createDefaultOpensearchContainer();
+  private static final ElasticsearchContainer ELASTIC =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-  @AutoCloseResource private final RestClientTransport transport = Mockito.spy(createRestClient());
+  @AutoCloseResource private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final ArchiverConfiguration config = new ArchiverConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
   private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
-  private final OpenSearchClient testClient = new OpenSearchClient(transport);
+  private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
 
   @Test
   void shouldDeleteDocuments() throws IOException {
@@ -102,37 +98,69 @@ final class OpenSearchRepositoryIT {
     final var indexName = UUID.randomUUID().toString();
     final var repository = createRepository();
     testClient.indices().create(r -> r.index(indexName));
-
+    final var initialLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .lifecycle();
+    assertThat(initialLifecycle).isNull();
     retention.setEnabled(true);
     retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
 
     // when
-    createLifeCyclePolicy();
     final var result = repository.setIndexLifeCycle(indexName);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
-
-    // Takes a while for the policy to be applied
-    Awaitility.await("until the policy has been visibly applied")
-        .untilAsserted(
-            () -> assertThat(fetchPolicyForIndex(indexName)).isEqualTo(retention.getPolicyName()));
+    final var actualLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .index()
+            .lifecycle();
+    assertThat(actualLifecycle)
+        .isNotNull()
+        .extracting(IndexSettingsLifecycle::name)
+        .isEqualTo("operate_delete_archived_indices");
   }
 
   @Test
-  void shouldNotSetIndexLifecycleIfRetentionIsDisabled() {
+  void shouldNotSetIndexLifecycleIfRetentionIsDisabled() throws IOException {
     // given
     final var indexName = UUID.randomUUID().toString();
     final var repository = createRepository();
+    testClient.indices().create(r -> r.index(indexName));
+    final var initialLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .lifecycle();
+    assertThat(initialLifecycle).isNull();
     retention.setEnabled(false);
+    retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
 
     // when
     final var result = repository.setIndexLifeCycle(indexName);
 
     // then
-    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
-    Mockito.verify(transport, Mockito.never())
-        .performRequestAsync(Mockito.any(), Mockito.any(), Mockito.any());
+    assertThat(result).succeedsWithin(Duration.ZERO);
+    final var actualLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .index()
+            .lifecycle();
+    assertThat(actualLifecycle).isNull();
   }
 
   @Test
@@ -241,22 +269,6 @@ final class OpenSearchRepositoryIT {
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
-  private void createBatchOperationIndex() throws IOException {
-    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
-    final var endDateProp =
-        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
-    final var properties =
-        TypeMapping.of(
-            m ->
-                m.properties(
-                    Map.of(
-                        BatchOperationTemplate.ID,
-                        idProp,
-                        BatchOperationTemplate.END_DATE,
-                        endDateProp)));
-    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
-  }
-
   private <T extends TDocument> void index(final String index, final T document) {
     try {
       testClient.index(b -> b.index(index).document(document).id(document.id()));
@@ -265,43 +277,21 @@ final class OpenSearchRepositoryIT {
     }
   }
 
-  private void createLifeCyclePolicy() {
-    final var engineClient = new OpensearchEngineClient(testClient);
-    try {
-      engineClient.putIndexLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
-    } catch (final Exception e) {
-      // policy was already created
-    }
-  }
-
-  private String fetchPolicyForIndex(final String indexName) {
-    final var genericClient =
-        new OpenSearchGenericClient(testClient._transport(), testClient._transportOptions());
-    final var request =
-        Requests.builder().method("get").endpoint("_plugins/_ism/explain/" + indexName).build();
-    try {
-      final var response = genericClient.execute(request);
-      final var jsonString = response.getBody().orElseThrow().bodyAsString();
-      final var json = MAPPER.readTree(jsonString);
-      final var index = json.get(indexName);
-      if (index == null) {
-        throw new AssertionError(
-            "Failed to explain non-existent index '%s'; see response: %s"
-                .formatted(indexName, jsonString));
-      }
-
-      return index.findPath("index.plugins.index_state_management.policy_id").asText();
-    } catch (final IOException e) {
-      throw new AssertionError("Failed to fetch policy for index " + indexName, e);
-    }
+  private void putLifecyclePolicy() throws IOException {
+    final var ilmClient = testClient.ilm();
+    final var phase =
+        Phase.of(
+            d -> d.minAge(t -> t.time("30d")).actions(JsonData.of(Map.of("delete", Map.of()))));
+    ilmClient.putLifecycle(
+        l -> l.name(retention.getPolicyName()).policy(p -> p.phases(h -> h.delete(phase))));
   }
 
   // no need to close resource returned here, since the transport is closed above anyway
-  private OpenSearchRepository createRepository() {
-    final var client = new OpenSearchAsyncClient(transport);
+  private ElasticsearchRepository createRepository() {
+    final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
-    return new OpenSearchRepository(
+    return new ElasticsearchRepository(
         1,
         config,
         retention,
@@ -311,6 +301,12 @@ final class OpenSearchRepositoryIT {
         Runnable::run,
         metrics,
         LOGGER);
+  }
+
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(ELASTIC.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
   private void createProcessInstanceIndex() throws IOException {
@@ -332,15 +328,25 @@ final class OpenSearchRepositoryIT {
     testClient.indices().create(r -> r.index(processInstanceIndex).mappings(properties));
   }
 
-  private RestClientTransport createRestClient() {
-    final var restClient =
-        RestClient.builder(HttpHost.create(OPENSEARCH.getHttpHostAddress())).build();
-    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  private void createBatchOperationIndex() throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var endDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        BatchOperationTemplate.ID,
+                        idProp,
+                        BatchOperationTemplate.END_DATE,
+                        endDateProp)));
+    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
   }
 
-  private record TestBatchOperation(String id, String endDate) implements TDocument {}
-
   private record TestDocument(String id) implements TDocument {}
+
+  private record TestBatchOperation(String id, String endDate) implements TDocument {}
 
   private record TestProcessInstance(
       String id, String endDate, String joinRelation, int partitionId) implements TDocument {}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
@@ -5,23 +5,15 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
-import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import co.elastic.clients.elasticsearch._types.mapping.Property;
-import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
-import co.elastic.clients.elasticsearch.core.search.Hit;
-import co.elastic.clients.elasticsearch.ilm.Phase;
-import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
-import co.elastic.clients.json.JsonData;
-import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
@@ -38,31 +30,43 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.http.HttpHost;
-import org.elasticsearch.client.RestClient;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.opensearch.client.RestClient;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.mapping.Property;
+import org.opensearch.client.opensearch._types.mapping.TypeMapping;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
+import org.opensearch.client.opensearch.generic.Requests;
+import org.opensearch.client.transport.rest_client.RestClientTransport;
+import org.opensearch.testcontainers.OpensearchContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SuppressWarnings("resource")
 @Testcontainers
 @AutoCloseResources
-final class ElasticsearchRepositoryIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRepositoryIT.class);
+final class OpenSearchRepositoryIT {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchRepositoryIT.class);
 
   @Container
-  private static final ElasticsearchContainer ELASTIC =
-      TestSearchContainers.createDefeaultElasticsearchContainer();
+  private static final OpensearchContainer<?> OPENSEARCH =
+      TestSearchContainers.createDefaultOpensearchContainer();
 
-  @AutoCloseResource private final RestClientTransport transport = createRestClient();
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+  @AutoCloseResource private final RestClientTransport transport = Mockito.spy(createRestClient());
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final ArchiverConfiguration config = new ArchiverConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
   private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
-  private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
+  private final OpenSearchClient testClient = new OpenSearchClient(transport);
 
   @Test
   void shouldDeleteDocuments() throws IOException {
@@ -98,69 +102,37 @@ final class ElasticsearchRepositoryIT {
     final var indexName = UUID.randomUUID().toString();
     final var repository = createRepository();
     testClient.indices().create(r -> r.index(indexName));
-    final var initialLifecycle =
-        testClient
-            .indices()
-            .getSettings(r -> r.index(indexName))
-            .get(indexName)
-            .settings()
-            .lifecycle();
-    assertThat(initialLifecycle).isNull();
+
     retention.setEnabled(true);
     retention.setPolicyName("operate_delete_archived_indices");
-    putLifecyclePolicy();
+
+    // when
+    createLifeCyclePolicy();
+    final var result = repository.setIndexLifeCycle(indexName);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+
+    // Takes a while for the policy to be applied
+    Awaitility.await("until the policy has been visibly applied")
+        .untilAsserted(
+            () -> assertThat(fetchPolicyForIndex(indexName)).isEqualTo(retention.getPolicyName()));
+  }
+
+  @Test
+  void shouldNotSetIndexLifecycleIfRetentionIsDisabled() {
+    // given
+    final var indexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    retention.setEnabled(false);
 
     // when
     final var result = repository.setIndexLifeCycle(indexName);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
-    final var actualLifecycle =
-        testClient
-            .indices()
-            .getSettings(r -> r.index(indexName))
-            .get(indexName)
-            .settings()
-            .index()
-            .lifecycle();
-    assertThat(actualLifecycle)
-        .isNotNull()
-        .extracting(IndexSettingsLifecycle::name)
-        .isEqualTo("operate_delete_archived_indices");
-  }
-
-  @Test
-  void shouldNotSetIndexLifecycleIfRetentionIsDisabled() throws IOException {
-    // given
-    final var indexName = UUID.randomUUID().toString();
-    final var repository = createRepository();
-    testClient.indices().create(r -> r.index(indexName));
-    final var initialLifecycle =
-        testClient
-            .indices()
-            .getSettings(r -> r.index(indexName))
-            .get(indexName)
-            .settings()
-            .lifecycle();
-    assertThat(initialLifecycle).isNull();
-    retention.setEnabled(false);
-    retention.setPolicyName("operate_delete_archived_indices");
-    putLifecyclePolicy();
-
-    // when
-    final var result = repository.setIndexLifeCycle(indexName);
-
-    // then
-    assertThat(result).succeedsWithin(Duration.ZERO);
-    final var actualLifecycle =
-        testClient
-            .indices()
-            .getSettings(r -> r.index(indexName))
-            .get(indexName)
-            .settings()
-            .index()
-            .lifecycle();
-    assertThat(actualLifecycle).isNull();
+    Mockito.verify(transport, Mockito.never())
+        .performRequestAsync(Mockito.any(), Mockito.any(), Mockito.any());
   }
 
   @Test
@@ -269,6 +241,22 @@ final class ElasticsearchRepositoryIT {
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
+  private void createBatchOperationIndex() throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var endDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        BatchOperationTemplate.ID,
+                        idProp,
+                        BatchOperationTemplate.END_DATE,
+                        endDateProp)));
+    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
+  }
+
   private <T extends TDocument> void index(final String index, final T document) {
     try {
       testClient.index(b -> b.index(index).document(document).id(document.id()));
@@ -277,21 +265,43 @@ final class ElasticsearchRepositoryIT {
     }
   }
 
-  private void putLifecyclePolicy() throws IOException {
-    final var ilmClient = testClient.ilm();
-    final var phase =
-        Phase.of(
-            d -> d.minAge(t -> t.time("30d")).actions(JsonData.of(Map.of("delete", Map.of()))));
-    ilmClient.putLifecycle(
-        l -> l.name(retention.getPolicyName()).policy(p -> p.phases(h -> h.delete(phase))));
+  private void createLifeCyclePolicy() {
+    final var engineClient = new OpensearchEngineClient(testClient);
+    try {
+      engineClient.putIndexLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
+    } catch (final Exception e) {
+      // policy was already created
+    }
+  }
+
+  private String fetchPolicyForIndex(final String indexName) {
+    final var genericClient =
+        new OpenSearchGenericClient(testClient._transport(), testClient._transportOptions());
+    final var request =
+        Requests.builder().method("get").endpoint("_plugins/_ism/explain/" + indexName).build();
+    try {
+      final var response = genericClient.execute(request);
+      final var jsonString = response.getBody().orElseThrow().bodyAsString();
+      final var json = MAPPER.readTree(jsonString);
+      final var index = json.get(indexName);
+      if (index == null) {
+        throw new AssertionError(
+            "Failed to explain non-existent index '%s'; see response: %s"
+                .formatted(indexName, jsonString));
+      }
+
+      return index.findPath("index.plugins.index_state_management.policy_id").asText();
+    } catch (final IOException e) {
+      throw new AssertionError("Failed to fetch policy for index " + indexName, e);
+    }
   }
 
   // no need to close resource returned here, since the transport is closed above anyway
-  private ElasticsearchRepository createRepository() {
-    final var client = new ElasticsearchAsyncClient(transport);
+  private OpenSearchRepository createRepository() {
+    final var client = new OpenSearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
-    return new ElasticsearchRepository(
+    return new OpenSearchRepository(
         1,
         config,
         retention,
@@ -301,12 +311,6 @@ final class ElasticsearchRepositoryIT {
         Runnable::run,
         metrics,
         LOGGER);
-  }
-
-  private RestClientTransport createRestClient() {
-    final var restClient =
-        RestClient.builder(HttpHost.create(ELASTIC.getHttpHostAddress())).build();
-    return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
   private void createProcessInstanceIndex() throws IOException {
@@ -328,25 +332,15 @@ final class ElasticsearchRepositoryIT {
     testClient.indices().create(r -> r.index(processInstanceIndex).mappings(properties));
   }
 
-  private void createBatchOperationIndex() throws IOException {
-    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
-    final var endDateProp =
-        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
-    final var properties =
-        TypeMapping.of(
-            m ->
-                m.properties(
-                    Map.of(
-                        BatchOperationTemplate.ID,
-                        idProp,
-                        BatchOperationTemplate.END_DATE,
-                        endDateProp)));
-    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(OPENSEARCH.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
-  private record TestDocument(String id) implements TDocument {}
-
   private record TestBatchOperation(String id, String endDate) implements TDocument {}
+
+  private record TestDocument(String id) implements TDocument {}
 
   private record TestProcessInstance(
       String id, String endDate, String joinRelation, int partitionId) implements TDocument {}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
@@ -5,12 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.exporter.archiver.TestRepository.DocumentMove;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.TestRepository.DocumentMove;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/TestRepository.java
@@ -5,9 +5,9 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.archiver;
+package io.camunda.exporter.tasks.archiver;
 
-import io.camunda.exporter.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;


### PR DESCRIPTION
## Description

This PR refactors the existing archiver in preparation to add different kinds of background tasks, such as the post-importer, or the one which will update the batch operation count.

## Related issues

related to #24297 
