### PR TITLE
Remove unused archiver property rolloverDateFormat from the Exporter

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1026,7 +1026,6 @@
         #
         #   archiver:
         #     enabled: true
-        #     rolloverDateFormat: "yyyy-MM-dd"
         #     elsRolloverDateFormat: "date"
         #     rolloverInterval: "1d"
         #     rolloverBatchSize: 100

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -901,7 +901,6 @@
         #
         #   archiver:
         #     enabled: true
-        #     rolloverDateFormat: "yyyy-MM-dd"
         #     elsRolloverDateFormat: "date"
         #     rolloverInterval: "1d"
         #     rolloverBatchSize: 100

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ConfigValidator.java
@@ -8,8 +8,6 @@
 package io.camunda.exporter.config;
 
 import io.camunda.zeebe.exporter.api.ExporterException;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
@@ -70,17 +68,6 @@ public final class ConfigValidator {
           String.format(
               "CamundaExporter retention minimumAge '%s' must match pattern '%s', but didn't.",
               minimumAge, PATTERN_MIN_AGE_FORMAT));
-    }
-
-    final String rolloverDateFormat = configuration.getArchiver().getRolloverDateFormat();
-    try {
-      DateTimeFormatter.ofPattern(rolloverDateFormat).withZone(ZoneId.systemDefault());
-    } catch (final IllegalArgumentException e) {
-      throw new ExporterException(
-          "CamundaExporter rolloverDateFormat "
-              + rolloverDateFormat
-              + "is not a valid DateTimeFormatter pattern: "
-              + e);
     }
 
     final String rolloverInterval = configuration.getArchiver().getRolloverInterval();

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -240,7 +240,6 @@ public class ExporterConfiguration {
 
   public static class ArchiverConfiguration {
     private boolean rolloverEnabled = true;
-    private String rolloverDateFormat = "yyyy-MM-dd";
     private String elsRolloverDateFormat = "date";
     private String rolloverInterval = "1d";
     private int rolloverBatchSize = 100;
@@ -253,14 +252,6 @@ public class ExporterConfiguration {
 
     public void setRolloverEnabled(final boolean rolloverEnabled) {
       this.rolloverEnabled = rolloverEnabled;
-    }
-
-    public String getRolloverDateFormat() {
-      return rolloverDateFormat;
-    }
-
-    public void setRolloverDateFormat(final String rolloverDateFormat) {
-      this.rolloverDateFormat = rolloverDateFormat;
     }
 
     public String getElsRolloverDateFormat() {
@@ -312,8 +303,6 @@ public class ExporterConfiguration {
       return "RetentionConfiguration{"
           + "rolloverEnabled="
           + rolloverEnabled
-          + ", rolloverDateFormat='"
-          + rolloverDateFormat
           + '\''
           + ", elsRolloverDateFormat='"
           + elsRolloverDateFormat
@@ -322,7 +311,7 @@ public class ExporterConfiguration {
           + rolloverInterval
           + '\''
           + ", rolloverBatchSize='"
-          + rolloverDateFormat
+          + rolloverBatchSize
           + '\''
           + ", waitPeriodBeforeArchiving='"
           + waitPeriodBeforeArchiving

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/config/ConfigValidatorTest.java
@@ -74,20 +74,6 @@ public class ConfigValidatorTest {
   }
 
   @Test
-  void shouldAssureRolloverDateFormatToBeValid() {
-    // given
-    // Should be a valid format for DateTimeFormatter. A valid date format should be for example
-    // "yyyy-MM-dd" or "dd-MM-yyyy".
-    config.getArchiver().setRolloverDateFormat("month-day-year");
-
-    // when - then
-    assertThatCode(() -> ConfigValidator.validate(config))
-        .isInstanceOf(ExporterException.class)
-        .hasMessageContaining(
-            "CamundaExporter rolloverDateFormat month-day-yearis not a valid DateTimeFormatter pattern: java.lang.IllegalArgumentException:");
-  }
-
-  @Test
   void shouldAssureRolloverIntervalToBeValid() {
     // given
     // Rollover interval must match pattern '%d{timeunit}', where timeunit is one of 'd', 'h',


### PR DESCRIPTION
## Description

This PR removes the unused archiver property `rolloverDateFormat` from the Exporter configuration.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/24566
