### PR TITLE
[Backport stable/8.4] ci: fix registry used for testbench images

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -28,20 +28,34 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: google-github-actions/auth@v2
-        id: auth
+      - name: Authenticate for zeebe image registry
+        uses: google-github-actions/auth@v2
+        id: auth-zeebe
         with:
           token_format: 'access_token'
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Authenticate for saas image registry
+        id: auth-saas
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/618877442292/locations/global/workloadIdentityPools/github/providers/camunda'
+          service_account: 'github-actions-zeebe-io@camunda-saas-registry.iam.gserviceaccount.com'
       - name: Setup BuildKit
         uses: docker/setup-buildx-action@v3
-      - name: Login to GCR
+      - name: Login to SaaS image registry
+        uses: docker/login-action@v3
+        with:
+          registry: europe-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth-saas.outputs.access_token }}
+      - name: Login to Zeebe image registry
         uses: docker/login-action@v3
         with:
           registry: gcr.io
           username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
+          password: ${{ steps.auth-zeebe.outputs.access_token }}
       - id: image-tag
         name: Calculate image tag
         shell: bash
@@ -62,7 +76,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe-docker
         id: build-zeebe-docker
         with:
-          repository: gcr.io/zeebe-io/zeebe
+          repository: europe-docker.pkg.dev/camunda-saas-registry/zeebe-io/zeebe
           version: ${{ steps.image-tag.outputs.image-tag }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
@@ -88,8 +102,9 @@ jobs:
           variables=$(echo "${{ inputs.variables }}" | envsubst)
           clients/go/cmd/zbctl/dist/zbctl create instance ${{ inputs.processId }} --variables "$variables"
         env:
-          IMAGE: ${{ steps.build-zeebe-docker.outputs.image }}
+          IMAGE: zeebe-io/zeebe:${{ steps.image-tag.outputs.image-tag }}
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
           ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.camunda.io/oauth/token'
           ZEEBE_CLIENT_ID: 'Jg9caDRuAWHchvM7JiaVlndL-qVFfp~0'
+


### PR DESCRIPTION
Similar to https://github.com/camunda/camunda/pull/24615 but for 8.4