### PR TITLE
Reject adding permissions if already exists

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
@@ -49,6 +49,7 @@ public final class AuthorizationAddPermissionProcessor
     permissionsBehavior
         .isAuthorized(command)
         .flatMap(permissionsBehavior::ownerExists)
+        .flatMap(permissionsBehavior::permissionAlreadyExists)
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),
             (rejection) -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -63,7 +62,7 @@ public final class AuthorizationCheckBehavior {
       return true;
     }
 
-    Set<String> authorizedResourceIdentifiers = Collections.emptySet();
+    Set<String> authorizedResourceIdentifiers = new HashSet<>();
 
     final var userKey = getUserKey(request);
     if (userKey.isPresent()) {
@@ -89,7 +88,7 @@ public final class AuthorizationCheckBehavior {
 
     final var userKey = getUserKey(request);
     if (userKey.isEmpty()) {
-      return Collections.emptySet();
+      return new HashSet<>();
     }
 
     return getUserAuthorizedResourceIdentifiers(
@@ -107,7 +106,7 @@ public final class AuthorizationCheckBehavior {
           getRoleAuthorizedResourceIdentifiers(List.of(ownerKey), resourceType, permissionType);
       // TODO add MAPPING
       // TODO add GROUP
-      default -> Collections.emptySet();
+      default -> new HashSet<>();
     };
   }
 
@@ -117,14 +116,14 @@ public final class AuthorizationCheckBehavior {
       final PermissionType permissionType) {
     final var userOptional = userState.getUser(userKey);
     if (userOptional.isEmpty()) {
-      return Collections.emptySet();
+      return new HashSet<>();
     }
     final var user = userOptional.get();
 
     // The default user has all permissions
     if (user.getUserType().equals(UserType.DEFAULT)) {
       // TODO this should change when we introduce a default "admin" role to the default user
-      return Set.of(WILDCARD_PERMISSION);
+      return new HashSet<>(Set.of(WILDCARD_PERMISSION));
     }
 
     // Get resource identifiers for this user

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.immutable.AuthorizationState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -24,6 +25,8 @@ public class PermissionsBehavior {
 
   public static final String OWNER_NOT_FOUND_MESSAGE =
       "Expected to find owner with key: '%d', but none was found";
+  public static final String PERMISSION_ALREADY_EXISTS_MESSAGE =
+      "Expected to add '%s' permission for resource '%s' and resource identifiers '%s', but this permission for resource identifiers '%s' already exist";
 
   private final AuthorizationState authorizationState;
   private final AuthorizationCheckBehavior authCheckBehavior;
@@ -66,5 +69,32 @@ public class PermissionsBehavior {
                 Either.left(
                     new Rejection(
                         RejectionType.NOT_FOUND, OWNER_NOT_FOUND_MESSAGE.formatted(ownerKey))));
+  }
+
+  public Either<Rejection, AuthorizationRecord> permissionAlreadyExists(
+      final AuthorizationRecord record) {
+    for (final PermissionValue permission : record.getPermissions()) {
+      final var addedResourceIds = permission.getResourceIds();
+      final var duplicateResourceIds =
+          authCheckBehavior.getAuthorizedResourceIdentifiers(
+              record.getOwnerKey(),
+              record.getOwnerType(),
+              record.getResourceType(),
+              permission.getPermissionType());
+      duplicateResourceIds.retainAll(addedResourceIds);
+
+      if (!duplicateResourceIds.isEmpty()) {
+        return Either.left(
+            new Rejection(
+                RejectionType.ALREADY_EXISTS,
+                PERMISSION_ALREADY_EXISTS_MESSAGE.formatted(
+                    permission.getPermissionType(),
+                    record.getResourceType(),
+                    addedResourceIds,
+                    duplicateResourceIds)));
+      }
+    }
+
+    return Either.right(record);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -112,7 +112,7 @@ public class AddPermissionAuthorizationTest {
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
-        .withPermission(PermissionType.DELETE, "bar")
+        .withPermission(PermissionType.DELETE, "bar", "baz")
         .add()
         .getValue();
 
@@ -133,11 +133,13 @@ public class AddPermissionAuthorizationTest {
         .describedAs("Permission already exists")
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
-            "Expected to add '%s' permission for resource '%s' and resource identifiers '%s', but this permission for resource identifiers '%s' already exist"
+            "Expected to add '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' already exist. Existing resource ids are: '%s'"
                 .formatted(
                     PermissionType.DELETE,
                     AuthorizationResourceType.DEPLOYMENT,
                     "[bar, foo]",
-                    "[bar]"));
+                    ownerKey,
+                    "[bar]",
+                    "[bar, baz]"));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -108,7 +108,6 @@ public class AddPermissionAuthorizationTest {
     engine
         .authorization()
         .permission()
-        .withAction(PermissionAction.ADD)
         .withOwnerKey(ownerKey)
         .withResourceType(AuthorizationResourceType.DEPLOYMENT)
         .withPermission(PermissionType.CREATE, "foo")
@@ -121,7 +120,6 @@ public class AddPermissionAuthorizationTest {
         engine
             .authorization()
             .permission()
-            .withAction(PermissionAction.ADD)
             .withOwnerKey(ownerKey)
             .withResourceType(AuthorizationResourceType.DEPLOYMENT)
             .withPermission(PermissionType.DELETE, "foo", "bar")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -92,4 +92,52 @@ public class AddPermissionAuthorizationTest {
         .hasRejectionReason(
             "Expected to find owner with key: '%d', but none was found".formatted(ownerKey));
   }
+
+  @Test
+  public void shouldRejectIfPermissionAlreadyExists() {
+    // given
+    final var ownerKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    engine
+        .authorization()
+        .permission()
+        .withAction(PermissionAction.ADD)
+        .withOwnerKey(ownerKey)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermission(PermissionType.CREATE, "foo")
+        .withPermission(PermissionType.DELETE, "bar")
+        .add()
+        .getValue();
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .permission()
+            .withAction(PermissionAction.ADD)
+            .withOwnerKey(ownerKey)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermission(PermissionType.DELETE, "foo", "bar")
+            .expectRejection()
+            .add();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("Permission already exists")
+        .hasRejectionType(RejectionType.ALREADY_EXISTS)
+        .hasRejectionReason(
+            "Expected to add '%s' permission for resource '%s' and resource identifiers '%s', but this permission for resource identifiers '%s' already exist"
+                .formatted(
+                    PermissionType.DELETE,
+                    AuthorizationResourceType.DEPLOYMENT,
+                    "[bar, foo]",
+                    "[bar]"));
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/AuthorizationClient.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Set;
 import java.util.function.Function;
 
 public final class AuthorizationClient {
@@ -87,9 +88,9 @@ public final class AuthorizationClient {
     }
 
     public AuthorizationPermissionClient withPermission(
-        final PermissionType permissionType, final String resourceId) {
+        final PermissionType permissionType, final String... resourceIds) {
       authorizationCreationRecord.addPermission(
-          new Permission().setPermissionType(permissionType).addResourceId(resourceId));
+          new Permission().setPermissionType(permissionType).addResourceIds(Set.of(resourceIds)));
       return this;
     }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

If a users tries to add new permissions, but one of the permissions already exists, we must reject the command with a nice error message for the user.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22064
