### PR TITLE
Provide basic support for `assignment` Task Listeners after `ASSIGN` command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -241,6 +241,7 @@ public final class BpmnJobBehavior {
   private static JobListenerEventType fromTaskListenerEventType(
       final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
+      case assignment -> JobListenerEventType.ASSIGNMENT;
       case complete -> JobListenerEventType.COMPLETE;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -12,9 +12,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -25,6 +27,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
 
   private static final String DEFAULT_ACTION = "assign";
 
+  private final UserTaskState userTaskState;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
@@ -33,6 +36,7 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
       final ProcessingState state,
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior) {
+    userTaskState = state.getUserTaskState();
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
@@ -55,8 +59,33 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
-    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-    responseWriter.writeEventOnCommand(
-        userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
+  }
+
+  @Override
+  public void onFinalizeCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = command.getKey();
+
+    userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
+
+    if (command.hasRequestMetadata()) {
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+      responseWriter.writeEventOnCommand(
+          userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
+    } else {
+      final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+
+      recordRequestMetadata.ifPresent(
+          metadata ->
+              responseWriter.writeResponse(
+                  userTaskKey,
+                  UserTaskIntent.ASSIGNED,
+                  userTaskRecord,
+                  ValueType.USER_TASK,
+                  metadata.getRequestId(),
+                  metadata.getRequestStreamId()));
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -401,8 +401,10 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.COMPLETING, 2, new UserTaskCompletingV2Applier(state));
     register(UserTaskIntent.COMPLETED, 1, new UserTaskCompletedV1Applier(state));
     register(UserTaskIntent.COMPLETED, 2, new UserTaskCompletedV2Applier(state));
-    register(UserTaskIntent.ASSIGNING, new UserTaskAssigningApplier(state));
-    register(UserTaskIntent.ASSIGNED, new UserTaskAssignedApplier(state));
+    register(UserTaskIntent.ASSIGNING, 1, new UserTaskAssigningV1Applier(state));
+    register(UserTaskIntent.ASSIGNING, 2, new UserTaskAssigningV2Applier(state));
+    register(UserTaskIntent.ASSIGNED, 1, new UserTaskAssignedV1Applier(state));
+    register(UserTaskIntent.ASSIGNED, 2, new UserTaskAssignedV2Applier(state));
     register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
     register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -53,6 +53,7 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
   private ZeebeTaskListenerEventType toTaskListenerEventType(JobListenerEventType eventType) {
     return switch (eventType) {
       case COMPLETE -> ZeebeTaskListenerEventType.complete;
+      case ASSIGNMENT -> ZeebeTaskListenerEventType.assignment;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV1Applier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskAssignedV1Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskAssignedV1Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    final String assignee = value.getAssignee();
+    final UserTaskRecord userTask = userTaskState.getUserTask(key);
+    userTask.setAssignee(assignee);
+    userTaskState.update(userTask);
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignedV2Applier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskAssignedV2Applier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskAssignedV2Applier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    final String assignee = value.getAssignee();
+    final UserTaskRecord userTask = userTaskState.getUserTask(key);
+    userTask.setAssignee(assignee);
+    userTaskState.update(userTask);
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+    userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV1Applier.java
@@ -14,12 +14,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public final class UserTaskAssigningApplier
+public final class UserTaskAssigningV1Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskAssigningApplier(final MutableProcessingState processingState) {
+  public UserTaskAssigningV1Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV2Applier.java
@@ -14,21 +14,20 @@ import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
-public final class UserTaskAssignedApplier
+public final class UserTaskAssigningV2Applier
     implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
 
   private final MutableUserTaskState userTaskState;
 
-  public UserTaskAssignedApplier(final MutableProcessingState processingState) {
+  public UserTaskAssigningV2Applier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
-    final String assignee = value.getAssignee();
-    final UserTaskRecord userTask = userTaskState.getUserTask(key);
-    userTask.setAssignee(assignee);
-    userTaskState.update(userTask);
-    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.ASSIGNING);
+    System.out.println("DMK: Key:" + key);
+    System.out.println("DMK: write intermediate state");
+    userTaskState.storeIntermediateState(value, LifecycleState.ASSIGNING);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssigningV2Applier.java
@@ -26,8 +26,6 @@ public final class UserTaskAssigningV2Applier
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.updateUserTaskLifecycleState(key, LifecycleState.ASSIGNING);
-    System.out.println("DMK: Key:" + key);
-    System.out.println("DMK: write intermediate state");
     userTaskState.storeIntermediateState(value, LifecycleState.ASSIGNING);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
@@ -16,16 +16,19 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class TaskListenerIndicesRecord extends UnpackedObject implements DbValue {
 
+  private final IntegerProperty assignmentTaskListenerIndexProp =
+      new IntegerProperty("assignmentTaskListenerIndex", 0);
   private final IntegerProperty completeTaskListenerIndexProp =
       new IntegerProperty("completeTaskListenerIndex", 0);
 
   TaskListenerIndicesRecord() {
-    super(1);
-    declareProperty(completeTaskListenerIndexProp);
+    super(2);
+    declareProperty(assignmentTaskListenerIndexProp).declareProperty(completeTaskListenerIndexProp);
   }
 
   public Integer getTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
+      case assignment -> assignmentTaskListenerIndexProp.getValue();
       case complete -> completeTaskListenerIndexProp.getValue();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
@@ -34,6 +37,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void incrementTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
+      case assignment -> assignmentTaskListenerIndexProp.increment();
       case complete -> completeTaskListenerIndexProp.increment();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
@@ -42,6 +46,7 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
 
   public void resetTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
+      case assignment -> assignmentTaskListenerIndexProp.reset();
       case complete -> completeTaskListenerIndexProp.reset();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -73,7 +73,7 @@ public class TaskListenerTest {
       new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldCompleteProcessWhenAllCompleteTaskListenersAreExecuted() {
+  public void shouldCompleteUserTaskAfterAllCompleteTaskListenersAreExecuted() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -132,7 +132,7 @@ public class TaskListenerTest {
     ENGINE
         .userTask()
         .ofInstance(processInstanceKey)
-        .withVariable("foo_var", "bar")
+        .withVariable("ignored", "variables")
         .withAssignee("me")
         .withAction("my_assign_action")
         .assign();
@@ -163,6 +163,8 @@ public class TaskListenerTest {
             Assertions.assertThat(userTask)
                 .hasAssignee("me")
                 .hasAction("my_assign_action")
+                .describedAs(
+                    "Expected all variables provided during UserTask assignment to be ignored")
                 .hasVariables(Collections.emptyMap()));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -831,12 +831,12 @@ public class TaskListenerTest {
       final JobListenerEventType eventType,
       final String... listenerTypes) {
     assertThat(
-        RecordingExporter.jobRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withJobKind(JobKind.TASK_LISTENER)
-            .withJobListenerEventType(eventType)
-            .withIntent(JobIntent.COMPLETED)
-            .limit(listenerTypes.length))
+            RecordingExporter.jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.TASK_LISTENER)
+                .withJobListenerEventType(eventType)
+                .withIntent(JobIntent.COMPLETED)
+                .limit(listenerTypes.length))
         .extracting(Record::getValue)
         .extracting(JobRecordValue::getType)
         .describedAs("Verify that all task listeners were completed in the correct sequence")
@@ -846,8 +846,8 @@ public class TaskListenerTest {
   private void assertUserTaskIntentsSequence(final UserTaskIntent... intents) {
     assertThat(intents).describedAs("Expected intents not to be empty").isNotEmpty();
     assertThat(
-        RecordingExporter.userTaskRecords()
-            .limit(r -> r.getIntent() == intents[intents.length - 1]))
+            RecordingExporter.userTaskRecords()
+                .limit(r -> r.getIntent() == intents[intents.length - 1]))
         .extracting(Record::getIntent)
         .describedAs("Verify the expected sequence of User Task intents")
         .containsSequence(intents);
@@ -858,10 +858,10 @@ public class TaskListenerTest {
       final UserTaskIntent intent,
       final Consumer<UserTaskRecordValue> consumer) {
     assertThat(
-        RecordingExporter.userTaskRecords(intent)
-            .withProcessInstanceKey(processInstanceKey)
-            .findFirst()
-            .map(Record::getValue))
+            RecordingExporter.userTaskRecords(intent)
+                .withProcessInstanceKey(processInstanceKey)
+                .findFirst()
+                .map(Record::getValue))
         .describedAs("Expected to have User Task record with '%s' intent", intent)
         .hasValueSatisfying(consumer);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -132,7 +132,6 @@ public class TaskListenerTest {
     ENGINE
         .userTask()
         .ofInstance(processInstanceKey)
-        .withVariable("ignored", "variables")
         .withAssignee("me")
         .withAction("my_assign_action")
         .assign();
@@ -160,12 +159,7 @@ public class TaskListenerTest {
         processInstanceKey,
         UserTaskIntent.ASSIGNED,
         userTask ->
-            Assertions.assertThat(userTask)
-                .hasAssignee("me")
-                .hasAction("my_assign_action")
-                .describedAs(
-                    "Expected all variables provided during UserTask assignment to be ignored")
-                .hasVariables(Collections.emptyMap()));
+            Assertions.assertThat(userTask).hasAssignee("me").hasAction("my_assign_action"));
   }
 
   @Test

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -39,5 +39,12 @@ public enum JobListenerEventType {
    * Represents the `complete` event for a task listener. This event type is used to indicate that
    * the listener should be triggered after a user task complete operation was invoked.
    */
-  COMPLETE
+  COMPLETE,
+
+  /**
+   * Represents the `assignment` event for a task listener. This event type is used to indicate that
+   * the listener should be triggered when a user task is assigned, claimed (assigned to the current
+   * user), or unassigned.
+   */
+  ASSIGNMENT
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -86,6 +86,7 @@ public class UserTaskListenersTest {
   @Test
   void shouldAssignUserTaskAfterCompletingAssignmentTaskListener() {
     // given
+    final var assignee = "demo_user";
     final var action = "my_assign_action";
     final var userTaskKey =
         resourcesHelper.createSingleUserTask(
@@ -95,9 +96,9 @@ public class UserTaskListenersTest {
         (jobClient, job) -> client.newCompleteCommand(job).send().join();
     client.newWorker().jobType("my_listener").handler(completeJobHandler).open();
 
-    // when: invoke complete user task command
+    // when: invoke `ASSIGN` user task command
     final var assignUserTaskFuture =
-        client.newUserTaskAssignCommand(userTaskKey).assignee("demo_user").action(action).send();
+        client.newUserTaskAssignCommand(userTaskKey).assignee(assignee).action(action).send();
 
     // wait for successful `ASSIGN` user task command completion
     assertThatCode(assignUserTaskFuture::join).doesNotThrowAnyException();
@@ -106,7 +107,7 @@ public class UserTaskListenersTest {
     ZeebeAssertHelper.assertUserTaskAssigned(
         userTaskKey,
         (userTask) -> {
-          assertThat(userTask.getAssignee()).isEqualTo("demo_user");
+          assertThat(userTask.getAssignee()).isEqualTo(assignee);
           assertThat(userTask.getVariables()).isEmpty();
           assertThat(userTask.getAction()).isEqualTo(action);
         });


### PR DESCRIPTION
## Description

This PR is the first of two required to provide foundational support for `assignment` task listeners on the User Task element. Specifically, this PR enables `assignment` task listeners that will be triggered after the `ASSIGN` command, covering both `assign` and `unassign` operations on a User Task.

### Out of scope:
- support for `assignment` task listeners that should be triggered after the `CLAIM` User Task command will be implemented in a separate PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #24232
