### PR TITLE
perf: remove redundant synchronized

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -148,7 +148,7 @@ public final class OAuthCredentialsCache {
     return this;
   }
 
-  public synchronized int size() {
+  public int size() {
     return credentialsByClientId.get().size();
   }
 


### PR DESCRIPTION
## Description

This was originally removed with bcc0ee4, but got reintroduced accidentally to 8.6.0 on main with f69acb4.

See https://camunda.slack.com/archives/C037W9NMATG/p1731082662618709?thread_ts=1731053567.928969&cid=C037W9NMATG