### PR TITLE
Reject removing permissions of one or more permissions don't exist

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
@@ -49,6 +49,7 @@ public final class AuthorizationRemovePermissionProcessor
     permissionsBehavior
         .isAuthorized(command)
         .flatMap(permissionsBehavior::ownerExists)
+        .flatMap(permissionsBehavior::permissionDoesNotExist)
         .ifRightOrLeft(
             authorizationRecord -> writeEventAndDistribute(command, authorizationRecord),
             (rejection) -> {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

If a users tries to remove a permissions, but one of the permissions already exists, we must reject the command with a nice error message for the user.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22625
