### PR TITLE
feat: Refactor the QueryResultConfig to be more typesafe #24525

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -27,7 +27,9 @@ import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableValueFilterTransformer;
 import io.camunda.search.clients.transformers.query.SearchQueryResultTransformer;
 import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
-import io.camunda.search.clients.transformers.result.ResultConfigTransformer;
+import io.camunda.search.clients.transformers.result.DecisionInstanceResultConfigTransformer;
+import io.camunda.search.clients.transformers.result.DecisionRequirementsResultConfigTransformer;
+import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.sort.FieldSortingTransformer;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.ComparableValueFilter;
@@ -59,7 +61,9 @@ import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
-import io.camunda.search.result.QueryResultConfig;
+import io.camunda.search.result.DecisionInstanceQueryResultConfig;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
+import io.camunda.search.result.ProcessInstanceQueryResultConfig;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.SortOption;
 import java.util.HashMap;
@@ -139,6 +143,12 @@ public final class ServiceTransformers {
     mappers.put(ProcessDefinitionFilter.class, new ProcessDefinitionFilterTransformer(mappers));
 
     // result config -> source config
-    mappers.put(QueryResultConfig.class, new ResultConfigTransformer());
+    mappers.put(
+        DecisionInstanceQueryResultConfig.class, new DecisionInstanceResultConfigTransformer());
+    mappers.put(
+        DecisionRequirementsQueryResultConfig.class,
+        new DecisionRequirementsResultConfigTransformer());
+    mappers.put(
+        ProcessInstanceQueryResultConfig.class, new ProcessInstanceResultConfigTransformer());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/TypedSearchQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/TypedSearchQueryTransformer.java
@@ -70,7 +70,11 @@ public final class TypedSearchQueryTransformer<F extends FilterBase, S extends S
   }
 
   private SearchSourceConfig toSearchSourceConfig(final QueryResultConfig resultConfig) {
-    final var resultConfigTransformer = getResultConfigTransformer();
+    if (resultConfig == null) {
+      return null;
+    }
+
+    final var resultConfigTransformer = getResultConfigTransformer(resultConfig.getClass());
     return resultConfigTransformer.apply(resultConfig);
   }
 
@@ -101,9 +105,10 @@ public final class TypedSearchQueryTransformer<F extends FilterBase, S extends S
     return (FieldSortingTransformer) transformer;
   }
 
