### PR TITLE
[Backport stable/8.6] fix: switch client credential cache key to clientId

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -57,11 +57,11 @@ public final class OAuthCredentialsCache {
   private static final ReentrantReadWriteLock.WriteLock WRITE_LOCK = READ_WRITE_LOCK.writeLock();
 
   private final File cacheFile;
-  private final AtomicReference<Map<String, OAuthCachedCredentials>> audiences;
+  private final AtomicReference<Map<String, OAuthCachedCredentials>> credentialsByClientId;
 
   public OAuthCredentialsCache(final File cacheFile) {
     this.cacheFile = cacheFile;
-    audiences = new AtomicReference<>(new HashMap<>());
+    credentialsByClientId = new AtomicReference<>(new HashMap<>());
   }
 
   public OAuthCredentialsCache readCache() throws IOException {
@@ -72,7 +72,7 @@ public final class OAuthCredentialsCache {
       }
 
       final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
-      audiences.set(cache);
+      credentialsByClientId.set(cache);
     } finally {
       READ_LOCK.unlock();
     }
@@ -81,11 +81,11 @@ public final class OAuthCredentialsCache {
   }
 
   public void writeCache() throws IOException {
-    final Map<String, OAuthCachedCredentials> values = audiences.get();
+    final Map<String, OAuthCachedCredentials> values = credentialsByClientId.get();
 
     final Map<String, Map<String, OAuthCachedCredentials>> cache = new HashMap<>(values.size());
-    for (final Entry<String, OAuthCachedCredentials> audience : values.entrySet()) {
-      cache.put(audience.getKey(), Collections.singletonMap(KEY_AUTH, audience.getValue()));
+    for (final Entry<String, OAuthCachedCredentials> clients : values.entrySet()) {
+      cache.put(clients.getKey(), Collections.singletonMap(KEY_AUTH, clients.getValue()));
     }
 
     WRITE_LOCK.lock();
@@ -97,18 +97,18 @@ public final class OAuthCredentialsCache {
     }
   }
 
-  public Optional<ZeebeClientCredentials> get(final String endpoint) {
-    final Map<String, OAuthCachedCredentials> cache = audiences.get();
-    return Optional.ofNullable(cache.get(endpoint)).map(OAuthCachedCredentials::getCredentials);
+  public Optional<ZeebeClientCredentials> get(final String clientId) {
+    final Map<String, OAuthCachedCredentials> cache = credentialsByClientId.get();
+    return Optional.ofNullable(cache.get(clientId)).map(OAuthCachedCredentials::getCredentials);
   }
 
   public synchronized ZeebeClientCredentials computeIfMissingOrInvalid(
-      final String endpoint,
+      final String clientId,
       final SupplierWithIO<ZeebeClientCredentials> zeebeClientCredentialsConsumer)
       throws IOException {
     final Optional<ZeebeClientCredentials> optionalCredentials =
         readCache()
-            .get(endpoint)
+            .get(clientId)
             .flatMap(
                 zeebeClientCredentials -> {
                   if (!zeebeClientCredentials.isValid()) {
@@ -121,15 +121,15 @@ public final class OAuthCredentialsCache {
       return optionalCredentials.get();
     } else {
       final ZeebeClientCredentials credentials = zeebeClientCredentialsConsumer.get();
-      put(endpoint, credentials).writeCache();
+      put(clientId, credentials).writeCache();
       return credentials;
     }
   }
 
   public <T> Optional<T> withCache(
-      final String endpoint, final FunctionWithIO<ZeebeClientCredentials, T> function)
+      final String clientId, final FunctionWithIO<ZeebeClientCredentials, T> function)
       throws IOException {
-    final Optional<ZeebeClientCredentials> optionalCredentials = readCache().get(endpoint);
+    final Optional<ZeebeClientCredentials> optionalCredentials = readCache().get(clientId);
     if (optionalCredentials.isPresent()) {
       return Optional.ofNullable(function.apply(optionalCredentials.get()));
     } else {
@@ -138,18 +138,18 @@ public final class OAuthCredentialsCache {
   }
 
   public OAuthCredentialsCache put(
-      final String endpoint, final ZeebeClientCredentials credentials) {
-    audiences.getAndUpdate(
+      final String clientId, final ZeebeClientCredentials credentials) {
+    credentialsByClientId.getAndUpdate(
         current -> {
           final HashMap<String, OAuthCachedCredentials> cache = new HashMap<>(current);
-          cache.put(endpoint, new OAuthCachedCredentials(credentials));
+          cache.put(clientId, new OAuthCachedCredentials(credentials));
           return cache;
         });
     return this;
   }
 
   public synchronized int size() {
-    return audiences.get().size();
+    return credentialsByClientId.get().size();
   }
 
   private void ensureCacheFileExists() throws IOException {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -58,14 +58,14 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   private static final Logger LOG = LoggerFactory.getLogger(OAuthCredentialsProvider.class);
   private final URL authorizationServerUrl;
   private final String payload;
-  private final String endpoint;
+  private final String clientId;
   private final OAuthCredentialsCache credentialsCache;
   private final Duration connectionTimeout;
   private final Duration readTimeout;
 
   OAuthCredentialsProvider(final OAuthCredentialsProviderBuilder builder) {
     authorizationServerUrl = builder.getAuthorizationServer();
-    endpoint = builder.getAudience();
+    clientId = builder.getClientId();
     payload = createParams(builder);
     credentialsCache = new OAuthCredentialsCache(builder.getCredentialsCache());
     connectionTimeout = builder.getConnectTimeout();
@@ -76,7 +76,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   @Override
   public void applyCredentials(final CredentialsApplier applier) throws IOException {
     final ZeebeClientCredentials zeebeClientCredentials =
-        credentialsCache.computeIfMissingOrInvalid(endpoint, this::fetchCredentials);
+        credentialsCache.computeIfMissingOrInvalid(clientId, this::fetchCredentials);
 
     String type = zeebeClientCredentials.getTokenType();
     if (type == null || type.isEmpty()) {
@@ -99,10 +99,10 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
       return statusCode.isUnauthorized()
           && credentialsCache
               .withCache(
-                  endpoint,
+                  clientId,
                   value -> {
                     final ZeebeClientCredentials fetchedCredentials = fetchCredentials();
-                    credentialsCache.put(endpoint, fetchedCredentials).writeCache();
+                    credentialsCache.put(clientId, fetchedCredentials).writeCache();
                     return !fetchedCredentials.equals(value) || !value.isValid();
                   })
               .orElse(false);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -174,7 +174,7 @@ public final class OAuthCredentialsProviderTest {
 
     // then
     assertThat(shouldRetry).isTrue();
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .get()
         .returns("foo", ZeebeClientCredentials::getAccessToken);
   }
@@ -219,7 +219,7 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, null);
-    cache.put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
+    cache.put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE)).writeCache();
 
     // when - should not make any request, but use the cached credentials
     provider.applyCredentials(applier);
@@ -249,7 +249,7 @@ public final class OAuthCredentialsProviderTest {
 
     // then
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .hasValue(new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE));
   }
 
@@ -267,14 +267,14 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     mockCredentials(ACCESS_TOKEN, null);
-    cache.put(AUDIENCE, new ZeebeClientCredentials("invalid", EXPIRY, TOKEN_TYPE)).writeCache();
+    cache.put(CLIENT_ID, new ZeebeClientCredentials("invalid", EXPIRY, TOKEN_TYPE)).writeCache();
 
     // when - should refresh on unauthorized and write new token
     provider.shouldRetryRequest(unauthorizedCode);
 
     // then
     wireMockInfo.getWireMock().verifyThat(1, RequestPatternBuilder.allRequests());
-    assertThat(cache.readCache().get(AUDIENCE))
+    assertThat(cache.readCache().get(CLIENT_ID))
         .hasValue(new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE));
   }
 
@@ -474,7 +474,7 @@ public final class OAuthCredentialsProviderTest {
       final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
       final ZeebeClientBuilder builder = clientBuilder();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
           .writeCache();
       recordingInterceptor.setInterceptAction(
           (call, headers) -> {
@@ -503,7 +503,7 @@ public final class OAuthCredentialsProviderTest {
       final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
       final ZeebeClientBuilder builder = clientBuilder();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
           .writeCache();
       recordingInterceptor.setInterceptAction(
           (call, headers) -> call.close(Status.UNAUTHENTICATED, headers));
@@ -533,7 +533,7 @@ public final class OAuthCredentialsProviderTest {
       mockUnauthorizedRestRequest();
       mockAuthorizedRestRequest();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials("firstToken", EXPIRY, TOKEN_TYPE))
           .writeCache();
       mockCredentials(ACCESS_TOKEN, null);
 
@@ -555,7 +555,7 @@ public final class OAuthCredentialsProviderTest {
       final ZeebeClientBuilder builder = clientBuilder();
       mockUnauthorizedRestRequest();
       cache
-          .put(AUDIENCE, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
+          .put(CLIENT_ID, new ZeebeClientCredentials(ACCESS_TOKEN, EXPIRY, TOKEN_TYPE))
           .writeCache();
       mockCredentials(ACCESS_TOKEN, null);
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -42,8 +42,8 @@ public final class OAuthCredentialsCacheTest {
   private static final ZonedDateTime EXPIRY =
       ZonedDateTime.of(3020, 1, 1, 0, 0, 0, 0, ZoneId.of("Z"));
 
-  private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
-  private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";
+  private static final String WOMBAT_CLIENT_ID = "wombat-client";
+  private static final String AARDVARK_CLIENT_ID = "aardvark-client";
   private static final String GOLDEN_FILE = "/oauth/credentialsCache.yml";
   private static final ZeebeClientCredentials WOMBAT =
       new ZeebeClientCredentials("wombat", EXPIRY, "Bearer");
@@ -208,8 +208,8 @@ public final class OAuthCredentialsCacheTest {
     cache.readCache();
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(cache.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(cache.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(cache.size()).isEqualTo(2);
   }
 
@@ -219,12 +219,12 @@ public final class OAuthCredentialsCacheTest {
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);
 
     // when
-    cache.put(WOMBAT_ENDPOINT, WOMBAT).put(AARDVARK_ENDPOINT, AARDVARK).writeCache();
+    cache.put(WOMBAT_CLIENT_ID, WOMBAT).put(AARDVARK_CLIENT_ID, AARDVARK).writeCache();
 
     // then
     final OAuthCredentialsCache copy = new OAuthCredentialsCache(cacheFile).readCache();
-    assertThat(copy.get(WOMBAT_ENDPOINT)).contains(WOMBAT);
-    assertThat(copy.get(AARDVARK_ENDPOINT)).contains(AARDVARK);
+    assertThat(copy.get(WOMBAT_CLIENT_ID)).contains(WOMBAT);
+    assertThat(copy.get(AARDVARK_CLIENT_ID)).contains(AARDVARK);
     assertThat(copy.size()).isEqualTo(2);
   }
 
@@ -240,17 +240,17 @@ public final class OAuthCredentialsCacheTest {
       cacheOperations.add(
           () ->
               cache.computeIfMissingOrInvalid(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   () -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
       cacheOperations.add(
           () ->
               cache.withCache(
-                  WOMBAT_ENDPOINT,
+                  WOMBAT_CLIENT_ID,
                   value -> {
-                    cache.put(WOMBAT_ENDPOINT, WOMBAT).writeCache();
+                    cache.put(WOMBAT_CLIENT_ID, WOMBAT).writeCache();
                     return WOMBAT;
                   }));
     }
@@ -273,6 +273,6 @@ public final class OAuthCredentialsCacheTest {
     }
 
     // then
-    assertThat(cache.get(WOMBAT_ENDPOINT)).isNotEmpty().contains(WOMBAT);
+    assertThat(cache.get(WOMBAT_CLIENT_ID)).isNotEmpty().contains(WOMBAT);
   }
 }

--- a/clients/java/src/test/resources/oauth/credentialsCache.yml
+++ b/clients/java/src/test/resources/oauth/credentialsCache.yml
@@ -1,14 +1,14 @@
 # OAuth Credentials Cache Golden File
 # Use this as a template which should match whatever the Cloud products generate
 ---
-wombat.cloud.camunda.io:
+wombat-client:
   auth:
     credentials:
       accesstoken: "wombat"
       tokentype: "Bearer"
       expiry: 3020-01-01T00:00:00.0Z
 
-aardvark.cloud.camunda.io:
+aardvark-client:
   auth:
     credentials:
       accesstoken: "aardvark"


### PR DESCRIPTION
# Description
Backport of #24519 to `stable/8.6`.

relates to #20471
original author: @megglos