### PR TITLE
impl: build `treePath` for flownode instance

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
@@ -25,7 +25,7 @@ public class FlowNodeInstanceTemplate extends OperateTemplateDescriptor
   public static final String PROCESS_INSTANCE_KEY = "processInstanceKey";
   public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
   public static final String BPMN_PROCESS_ID = "bpmnProcessId";
-  public static final String INCIDENT_KEY = "incidentKey";
+  @Deprecated public static final String INCIDENT_KEY = "incidentKey";
   public static final String STATE = "state";
   public static final String TYPE = "type";
   public static final String TREE_PATH = "treePath";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/FlowNodeInstanceEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/FlowNodeInstanceEntity.java
@@ -19,7 +19,7 @@ public class FlowNodeInstanceEntity extends OperateZeebeEntity<FlowNodeInstanceE
   private OffsetDateTime endDate;
   private FlowNodeState state;
   private FlowNodeType type;
-  private Long incidentKey;
+  @Deprecated private Long incidentKey;
   private Long processInstanceKey;
 
   /** Attention! This field will be filled in only for data imported after v. 8.2.0. */
@@ -81,10 +81,12 @@ public class FlowNodeInstanceEntity extends OperateZeebeEntity<FlowNodeInstanceE
     return this;
   }
 
+  @Deprecated
   public Long getIncidentKey() {
     return incidentKey;
   }
 
+  @Deprecated
   public FlowNodeInstanceEntity setIncidentKey(final Long incidentKey) {
     this.incidentKey = incidentKey;
     return this;

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -23,8 +23,8 @@ import io.camunda.exporter.handlers.EventFromJobHandler;
 import io.camunda.exporter.handlers.EventFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.EventFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.ExportHandler;
-import io.camunda.exporter.handlers.FlowNodeInstanceIncidentHandler;
-import io.camunda.exporter.handlers.FlowNodeInstanceProcessInstanceHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GroupCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.IncidentHandler;
@@ -195,9 +195,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptorsMap.get(DecisionRequirementsIndex.class).getFullQualifiedName()),
             new PostImporterQueueFromIncidentHandler(
                 templateDescriptorsMap.get(PostImporterQueueTemplate.class).getFullQualifiedName()),