-  private ResultConfigTransformer getResultConfigTransformer() {
+  private <T extends QueryResultConfig>
+      ResultConfigTransformer<QueryResultConfig> getResultConfigTransformer(final Class<T> clazz) {
     final ServiceTransformer<QueryResultConfig, SearchSourceConfig> transformer =
-        transformers.getTransformer(QueryResultConfig.class);
+        transformers.getTransformer(clazz);
     return (ResultConfigTransformer) transformer;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/DecisionInstanceResultConfigTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/DecisionInstanceResultConfigTransformer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.result;
+
+import io.camunda.search.clients.source.SearchSourceConfig;
+import io.camunda.search.clients.source.SearchSourceFilter;
+import io.camunda.search.result.DecisionInstanceQueryResultConfig;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DecisionInstanceResultConfigTransformer
+    implements ResultConfigTransformer<DecisionInstanceQueryResultConfig> {
+
+  @Override
+  public SearchSourceConfig apply(final DecisionInstanceQueryResultConfig value) {
+    if (value != null) {
+      final List<String> exclusions = new ArrayList<>();
+
+      if (!value.includeEvaluatedInputs()) {
+        exclusions.add("evaluatedInputs");
+      }
+      if (!value.includeEvaluatedOutputs()) {
+        exclusions.add("evaluatedOutputs");
+      }
+
+      return new SearchSourceConfig(new SearchSourceFilter.Builder().excludes(exclusions).build());
+    }
+    return null;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/DecisionRequirementsResultConfigTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/DecisionRequirementsResultConfigTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.result;
+
+import io.camunda.search.clients.source.SearchSourceConfig;
+import io.camunda.search.clients.source.SearchSourceFilter;
+import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
+import java.util.List;
+
+public final class DecisionRequirementsResultConfigTransformer
+    implements ResultConfigTransformer<DecisionRequirementsQueryResultConfig> {
+
+  @Override
+  public SearchSourceConfig apply(final DecisionRequirementsQueryResultConfig value) {
+    if (value != null) {
+      final var builder = new SearchSourceFilter.Builder();
+
+      if (!value.includeXml()) {
+        builder.excludes(List.of("xml"));
+      }
+
+      return new SearchSourceConfig(builder.build());
+    }
+    return null;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.result;
+
+import io.camunda.search.clients.source.SearchSourceConfig;
+import io.camunda.search.clients.source.SearchSourceFilter;
+import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import java.util.List;
+
+public final class ProcessInstanceResultConfigTransformer
+    implements ResultConfigTransformer<ProcessInstanceQueryResultConfig> {
+
+  @Override
+  public SearchSourceConfig apply(final ProcessInstanceQueryResultConfig value) {
+    if (value != null) {
+      final var builder = new SearchSourceFilter.Builder();
+
+      if (value.onlyKey()) {
+        builder.includes(List.of("key"));
+      }
+
+      return new SearchSourceConfig(builder.build());
+    }
+    return null;
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ResultConfigTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/result/ResultConfigTransformer.java
@@ -8,46 +8,8 @@
 package io.camunda.search.clients.transformers.result;
 
 import io.camunda.search.clients.source.SearchSourceConfig;
-import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.result.QueryResultConfig;
-import io.camunda.search.result.QueryResultConfig.FieldFilter;
-import java.util.List;
-import java.util.stream.Collectors;
 
-public final class ResultConfigTransformer
-    implements ServiceTransformer<QueryResultConfig, SearchSourceConfig> {
-
-  @Override
-  public SearchSourceConfig apply(final QueryResultConfig value) {
-    if (value != null) {
-      final var builder = new SearchSourceConfig.Builder();
-      final List<FieldFilter> fieldFilters = value.getFieldFilters();
-      if (fieldFilters != null && !fieldFilters.isEmpty()) {
-        builder.filter(toSearchSourceFilter(fieldFilters));
-      }
-      return builder.build();
-    }
-    return null;
-  }
-
-  private SearchSourceFilter toSearchSourceFilter(final List<FieldFilter> value) {
-    final var includedVsExcludedMap =
-        value.stream()
-            .collect(
-                Collectors.partitioningBy(
-                    FieldFilter::include,
-                    Collectors.mapping(FieldFilter::field, Collectors.toList())));
-    final List<String> includes = includedVsExcludedMap.get(true);
-    final List<String> excludes = includedVsExcludedMap.get(false);
-
-    final var builder = new SearchSourceFilter.Builder();
-    if (!includes.isEmpty()) {
-      builder.includes(includes);
-    }
-    if (!excludes.isEmpty()) {
-      builder.excludes(excludes);
-    }
-    return builder.build();
-  }
-}
+public interface ResultConfigTransformer<T extends QueryResultConfig>
+    extends ServiceTransformer<T, SearchSourceConfig> {}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/SearchQueryBuilderTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/query/SearchQueryBuilderTest.java
@@ -25,7 +25,7 @@ public class SearchQueryBuilderTest {
     final var searchQueryPage = new SearchQueryPage.Builder().size(50).build();
     final var searchQuerySort = ProcessInstanceSort.of(builder -> builder.startDate().asc());
     final var searchQueryResultConfig =
-        ProcessInstanceQueryResultConfig.of(builder -> builder.key().include());
+        ProcessInstanceQueryResultConfig.of(builder -> builder.onlyKey(true));
     final var filter = new ProcessInstanceFilter.Builder().build(); // all
 
     // when

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/DecisionInstanceResultConfigTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/DecisionInstanceResultConfigTest.java
@@ -20,11 +20,10 @@ class DecisionInstanceResultConfigTest extends AbstractResultConfigTest {
     final var source =
         transformRequest(
             SearchQueryBuilders.decisionInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.evaluatedInputs().include())));
+                q -> q.resultConfig(r -> r.includeEvaluatedInputs(true))));
 
     // then
-    assertThat(source.sourceFilter().includes()).containsExactly("evaluatedInputs");
-    assertThat(source.sourceFilter().excludes()).isNull();
+    assertThat(source.sourceFilter().excludes()).containsExactly("evaluatedOutputs");
   }
 
   @Test
@@ -33,26 +32,35 @@ class DecisionInstanceResultConfigTest extends AbstractResultConfigTest {
     final var source =
         transformRequest(
             SearchQueryBuilders.decisionInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.evaluatedOutputs().exclude())));
+                q -> q.resultConfig(r -> r.includeEvaluatedOutputs(true))));
 
     // then
-    assertThat(source.sourceFilter().excludes()).containsExactly("evaluatedOutputs");
-    assertThat(source.sourceFilter().includes()).isNull();
+    assertThat(source.sourceFilter().excludes()).containsExactly("evaluatedInputs");
   }
 
   @Test
-  void shouldSourceConfigExcludeEvaluatedInputsAndEvaluatedOutputs() {
+  void shouldSourceConfigIncludeEvaluatedInputsAndEvaluatedOutputs() {
     // when
     final var source =
         transformRequest(
             SearchQueryBuilders.decisionInstanceSearchQuery(
                 q ->
                     q.resultConfig(
-                        r -> r.evaluatedInputs().exclude().evaluatedOutputs().exclude())));
+                        r -> r.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
+
+    // then
+    assertThat(source.sourceFilter().excludes()).isEmpty();
+  }
+
+  @Test
+  void shouldSourceConfigBeDefault() {
+    // when
+    final var source =
+        transformRequest(
+            SearchQueryBuilders.decisionInstanceSearchQuery(q -> q.resultConfig(r -> r)));
 
     // then
     assertThat(source.sourceFilter().excludes())
         .containsExactly("evaluatedInputs", "evaluatedOutputs");
-    assertThat(source.sourceFilter().includes()).isNull();
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/DecisionRequirementsResultConfigTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/DecisionRequirementsResultConfigTest.java
@@ -20,11 +20,11 @@ public class DecisionRequirementsResultConfigTest extends AbstractResultConfigTe
     final var source =
         transformRequest(
             SearchQueryBuilders.decisionRequirementsSearchQuery(
-                q -> q.resultConfig(r -> r.xml().include())));
+                q -> q.resultConfig(r -> r.includeXml(true))));
 
     // then
-    assertThat(source.sourceFilter().includes()).containsExactly("xml");
     assertThat(source.sourceFilter().excludes()).isNull();
+    assertThat(source.sourceFilter().includes()).isNull();
   }
 
   @Test
