### PR TITLE
feat: apply authorization on Process instance GET endpoints

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_INSTANCE;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.application.Profile;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
+import io.camunda.it.utils.ZeebeClientTestFactory.Authenticated;
+import io.camunda.it.utils.ZeebeClientTestFactory.Permissions;
+import io.camunda.it.utils.ZeebeClientTestFactory.User;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class ProcessInstanceAuthorizationIT {
+  private static final String PROCESS_ID_1 = "incident_process_v1";
+  private static final String PROCESS_ID_2 = "service_tasks_v1";
+  private static final String ADMIN = "admin";
+  private static final String USER1 = "user1";
+  private static final String USER2 = "user2";
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of("*"))));
+  private static final User USER1_USER =
+      new User(
+          USER1,
+          "password",
+          List.of(new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of(PROCESS_ID_1))));
+  private static final User USER2_USER =
+      new User(
+          USER2,
+          "password",
+          List.of(new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of(PROCESS_ID_2))));
+
+  @RegisterExtension
+  static final BrokerWithCamundaExporterITInvocationProvider PROVIDER =
+      new BrokerWithCamundaExporterITInvocationProvider()
+          .withAdditionalProfiles(Profile.AUTH_BASIC)
+          .withAuthorizationsEnabled()
+          .withUsers(ADMIN_USER, USER1_USER, USER2_USER);
+
+  private boolean initialized;
+
+  @BeforeEach
+  void setUp(@Authenticated(ADMIN) final ZeebeClient adminClient) {
+    if (!initialized) {
+      deployResource(adminClient, "process/incident_process_v1.bpmn");
+      deployResource(adminClient, "process/service_tasks_v1.bpmn");
+
+      startProcessInstance(adminClient, PROCESS_ID_1);
+      startProcessInstance(adminClient, PROCESS_ID_2);
+
+      waitForFlowNodeInstancesBeingExported(adminClient, 4);
+      initialized = true;
+    }
+  }
+
+  @TestTemplate
+  public void searchShouldReturnAuthorizedProcessInstances(
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // when
+    final var result = zeebeClient.newProcessInstanceQuery().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo(PROCESS_ID_1);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnAuthorizedProcessInstance(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_1);
+    // when
+    final var result = zeebeClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessDefinitionId()).isEqualTo(PROCESS_ID_1);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnForbiddenForUnauthorizedProcessInstance(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_2);
+    // when
+    final Executable executeGet =
+        () -> zeebeClient.newProcessInstanceGetRequest(processInstanceKey).send().join();
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @TestTemplate
+  public void searchShouldReturnAuthorizedFlowNodeInstances(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final long processDefinitionKey = getProcessDefinitionKey(adminClient, PROCESS_ID_1);
+    // when
+    final var result = zeebeClient.newFlownodeInstanceQuery().send().join();
+    // then
+    assertThat(result.items()).hasSize(2);
+    assertThat(result.items().getFirst().getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+    assertThat(result.items().getLast().getProcessDefinitionKey()).isEqualTo(processDefinitionKey);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnAuthorizedFlowNodeInstance(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var flowNodeInstanceKey = getAnyFlowNodeInstanceKey(adminClient, PROCESS_ID_1);
+    // when
+    final var result = zeebeClient.newFlowNodeInstanceGetRequest(flowNodeInstanceKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessDefinitionKey())
+        .isEqualTo(getProcessDefinitionKey(adminClient, PROCESS_ID_1));
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnForbiddenForUnauthorizedFlowNodeInstance(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var flowNodeInstanceKey = getAnyFlowNodeInstanceKey(adminClient, PROCESS_ID_2);
+    // when
+    final Executable executeGet =
+        () -> zeebeClient.newFlowNodeInstanceGetRequest(flowNodeInstanceKey).send().join();
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @TestTemplate
+  public void searchShouldReturnAuthorizedIncidents(
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // when
+    final var result = zeebeClient.newIncidentQuery().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessDefinitionId()).isEqualTo(PROCESS_ID_1);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnAuthorizedIncident(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var incidentKey = getAnyIncidentKey(adminClient, PROCESS_ID_1);
+    // when
+    final var result = zeebeClient.newIncidentGetRequest(incidentKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessDefinitionKey())
+        .isEqualTo(getProcessDefinitionKey(adminClient, PROCESS_ID_1));
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnForbiddenForUnauthorizedIncident(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER2) final ZeebeClient zeebeClient) {
+    // given
+    final var incidentKey = getAnyIncidentKey(adminClient, PROCESS_ID_1);
+    // when
+    final Executable executeGet =
+        () -> zeebeClient.newIncidentGetRequest(incidentKey).send().join();
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  @TestTemplate
+  public void searchShouldReturnAuthorizedVariables(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_1);
+    // when
+    final var result = zeebeClient.newVariableQuery().send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnAuthorizedVariable(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_1);
+    final var variableKey = getAnyVariableKey(adminClient, processInstanceKey);
+    // when
+    final var result = zeebeClient.newVariableGetRequest(variableKey).send().join();
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnForbiddenForUnauthorizedVariable(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(USER1) final ZeebeClient zeebeClient) {
+    // given
+    final var processInstanceKey = getProcessInstanceKey(adminClient, PROCESS_ID_2);
+    final var variableKey = getAnyVariableKey(adminClient, processInstanceKey);
+    // when
+    final Executable executeGet =
+        () -> zeebeClient.newVariableGetRequest(variableKey).send().join();
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+  }
+
+  private long getProcessInstanceKey(final ZeebeClient zeebeClient, final String processId) {
+    return zeebeClient
+        .newProcessInstanceQuery()
+        .filter(f -> f.processDefinitionId(processId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getProcessInstanceKey();
+  }
+
+  private long getAnyFlowNodeInstanceKey(final ZeebeClient zeebeClient, final String processId) {
+    return zeebeClient
+        .newFlownodeInstanceQuery()
+        .filter(f -> f.processDefinitionId(processId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getFlowNodeInstanceKey();
+  }
+
+  private long getAnyIncidentKey(final ZeebeClient zeebeClient, final String processId) {
+    return zeebeClient
+        .newIncidentQuery()
+        .filter(f -> f.processDefinitionId(processId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getIncidentKey();
+  }
+
+  private long getAnyVariableKey(final ZeebeClient zeebeClient, final long processInstanceKey) {
+    return zeebeClient
+        .newVariableQuery()
+        .filter(f -> f.processInstanceKey(processInstanceKey))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getVariableKey();
+  }
+
+  private long getProcessDefinitionKey(final ZeebeClient adminClient, final String processId) {
+    return adminClient
+        .newProcessDefinitionQuery()
+        .filter(f -> f.processDefinitionId(processId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getProcessDefinitionKey();
+  }
+
+  private void deployResource(final ZeebeClient zeebeClient, final String resourceName) {
+    zeebeClient.newDeployResourceCommand().addResourceFromClasspath(resourceName).send().join();
+  }
+
+  private void startProcessInstance(final ZeebeClient zeebeClient, final String processId) {
+    zeebeClient.newCreateInstanceCommand().bpmnProcessId(processId).latestVersion().send().join();
+  }
+
+  private void waitForFlowNodeInstancesBeingExported(
+      final ZeebeClient zeebeClient, final int expectedCount) {
+    Awaitility.await("should receive data from ES")
+        .atMost(Duration.ofMinutes(1))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () ->
+                assertThat(zeebeClient.newFlownodeInstanceQuery().send().join().items())
+                    .hasSize(expectedCount));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -154,7 +154,7 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
     assertThat(exception.details().getTitle()).isEqualTo("NOT_FOUND");
     assertThat(exception.details().getStatus()).isEqualTo(404);
     assertThat(exception.details().getDetail())
-        .isEqualTo("Process Instance with key 100 not found");
+        .isEqualTo("Process instance with key 100 not found");
   }
 
   @Test

--- a/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/VariableEntity.java
@@ -18,4 +18,5 @@ public final record VariableEntity(
     boolean isPreview,
     Long scopeKey,
     Long processInstanceKey,
+    String bpmnProcessId,
     String tenantId) {}

--- a/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
@@ -8,30 +8,41 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
+import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public final class FlowNodeInstanceServiceTest {
 
   private FlowNodeInstanceServices services;
   private FlowNodeInstanceSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(FlowNodeInstanceSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = mock(Authentication.class);
     services =
         new FlowNodeInstanceServices(
-            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
   }
 
   @Test
@@ -47,5 +58,43 @@ public final class FlowNodeInstanceServiceTest {
 
     // then
     assertThat(result).isEqualTo(searchQueryResult);
+  }
+
+  @Test
+  public void shouldReturnFlowNodeInstanceByKey() {
+    // given
+    final var entity = mock(FlowNodeInstanceEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
+    when(client.searchFlowNodeInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(true);
+    // when
+    final var searchQueryResult = services.getByKey(1L);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(entity);
+  }
+
+  @Test
+  public void getByKeyShouldThrowForbiddenExceptionIfNotAuthorized() {
+    // given
+    final var entity = mock(FlowNodeInstanceEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
+    when(client.searchFlowNodeInstances(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(false);
+    // when
+    final Executable executeGetByKey = () -> services.getByKey(1L);
+    // then
+    final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -8,30 +8,41 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.IncidentSearchClient;
+import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public final class IncidentServiceTest {
 
   private IncidentServices services;
   private IncidentSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(IncidentSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = mock(Authentication.class);
     services =
         new IncidentServices(
-            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
   }
 
   @Test
@@ -47,5 +58,43 @@ public final class IncidentServiceTest {
 
     // then
     assertThat(searchQueryResult).isEqualTo(result);
+  }
+
+  @Test
+  public void shouldReturnIncidentByKey() {
+    // given
+    final var entity = mock(IncidentEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
+    when(client.searchIncidents(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(true);
+    // when
+    final var searchQueryResult = services.getByKey(1L);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(entity);
+  }
+
+  @Test
+  public void getByKeyShouldThrowForbiddenExceptionIfNotAuthorized() {
+    // given
+    final var entity = mock(IncidentEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
+    when(client.searchIncidents(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(false);
+    // when
+    final Executable executeGetByKey = () -> services.getByKey(1L);
+    // then
+    final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -18,25 +19,33 @@ import io.camunda.search.filter.VariableFilter;
 import io.camunda.search.filter.VariableFilter.Builder;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 public class VariableServiceTest {
 
   private VariableServices services;
   private VariableSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(VariableSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = mock(Authentication.class);
     services =
         new VariableServices(
-            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
   }
 
   @Test
@@ -67,13 +76,38 @@ public class VariableServiceTest {
   public void shouldReturnSingleVariableForGet() {
     // given
     final var entity = mock(VariableEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
     final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
     when(client.searchVariables(any())).thenReturn(result);
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(true);
 
     // when
     final var searchQueryResult = services.getByKey(1L);
 
     // then
     assertThat(searchQueryResult).isEqualTo(entity);
+  }
+
+  @Test
+  public void getByKeyShouldThrowForbiddenExceptionIfNotAuthorized() {
+    // given
+    final var entity = mock(VariableEntity.class);
+    final var processId = "processId";
+    when(entity.bpmnProcessId()).thenReturn(processId);
+    when(client.searchVariables(any()))
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+    when(securityContextProvider.isAuthorized(
+            processId, authentication, Authorization.of(a -> a.processDefinition().readInstance())))
+        .thenReturn(false);
+    // when
+    final Executable executeGetByKey = () -> services.getByKey(1L);
+    // then
+    final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
+++ b/service/src/test/java/io/camunda/service/security/SecurityContextProviderTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.security.auth.SecurityContext;
+import io.camunda.security.configuration.SecurityConfiguration;
+import io.camunda.security.impl.AuthorizationChecker;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+class SecurityContextProviderTest {
+
+  private SecurityConfiguration securityConfiguration;
+  private AuthorizationChecker authorizationChecker;
+  private SecurityContextProvider securityContextProvider;
+
+  @BeforeEach
+  void before() {
+    securityConfiguration = mock(SecurityConfiguration.class, Answers.RETURNS_DEEP_STUBS);
+    authorizationChecker = mock(AuthorizationChecker.class);
+    securityContextProvider =
+        new SecurityContextProvider(securityConfiguration, authorizationChecker);
+  }
+
+  @Test
+  void shouldProvideSecurityContextWithAuthorizationWhenDisabled() {
+    // given
+    final var authentication = mock(Authentication.class);
+    final var authorization = mock(Authorization.class);
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
+
+    // when
+    final var securityContext =
+        securityContextProvider.provideSecurityContext(authentication, authorization);
+
+    // then
+    assertThat(securityContext.authorization()).isEqualTo(authorization);
+    assertThat(securityContext.requiresAuthorizationChecks()).isTrue();
+    assertThat(securityContext.authentication()).isEqualTo(authentication);
+  }
+
+  @Test
+  void shouldProvideSecurityContextWithoutAuthorizationWhenDisabled() {
+    // given
+    final var authentication = mock(Authentication.class);
+    final var authorization = mock(Authorization.class);
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
+
+    // when
+    final var securityContext =
+        securityContextProvider.provideSecurityContext(authentication, authorization);
+
+    // then
+    assertThat(securityContext.authorization()).isNull();
+    assertThat(securityContext.requiresAuthorizationChecks()).isFalse();
+    assertThat(securityContext.authentication()).isEqualTo(authentication);
+  }
+
+  @Test
+  void isAuthorizedShouldReturnTrueWhenAuthorizationIsDisabled() {
+    // given
+    final var authentication = mock(Authentication.class);
+    final var authorization = mock(Authorization.class);
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
+
+    // when
+    final var authorized =
+        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
+
+    // then
+    assertThat(authorized).isTrue();
+    verify(authorizationChecker, never()).isAuthorized(any(), any());
+  }
+
+  @Test
+  void isAuthorizedShouldReturnTrueWhenAuthorizationCheckerReturnsTrue() {
+    // given
+    final var authentication = mock(Authentication.class);
+    final var authorization = mock(Authorization.class);
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
+    when(authorizationChecker.isAuthorized(any(), any())).thenReturn(true);
+
+    // when
+    final var authorized =
+        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
+
+    // then
+    assertThat(authorized).isTrue();
+    verify(authorizationChecker)
+        .isAuthorized(
+            "resourceKey",
+            SecurityContext.of(
+                s -> s.withAuthentication(authentication).withAuthorization(authorization)));
+  }
+
+  @Test
+  void isAuthorizedShouldReturnFalseWhenAuthorizationCheckerReturnsFalse() {
+    // given
+    final var authentication = mock(Authentication.class);
+    final var authorization = mock(Authorization.class);
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
+    when(authorizationChecker.isAuthorized(any(), any())).thenReturn(false);
+
+    // when
+    final var authorized =
+        securityContextProvider.isAuthorized("resourceKey", authentication, authorization);
+
+    // then
+    assertThat(authorized).isFalse();
+    verify(authorizationChecker)
+        .isAuthorized(
+            "resourceKey",
+            SecurityContext.of(
+                s -> s.withAuthentication(authentication).withAuthorization(authorization)));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
@@ -55,7 +55,9 @@ public class FlowNodeInstanceQueryController {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toFlowNodeInstance(
-                  flownodeInstanceServices.getByKey(flowNodeInstanceKey)));
+                  flownodeInstanceServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getByKey(flowNodeInstanceKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryController.java
@@ -55,7 +55,11 @@ public class IncidentQueryController {
       @PathVariable("incidentKey") final Long incidentKey) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toIncident(incidentServices.getByKey(incidentKey)));
+          .body(
+              SearchQueryResponseMapper.toIncident(
+                  incidentServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getByKey(incidentKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
@@ -65,7 +65,9 @@ public class ProcessInstanceQueryController {
       return ResponseEntity.ok()
           .body(
               SearchQueryResponseMapper.toProcessInstance(
-                  processInstanceServices.getByKey(processInstanceKey)));
+                  processInstanceServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getByKey(processInstanceKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/VariableQueryController.java
@@ -61,7 +61,11 @@ public class VariableQueryController {
     try {
       // Success case: Return the left side with the VariableItem wrapped in ResponseEntity
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toVariable(variableServices.getByKey(variableKey)));
+          .body(
+              SearchQueryResponseMapper.toVariable(
+                  variableServices
+                      .withAuthentication(RequestMapper.getAuthentication())
+                      .getByKey(variableKey)));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -178,7 +178,9 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
       new Builder<VariableEntity>()
           .total(1L)
           .items(
-              List.of(new VariableEntity(0L, "name", "value", "test", false, 1L, 2L, "<default>")))
+              List.of(
+                  new VariableEntity(
+                      0L, "name", "value", "test", false, 1L, 2L, "bpid", "<default>")))
           .sortValues(new Object[] {"v"})
           .build();
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -75,7 +75,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
   private static final SearchQueryResult<VariableEntity> SEARCH_QUERY_RESULT =
       new Builder<VariableEntity>()
           .total(1L)
-          .items(List.of(new VariableEntity(0L, "n", "v", "v", false, 2L, 3L, "<default>")))
+          .items(List.of(new VariableEntity(0L, "n", "v", "v", false, 2L, 3L, "bpid", "<default>")))
           .sortValues(new Object[] {"v"})
           .build();
   @MockBean VariableServices variableServices;
@@ -86,7 +86,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
         .thenReturn(variableServices);
 
     when(variableServices.getByKey(VALID_VARIABLE_KEY))
-        .thenReturn(new VariableEntity(0L, "n", "v", "v", false, 2L, 3L, "<default>"));
+        .thenReturn(new VariableEntity(0L, "n", "v", "v", false, 2L, 3L, "bpid", "<default>"));
 
     when(variableServices.getByKey(INVALID_VARIABLE_KEY))
         .thenThrow(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adding `PROCESS_DEFINITION.READ_INSTANCE` permission check on the following endpoints

```
GET /process-instances/{processInstanceKey}
GET /flownode-instances/{flowNodeInstanceKey}
GET /incidents/{incidentKey}
GET /variables/{variableKey}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23180
