### PR TITLE
Remove permission REST api and Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.client.api.command.EvaluateDecisionCommandStep1;
 import io.camunda.zeebe.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
@@ -1145,6 +1146,29 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   AddPermissionsCommandStep1 newAddPermissionsCommand(long ownerKey);
+
+  /**
+   * Command to remove permissions from an owner.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newRemovePermissionsCommand(ownerKey)
+   *  .resourceType(resourceType)
+   *  .permission(permissionType)
+   *  .resourceIds(resourceIds)
+   *  .permission(permissionType)
+   *  .resourceId(resourceId)
+   *  .resourceId(resourceId)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * @param ownerKey the key of the owner
+   * @return a builder for the command
+   */
+  RemovePermissionsCommandStep1 newRemovePermissionsCommand(long ownerKey);
 
   /*
    * Retrieves the XML representation of a decision requirements.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/RemovePermissionsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/RemovePermissionsCommandStep1.java
@@ -15,53 +15,52 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
+import io.camunda.zeebe.client.api.response.RemovePermissionsResponse;
 import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
 import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
 import java.util.List;
 
-public interface AddPermissionsCommandStep1 {
-
+public interface RemovePermissionsCommandStep1 {
   /**
-   * Sets the resource type for which the permissions should be added.
+   * Sets the resource type for which the permissions should be removed.
    *
    * @param resourceType the resource type
    * @return the builder for this command
    */
-  AddPermissionsCommandStep2 resourceType(ResourceTypeEnum resourceType);
+  RemovePermissionsCommandStep2 resourceType(ResourceTypeEnum resourceType);
 