@@ -33,7 +33,7 @@ public class DecisionRequirementsResultConfigTest extends AbstractResultConfigTe
     final var source =
         transformRequest(
             SearchQueryBuilders.decisionRequirementsSearchQuery(
-                q -> q.resultConfig(r -> r.xml().exclude())));
+                q -> q.resultConfig(r -> r.includeXml(false))));
 
     // then
     assertThat(source.sourceFilter().excludes()).containsExactly("xml");

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/result/ProcessInstanceResultConfigTest.java
@@ -20,11 +20,10 @@ public class ProcessInstanceResultConfigTest extends AbstractResultConfigTest {
     final var source =
         transformRequest(
             SearchQueryBuilders.processInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.key().include())));
+                q -> q.resultConfig(r -> r.onlyKey(true))));
 
     // then
     assertThat(source.sourceFilter().includes()).containsExactly("key");
-    assertThat(source.sourceFilter().excludes()).isNull();
   }
 
   @Test
@@ -33,10 +32,9 @@ public class ProcessInstanceResultConfigTest extends AbstractResultConfigTest {
     final var source =
         transformRequest(
             SearchQueryBuilders.processInstanceSearchQuery(
-                q -> q.resultConfig(r -> r.key().exclude())));
+                q -> q.resultConfig(r -> r.onlyKey(false))));
 
     // then
