### PR TITLE
[Backport stable/8.3] fix: switch client credential cache key to clientId

### DIFF
--- a/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -266,7 +266,7 @@ public final class OAuthCredentialsProviderTest {
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(new File(cachePath));
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
 
-    cache.put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
+    cache.put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
     builder
         .usePlaintext()
         .credentialsProvider(
@@ -626,6 +626,6 @@ public final class OAuthCredentialsProviderTest {
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(new File(cachePath)).readCache();
     final ZeebeClientCredentials credentials =
         new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE);
-    assertThat(cache.get(AUDIENCE)).contains(credentials);
+    assertThat(cache.get(CLIENT_ID)).contains(credentials);
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -39,8 +39,8 @@ import org.junit.rules.TemporaryFolder;
 
 public final class OAuthCredentialsCacheTest {
 
-  private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
-  private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";
+  private static final String WOMBAT_CLIENT_ID = "wombat-client";
+  private static final String AARDVARK_CLIENT_ID = "aardvark-client";
   private static final String GOLDEN_FILE = "/oauth/credentialsCache.yml";
   private static final ZeebeClientCredentials WOMBAT =
       new ZeebeClientCredentials("wombat", EXPIRY, "Bearer");
@@ -205,8 +205,8 @@ public final class OAuthCredentialsCacheTest {
     cache.readCache();
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(cache.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(cache.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(cache.size()).isEqualTo(2);
   }
 
@@ -216,12 +216,12 @@ public final class OAuthCredentialsCacheTest {
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
 
     // when
-    cache.put(WOMBAT_ENDPOINT, WOMBAT).put(AARDVARK_ENDPOINT, AARDVARK).writeCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT).put(AARDVARK_CLIENT_ID, AARDVARK).writeCache();
 
     // then
     final OAuthCredentialsCache copy = new OAuthCredentialsCache(cacheFile).readCache();
-    assertThat(copy.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(copy.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(copy.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(copy.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(copy.size()).isEqualTo(2);
   }
 
@@ -237,17 +237,17 @@ public final class OAuthCredentialsCacheTest {
       cacheOperations.add(
           () ->
               cache.computeIfMissingOrInvalid(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   () -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
       cacheOperations.add(
           () ->
               cache.withCache(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   value -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
     }
@@ -270,6 +270,6 @@ public final class OAuthCredentialsCacheTest {
     }
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).isNotEmpty().contains(WOMBAT);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).isNotEmpty().contains(WOMBAT);
   }
 }

--- a/clients/java/src/test/resources/oauth/credentialsCache.yml
+++ b/clients/java/src/test/resources/oauth/credentialsCache.yml
@@ -1,14 +1,14 @@
 # OAuth Credentials Cache Golden File
 # Use this as a template which should match whatever the Cloud products generate
 ---
-wombat.cloud.camunda.io:
+wombat-client:
   auth:
     credentials:
       accesstoken: "wombat"
       tokentype: "Bearer"
       expiry: 3020-01-01T00:00:00.0Z
 
-aardvark.cloud.camunda.io:
+aardvark-client:
   auth:
     credentials:
       accesstoken: "aardvark"


### PR DESCRIPTION
# Description
Backport of #24519 to `stable/8.3`.

relates to #20471
original author: @megglos