### PR TITLE
fix: allow empty tasklist index prefix

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class TasklistElasticsearchProperties extends ElasticsearchProperties {
 
-  public static final String DEFAULT_INDEX_PREFIX = "tasklist";
+  public static final String DEFAULT_INDEX_PREFIX = "";
   private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public class TasklistOpenSearchProperties extends OpenSearchProperties {
 
-  public static final String DEFAULT_INDEX_PREFIX = "tasklist";
+  public static final String DEFAULT_INDEX_PREFIX = "";
   private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;
   private static final String DEFAULT_REFRESH_INTERVAL = "1s";

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -20,6 +20,11 @@
       <artifactId>tasklist-common</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>webapps-schema</artifactId>
+    </dependency>
+
     <!-- SPRING -->
 
     <dependency>

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/IndexSchemaValidatorElasticSearch.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.es;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatAllVersionsIndexNameRegexPattern;
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatTasklistIndexPattern;
 import static io.camunda.tasklist.util.CollectionUtil.map;
 
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
@@ -43,12 +45,13 @@ public class IndexSchemaValidatorElasticSearch extends IndexSchemaValidatorUtil
   @Autowired RetryElasticsearchClient retryElasticsearchClient;
 
   private Set<String> getAllIndexNamesForIndex(final String index) {
-    final String indexPattern = String.format("%s-%s*", getIndexPrefix(), index);
+    final String indexPattern = formatTasklistIndexPattern(getIndexPrefix());
     LOGGER.debug("Getting all indices for {}", indexPattern);
     final Set<String> indexNames = retryElasticsearchClient.getIndexNames(indexPattern);
     // since we have indices with similar names, we need to additionally filter index names
     // e.g. task and task-variable
-    final String patternWithVersion = String.format("%s-%s-\\d.*", getIndexPrefix(), index);
+    final String patternWithVersion =
+        formatAllVersionsIndexNameRegexPattern(getIndexPrefix(), index);
     return indexNames.stream()
         .filter(n -> n.matches(patternWithVersion))
         .collect(Collectors.toSet());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/IndexSchemaValidatorOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/IndexSchemaValidatorOpenSearch.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.os;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatAllVersionsIndexNameRegexPattern;
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatTasklistIndexPattern;
 import static io.camunda.tasklist.util.CollectionUtil.map;
 
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
@@ -44,12 +46,13 @@ public class IndexSchemaValidatorOpenSearch extends IndexSchemaValidatorUtil
   @Autowired SchemaManager schemaManager;
 
   private Set<String> getAllIndexNamesForIndex(final String index) {
-    final String indexPattern = String.format("%s-%s*", getIndexPrefix(), index);
+    final String indexPattern = formatTasklistIndexPattern(getIndexPrefix());
     LOGGER.debug("Getting all indices for {}", indexPattern);
     final Set<String> indexNames = retryOpenSearchClient.getIndexNames(indexPattern);
     // since we have indices with similar names, we need to additionally filter index names
     // e.g. task and task-variable
-    final String patternWithVersion = String.format("%s-%s-\\d.*", getIndexPrefix(), index);
+    final String patternWithVersion =
+        formatAllVersionsIndexNameRegexPattern(getIndexPrefix(), index);
     return indexNames.stream()
         .filter(n -> n.matches(patternWithVersion))
         .collect(Collectors.toSet());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/AbstractIndexDescriptor.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/AbstractIndexDescriptor.java
@@ -8,6 +8,10 @@
 package io.camunda.tasklist.schema.indices;
 
 import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.ALL_VERSIONS_INDEX_NAME_PATTERN;
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.FULL_QUALIFIED_INDEX_NAME_PATTERN;
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.formatIndexPrefix;
+import static io.camunda.webapps.schema.descriptors.ComponentNames.TASK_LIST;
 
 import io.camunda.tasklist.property.TasklistProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,11 +33,7 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
 
   @Override
   public String getFullQualifiedName() {
-    final String indexPrefix =
-        ELASTIC_SEARCH.equals(tasklistProperties.getDatabase())
-            ? tasklistProperties.getElasticsearch().getIndexPrefix()
-            : tasklistProperties.getOpenSearch().getIndexPrefix();
-    return String.format("%s-%s-%s_", indexPrefix, getIndexName(), getVersion());
+    return formatFullQualifiedIndexName(getIndexPrefix(), getIndexName(), getVersion());
   }
 
   @Override
@@ -47,6 +47,36 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
 
   @Override
   public String getAllVersionsIndexNameRegexPattern() {
-    return String.format("%s-%s-\\d.*", tasklistProperties.getIndexPrefix(), getIndexName());
+    return formatAllVersionsIndexNameRegexPattern(getIndexPrefix(), getIndexName());
+  }
+
+  public static String formatFullQualifiedIndexName(
+      final String indexPrefix, final String indexName, final String version) {
+    return String.format(
+        FULL_QUALIFIED_INDEX_NAME_PATTERN,
+        formatIndexPrefix(indexPrefix),
+        TASK_LIST,
+        indexName,
+        version);
+  }
+
+  public static String formatTasklistIndexPattern(final String indexPrefix) {
+    return formatPrefixAndComponent(indexPrefix) + "*";
+  }
+
+  public static String formatPrefixAndComponent(final String indexPrefix) {
+    return formatIndexPrefix(indexPrefix) + TASK_LIST;
+  }
+
+  public static String formatAllVersionsIndexNameRegexPattern(
+      final String prefix, final String index) {
+    return String.format(
+        ALL_VERSIONS_INDEX_NAME_PATTERN, formatIndexPrefix(prefix), TASK_LIST, index);
+  }
+
+  private String getIndexPrefix() {
+    return ELASTIC_SEARCH.equals(tasklistProperties.getDatabase())
+        ? tasklistProperties.getElasticsearch().getIndexPrefix()
+        : tasklistProperties.getOpenSearch().getIndexPrefix();
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.tasklist.schema.manager;
 
+import static io.camunda.webapps.schema.descriptors.AbstractIndexDescriptor.formatIndexPrefix;
+import static io.camunda.webapps.schema.descriptors.ComponentNames.TASK_LIST;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
@@ -165,7 +168,7 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   private String settingsTemplateName() {
     final TasklistElasticsearchProperties elsConfig = tasklistProperties.getElasticsearch();
-    return String.format("%s_template", elsConfig.getIndexPrefix());
+    return String.format("%s%s_template", formatIndexPrefix(elsConfig.getIndexPrefix()), TASK_LIST);
   }
 
   private Settings getIndexSettings() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/os/OpenSearchMigrator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/os/OpenSearchMigrator.java
@@ -10,6 +10,7 @@ package io.camunda.tasklist.schema.migration.os;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.NO_REPLICA;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.NUMBERS_OF_REPLICA;
 import static io.camunda.tasklist.es.RetryElasticsearchClient.REFRESH_INTERVAL;
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatFullQualifiedIndexName;
 import static io.camunda.tasklist.util.CollectionUtil.filter;
 
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
@@ -77,19 +78,19 @@ public class OpenSearchMigrator implements Migrator {
   public void migrate() throws MigrationException {
     try {
       stepsRepository.updateSteps();
-    } catch (IOException | OpenSearchException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new MigrationException(
           String.format("Migration failed in updating steps: %s ", e.getMessage()));
     }
     boolean failed = false;
     final List<Future<Boolean>> results =
         indexDescriptors.stream().map(this::migrateIndexInThread).toList();
-    for (Future<Boolean> result : results) {
+    for (final Future<Boolean> result : results) {
       try {
         if (!result.get()) {
           failed = true;
         }
-      } catch (Exception e) {
+      } catch (final Exception e) {
         LOGGER.error("Migration failed: ", e);
         failed = true;
       }
@@ -100,13 +101,13 @@ public class OpenSearchMigrator implements Migrator {
     }
   }
 
-  private Future<Boolean> migrateIndexInThread(IndexDescriptor indexDescriptor) {
+  private Future<Boolean> migrateIndexInThread(final IndexDescriptor indexDescriptor) {
     return getTaskExecutor()
         .submit(
             () -> {
               try {
                 migrateIndexIfNecessary(indexDescriptor);
-              } catch (Exception e) {
+              } catch (final Exception e) {
                 LOGGER.error("Migration for {} failed:", indexDescriptor.getIndexName(), e);
                 return false;
               }
@@ -114,7 +115,7 @@ public class OpenSearchMigrator implements Migrator {
             });
   }
 
-  private void migrateIndexIfNecessary(IndexDescriptor indexDescriptor)
+  private void migrateIndexIfNecessary(final IndexDescriptor indexDescriptor)
       throws MigrationException, IOException {
     LOGGER.info("Check if index {} needs to migrate.", indexDescriptor.getIndexName());
     final Set<String> olderVersions = indexSchemaValidator.olderVersionsForIndex(indexDescriptor);
@@ -138,8 +139,7 @@ public class OpenSearchMigrator implements Migrator {
       migrateIndex(indexDescriptor, plan);
       if (migrationProperties.isDeleteSrcSchema()) {
         final String olderBaseIndexName =
-            String.format(
-                "%s-%s-%s_",
+            formatFullQualifiedIndexName(
                 tasklistProperties.getElasticsearch().getIndexPrefix(),
                 indexDescriptor.getIndexName(),
                 olderVersion);
@@ -190,7 +190,7 @@ public class OpenSearchMigrator implements Migrator {
   }
 
   private Map<String, String> getIndexSettingsOrDefaultsFor(
-      final IndexDescriptor indexDescriptor, TasklistOpenSearchProperties osConfig) {
+      final IndexDescriptor indexDescriptor, final TasklistOpenSearchProperties osConfig) {
     final Map<String, String> settings = new HashMap<>();
     settings.put(
         REFRESH_INTERVAL,
@@ -222,8 +222,8 @@ public class OpenSearchMigrator implements Migrator {
                     .isBetween(sourceVersion, destinationVersion));
 
     final String indexPrefix = tasklistProperties.getElasticsearch().getIndexPrefix();
-    final String srcIndex = String.format("%s-%s-%s", indexPrefix, indexName, srcVersion);
-    final String dstIndex = String.format("%s-%s-%s", indexPrefix, indexName, dstVersion);
+    final String srcIndex = formatFullQualifiedIndexName(indexPrefix, indexName, srcVersion);
+    final String dstIndex = formatFullQualifiedIndexName(indexPrefix, indexName, dstVersion);
 
     return ReindexPlanOpenSearch.create()
         .setBatchSize(migrationProperties.getReindexBatchSize())

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/templates/AbstractTemplateDescriptor.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/templates/AbstractTemplateDescriptor.java
@@ -10,6 +10,8 @@ package io.camunda.tasklist.schema.templates;
 import static io.camunda.tasklist.property.TasklistProperties.ELASTIC_SEARCH;
 import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.SCHEMA_FOLDER_ELASTICSEARCH;
 import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.SCHEMA_FOLDER_OPENSEARCH;
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatAllVersionsIndexNameRegexPattern;
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatFullQualifiedIndexName;
 
 import io.camunda.tasklist.property.TasklistProperties;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,11 +29,7 @@ public abstract class AbstractTemplateDescriptor implements TemplateDescriptor {
 
   @Override
   public String getFullQualifiedName() {
-    final String indexPrefix =
-        ELASTIC_SEARCH.equals(tasklistProperties.getDatabase())
-            ? tasklistProperties.getElasticsearch().getIndexPrefix()
-            : tasklistProperties.getOpenSearch().getIndexPrefix();
-    return String.format("%s-%s-%s_", indexPrefix, getIndexName(), getVersion());
+    return formatFullQualifiedIndexName(getIndexPrefix(), getIndexName(), getVersion());
   }
 
   @Override
@@ -45,6 +43,12 @@ public abstract class AbstractTemplateDescriptor implements TemplateDescriptor {
 
   @Override
   public String getAllVersionsIndexNameRegexPattern() {
-    return String.format("%s-%s-\\d.*", tasklistProperties.getIndexPrefix(), getIndexName());
+    return formatAllVersionsIndexNameRegexPattern(getIndexPrefix(), getIndexName());
+  }
+
+  private String getIndexPrefix() {
+    return ELASTIC_SEARCH.equals(tasklistProperties.getDatabase())
+        ? tasklistProperties.getElasticsearch().getIndexPrefix()
+        : tasklistProperties.getOpenSearch().getIndexPrefix();
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.util;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatTasklistIndexPattern;
+
 import com.google.common.collect.Maps;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.TasklistProperties;
@@ -141,7 +143,7 @@ public class IndexSchemaValidatorUtil {
       final Set<IndexDescriptor> indexDescriptors) throws IOException {
     final Map<IndexDescriptor, Set<IndexMappingProperty>> newFields = new HashMap<>();
     final Map<String, IndexMapping> indexMappings =
-        schemaManager.getIndexMappings(schemaManager.getIndexPrefix() + "*");
+        schemaManager.getIndexMappings(formatTasklistIndexPattern(schemaManager.getIndexPrefix()));
     for (final IndexDescriptor indexDescriptor : indexDescriptors) {
       final Map<String, IndexMapping> indexMappingsGroup =
           filterIndexMappings(indexMappings, indexDescriptor);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticSearchSchemaManagementIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.es;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatPrefixAndComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -194,7 +195,7 @@ public class ElasticSearchSchemaManagementIT extends TasklistZeebeIntegrationTes
   }
 
   private String getFullIndexName() {
-    return schemaManager.getIndexPrefix() + "-" + INDEX_NAME;
+    return formatPrefixAndComponent(schemaManager.getIndexPrefix()) + "-" + INDEX_NAME;
   }
 
   private void updateSchemaContent(final String content) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/IndexSchemaValidatorIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.es;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatPrefixAndComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -178,6 +179,6 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   }
 
   private String getFullIndexName() {
-    return schemaManager.getIndexPrefix() + "-" + INDEX_NAME;
+    return formatPrefixAndComponent(schemaManager.getIndexPrefix()) + "-" + INDEX_NAME;
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/IndexSchemaValidatorIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.os;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatPrefixAndComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -170,6 +171,6 @@ public class IndexSchemaValidatorIT extends TasklistIntegrationTest {
   }
 
   private String getFullIndexName() {
-    return schemaManager.getIndexPrefix() + "-" + INDEX_NAME;
+    return formatPrefixAndComponent(schemaManager.getIndexPrefix()) + "-" + INDEX_NAME;
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchSchemaManagementIT.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.os;
 
+import static io.camunda.tasklist.schema.indices.AbstractIndexDescriptor.formatPrefixAndComponent;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
@@ -189,7 +190,7 @@ public class OpenSearchSchemaManagementIT extends TasklistZeebeIntegrationTest {
   }
 
   private String getFullIndexName() {
-    return schemaManager.getIndexPrefix() + "-" + INDEX_NAME;
+    return formatPrefixAndComponent(schemaManager.getIndexPrefix()) + "-" + INDEX_NAME;
   }
 
   private void updateSchemaContent(final String content) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -92,7 +92,7 @@ public class ElasticsearchTestExtension
   @Override
   public void beforeEach(final ExtensionContext extensionContext) {
     if (indexPrefix == null) {
-      indexPrefix = TestUtil.createRandomString(10) + "-tasklist";
+      indexPrefix = TestUtil.createRandomString(10);
     }
     tasklistProperties.getElasticsearch().setIndexPrefix(indexPrefix);
     if (tasklistProperties.getElasticsearch().isCreateSchema()) {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/AbstractIndexDescriptor.java
@@ -15,6 +15,8 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
       SCHEMA_FOLDER_OPENSEARCH + "/index/%s-%s.json";
   public static final String SCHEMA_CREATE_INDEX_JSON_ELASTICSEARCH =
       SCHEMA_FOLDER_ELASTICSEARCH + "/index/%s-%s.json";
+  public static final String FULL_QUALIFIED_INDEX_NAME_PATTERN = "%s%s-%s-%s_";
+  public static final String ALL_VERSIONS_INDEX_NAME_PATTERN = "%s%s-%s-\\d.*";
 
   protected String indexPrefix;
   protected boolean isElasticsearch;
@@ -27,7 +29,11 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
   @Override
   public String getFullQualifiedName() {
     return String.format(
-        "%s%s-%s-%s_", formattedIndexPrefix(), getComponentName(), getIndexName(), getVersion());
+        FULL_QUALIFIED_INDEX_NAME_PATTERN,
+        formattedIndexPrefix(),
+        getComponentName(),
+        getIndexName(),
+        getVersion());
   }
 
   @Override
@@ -45,7 +51,10 @@ public abstract class AbstractIndexDescriptor implements IndexDescriptor {
   @Override
   public String getAllVersionsIndexNameRegexPattern() {
     return String.format(
-        "%s%s-%s-\\d.*", formattedIndexPrefix(), getComponentName(), getIndexName());
+        ALL_VERSIONS_INDEX_NAME_PATTERN,
+        formattedIndexPrefix(),
+        getComponentName(),
+        getIndexName());
   }
 
   @Override


### PR DESCRIPTION
## Description

This adds empty prefix support to the tasklist index classes. Although most get removed going forward, this will allow empty prefix usage already with 8.7.0-SNAPSHOT and also make it the default while Tasklist still creates indices.

Note, I didn't migrate the Tasklist template/index classes to be based on the abstract classes from the common webapps schema module. Assuming this is not relevant as needed template/index setup will be done by the exporter going forward anyway.

This is a similar change as done to Operate with #24512.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23973