-  interface AddPermissionsCommandStep2 {
+  interface RemovePermissionsCommandStep2 {
 
     /**
-     * Sets the permission type of the permissions that should be added.
+     * Sets the permission type of the permissions that should be removed.
      *
      * @param permissionType the permission type
      * @return the builder for this command
      */
-    AddPermissionsCommandStep3 permission(PermissionTypeEnum permissionType);
+    RemovePermissionsCommandStep3 permission(PermissionTypeEnum permissionType);
   }
 
-  interface AddPermissionsCommandStep3 {
+  interface RemovePermissionsCommandStep3 {
 
     /**
-     * Adds all resourceIds in the list to the add permissions request.
+     * Adds all resourceIds in the list to the remove permissions request.
      *
      * @param resourceIds the list of resource ids
      * @return the builder for this command
      */
-    AddPermissionsCommandStep4 resourceIds(List<String> resourceIds);
+    RemovePermissionsCommandStep4 resourceIds(List<String> resourceIds);
 
     /**
-     * Adds a resourceId to the add permissions request.
+     * Adds a resourceId to the remove permissions request.
      *
      * @param resourceId the resource id
      * @return the builder for this command
      */
-    AddPermissionsCommandStep4 resourceId(String resourceId);
+    RemovePermissionsCommandStep4 resourceId(String resourceId);
   }
 
-  interface AddPermissionsCommandStep4
-      extends AddPermissionsCommandStep2,
-          AddPermissionsCommandStep3,
-          FinalCommandStep<AddPermissionsResponse> {}
+  interface RemovePermissionsCommandStep4
+      extends RemovePermissionsCommandStep2,
+          RemovePermissionsCommandStep3,
+          FinalCommandStep<RemovePermissionsResponse> {}
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/RemovePermissionsResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/RemovePermissionsResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface RemovePermissionsResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -46,6 +46,7 @@ import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
 import io.camunda.zeebe.client.api.command.MigrateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ModifyProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
@@ -108,6 +109,7 @@ import io.camunda.zeebe.client.impl.command.JobUpdateTimeoutCommandImpl;
 import io.camunda.zeebe.client.impl.command.MigrateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.ModifyProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.PublishMessageCommandImpl;
+import io.camunda.zeebe.client.impl.command.RemovePermissionsCommandImpl;
 import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
@@ -696,6 +698,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
+  public RemovePermissionsCommandStep1 newRemovePermissionsCommand(final long ownerKey) {
+    return new RemovePermissionsCommandImpl(ownerKey, httpClient, jsonMapper);
+  }
+
+  @Override
   public DecisionRequirementsGetXmlRequest newDecisionRequirementsGetXmlRequest(
       final long decisionRequirementsKey) {
     return new DecisionRequirementsGetXmlRequestImpl(httpClient, decisionRequirementsKey);
@@ -732,6 +739,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     return new UserTaskVariableQueryImpl(httpClient, jsonMapper, userTaskKey);
   }
 
+  @Override
   public CreateDocumentCommandStep1 newCreateDocumentCommand() {
     return new CreateDocumentCommandImpl(jsonMapper, httpClient, config);
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PatchAuthorizationCommand.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PatchAuthorizationCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest;
+import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ActionEnum;
+import io.camunda.zeebe.client.protocol.rest.PermissionDTO;
+import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
+import java.util.List;
+
+public class PatchAuthorizationCommand {
+
+  private final AuthorizationPatchRequest request;
+  private PermissionDTO currentPermission;
+
+  public PatchAuthorizationCommand(final ActionEnum action) {
+    request = new AuthorizationPatchRequest().action(action);
+  }
+
+  public void resourceType(final ResourceTypeEnum resourceType) {
+    ArgumentUtil.ensureNotNull("resourceType", resourceType);
+    request.resourceType(resourceType);
+  }
+
+  public void permission(final PermissionTypeEnum permissionType) {
+    ArgumentUtil.ensureNotNull("permissionType", permissionType);
+    currentPermission = new PermissionDTO();
+    currentPermission.permissionType(permissionType);
+    request.addPermissionsItem(currentPermission);
+  }
+
+  public void resourceIds(final List<String> resourceIds) {
+    ArgumentUtil.ensureNotNullOrEmpty("resourceIds", resourceIds);
+    resourceIds.forEach(this::resourceId);
+  }
+
+  public void resourceId(final String resourceId) {
+    ArgumentUtil.ensureNotNullNorEmpty("resourceId", resourceId);
+    currentPermission.addResourceIdsItem(resourceId);
+  }
+
+  public AuthorizationPatchRequest getRequest() {
+    return request;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/RemovePermissionsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/RemovePermissionsCommandImpl.java
@@ -17,12 +17,12 @@ package io.camunda.zeebe.client.impl.command;
 
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
-import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
-import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep2;
-import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep3;
-import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1.AddPermissionsCommandStep4;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
-import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1.RemovePermissionsCommandStep2;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1.RemovePermissionsCommandStep3;
+import io.camunda.zeebe.client.api.command.RemovePermissionsCommandStep1.RemovePermissionsCommandStep4;
+import io.camunda.zeebe.client.api.response.RemovePermissionsResponse;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.protocol.rest.AuthorizationPatchRequest.ActionEnum;
@@ -33,11 +33,11 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
-public class AddPermissionsCommandImpl
-    implements AddPermissionsCommandStep1,
-        AddPermissionsCommandStep2,
-        AddPermissionsCommandStep3,
-        AddPermissionsCommandStep4 {
+public class RemovePermissionsCommandImpl
+    implements RemovePermissionsCommandStep1,
+        RemovePermissionsCommandStep2,
+        RemovePermissionsCommandStep3,
+        RemovePermissionsCommandStep4 {
 
   private final PatchAuthorizationCommand delegate;
   private final HttpClient httpClient;
@@ -45,49 +45,49 @@ public class AddPermissionsCommandImpl
   private final String path;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AddPermissionsCommandImpl(
+  public RemovePermissionsCommandImpl(
       final long ownerKey, final HttpClient httpClient, final JsonMapper jsonMapper) {
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     path = "/authorizations/" + ownerKey;
     httpRequestConfig = httpClient.newRequestConfig();
-    delegate = new PatchAuthorizationCommand(ActionEnum.ADD);
+    delegate = new PatchAuthorizationCommand(ActionEnum.REMOVE);
   }
 
   @Override
-  public AddPermissionsCommandStep2 resourceType(final ResourceTypeEnum resourceType) {
+  public RemovePermissionsCommandStep2 resourceType(final ResourceTypeEnum resourceType) {
     delegate.resourceType(resourceType);
     return this;
   }
 
   @Override
-  public AddPermissionsCommandStep3 permission(final PermissionTypeEnum permissionType) {
+  public RemovePermissionsCommandStep3 permission(final PermissionTypeEnum permissionType) {
     delegate.permission(permissionType);
     return this;
   }
 
   @Override
-  public AddPermissionsCommandStep4 resourceIds(final List<String> resourceIds) {
+  public RemovePermissionsCommandStep4 resourceIds(final List<String> resourceIds) {
     delegate.resourceIds(resourceIds);
     return this;
   }
 
   @Override
-  public AddPermissionsCommandStep4 resourceId(final String resourceId) {
+  public RemovePermissionsCommandStep4 resourceId(final String resourceId) {
     delegate.resourceId(resourceId);
     return this;
   }
 
   @Override
-  public FinalCommandStep<AddPermissionsResponse> requestTimeout(final Duration requestTimeout) {
+  public FinalCommandStep<RemovePermissionsResponse> requestTimeout(final Duration requestTimeout) {
     ArgumentUtil.ensurePositive("requestTimeout", requestTimeout);
     httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
-  public ZeebeFuture<AddPermissionsResponse> send() {
-    final HttpZeebeFuture<AddPermissionsResponse> result = new HttpZeebeFuture<>();
+  public ZeebeFuture<RemovePermissionsResponse> send() {
+    final HttpZeebeFuture<RemovePermissionsResponse> result = new HttpZeebeFuture<>();
     httpClient.patch(
         path, jsonMapper.toJson(delegate.getRequest()), httpRequestConfig.build(), result);
     return result;

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -89,7 +89,6 @@ public class AuthorizationServices
     final var brokerRequest =
         new BrokerAuthorizationPatchRequest(intent)
             .setOwnerKey(request.ownerKey())
-            .setAction(request.action())
             .setResourceType(request.resourceType());
     request.permissions().forEach(brokerRequest::addPermissions);
     return sendBrokerRequest(brokerRequest);

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -19,6 +19,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerAuthorizationPatchRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
@@ -81,8 +82,12 @@ public class AuthorizationServices
 
   public CompletableFuture<AuthorizationRecord> patchAuthorization(
       final PatchAuthorizationRequest request) {
+    final var intent =
+        request.action() == PermissionAction.ADD
+            ? AuthorizationIntent.ADD_PERMISSION
+            : AuthorizationIntent.REMOVE_PERMISSION;
     final var brokerRequest =
-        new BrokerAuthorizationPatchRequest()
+        new BrokerAuthorizationPatchRequest(intent)
             .setOwnerKey(request.ownerKey())
             .setAction(request.action())
             .setResourceType(request.resourceType());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -107,7 +106,6 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
   private void addUserPermissions(final long key, final String username) {
     final var authorizationRecord =
         new AuthorizationRecord()
-            .setAction(PermissionAction.ADD)
             .setOwnerKey(key)
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceType(AuthorizationResourceType.USER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -54,7 +53,6 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
@@ -122,7 +120,6 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
@@ -158,7 +155,6 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
@@ -48,7 +47,6 @@ public class AddPermissionAuthorizationTest {
         engine
             .authorization()
             .permission()
-            .withAction(PermissionAction.ADD)
             .withOwnerKey(ownerKey)
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")
@@ -59,15 +57,11 @@ public class AddPermissionAuthorizationTest {
     // then
     assertThat(response)
         .extracting(
-            AuthorizationRecordValue::getAction,
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
         .containsExactly(
-            PermissionAction.ADD,
-            ownerKey,
-            AuthorizationOwnerType.USER,
-            AuthorizationResourceType.DEPLOYMENT);
+            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
     assertThat(response.getPermissions())
         .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
         .containsExactly(
@@ -85,7 +79,6 @@ public class AddPermissionAuthorizationTest {
         engine
             .authorization()
             .permission()
-            .withAction(PermissionAction.ADD)
             .withOwnerKey(ownerKey)
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.Au
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -182,12 +181,7 @@ public class AuthorizationCheckBehaviorTest {
       final PermissionType permissionType,
       final String... resourceIds) {
     final var client =
-        engine
-            .authorization()
-            .permission()
-            .withAction(PermissionAction.ADD)
-            .withOwnerKey(userKey)
-            .withResourceType(resourceType);
+        engine.authorization().permission().withOwnerKey(userKey).withResourceType(resourceType);
 
     for (final String resourceId : resourceIds) {
       client.withPermission(permissionType, resourceId);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -50,7 +49,6 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.REMOVE)
         .withOwnerKey(ownerKey)
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)
@@ -115,7 +113,6 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.REMOVE)
         .withOwnerKey(ownerKey)
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)
@@ -146,7 +143,6 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.REMOVE)
         .withOwnerKey(ownerKey)
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)
@@ -195,7 +191,6 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(resourceType)
         .withPermission(permissionType, resourceId)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
@@ -45,7 +44,6 @@ public class RemovePermissionAuthorizationTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
@@ -58,7 +56,6 @@ public class RemovePermissionAuthorizationTest {
         engine
             .authorization()
             .permission()
-            .withAction(PermissionAction.REMOVE)
             .withOwnerKey(ownerKey)
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")
@@ -69,15 +66,11 @@ public class RemovePermissionAuthorizationTest {
     // then
     assertThat(response)
         .extracting(
-            AuthorizationRecordValue::getAction,
             AuthorizationRecordValue::getOwnerKey,
             AuthorizationRecordValue::getOwnerType,
             AuthorizationRecordValue::getResourceType)
         .containsExactly(
-            PermissionAction.REMOVE,
-            ownerKey,
-            AuthorizationOwnerType.USER,
-            AuthorizationResourceType.DEPLOYMENT);
+            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
     assertThat(response.getPermissions())
         .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
         .containsExactly(
@@ -95,7 +88,6 @@ public class RemovePermissionAuthorizationTest {
         engine
             .authorization()
             .permission()
-            .withAction(PermissionAction.REMOVE)
             .withOwnerKey(ownerKey)
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.CREATE, "foo")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RoleTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -277,7 +276,6 @@ public class RoleTest {
         .withOwnerKey(roleKey)
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.ROLE)
-        .withAction(PermissionAction.REMOVE)
         .add();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -262,7 +261,6 @@ public class GroupTest {
         .withOwnerKey(groupKey)
         .withOwnerType(AuthorizationOwnerType.ROLE)
         .withResourceType(AuthorizationResourceType.ROLE)
-        .withAction(PermissionAction.REMOVE)
         .add();
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.function.Function;
@@ -73,11 +72,6 @@ public final class AuthorizationClient {
 
     public AuthorizationPermissionClient withOwnerKey(final Long ownerKey) {
       authorizationCreationRecord.setOwnerKey(ownerKey);
-      return this;
-    }
-
-    public AuthorizationPermissionClient withAction(final PermissionAction action) {
-      authorizationCreationRecord.setAction(action);
       return this;
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationControllerTest.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.net.URI;
 import java.util.List;
@@ -80,7 +79,6 @@ public class AuthorizationControllerTest extends RestControllerTest {
         new AuthorizationRecord()
             .setOwnerKey(ownerKey)
             .setOwnerType(AuthorizationOwnerType.USER)
-            .setAction(PermissionAction.valueOf(request.getAction().name()))
             .setResourceType(AuthorizationResourceType.valueOf(request.getResourceType().name()))
             .addPermission(permission);
 
@@ -101,7 +99,6 @@ public class AuthorizationControllerTest extends RestControllerTest {
     verify(authorizationServices, times(1)).patchAuthorization(captor.capture());
     final var capturedRequest = captor.getValue();
     assertEquals(capturedRequest.ownerKey(), authorizationRecord.getOwnerKey());
-    assertEquals(capturedRequest.action(), authorizationRecord.getAction());
     assertEquals(capturedRequest.resourceType(), authorizationRecord.getResourceType());
     assertEquals(capturedRequest.permissions().size(), 1);
     assertEquals(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
@@ -22,8 +22,8 @@ import org.agrona.DirectBuffer;
 public class BrokerAuthorizationPatchRequest extends BrokerExecuteCommand<AuthorizationRecord> {
   private final AuthorizationRecord requestDto = new AuthorizationRecord();
 
-  public BrokerAuthorizationPatchRequest() {
-    super(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION);
+  public BrokerAuthorizationPatchRequest(final AuthorizationIntent intent) {
+    super(ValueType.AUTHORIZATION, intent);
     setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Set;
 import org.agrona.DirectBuffer;
@@ -29,11 +28,6 @@ public class BrokerAuthorizationPatchRequest extends BrokerExecuteCommand<Author
 
   public BrokerAuthorizationPatchRequest setOwnerKey(final Long ownerKey) {
     requestDto.setOwnerKey(ownerKey);
-    return this;
-  }
-
-  public BrokerAuthorizationPatchRequest setAction(final PermissionAction action) {
-    requestDto.setAction(action);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/AuthorizationRecord.java
@@ -14,13 +14,10 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import java.util.List;
 
 public final class AuthorizationRecord extends UnifiedRecordValue
     implements AuthorizationRecordValue {
-  private final EnumProperty<PermissionAction> actionProp =
-      new EnumProperty<>("action", PermissionAction.class);
   private final LongProperty ownerKeyProp = new LongProperty("ownerKey");
   private final EnumProperty<AuthorizationOwnerType> ownerTypeProp =
       new EnumProperty<>(
@@ -31,16 +28,14 @@ public final class AuthorizationRecord extends UnifiedRecordValue
       new ArrayProperty<>("permissions", Permission::new);
 
   public AuthorizationRecord() {
-    super(5);
-    declareProperty(actionProp)
-        .declareProperty(ownerTypeProp)
+    super(4);
+    declareProperty(ownerTypeProp)
         .declareProperty(ownerKeyProp)
         .declareProperty(resourceTypeProp)
         .declareProperty(permissionsProp);
   }
 
   public void wrap(final AuthorizationRecord record) {
-    actionProp.setValue(record.getAction());
     ownerTypeProp.setValue(record.getOwnerType());
     ownerKeyProp.setValue(record.getOwnerKey());
     resourceTypeProp.setValue(record.getResourceType());
@@ -49,22 +44,11 @@ public final class AuthorizationRecord extends UnifiedRecordValue
 
   public AuthorizationRecord copy() {
     final AuthorizationRecord copy = new AuthorizationRecord();
-    copy.actionProp.setValue(getAction());
     copy.ownerKeyProp.setValue(getOwnerKey());
     copy.ownerTypeProp.setValue(getOwnerType());
     copy.resourceTypeProp.setValue(getResourceType());
     getPermissions().forEach(copy::addPermission);
     return copy;
-  }
-
-  @Override
-  public PermissionAction getAction() {
-    return actionProp.getValue();
-  }
-
-  public AuthorizationRecord setAction(final PermissionAction action) {
-    actionProp.setValue(action);
-    return this;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -77,7 +77,6 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserType;
@@ -2612,7 +2611,6 @@ final class JsonSerializableToJsonTest {
         (Supplier<AuthorizationRecord>)
             () ->
                 new AuthorizationRecord()
-                    .setAction(PermissionAction.ADD)
                     .setOwnerKey(1L)
                     .setOwnerType(AuthorizationOwnerType.USER)
                     .setResourceType(AuthorizationResourceType.DEPLOYMENT)
@@ -2625,7 +2623,6 @@ final class JsonSerializableToJsonTest {
                         new Permission().setPermissionType(PermissionType.READ).addResourceId("*")),
         """
         {
-          "action": "ADD",
           "ownerKey": 1,
           "ownerType": "USER",
           "resourceType": "DEPLOYMENT",
@@ -2650,12 +2647,10 @@ final class JsonSerializableToJsonTest {
         (Supplier<AuthorizationRecord>)
             () ->
                 new AuthorizationRecord()
-                    .setAction(PermissionAction.ADD)
                     .setOwnerKey(1L)
                     .setResourceType(AuthorizationResourceType.DEPLOYMENT),
         """
         {
-          "action": "ADD",
           "ownerKey": 1,
           "ownerType": "UNSPECIFIED",
           "resourceType": "DEPLOYMENT",

--- a/zeebe/protocol/ignored-changes.json
+++ b/zeebe/protocol/ignored-changes.json
@@ -84,6 +84,59 @@
           "code": "java.class.removed",
           "old": "enum io.camunda.zeebe.protocol.record.value.PermissionType",
           "justification": "PermissionType is moved to security-core module"
+        },
+        {
+          "justification": "JOB was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and JOB is not one of them.",
+          "code": "java.field.removed",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.JOB"
+        },
+        {
+          "justification": "USER_GROUP was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_GROUP is not one of them.",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_GROUP",
+          "code": "java.field.removed"
+        },
+        {
+          "justification": "USER_TASK was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_TASK is not one of them.",
+          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK",
+          "code": "java.field.removed"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue::getAction()",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::getAction()",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.List<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",
+          "new": "method java.util.Set<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",
+          "justification": "This method was added and released with 8.6 without any way to use it. We can safely change the return type in 8.7."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.returnTypeChanged",
+          "old": "method java.util.List<java.lang.String> io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue::getResourceIds()",
+          "new": "method java.util.Set<java.lang.String> io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue::getResourceIds()",
+          "justification": "This method was added and released with 8.6 without any way to use it. We can safely change the return type in 8.7."
         }
       ]
     }

--- a/zeebe/protocol/revapi.json
+++ b/zeebe/protocol/revapi.json
@@ -74,59 +74,6 @@
           "code": "java.class.removed",
           "old": "enum io.camunda.zeebe.protocol.record.value.ExecutionListenerEventType",
           "elementKind": "enum"
-        },
-        {
-          "justification": "JOB was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and JOB is not one of them.",
-          "code": "java.field.removed",
-          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.JOB"
-        },
-        {
-          "justification": "USER_GROUP was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_GROUP is not one of them.",
-          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_GROUP",
-          "code": "java.field.removed"
-        },
-        {
-          "justification": "USER_TASK was added and released with 8.6 without any way to use it. For 8.7 the definitive types became available and USER_TASK is not one of them.",
-          "old": "field io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER_TASK",
-          "code": "java.field.removed"
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue::getAction()",
-          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
-          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::getAction()",
-          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.removed",
-          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
-          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.returnTypeChanged",
-          "old": "method java.util.List<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",
-          "new": "method java.util.Set<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",
-          "justification": "This method was added and released with 8.6 without any way to use it. We can safely change the return type in 8.7."
-        },
-        {
-          "ignore": true,
-          "code": "java.method.returnTypeChanged",
-          "old": "method java.util.List<java.lang.String> io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue::getResourceIds()",
-          "new": "method java.util.Set<java.lang.String> io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue::getResourceIds()",
-          "justification": "This method was added and released with 8.6 without any way to use it. We can safely change the return type in 8.7."
         }
       ]
     }

--- a/zeebe/protocol/revapi.json
+++ b/zeebe/protocol/revapi.json
@@ -92,6 +92,30 @@
         },
         {
           "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue::getAction()",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue.Builder::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.PermissionAction io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::getAction()",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue::withAction(io.camunda.zeebe.protocol.record.value.PermissionAction)",
+          "justification": "Action is not required. The record was released with 8.6 without any way to write it. Because of this we can safely remove it."
+        },
+        {
+          "ignore": true,
           "code": "java.method.returnTypeChanged",
           "old": "method java.util.List<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",
           "new": "method java.util.Set<java.lang.String> io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue::getResourceIds()",

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/AuthorizationRecordValue.java
@@ -25,8 +25,6 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableAuthorizationRecordValue.Builder.class)
 public interface AuthorizationRecordValue extends RecordValue {
 
-  PermissionAction getAction();
-
   Long getOwnerKey();
 
   AuthorizationOwnerType getOwnerType();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/AuthorizationRemovePermissionAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/AuthorizationRemovePermissionAuthorizationIT.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.authorization;
+
+import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.application.Profile;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
+import io.camunda.zeebe.it.util.AuthorizationsUtil;
+import io.camunda.zeebe.it.util.AuthorizationsUtil.Permissions;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@AutoCloseResources
+@Testcontainers
+@ZeebeIntegration
+public class AuthorizationRemovePermissionAuthorizationIT {
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  @TestZeebe(autoStart = false)
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withBrokerConfig(
+              b -> b.getExperimental().getEngine().getAuthorizations().setEnableAuthorization(true))
+          .withAdditionalProfile(Profile.AUTH_BASIC);
+
+  private static final String PROCESS_ID = "processId";
+
+  private static ZeebeClient defaultUserClient;
+  private static AuthorizationsUtil authUtil;
+
+  @BeforeAll
+  static void beforeAll() {
+    BROKER.withCamundaExporter("http://" + CONTAINER.getHttpHostAddress());
+    BROKER.start();
+
+    final var defaultUsername = "demo";
+    defaultUserClient = createClient(BROKER, defaultUsername, "demo");
+    authUtil = new AuthorizationsUtil(BROKER, defaultUserClient, CONTAINER.getHttpHostAddress());
+
+    authUtil.awaitUserExistsInElasticsearch(defaultUsername);
+    defaultUserClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent().done(), "process.xml")
+        .send()
+        .join();
+  }
+
+  @Test
+  void shouldBeAuthorizedToRemovePermissionsWithDefaultUser() {
+    // given
+    final var username = UUID.randomUUID().toString();
+    final var resourceType = ResourceTypeEnum.DEPLOYMENT;
+    final var permissionType = PermissionTypeEnum.DELETE;
+    final var resourceId = "resourceId";
+    final var userKey =
+        authUtil.createUserWithPermissions(
+            username,
+            "password",
+            new Permissions(resourceType, permissionType, List.of(resourceId)));
+
+    // when then
+    final var response =
+        defaultUserClient
+            .newRemovePermissionsCommand(userKey)
+            .resourceType(resourceType)
+            .permission(permissionType)
+            .resourceId(resourceId)
+            .send()
+            .join();
+
+    // The Rest API returns a null future for an empty response
+    // We can verify for null, as if we'd be unauthenticated we'd get an exception
+    assertThat(response).isNull();
+  }
+
+  @Test
+  void shouldBeAuthorizedToRemovePermissionsWithUser() {
+    // given
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    final var resourceType = ResourceTypeEnum.AUTHORIZATION;
+    final var permissionType = PermissionTypeEnum.UPDATE;
+    final var resourceId = "*";
+    final var userKey =
+        authUtil.createUserWithPermissions(
+            username, password, new Permissions(resourceType, permissionType, List.of(resourceId)));
+
+    try (final var client = authUtil.createClient(username, password)) {
+      // when then
+      final var response =
+          client
+              .newRemovePermissionsCommand(userKey)
+              .resourceType(resourceType)
+              .permission(permissionType)
+              .resourceId(resourceId)
+              .send()
+              .join();
+      // The Rest API returns a null future for an empty response
+      // We can verify for null, as if we'd be unauthenticated we'd get an exception
+      assertThat(response).isNull();
+    }
+  }
+
+  @Test
+  void shouldBeUnauthorizedToRemovePermissionsIfNoPermissions() {
+    // given
+    final var username = UUID.randomUUID().toString();
+    final var password = "password";
+    authUtil.createUser(username, password);
+
+    // when
+    try (final var client = authUtil.createClient(username, password)) {
+      final var response =
+          client
+              // We can use any owner key. The authorization check happens before we use it.
+              .newRemovePermissionsCommand(1L)
+              .resourceType(ResourceTypeEnum.DEPLOYMENT)
+              .permission(PermissionTypeEnum.CREATE)
+              .resourceId("*")
+              .send();
+
+      // then
+      assertThatThrownBy(response::join)
+          .isInstanceOf(ProblemException.class)
+          .hasMessageContaining("title: UNAUTHORIZED")
+          .hasMessageContaining("status: 401")
+          .hasMessageContaining(
+              "Unauthorized to perform operation 'UPDATE' on resource 'AUTHORIZATION'");
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AddPermissionsTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
-import io.camunda.zeebe.protocol.record.value.PermissionAction;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -65,7 +64,6 @@ public class AddPermissionsTest {
             .limit(2)
             .getLast()
             .getValue();
-    assertThat(recordValue.getAction()).isEqualTo(PermissionAction.ADD);
     assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);
     assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
     final var permission = recordValue.getPermissions().getFirst();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RemovePermissionsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.AddPermissionsResponse;
+import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
+import io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class RemovePermissionsTest {
+
+  ZeebeClient client;
+
+  @TestZeebe
+  final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  void init() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  void shouldRemovePermissionsFromOwner() {
+    // given
+    final long ownerKey = createUser();
+    final var resourceType = ResourceTypeEnum.DEPLOYMENT;
+    final var permissionType = PermissionTypeEnum.CREATE;
+    final var resourceId = "resourceId";
+    addPermissionToOwner(ownerKey, resourceType, permissionType, resourceId);
+
+    // when
+    client
+        .newRemovePermissionsCommand(ownerKey)
+        .resourceType(resourceType)
+        .permission(permissionType)
+        .resourceId(resourceId)
+        .send()
+        .join();
+
+    // then
+    final var recordValue =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_REMOVED)
+            .withOwnerKey(ownerKey)
+            .limit(1)
+            .getFirst()
+            .getValue();
+    assertThat(recordValue.getResourceType()).isEqualTo(AuthorizationResourceType.DEPLOYMENT);
+    assertThat(recordValue.getOwnerType()).isEqualTo(AuthorizationOwnerType.USER);
+    final var permission = recordValue.getPermissions().getFirst();
+    assertThat(permission.getPermissionType()).isEqualTo(PermissionType.CREATE);
+    assertThat(permission.getResourceIds()).containsExactly(resourceId);
+  }
+
+  @Test
+  void shouldRejectWhenOwnerNotFound() {
+    // given
+    final var nonExistingOwnerKey = 1L;
+
+    // when
+    final var future =
+        client
+            .newRemovePermissionsCommand(nonExistingOwnerKey)
+            .resourceType(ResourceTypeEnum.DEPLOYMENT)
+            .permission(PermissionTypeEnum.CREATE)
+            .resourceId("resourceId")
+            .send();
+
+    // then
+    assertThatThrownBy(future::join)
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to find owner with key: '%d', but none was found"
+                .formatted(nonExistingOwnerKey));
+  }
+
+  private long createUser() {
+    return client
+        .newUserCreateCommand()
+        .username("foo")
+        .name("Foo Bar")
+        .email("bar@baz.com")
+        .password("zabraboof")
+        .send()
+        .join()
+        .getUserKey();
+  }
+
+  private AddPermissionsResponse addPermissionToOwner(
+      final long ownerKey,
+      final ResourceTypeEnum resourceType,
+      final PermissionTypeEnum permissionType,
+      final String resourceId) {
+    return client
+        .newAddPermissionsCommand(ownerKey)
+        .resourceType(resourceType)
+        .permission(permissionType)
+        .resourceId(resourceId)
+        .send()
+        .join();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds support for permission removal through the REST api and the Java client. The biggest part of this is refactoring and testing. The endpoint for adding a permissions could be reused, so the actual implementation was very straightforward.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22627
