### PR TITLE
Enable OpenSearch support for Archiver

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
@@ -184,7 +184,6 @@ public final class ElasticsearchRepository implements ArchiverRepository {
 
   @Override
   public void close() throws Exception {
-    // TODO: verify if I close the transport that any pending futures are cancelled
     client._transport().close();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
@@ -203,6 +203,46 @@ final class ElasticsearchRepositoryIT {
   }
 
   @Test
+  void shouldMoveDocuments() throws IOException {
+    // given
+    final var sourceIndexName = UUID.randomUUID().toString();
+    final var destIndexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(sourceIndexName, doc));
+    testClient.indices().refresh(r -> r.index(sourceIndexName));
+    testClient.indices().create(r -> r.index(destIndexName));
+
+    // when - delete the first two documents
+    final var result =
+        repository.moveDocuments(
+            sourceIndexName,
+            destIndexName,
+            "id",
+            documents.stream().limit(2).map(TestDocument::id).toList(),
+            Runnable::run);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(sourceIndexName, destIndexName));
+    final var remaining =
+        testClient.search(r -> r.index(sourceIndexName).requestCache(false), TestDocument.class);
+    final var reindexed =
+        testClient.search(r -> r.index(destIndexName).requestCache(false), TestDocument.class);
+    assertThat(reindexed.hits().hits())
+        .as("only first two documents were reindexed")
+        .hasSize(2)
+        .map(Hit::id)
+        .containsExactlyInAnyOrder("1", "2");
+    assertThat(remaining.hits().hits())
+        .as("only the last document is remaining")
+        .hasSize(1)
+        .extracting(Hit::id)
+        .containsExactlyInAnyOrder("3");
+  }
+
+  @Test
   void shouldGetProcessInstancesNextBatch() throws IOException {
     // given - 4 documents, where 2 is on a different partition, 3 is the wrong join relation type,
     // and 4 was finished too recently: we then expect only 1 to be returned

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepositoryIT.java
@@ -175,7 +175,7 @@ final class ElasticsearchRepositoryIT {
     testClient.indices().refresh(r -> r.index(sourceIndexName));
     testClient.indices().create(r -> r.index(destIndexName));
 
-    // when - delete the first two documents
+    // when - reindex the first two documents
     final var result =
         repository.reindexDocuments(
             sourceIndexName,
@@ -214,7 +214,7 @@ final class ElasticsearchRepositoryIT {
     testClient.indices().refresh(r -> r.index(sourceIndexName));
     testClient.indices().create(r -> r.index(destIndexName));
 
-    // when - delete the first two documents
+    // when - move the first two documents
     final var result =
         repository.moveDocuments(
             sourceIndexName,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
@@ -147,7 +147,7 @@ final class OpenSearchRepositoryIT {
     testClient.indices().refresh(r -> r.index(sourceIndexName));
     testClient.indices().create(r -> r.index(destIndexName));
 
-    // when - delete the first two documents
+    // when - reindex the first two documents
     final var result =
         repository.reindexDocuments(
             sourceIndexName,
@@ -186,7 +186,7 @@ final class OpenSearchRepositoryIT {
     testClient.indices().refresh(r -> r.index(sourceIndexName));
     testClient.indices().create(r -> r.index(destIndexName));
 
-    // when - delete the first two documents
+    // when - move the first two documents
     final var result =
         repository.moveDocuments(
             sourceIndexName,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchRepositoryIT.java
@@ -175,6 +175,46 @@ final class OpenSearchRepositoryIT {
   }
 
   @Test
+  void shouldMoveDocuments() throws IOException {
+    // given
+    final var sourceIndexName = UUID.randomUUID().toString();
+    final var destIndexName = UUID.randomUUID().toString();
+    final var repository = createRepository();
+    final var documents =
+        List.of(new TestDocument("1"), new TestDocument("2"), new TestDocument("3"));
+    documents.forEach(doc -> index(sourceIndexName, doc));
+    testClient.indices().refresh(r -> r.index(sourceIndexName));
+    testClient.indices().create(r -> r.index(destIndexName));
+
+    // when - delete the first two documents
+    final var result =
+        repository.moveDocuments(
+            sourceIndexName,
+            destIndexName,
+            "id",
+            documents.stream().limit(2).map(TestDocument::id).toList(),
+            Runnable::run);
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofSeconds(30));
+    testClient.indices().refresh(r -> r.index(sourceIndexName, destIndexName));
+    final var remaining =
+        testClient.search(r -> r.index(sourceIndexName).requestCache(false), TestDocument.class);
+    final var reindexed =
+        testClient.search(r -> r.index(destIndexName).requestCache(false), TestDocument.class);
+    assertThat(reindexed.hits().hits())
+        .as("only first two documents were reindexed")
+        .hasSize(2)
+        .map(Hit::id)
+        .containsExactlyInAnyOrder("1", "2");
+    assertThat(remaining.hits().hits())
+        .as("only the last document is remaining")
+        .hasSize(1)
+        .extracting(Hit::id)
+        .containsExactlyInAnyOrder("3");
+  }
+
+  @Test
   void shouldGetProcessInstancesNextBatch() throws IOException {
     // given - 4 documents, where 2 is on a different partition, 3 is the wrong join relation type,
     // and 4 was finished too recently: we then expect only 1 to be returned


### PR DESCRIPTION
## Description

This PR wires the OpenSearch repository for the archiver, allowing it pick the right implementation between ES/OS.

It also adds integration tests for `ArchiverRepository#moveDocuments` for both the ES and OS implementations.

closes #24094 