-    assertThat(source.sourceFilter().excludes()).containsExactly("key");
     assertThat(source.sourceFilter().includes()).isNull();
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/ProcessInstanceQuery.java
@@ -11,7 +11,6 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
-import io.camunda.search.result.QueryResultConfig;
 import io.camunda.search.result.QueryResultConfigBuilders;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.SortOptionBuilders;
@@ -23,7 +22,7 @@ public record ProcessInstanceQuery(
     ProcessInstanceFilter filter,
     ProcessInstanceSort sort,
     SearchQueryPage page,
-    QueryResultConfig resultConfig)
+    ProcessInstanceQueryResultConfig resultConfig)
     implements TypedSearchQuery<ProcessInstanceFilter, ProcessInstanceSort> {
 
   public static ProcessInstanceQuery of(

--- a/search/search-domain/src/main/java/io/camunda/search/result/DecisionInstanceQueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/DecisionInstanceQueryResultConfig.java
@@ -8,46 +8,42 @@
 package io.camunda.search.result;
 
 import io.camunda.util.ObjectBuilder;
-import java.util.List;
 import java.util.function.Function;
 
-public record DecisionInstanceQueryResultConfig(List<FieldFilter> fieldFilters)
-    implements QueryResultConfig {
-  @Override
-  public List<FieldFilter> getFieldFilters() {
-    return fieldFilters;
-  }
+public record DecisionInstanceQueryResultConfig(
+    Boolean includeEvaluatedInputs, Boolean includeEvaluatedOutputs) implements QueryResultConfig {
 
   public static DecisionInstanceQueryResultConfig of(
       final Function<
               DecisionInstanceQueryResultConfig.Builder,
               ObjectBuilder<DecisionInstanceQueryResultConfig>>
           fn) {
-    return QueryResultConfigBuilders.decisionInstance(fn);
+    return fn.apply(new Builder()).build();
   }
 
-  public static final class Builder
-      extends AbstractBuilder<DecisionInstanceQueryResultConfig.Builder>
-      implements ObjectBuilder<DecisionInstanceQueryResultConfig> {
+  public static final class Builder implements ObjectBuilder<DecisionInstanceQueryResultConfig> {
 
-    public DecisionInstanceQueryResultConfig.Builder evaluatedInputs() {
-      currentFieldFilter = new FieldFilter("evaluatedInputs", null);
+    private static final Boolean DEFAULT_INCLUDE_EVALUATED_INPUTS = false;
+    private static final Boolean DEFAULT_INCLUDE_EVALUATED_OUTPUTS = false;
+
+    private Boolean includeEvaluatedInputs = DEFAULT_INCLUDE_EVALUATED_INPUTS;
+    private Boolean includeEvaluatedOutputs = DEFAULT_INCLUDE_EVALUATED_OUTPUTS;
+
+    public DecisionInstanceQueryResultConfig.Builder includeEvaluatedInputs(
+        final boolean includeEvaluatedInputs) {
+      this.includeEvaluatedInputs = includeEvaluatedInputs;
       return this;
     }
 
-    public DecisionInstanceQueryResultConfig.Builder evaluatedOutputs() {
-      currentFieldFilter = new FieldFilter("evaluatedOutputs", null);
-      return this;
-    }
-
-    @Override
-    protected DecisionInstanceQueryResultConfig.Builder self() {
+    public DecisionInstanceQueryResultConfig.Builder includeEvaluatedOutputs(
+        final boolean includeEvaluatedOutputs) {
+      this.includeEvaluatedOutputs = includeEvaluatedOutputs;
       return this;
     }
 
     @Override
     public DecisionInstanceQueryResultConfig build() {
-      return new DecisionInstanceQueryResultConfig(fieldFilters);
+      return new DecisionInstanceQueryResultConfig(includeEvaluatedInputs, includeEvaluatedOutputs);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/result/DecisionRequirementsQueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/DecisionRequirementsQueryResultConfig.java
@@ -8,38 +8,31 @@
 package io.camunda.search.result;
 
 import io.camunda.util.ObjectBuilder;
-import java.util.List;
 import java.util.function.Function;
 
-public record DecisionRequirementsQueryResultConfig(List<FieldFilter> fieldFilters)
+public record DecisionRequirementsQueryResultConfig(boolean includeXml)
     implements QueryResultConfig {
-
-  @Override
-  public List<FieldFilter> getFieldFilters() {
-    return fieldFilters;
-  }
 
   public static DecisionRequirementsQueryResultConfig of(
       final Function<Builder, ObjectBuilder<DecisionRequirementsQueryResultConfig>> fn) {
-    return QueryResultConfigBuilders.decisionRequirements(fn);
+    return fn.apply(new Builder()).build();
   }
 
-  public static final class Builder extends AbstractBuilder<Builder>
+  public static final class Builder
       implements ObjectBuilder<DecisionRequirementsQueryResultConfig> {
 
-    public Builder xml() {
-      currentFieldFilter = new FieldFilter("xml", null);
-      return this;
-    }
+    private static final Boolean DEFAULT_INCLUDE_XML = false;
 
-    @Override
-    protected Builder self() {
+    private Boolean includeXml = DEFAULT_INCLUDE_XML;
+
+    public Builder includeXml(final boolean includeXml) {
+      this.includeXml = includeXml;
       return this;
     }
 
     @Override
     public DecisionRequirementsQueryResultConfig build() {
-      return new DecisionRequirementsQueryResultConfig(fieldFilters);
+      return new DecisionRequirementsQueryResultConfig(includeXml);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/result/ProcessInstanceQueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/ProcessInstanceQueryResultConfig.java
@@ -8,38 +8,29 @@
 package io.camunda.search.result;
 
 import io.camunda.util.ObjectBuilder;
-import java.util.List;
 import java.util.function.Function;
 
-public record ProcessInstanceQueryResultConfig(List<FieldFilter> fieldFilters)
-    implements QueryResultConfig {
-
-  @Override
-  public List<FieldFilter> getFieldFilters() {
-    return fieldFilters;
-  }
+public record ProcessInstanceQueryResultConfig(Boolean onlyKey) implements QueryResultConfig {
 
   public static ProcessInstanceQueryResultConfig of(
       final Function<Builder, ObjectBuilder<ProcessInstanceQueryResultConfig>> fn) {
-    return QueryResultConfigBuilders.processInstance(fn);
+    return fn.apply(new Builder()).build();
   }
 
-  public static final class Builder extends AbstractBuilder<Builder>
-      implements ObjectBuilder<ProcessInstanceQueryResultConfig> {
+  public static final class Builder implements ObjectBuilder<ProcessInstanceQueryResultConfig> {
 
-    public Builder key() {
-      currentFieldFilter = new FieldFilter("key", null);
-      return this;
-    }
+    private static final Boolean DEFAULT_ONLY_KEY = false;
 
-    @Override
-    protected Builder self() {
+    private Boolean onlyKey = DEFAULT_ONLY_KEY;
+
+    public Builder onlyKey(final boolean onlyKey) {
+      this.onlyKey = onlyKey;
       return this;
     }
 
     @Override
     public ProcessInstanceQueryResultConfig build() {
-      return new ProcessInstanceQueryResultConfig(fieldFilters);
+      return new ProcessInstanceQueryResultConfig(onlyKey);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/result/QueryResultConfig.java
+++ b/search/search-domain/src/main/java/io/camunda/search/result/QueryResultConfig.java
@@ -7,40 +7,4 @@
  */
 package io.camunda.search.result;
 
-import java.util.ArrayList;
-import java.util.List;
-
-public interface QueryResultConfig {
-
-  List<FieldFilter> getFieldFilters();
-
-  abstract class AbstractBuilder<T> {
-
-    protected final List<FieldFilter> fieldFilters = new ArrayList<>();
-
-    protected FieldFilter currentFieldFilter;
-
-    protected abstract T self();
-
-    protected T addInclusion(final boolean include) {
-      if (currentFieldFilter != null) {
-        final var field = currentFieldFilter.field();
-        final var newFieldFilter = new FieldFilter(field, include);
-        fieldFilters.add(newFieldFilter);
-        currentFieldFilter = null;
-      }
-      // else if not set, then noop
-      return self();
-    }
-
-    public T include() {
-      return addInclusion(true);
-    }
-
-    public T exclude() {
-      return addInclusion(false);
-    }
-  }
-
-  record FieldFilter(String field, Boolean include) {}
-}
+public interface QueryResultConfig {}

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -60,7 +60,7 @@ public final class DecisionInstanceServices
                 .sort(query.sort())
                 .page(query.page())
                 .resultConfig(
-                    ofNullable(query.resultConfig()).orElseGet(() -> defaultSearchResultConfig())));
+                    ofNullable(query.resultConfig()).orElseGet(this::defaultSearchResultConfig)));
   }
 
   /**
@@ -95,8 +95,20 @@ public final class DecisionInstanceServices
         .searchDecisionInstances(decisionInstanceSearchQuery(fn));
   }
 
+  /**
+   * The default config excludes evaluateInputs and evaluateOutputs fields. To include them, the
+   * user must provide a config like
+   *
+   * <pre>
+   *   {
+   *     "includeEvaluatedInputs": true,
+   *     "includeEvaluatedOutputs": true
+   *   }
+   * </pre>
+   *
+   * @return a default config
+   */
   private DecisionInstanceQueryResultConfig defaultSearchResultConfig() {
-    return DecisionInstanceQueryResultConfig.of(
-        r -> r.evaluatedInputs().exclude().evaluatedOutputs().exclude());
+    return DecisionInstanceQueryResultConfig.of(r -> r);
   }
 }

--- a/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionRequirementsServices.java
@@ -60,7 +60,7 @@ public final class DecisionRequirementsServices
                         .page(query.page())
                         .resultConfig(
                             ofNullable(query.resultConfig())
-                                .orElseGet(() -> defaultSearchResultConfig()))));
+                                .orElseGet(this::defaultSearchResultConfig))));
   }
 
   /**
@@ -68,7 +68,7 @@ public final class DecisionRequirementsServices
    * fetched from the database.
    */
   private DecisionRequirementsQueryResultConfig defaultSearchResultConfig() {
-    return DecisionRequirementsQueryResultConfig.of(r -> r.xml().exclude());
+    return DecisionRequirementsQueryResultConfig.of(r -> r);
   }
 
   public DecisionRequirementsEntity getByKey(final Long key) {

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -96,6 +96,6 @@ class DecisionInstanceServiceTest {
                         .sort(s -> s.evaluationDate().asc())
                         .page(p -> p.size(20))
                         .resultConfig(
-                            r -> r.evaluatedInputs().exclude().evaluatedOutputs().exclude())));
+                            r -> r.includeEvaluatedInputs(false).includeEvaluatedOutputs(false))));
   }
 }


### PR DESCRIPTION
## Description

Refactors the QueryResultConfig to be more typesafe and specific to the businessEntity and therefore easier to use across ES/OS *and* RDBMS search clients

## Related issues

Needed for #23267 

closes #24525 
