### PR TITLE
[Backport stable/8.5] fix: switch client credential cache key to clientId

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -58,14 +58,14 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(OAuthCredentialsProvider.class);
   private final URL authorizationServerUrl;
   private final String payload;
-  private final String endpoint;
+  private final String clientId;
   private final OAuthCredentialsCache credentialsCache;
   private final Duration connectionTimeout;
   private final Duration readTimeout;
 
   OAuthCredentialsProvider(final OAuthCredentialsProviderBuilder builder) {
     authorizationServerUrl = builder.getAuthorizationServer();
-    endpoint = builder.getAudience();
+    clientId = builder.getClientId();
     payload = createParams(builder);
     credentialsCache = new OAuthCredentialsCache(builder.getCredentialsCache());
     connectionTimeout = builder.getConnectTimeout();
@@ -76,7 +76,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   @Override
   public void applyCredentials(final CredentialsApplier applier) throws IOException {
     final ZeebeClientCredentials zeebeClientCredentials =
-        credentialsCache.computeIfMissingOrInvalid(endpoint, this::fetchCredentials);
+        credentialsCache.computeIfMissingOrInvalid(clientId, this::fetchCredentials);
 
     String type = zeebeClientCredentials.getTokenType();
     if (type == null || type.isEmpty()) {
@@ -99,10 +99,10 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
       return statusCode.isUnauthorized()
           && credentialsCache
               .withCache(
-                  endpoint,
+                  clientId,
                   value -> {
                     final ZeebeClientCredentials fetchedCredentials = fetchCredentials();
-                    credentialsCache.put(endpoint, fetchedCredentials).writeCache();
+                    credentialsCache.put(clientId, fetchedCredentials).writeCache();
                     return !fetchedCredentials.equals(value) || !value.isValid();
                   })
               .orElse(false);

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -172,7 +172,7 @@ public final class OAuthCredentialsProviderTest {
 
     // then
     assertThat(shouldRetry).isTrue();
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .get()
         .returns("foo", ZeebeClientCredentials::getAccessToken);
   }
@@ -217,7 +217,7 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, null);
-    cache.put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
+    cache.put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
 
     // when - should not make any request, but use the cached credentials
     provider.applyCredentials(applier);
@@ -247,7 +247,7 @@ public final class OAuthCredentialsProviderTest {
 
     // then
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .hasValue(new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE));
   }
 
@@ -265,14 +265,14 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, null);
-    cache.put(AUDIENCE, new ZeebeClientCredentials("invalid", EXPIRY, TOKEN_TYPE)).writeCache();
+    cache.put(CLIENT_ID, new ZeebeClientCredentials("invalid", EXPIRY, TOKEN_TYPE)).writeCache();
 
     // when - should refresh on unauthorized and write new token
     provider.shouldRetryRequest(unauthorizedCode);
 
     // then
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .hasValue(new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE));
   }
 
@@ -472,7 +472,7 @@ public final class OAuthCredentialsProviderTest {
       final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
       final ZeebeClientBuilder builder = clientBuilder();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
           .writeCache();
       recordingInterceptor.setInterceptAction(
           (call, headers) -> {
@@ -501,7 +501,7 @@ public final class OAuthCredentialsProviderTest {
       final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
       final ZeebeClientBuilder builder = clientBuilder();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
           .writeCache();
       recordingInterceptor.setInterceptAction(
           (call, headers) -> call.close(Status.UNAUTHENTICATED, headers));
@@ -531,7 +531,7 @@ public final class OAuthCredentialsProviderTest {
       mockUnauthorizedRestRequest();
       mockAuthorizedRestRequest();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
           .writeCache();
       mockCredentials(ACCESS_TOKEN, null);
 
@@ -553,7 +553,7 @@ public final class OAuthCredentialsProviderTest {
       final ZeebeClientBuilder builder = clientBuilder();
       mockUnauthorizedRestRequest();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
           .writeCache();
       mockCredentials(ACCESS_TOKEN, null);
 

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -42,8 +42,8 @@ public final class OAuthCredentialsCacheTest {
   private static final ZonedDateTime EXPIRY =
       ZonedDateTime.of(3020, 1, 1, 0, 0, 0, 0, ZoneId.of("Z"));
 
-  private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
-  private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";
+  private static final String WOMBAT_CLIENT_ID = "wombat-client";
+  private static final String AARDVARK_CLIENT_ID = "aardvark-client";
   private static final String GOLDEN_FILE = "/oauth/credentialsCache.yml";
   private static final ZeebeClientCredentials WOMBAT =
       new ZeebeClientCredentials("wombat", EXPIRY, "Bearer");
@@ -208,8 +208,8 @@ public final class OAuthCredentialsCacheTest {
     cache.readCache();
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(cache.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(cache.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(cache.size()).isEqualTo(2);
   }
 
@@ -219,12 +219,12 @@ public final class OAuthCredentialsCacheTest {
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
 
     // when
-    cache.put(WOMBAT_ENDPOINT, WOMBAT).put(AARDVARK_ENDPOINT, AARDVARK).writeCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT).put(AARDVARK_CLIENT_ID, AARDVARK).writeCache();
 
     // then
     final OAuthCredentialsCache copy = new OAuthCredentialsCache(cacheFile).readCache();
-    assertThat(copy.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(copy.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(copy.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(copy.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(copy.size()).isEqualTo(2);
   }
 
@@ -240,17 +240,17 @@ public final class OAuthCredentialsCacheTest {
       cacheOperations.add(
           () ->
               cache.computeIfMissingOrInvalid(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   () -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
       cacheOperations.add(
           () ->
               cache.withCache(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   value -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
     }
@@ -273,6 +273,6 @@ public final class OAuthCredentialsCacheTest {
     }
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).isNotEmpty().contains(WOMBAT);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).isNotEmpty().contains(WOMBAT);
   }
 }

--- a/zeebe/clients/java/src/test/resources/oauth/credentialsCache.yml
+++ b/zeebe/clients/java/src/test/resources/oauth/credentialsCache.yml
@@ -1,14 +1,14 @@
 # OAuth Credentials Cache Golden File
 # Use this as a template which should match whatever the Cloud products generate
 ---
-wombat.cloud.camunda.io:
+wombat-client:
   auth:
     credentials:
       accesstoken: "wombat"
       tokentype: "Bearer"
       expiry: 3020-01-01T00:00:00.0Z
 
-aardvark.cloud.camunda.io:
+aardvark-client:
   auth:
     credentials:
       accesstoken: "aardvark"


### PR DESCRIPTION
# Description
Backport of #24519 to `stable/8.5`.

relates to #20471
original author: @megglos