### PR TITLE
Add `action` User Task property logging to `CompactRecordLogger`

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -809,6 +809,7 @@ public class CompactRecordLogger {
     addIfNotEmpty(result, value.getDueDate(), " dueDate");
     addIfNotEmpty(result, value.getFollowUpDate(), " followUpDate");
     result.append(" priority").append(value.getPriority());
+    addIfNotEmpty(result, value.getAction(), " action");
 
     if (value.getFormKey() != -1) {
       result.append(" with <form ").append(shortenKey(value.getFormKey())).append(">");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -808,7 +808,7 @@ public class CompactRecordLogger {
     addIfNotEmpty(result, value.getCandidateGroupsList(), " candidateGroupsList");
     addIfNotEmpty(result, value.getDueDate(), " dueDate");
     addIfNotEmpty(result, value.getFollowUpDate(), " followUpDate");
-    result.append(" priority").append(value.getPriority());
+    result.append(" priority").append(" '").append(value.getPriority()).append("'");
     addIfNotEmpty(result, value.getAction(), " action");
 
     if (value.getFormKey() != -1) {


### PR DESCRIPTION
## Description
This PR enhances the `CompactRecordLogger` by adding `action` property logging for user task records and align the logging of `priority` with the format how other properties are logged.

This improvement aims to support easier debugging and testing of user task flows by including the `action` property in logs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24234 