-            new FlowNodeInstanceIncidentHandler(
+            new FlowNodeInstanceFromIncidentHandler(
                 templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
-            new FlowNodeInstanceProcessInstanceHandler(
+            new FlowNodeInstanceFromProcessInstanceHandler(
                 templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new IncidentHandler(
                 templateDescriptorsMap.get(IncidentTemplate.class).getFullQualifiedName(),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -20,12 +20,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class FlowNodeInstanceIncidentHandler
+public class FlowNodeInstanceFromIncidentHandler
     implements ExportHandler<FlowNodeInstanceEntity, IncidentRecordValue> {
 
   private final String indexName;
 
-  public FlowNodeInstanceIncidentHandler(final String indexName) {
+  public FlowNodeInstanceFromIncidentHandler(final String indexName) {
     this.indexName = indexName;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandler.java
@@ -105,7 +105,7 @@ public class FlowNodeInstanceFromIncidentHandler
       updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
     }
     updateFields.put(FlowNodeInstanceTemplate.INCIDENT_KEY, entity.getIncidentKey());
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -88,7 +88,7 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     entity.setBpmnProcessId(recordValue.getBpmnProcessId());
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
-    if (intentStr.equals(ELEMENT_ACTIVATING.name())) {
+    if (intent.equals(ELEMENT_ACTIVATING)) {
       // we set the default value here, which may be updated later within incident export
       entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
       entity.setLevel(1);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-public class FlowNodeInstanceProcessInstanceHandler
+public class FlowNodeInstanceFromProcessInstanceHandler
     implements ExportHandler<FlowNodeInstanceEntity, ProcessInstanceRecordValue> {
 
   private static final Set<Intent> AI_FINISH_STATES = Set.of(ELEMENT_COMPLETED, ELEMENT_TERMINATED);
@@ -39,7 +39,7 @@ public class FlowNodeInstanceProcessInstanceHandler
 
   private final String indexName;
 
-  public FlowNodeInstanceProcessInstanceHandler(final String indexName) {
+  public FlowNodeInstanceFromProcessInstanceHandler(final String indexName) {
     this.indexName = indexName;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -88,11 +88,11 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     entity.setBpmnProcessId(recordValue.getBpmnProcessId());
     entity.setTenantId(tenantOrDefault(recordValue.getTenantId()));
 
-    // Parent tree path is intentionally not calculated here, we set the value as if the instance is
-    // on the 1st level
-    // will be changed within https://github.com/camunda/camunda/issues/18378
-    entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
-    entity.setLevel(1);
+    if (intentStr.equals(ELEMENT_ACTIVATING.name())) {
+      // we set the default value here, which may be updated later within incident export
+      entity.setTreePath(recordValue.getProcessInstanceKey() + "/" + record.getKey());
+      entity.setLevel(1);
+    }
 
     final OffsetDateTime recordTime =
         OffsetDateTime.ofInstant(Instant.ofEpochMilli(record.getTimestamp()), ZoneOffset.UTC);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
@@ -113,7 +113,6 @@ public class ListViewProcessInstanceFromIncidentHandler
   public void flush(
       final ProcessInstanceForListViewEntity entity, final BatchRequest batchRequest) {
 
-    LOGGER.debug("Flow node instance for list view: id {}", entity.getId());
     final Map<String, Object> updateFields = new LinkedHashMap<>();
     updateFields.put(TREE_PATH, entity.getTreePath());
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandler.java
@@ -116,7 +116,7 @@ public class ListViewProcessInstanceFromIncidentHandler
     final Map<String, Object> updateFields = new LinkedHashMap<>();
     updateFields.put(TREE_PATH, entity.getTreePath());
 
-    batchRequest.update(indexName, entity.getId(), updateFields);
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
@@ -27,8 +27,8 @@ import io.camunda.exporter.handlers.EventFromJobHandler;
 import io.camunda.exporter.handlers.EventFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.EventFromProcessMessageSubscriptionHandler;
 import io.camunda.exporter.handlers.ExportHandler;
-import io.camunda.exporter.handlers.FlowNodeInstanceIncidentHandler;
-import io.camunda.exporter.handlers.FlowNodeInstanceProcessInstanceHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceFromIncidentHandler;
+import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GroupCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.IncidentHandler;
@@ -193,7 +193,7 @@ public class CamundaExporterHandlerIT {
   void shouldExportUsingFlowNodeInstanceIncidentHandler(
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
-    final var handler = getHandler(config, FlowNodeInstanceIncidentHandler.class);
+    final var handler = getHandler(config, FlowNodeInstanceFromIncidentHandler.class);
     basicAssertWhereHandlerCreatesDefaultEntity(
         handler, config, clientAdapter, defaultRecordGenerator(handler));
   }
@@ -202,7 +202,7 @@ public class CamundaExporterHandlerIT {
   void shouldExportUsingFlowNodeInstanceProcessInstanceHandler(
       final ExporterConfiguration config, final SearchClientAdapter clientAdapter)
       throws IOException {
-    final var handler = getHandler(config, FlowNodeInstanceProcessInstanceHandler.class);
+    final var handler = getHandler(config, FlowNodeInstanceFromProcessInstanceHandler.class);
     basicAssertWhereHandlerCreatesDefaultEntity(
         handler, config, clientAdapter, defaultRecordGenerator(handler));
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -24,12 +24,12 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class FlowNodeInstanceIncidentHandlerTest {
+public class FlowNodeInstanceFromIncidentHandlerTest {
 
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-flownode-instance";
-  private final FlowNodeInstanceIncidentHandler underTest =
-      new FlowNodeInstanceIncidentHandler(indexName);
+  private final FlowNodeInstanceFromIncidentHandler underTest =
+      new FlowNodeInstanceFromIncidentHandler(indexName);
 
   @Test
   public void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -106,7 +106,8 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).update(indexName, inputEntity.getId(), expectedUpdateFields);
+    verify(mockRequest, times(1))
+        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromIncidentHandlerTest.java
@@ -149,11 +149,20 @@ public class FlowNodeInstanceFromIncidentHandlerTest {
   @Test
   public void shouldUpdateEntityForResolvedIncident() {
     // given
+    final long elementInstanceKey = 123;
+    final IncidentRecordValue incidentRecordValue =
+        factory
+            .generateObject(ImmutableIncidentRecordValue.Builder.class)
+            .withElementInstanceKey(elementInstanceKey)
+            .build();
     final Record<IncidentRecordValue> incidentRecord =
-        factory.generateRecord(ValueType.INCIDENT, r -> r.withIntent(IncidentIntent.RESOLVED));
+        factory.generateRecord(
+            ValueType.INCIDENT,
+            r -> r.withIntent(IncidentIntent.RESOLVED).withValue(incidentRecordValue));
 
     // when
-    final FlowNodeInstanceEntity flowNodeInstanceEntity = new FlowNodeInstanceEntity();
+    final FlowNodeInstanceEntity flowNodeInstanceEntity =
+        new FlowNodeInstanceEntity().setId(String.valueOf(elementInstanceKey));
     underTest.updateEntity(incidentRecord, flowNodeInstanceEntity);
 
     // then

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -35,11 +35,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-public class FlowNodeInstanceProcessInstanceHandlerTest {
+public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-list-view";
-  private final FlowNodeInstanceProcessInstanceHandler underTest =
-      new FlowNodeInstanceProcessInstanceHandler(indexName);
+  private final FlowNodeInstanceFromProcessInstanceHandler underTest =
+      new FlowNodeInstanceFromProcessInstanceHandler(indexName);
 
   @Test
   public void testGetHandledValueType() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromIncidentHandlerTest.java
@@ -134,7 +134,8 @@ public class ListViewProcessInstanceFromIncidentHandlerTest {
     // when
     underTest.flush(inputEntity, mockRequest);
     // then
-    verify(mockRequest, times(1)).update(indexName, inputEntity.getId(), expectedUpdateFields);
+    verify(mockRequest, times(1))
+        .upsert(indexName, inputEntity.getId(), inputEntity, expectedUpdateFields);
   }
 
   @Test


### PR DESCRIPTION
## Description

* implemented setting the `treePath` for flow node instance entities from incident Zeebe record
* removed unnecessary flow node instance update, as now the records are always processed in ordered way and we can be sure that flow node instance entity already exists as the moment when incident record comes
* deprecated and stopped filling `incidentKey` field as it's not used for a long time

## Related issues

closes #24061
