### PR TITLE
feat: Export Component Health as metrics

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -435,6 +435,10 @@
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
@@ -755,6 +759,7 @@
             <dependency>io.camunda:camunda-exporter</dependency>
             <dependency>io.camunda:zeebe-elasticsearch-exporter</dependency>
             <dependency>io.camunda:zeebe-opensearch-exporter</dependency>
+            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
 
             <!-- Needed for Spring Actuators, and REST API -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -73,11 +73,12 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
     this.meterRegistry = meterRegistry;
+    meterRegistry.throwExceptionOnRegistrationFailure();
   }
 
   @Bean
   public ExporterRepository exporterRepository(
-      @Autowired(required = false) List<ExporterDescriptor> exporterDescriptors) {
+      @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
     if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
       LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
       return new ExporterRepository(exporterDescriptors);

--- a/monitor/docker-compose.yml
+++ b/monitor/docker-compose.yml
@@ -36,4 +36,11 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=camunda
       - GF_USERS_ALLOW_SIGN_UP=false
 
+  zeebe:
+    image: camunda/zeebe:current-test
+    container_name: zeebe
+    ports:
+      - 9600:9600
+
+
 

--- a/monitor/prometheus/prometheus.yml
+++ b/monitor/prometheus/prometheus.yml
@@ -8,6 +8,7 @@ scrape_configs:
          - targets: ['localhost:9090']
 
   - job_name: 'zeebe'
+    metrics_path: /actuator/prometheus
     static_configs:
       - targets: ['zeebe:9600']
         labels:

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 /** Abstract partition. */
 public final class RaftPartition implements Partition, HealthMonitorable {
   private static final Logger LOG = LoggerFactory.getLogger(RaftPartition.class);
-  private static final String PARTITION_NAME_FORMAT = "%s-partition-%d";
+  private static final String PARTITION_NAME_FORMAT = "RaftPartition-%d";
   private final PartitionId partitionId;
   private final RaftPartitionConfig config;
   private final File dataDirectory;
@@ -141,7 +141,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
    * @return the partition name
    */
   public String name() {
-    return String.format(PARTITION_NAME_FORMAT, partitionId.group(), partitionId.id());
+    return String.format(PARTITION_NAME_FORMAT, partitionId.id());
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
+import io.camunda.zeebe.broker.system.monitoring.HealthTreeMetrics;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.util.LogUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.micrometer.core.instrument.Tag;
 import io.netty.util.NetUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -63,7 +65,10 @@ public final class Broker implements AutoCloseable {
     final ActorScheduler scheduler = this.systemContext.getScheduler();
     final BrokerInfo localBroker = createBrokerInfo(getConfig());
 
-    healthCheckService = new BrokerHealthCheckService(localBroker);
+    healthCheckService =
+        new BrokerHealthCheckService(
+            localBroker,
+            new HealthTreeMetrics(systemContext.getMeterRegistry(), Tag.of("partition", "none")));
 
     final var startupContext =
         new BrokerStartupContextImpl(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.logstreams.state.StatePositionSupplier;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupAndTransitionContextImpl;
 import io.camunda.zeebe.broker.system.partitions.PartitionStartupContext;
@@ -140,7 +141,8 @@ public final class ZeebePartitionFactory {
   public ZeebePartition constructPartition(
       final RaftPartition raftPartition,
       final FileBasedSnapshotStore snapshotStore,
-      final DynamicPartitionConfig initialPartitionConfig) {
+      final DynamicPartitionConfig initialPartitionConfig,
+      final BrokerHealthCheckService brokerHealthCheckService) {
     final var communicationService = clusterServices.getCommunicationService();
     final var membershipService = clusterServices.getMembershipService();
     final var typedRecordProcessorsFactory = createFactory(localBroker, featureFlags);
@@ -169,7 +171,8 @@ public final class ZeebePartitionFactory {
             diskSpaceUsageMonitor,
             gatewayBrokerTransport,
             topologyManager,
-            meterRegistry);
+            meterRegistry,
+            brokerHealthCheckService);
     context.setDynamicPartitionConfig(initialPartitionConfig);
 
     final PartitionTransition newTransitionBehavior = new PartitionTransitionImpl(TRANSITION_STEPS);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -39,7 +39,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
 
     final var partitionId = context.partitionMetadata().id().id();
     context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
-    context.brokerHealthCheckService().removeMonitoredPartition(partitionId);
+    context.brokerHealthCheckService().removeMonitoredPartition(context.zeebePartition());
     context.topologyManager().removePartition(partitionId);
 
     result.complete(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/ZeebePartitionStep.java
@@ -26,7 +26,10 @@ public final class ZeebePartitionStep implements StartupStep<PartitionStartupCon
         context
             .zeebePartitionFactory()
             .constructPartition(
-                context.raftPartition(), context.snapshotStore(), context.initialPartitionConfig());
+                context.raftPartition(),
+                context.snapshotStore(),
+                context.initialPartitionConfig(),
+                context.brokerHealthCheckService());
     final var submit = context.schedulingService().submitActor(zeebePartition);
     context
         .concurrencyControl()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -14,14 +14,13 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import io.camunda.zeebe.util.health.HealthMonitorable;
-import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
@@ -104,9 +103,12 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
   private final HealthMonitor healthMonitor;
   private final MemberId nodeId;
 
-  public BrokerHealthCheckService(final BrokerInfo localBroker) {
+  public BrokerHealthCheckService(
+      final BrokerInfo localBroker, final HealthTreeMetrics healthGraphMetrics) {
     nodeId = MemberId.from(String.valueOf(localBroker.getNodeId()));
-    healthMonitor = new CriticalComponentsHealthMonitor("Broker-" + nodeId, actor, LOG);
+    healthMonitor =
+        new CriticalComponentsHealthMonitor(
+            "Broker-" + nodeId, actor, healthGraphMetrics, Optional.empty(), LOG);
   }
 
   public void registerBootstrapPartitions(final Collection<PartitionMetadata> partitions) {
@@ -120,6 +122,11 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
 
   public boolean isBrokerReady() {
     return brokerStarted && allPartitionsInstalled;
+  }
+
+  public String componentName() {
+    // Broker-{id}, different from the actor name
+    return healthMonitor.getName();
   }
 
   @Override
@@ -199,11 +206,5 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
 
   public boolean isBrokerStarted() {
     return brokerStarted;
-  }
-
-  public ActorFuture<HealthReport> getHealthReport() {
-    final var future = new CompletableActorFuture<HealthReport>();
-    actor.run(() -> future.complete(healthMonitor.getHealthReport()));
-    return future;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionRaftListener;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -93,7 +94,6 @@ import org.slf4j.Logger;
  */
 public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
-  private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private Map<Integer, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
@@ -116,8 +116,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
         partitions.stream().collect(Collectors.toMap(metadata -> metadata.id().id(), p -> false));
     partitions.forEach(
         metadata ->
-            healthMonitor.monitorComponent(
-                String.format(PARTITION_COMPONENT_NAME_FORMAT, metadata.id().id())));
+            healthMonitor.monitorComponent(ZeebePartition.buildActorName(metadata.id().id())));
   }
 
   public boolean isBrokerReady() {
@@ -171,22 +170,20 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     healthMonitor.startMonitoring();
   }
 
-  private void registerComponent(final String componentName, final HealthMonitorable component) {
-    actor.run(() -> healthMonitor.registerComponent(componentName, component));
+  private void registerComponent(final HealthMonitorable component) {
+    actor.run(() -> healthMonitor.registerComponent(component));
   }
 
   public void registerMonitoredPartition(final int partitionId, final HealthMonitorable partition) {
-    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
-    registerComponent(componentName, partition);
+    registerComponent(partition);
   }
 
-  public void removeMonitoredPartition(final int partitionId) {
-    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
-    removeComponent(componentName);
+  public void removeMonitoredPartition(final HealthMonitorable partition) {
+    removeComponent(partition);
   }
 
-  private void removeComponent(final String componentName) {
-    actor.run(() -> healthMonitor.removeComponent(componentName));
+  private void removeComponent(final HealthMonitorable component) {
+    actor.run(() -> healthMonitor.removeComponent(component));
   }
 
   public boolean isBrokerHealthy() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetrics.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import io.camunda.zeebe.util.health.ComponentTreeListener;
+import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthStatus;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class HealthTreeMetrics implements ComponentTreeListener {
+  public static final String EDGES_NAME = "zeebe.broker.health.edges";
+  public static final String NODES_NAME = "zeebe.broker.health.nodes";
+  private static final Logger LOG = LoggerFactory.getLogger(HealthTreeMetrics.class);
+  private static final int MAX_PATH_ITERATIONS = 8;
+  private final MeterRegistry meterRegistry;
+  private final Map<String, Meter.Id> meters = new HashMap<>();
+  // Map of child -> parent: a child only has 1 parent
+  private final Map<String, String> relationships = new HashMap<>();
+  private final Tag extraTags;
+
+  public HealthTreeMetrics(final MeterRegistry meterRegistry) {
+    this(meterRegistry, null);
+  }
+
+  public HealthTreeMetrics(final MeterRegistry meterRegistry, final Tag extraTags) {
+    this.meterRegistry = meterRegistry;
+    this.extraTags = extraTags;
+  }
+
+  /**
+   * @param status to be mapped
+   * @return a numerical value mapped from status that can be reported by the gauge
+   */
+  private static int statusValue(final HealthStatus status) {
+    return switch (status) {
+      case HEALTHY -> 1;
+      case UNHEALTHY -> -1;
+      case DEAD -> -2;
+      case null -> 0;
+    };
+  }
+
+  @Override
+  public void registerNode(final HealthMonitorable component) {
+    final var gauge = buildNodeGauge(component);
+    meters.put(component.getName(), gauge.getId());
+  }
+
+  @Override
+  public void unregisterNode(final HealthMonitorable component) {
+    removeFromRegistry(component.getName());
+  }
+
+  @Override
+  public void registerRelationship(final String child, final String parent) {
+    final var gauge = buildRelationshipGauge(child, parent);
+    relationships.put(child, parent);
+    meters.put(edgeName(child, parent), gauge.getId());
+  }
+
+  @Override
+  public void unregisterRelationship(final String child, final String to) {
+    final var parent = relationships.get(child);
+    if (parent == null || !parent.equals(to)) {
+      LOG.warn("Tried to remove invalid relationship: child={}, parent={}", child, to);
+    } else {
+      relationships.remove(child);
+    }
+    removeFromRegistry(edgeName(child, to));
+  }
+
+  @Override
+  public void close() {
+    for (final var id : meters.values()) {
+      meterRegistry.remove(id);
+    }
+    meters.clear();
+  }
+
+  private Gauge buildRelationshipGauge(final String from, final String to) {
+    return Gauge.builder(EDGES_NAME, () -> 0)
+        .tags(tagsFor(Tags.of("source", from, "target", to, "id", edgeName(from, to))))
+        .register(meterRegistry);
+  }
+
+  private Gauge buildNodeGauge(final HealthMonitorable component) {
+    return Gauge.builder(
+            NODES_NAME,
+            component,
+            // make sure to not close over anything else than `c`
+            c -> c != null ? statusValue(c.getHealthReport().getStatus()) : statusValue(null))
+        .tags(tagsFor(Tags.of("id", component.getName(), "path", pathOf(component.getName()))))
+        .register(meterRegistry);
+  }
+
+  public String pathOf(final String from) {
+    final var pathElements = new LinkedList<String>();
+    pathElements.add(from);
+    var parent = relationships.get(from);
+    var i = 0;
+    while (parent != null && i++ < MAX_PATH_ITERATIONS) {
+      pathElements.addFirst(parent);
+      parent = relationships.get(parent);
+    }
+    return String.join("/", pathElements);
+  }
+
+  private Tags tagsFor(final Tags tags) {
+    if (extraTags != null) {
+      return tags.and(extraTags);
+    } else {
+      return tags;
+    }
+  }
+
+  private void removeFromRegistry(final String metricName) {
+    final var meterId = meters.remove(metricName);
+    if (meterId != null) {
+      meterRegistry.remove(meterId);
+    }
+  }
+
+  private static String edgeName(final String from, final String to) {
+    return from + "-" + to;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -110,7 +110,7 @@ public class PartitionStartupAndTransitionContextImpl
   private final MeterRegistry brokerMeterRegistry;
   private MeterRegistry partitionMeterRegistry;
   private ControllableStreamClock clock;
-  private final HealthTreeMetrics healthGraphMetrics;
+  private final HealthTreeMetrics componentTreeListener;
   private final BrokerHealthCheckService brokerHealthCheckService;
 
   public PartitionStartupAndTransitionContextImpl(
@@ -156,7 +156,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.topologyManager = topologyManager;
     this.brokerMeterRegistry = new CompositeMeterRegistry().add(brokerMeterRegistry);
     this.brokerMeterRegistry.config().commonTags(Tags.of("partition", String.valueOf(partitionId)));
-    healthGraphMetrics = new HealthTreeMetrics(this.brokerMeterRegistry);
+    componentTreeListener = new HealthTreeMetrics(this.brokerMeterRegistry);
     this.brokerHealthCheckService = brokerHealthCheckService;
   }
 
@@ -454,7 +454,7 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   public ComponentTreeListener getComponentTreeListener() {
-    return healthGraphMetrics;
+    return componentTreeListener;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupContext.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions;
 
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.scheduler.ActorControl;
@@ -46,4 +47,6 @@ public interface PartitionStartupContext {
 
   // can be called any time after bootstrap has completed
   PartitionTransitionContext createTransitionContext();
+
+  BrokerHealthCheckService brokerHealthCheckService();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -85,7 +85,11 @@ public final class ZeebePartition extends Actor
     actorName = buildActorName("ZeebePartition", transitionContext.getPartitionId());
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
-            "Partition-" + transitionContext.getPartitionId(), actor, LOG));
+            "Partition-" + transitionContext.getPartitionId(),
+            actor,
+            transitionContext.getComponentTreeListener(),
+            Optional.of(transitionContext.brokerHealthCheckService().componentName()),
+            LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
     healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
     healthMetrics.setUnhealthy();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -43,8 +43,8 @@ public final class ZeebePartition extends Actor
         DiskSpaceUsageListener,
         SnapshotReplicationListener {
 
+  public static final String ACTOR_NAME_PREFIX = "Partition";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
-
   private final StartupProcess<PartitionStartupContext> startupProcess;
 
   private Role raftRole;
@@ -82,10 +82,10 @@ public final class ZeebePartition extends Actor
 
     transition.setConcurrencyControl(actor);
 
-    actorName = buildActorName("ZeebePartition", transitionContext.getPartitionId());
+    actorName = buildActorName(transitionContext.getPartitionId());
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
-            "Partition-" + transitionContext.getPartitionId(),
+            ZeebePartition.buildActorName(transitionContext.getPartitionId()),
             actor,
             transitionContext.getComponentTreeListener(),
             Optional.of(transitionContext.brokerHealthCheckService().componentName()),
@@ -95,6 +95,10 @@ public final class ZeebePartition extends Actor
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics = new RoleMetrics(transitionContext.getPartitionId());
+  }
+
+  public static String buildActorName(final int partitionId) {
+    return buildActorName(ACTOR_NAME_PREFIX, partitionId);
   }
 
   public PartitionAdminAccess getAdminAccess() {
@@ -143,15 +147,11 @@ public final class ZeebePartition extends Actor
   @Override
   protected void onActorStarted() {
     context.getComponentHealthMonitor().startMonitoring();
-    context
-        .getComponentHealthMonitor()
-        .registerComponent(context.getRaftPartition().name(), context.getRaftPartition());
+    context.getComponentHealthMonitor().registerComponent(context.getRaftPartition());
     // Add a component that keep track of health of ZeebePartition. This way
     // criticalComponentsHealthMonitor can monitor the health of ZeebePartition similar to other
     // components.
-    context
-        .getComponentHealthMonitor()
-        .registerComponent(zeebePartitionHealth.getName(), zeebePartitionHealth);
+    context.getComponentHealthMonitor().registerComponent(zeebePartitionHealth);
   }
 
   @Override
@@ -183,8 +183,8 @@ public final class ZeebePartition extends Actor
           closing = true;
 
           removeListeners();
-          context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
-          context.getComponentHealthMonitor().removeComponent(context.getRaftPartition().name());
+          context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth);
+          context.getComponentHealthMonitor().removeComponent(context.getRaftPartition());
 
           final var inactiveTransitionFuture = transitionToInactive();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -37,7 +37,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   public ZeebePartitionHealth(
       final int partitionId, final PartitionTransition partitionTransition) {
-    name = "ZeebePartition-" + partitionId;
+    name = "ZeebePartitionHealth-" + partitionId;
     this.partitionTransition = partitionTransition;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -61,7 +61,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var director = context.getExporterDirector();
     if (director != null && shouldCloseOnTransition(targetRole, context.getCurrentRole())) {
-      context.getComponentHealthMonitor().removeComponent(director.getName());
+      context.getComponentHealthMonitor().removeComponent(director);
       final ActorFuture<Void> future = director.closeAsync();
       future.onComplete(
           (success, error) -> {
@@ -129,7 +129,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());
 
-    context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+    context.getComponentHealthMonitor().registerComponent(director);
 
     final var startFuture = director.startAsync(context.getActorSchedulingService());
     startFuture.onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -40,7 +40,6 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
       context.setStreamClock(null);
-      context.getComponentHealthMonitor().removeComponent(logStream.getLogName());
       logStream.close();
       context.setLogStream(null);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -28,7 +28,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
       final var director = context.getSnapshotDirector();
-      context.getComponentHealthMonitor().removeComponent(director.getName());
+      context.getComponentHealthMonitor().removeComponent(director);
       context.getRaftPartition().getServer().removeCommittedEntryListener(director);
       final ActorFuture<Void> future = director.closeAsync();
       future.onComplete(
@@ -79,7 +79,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
           (ok, error) -> {
             if (error == null) {
               context.setSnapshotDirector(director);
-              context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+              context.getComponentHealthMonitor().registerComponent(director);
               if (targetRole == Role.LEADER) {
                 server.addCommittedEntryListener(director);
               }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -65,7 +65,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
 
     if (streamprocessor != null
         && (shouldInstallOnTransition(targetRole, currentRole) || targetRole == Role.INACTIVE)) {
-      context.getComponentHealthMonitor().removeComponent(streamprocessor.getName());
+      context.getComponentHealthMonitor().removeComponent(streamprocessor);
       final ActorFuture<Void> future = streamprocessor.closeAsync();
       future.onComplete(
           (success, error) -> {
@@ -103,9 +103,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
                 streamProcessor.resumeProcessing();
               }
 
-              context
-                  .getComponentHealthMonitor()
-                  .registerComponent(streamProcessor.getName(), streamProcessor);
+              context.getComponentHealthMonitor().registerComponent(streamProcessor);
               future.complete(null);
             } else {
               future.completeExceptionally(err);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckServiceTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.Test;
 
 public class BrokerHealthCheckServiceTest {
@@ -20,7 +21,8 @@ public class BrokerHealthCheckServiceTest {
   public void shouldNotBeReadyHealthyOrStartedBeforePartitionManagerIsRegistered() {
     // given
     final var brokerInfo = mock(BrokerInfo.class);
-    final var healthCheckService = new BrokerHealthCheckService(brokerInfo);
+    final var healthCheckService =
+        new BrokerHealthCheckService(brokerInfo, new HealthTreeMetrics(new SimpleMeterRegistry()));
 
     // when
 
@@ -41,7 +43,8 @@ public class BrokerHealthCheckServiceTest {
   public void shouldThrowIllegalStateExceptionIfStatusIsUpdatedBeforePartitionsAreKnown() {
     // given
     final var brokerInfo = mock(BrokerInfo.class);
-    final var healthCheckService = new BrokerHealthCheckService(brokerInfo);
+    final var healthCheckService =
+        new BrokerHealthCheckService(brokerInfo, new HealthTreeMetrics(new SimpleMeterRegistry()));
 
     // when + then
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/monitoring/HealthTreeMetricsTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.monitoring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.util.health.FailureListener;
+import io.camunda.zeebe.util.health.HealthMonitorable;
+import io.camunda.zeebe.util.health.HealthReport;
+import io.camunda.zeebe.util.health.HealthStatus;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class HealthTreeMetricsTest {
+  private MeterRegistry meterRegistry;
+  @AutoCloseResource private HealthTreeMetrics metrics;
+
+  @BeforeEach
+  public void setup() {
+    meterRegistry = new SimpleMeterRegistry();
+    metrics = new HealthTreeMetrics(meterRegistry);
+  }
+
+  @Test
+  public void shouldAddNodeMetricWhenComponentRegisters() {
+    // given
+    final var component = new DummyComponent("test-1");
+
+    metrics.registerRelationship("test-1", "parent-2");
+    metrics.registerRelationship("parent-2", "parent-1");
+    // when
+    metrics.registerNode(component);
+    final var meter = meterRegistry.get(HealthTreeMetrics.NODES_NAME).gauge();
+
+    // then
+    assertThat(meter.getId().getTags())
+        .containsAll(Tags.of("id", "test-1", "path", "parent-1/parent-2/test-1"));
+
+    // when
+    metrics.unregisterNode(component);
+    metrics.unregisterRelationship("test-1", "parent-2");
+    metrics.unregisterRelationship("parent-2", "parent-1");
+
+    // then
+    assertThat(meterRegistry.getMeters()).isEmpty();
+  }
+
+  @ParameterizedTest
+  @MethodSource("generateReports")
+  public void nodeMetricShouldReflectComponentStatus(
+      final HealthStatus status, final double expected) {
+    // given
+    final var component = new DummyComponent("test-1");
+    metrics.registerNode(component);
+    final var meter = meterRegistry.get(HealthTreeMetrics.NODES_NAME).gauge();
+
+    // when
+    component.setReport(HealthReport.fromStatus(status, component));
+
+    // then
+    assertThat(meter.value()).isEqualTo(expected);
+  }
+
+  public static Stream<Arguments> generateReports() {
+    return Stream.of(
+        Arguments.of(HealthStatus.HEALTHY, 1.0),
+        Arguments.of(HealthStatus.UNHEALTHY, -1.0),
+        Arguments.of(HealthStatus.DEAD, -2.0));
+  }
+
+  @Test
+  public void shouldAddEdgeMetricWhenComponentRegisters() {
+    // given
+
+    // when
+    metrics.registerRelationship("test-1", "test-2");
+    final var meter = meterRegistry.get(HealthTreeMetrics.EDGES_NAME).gauge();
+
+    // then
+    assertThat(meter.getId().getTags())
+        .containsAll(Tags.of("id", "test-1-test-2", "source", "test-1", "target", "test-2"));
+
+    // when
+    metrics.unregisterRelationship("test-1", "test-2");
+
+    // then
+    assertThat(meterRegistry.getMeters()).isEmpty();
+  }
+
+  @Test
+  public void shouldCloseCorrectly() {
+    // given
+    final var component = new DummyComponent("test-1");
+    metrics.registerRelationship("test-1", "test-2");
+    metrics.registerNode(component);
+    assertThat(meterRegistry.getMeters()).isNotEmpty();
+
+    // when
+    metrics.close();
+
+    // then
+    assertThat(meterRegistry.getMeters()).isEmpty();
+  }
+
+  private static class DummyComponent implements HealthMonitorable {
+    private final String name;
+
+    private Optional<HealthReport> report = Optional.empty();
+
+    public DummyComponent(final String name) {
+      this.name = name;
+    }
+
+    public void setReport(final HealthReport healthReport) {
+      report = Optional.of(healthReport);
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public HealthReport getHealthReport() {
+      return report.orElse(
+          new HealthReport(name, HealthStatus.HEALTHY, null, Collections.emptyMap()));
+    }
+
+    @Override
+    public void addFailureListener(final FailureListener failureListener) {}
+
+    @Override
+    public void removeFailureListener(final FailureListener failureListener) {}
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -27,6 +27,7 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.partition.RaftPartition;
 import io.atomix.raft.partition.impl.RaftPartitionServer;
+import io.camunda.zeebe.broker.system.monitoring.BrokerHealthCheckService;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionTransitionImpl;
 import io.camunda.zeebe.broker.system.partitions.impl.RecoverablePartitionTransitionException;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -34,6 +35,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.health.CriticalComponentsHealthMonitor;
 import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
+import io.camunda.zeebe.util.health.ComponentTreeListener;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -79,6 +81,10 @@ public class ZeebePartitionTest {
     when(ctx.getPartitionContext()).thenReturn(ctx);
     when(ctx.getComponentHealthMonitor()).thenReturn(healthMonitor);
     when(ctx.createTransitionContext()).thenReturn(ctx);
+    final BrokerHealthCheckService brokerCheckMock = mock();
+    when(brokerCheckMock.componentName()).thenReturn("Broker-0");
+    when(ctx.brokerHealthCheckService()).thenReturn(brokerCheckMock);
+    when(ctx.getComponentTreeListener()).thenReturn(ComponentTreeListener.noop());
 
     partition = new ZeebePartition(ctx, transition, List.of(new NoopStartupStep()));
   }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -78,9 +78,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public void removeComponent(final String componentName) {
+  public void removeComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
+          final var componentName = component.getName();
           final var monitoredComponent = monitoredComponents.remove(componentName);
           if (monitoredComponent != null) {
             componentHealth.remove(componentName);
@@ -93,9 +94,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public void registerComponent(final String componentName, final HealthMonitorable component) {
+  public void registerComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
+          final var componentName = component.getName();
           final var monitoredComponent = new MonitoredComponent(componentName, component);
           monitoredComponents.put(componentName, monitoredComponent);
           componentHealth.put(componentName, component.getHealthReport());

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -82,8 +82,8 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorComponent() {
     // given
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("test", component);
+    final ControllableComponent component = new ControllableComponent("test");
+    monitor.registerComponent(component);
 
     // when
     waitUntilAllDone();
@@ -105,7 +105,7 @@ public class CriticalComponentsHealthMonitorTest {
   public void shouldRecover() {
     // given
     final ControllableComponent component = new ControllableComponent("test");
-    monitor.registerComponent("test", component);
+    monitor.registerComponent(component);
     waitUntilAllDone();
     component.setUnhealthy();
     waitUntilAllDone();
@@ -122,11 +122,11 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorMultipleComponent() {
     // given
-    final ControllableComponent component1 = new ControllableComponent();
-    final ControllableComponent component2 = new ControllableComponent();
+    final ControllableComponent component1 = new ControllableComponent("test1");
+    final ControllableComponent component2 = new ControllableComponent("test2");
 
-    monitor.registerComponent("test1", component1);
-    monitor.registerComponent("test2", component2);
+    monitor.registerComponent(component1);
+    monitor.registerComponent(component2);
 
     waitUntilAllDone();
     Awaitility.await("component is healthy")
@@ -162,12 +162,12 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldRemoveComponent() {
     // given
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("test", component);
+    final ControllableComponent component = new ControllableComponent("test");
+    monitor.registerComponent(component);
     Awaitility.await().until(() -> monitor.getHealthReport().getStatus() == HealthStatus.HEALTHY);
 
     // when
-    monitor.removeComponent("test");
+    monitor.removeComponent(component);
     waitUntilAllDone();
     component.setUnhealthy();
     waitUntilAllDone();
@@ -179,11 +179,11 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorComponentDeath() {
     // given
-    final ControllableComponent component1 = new ControllableComponent();
-    final ControllableComponent component2 = new ControllableComponent();
+    final ControllableComponent component1 = new ControllableComponent("comp1");
+    final ControllableComponent component2 = new ControllableComponent("comp2");
 
-    monitor.registerComponent("comp1", component1);
-    monitor.registerComponent("comp2", component2);
+    monitor.registerComponent(component1);
+    monitor.registerComponent(component2);
     waitUntilAllDone();
 
     // when/then
@@ -239,8 +239,8 @@ public class CriticalComponentsHealthMonitorTest {
   public void shouldTrackRootIssue() {
     // given
     final var issue = HealthIssue.of(new IllegalStateException(), Instant.ofEpochMilli(19201293L));
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("component", component);
+    final ControllableComponent component = new ControllableComponent("component");
+    monitor.registerComponent(component);
     waitUntilAllDone();
 
     // when
@@ -271,13 +271,13 @@ public class CriticalComponentsHealthMonitorTest {
 
       parentComponents[i] = parentComponent;
       if (i > 0) {
-        parentComponents[i - 1].registerComponent(parentComponent.getName(), parentComponent);
+        parentComponents[i - 1].registerComponent(parentComponent);
       }
 
       for (int j = 0; j < components[i].length; j++) {
         final var component = new ControllableComponent("child-at-%d-%d".formatted(i, j));
         components[i][j] = component;
-        parentComponents[i].registerComponent(component.getName(), component);
+        parentComponents[i].registerComponent(component);
       }
       waitUntilAllDone();
     }
@@ -287,10 +287,6 @@ public class CriticalComponentsHealthMonitorTest {
     private final Set<FailureListener> failureListeners = new HashSet<>();
     private volatile HealthReport healthReport;
     private final String name;
-
-    public ControllableComponent() {
-      this(null);
-    }
 
     public ControllableComponent(final String name) {
       this.name = name;

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -8,10 +8,16 @@
 package io.camunda.zeebe.scheduler.health;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.util.health.ComponentTreeListener;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthIssue;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -19,6 +25,7 @@ import io.camunda.zeebe.util.health.HealthReport;
 import io.camunda.zeebe.util.health.HealthStatus;
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -34,9 +41,12 @@ public class CriticalComponentsHealthMonitorTest {
   @Rule public ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule();
   private CriticalComponentsHealthMonitor monitor;
   private ActorControl actorControl;
+  private ComponentTreeListener graphListener;
+  private final String parentComponent = "parent";
 
   @Before
   public void setup() {
+    graphListener = mock();
     final Actor testActor =
         new Actor() {
           @Override
@@ -48,7 +58,11 @@ public class CriticalComponentsHealthMonitorTest {
           protected void onActorStarting() {
             monitor =
                 new CriticalComponentsHealthMonitor(
-                    "TestMonitor", actor, LoggerFactory.getLogger("test"));
+                    "TestMonitor",
+                    actor,
+                    graphListener,
+                    Optional.of(parentComponent),
+                    LoggerFactory.getLogger("test"));
             actorControl = actor;
           }
 
@@ -58,6 +72,11 @@ public class CriticalComponentsHealthMonitorTest {
           }
         };
     actorSchedulerRule.submitActor(testActor).join();
+  }
+
+  @Test
+  public void shouldRegisterItselfToTheRegistry() {
+    verify(graphListener, times(1)).registerNode(monitor, Optional.of(parentComponent));
   }
 
   @Test
@@ -189,22 +208,9 @@ public class CriticalComponentsHealthMonitorTest {
     final ControllableComponent[][] components =
         new ControllableComponent[parentComponents.length][children];
 
-    for (int i = 0; i < parentComponents.length; i++) {
-      final var parentComponent =
-          new CriticalComponentsHealthMonitor("parent-%d".formatted(i), actorControl, LOG);
-
-      parentComponents[i] = parentComponent;
-      if (i > 0) {
-        parentComponents[i - 1].registerComponent(parentComponent.getName(), parentComponent);
-      }
-
-      for (int j = 0; j < children; j++) {
-        final var component = new ControllableComponent("child-at-%d-%d".formatted(i, j));
-        components[i][j] = component;
-        parentComponents[i].registerComponent(component.getName(), component);
-      }
-    }
+    setupComponentTree(parentComponents, components);
     waitUntilAllDone();
+    verify(graphListener, atLeast(levels * children)).registerNode(any(), any());
     final var root = parentComponents[0];
 
     // when
@@ -212,8 +218,7 @@ public class CriticalComponentsHealthMonitorTest {
     final var unhealthyFrom = levels - 2;
     components[unhealthyFrom][0].setUnhealthy();
     waitUntilAllDone();
-    final var report = root.getHealthReport();
-    var parentAtLevel = report;
+    var parentAtLevel = root.getHealthReport();
 
     // then
     for (int i = 0; i < levels; i++) {
@@ -254,6 +259,28 @@ public class CriticalComponentsHealthMonitorTest {
 
   private void waitUntilAllDone() {
     actorControl.call(() -> null).join();
+  }
+
+  private void setupComponentTree(
+      final CriticalComponentsHealthMonitor[] parentComponents,
+      final ControllableComponent[][] components) {
+    for (int i = 0; i < parentComponents.length; i++) {
+      final var parentComponent =
+          new CriticalComponentsHealthMonitor(
+              "parent-%d".formatted(i), actorControl, graphListener, Optional.empty(), LOG);
+
+      parentComponents[i] = parentComponent;
+      if (i > 0) {
+        parentComponents[i - 1].registerComponent(parentComponent.getName(), parentComponent);
+      }
+
+      for (int j = 0; j < components[i].length; j++) {
+        final var component = new ControllableComponent("child-at-%d-%d".formatted(i, j));
+        components[i][j] = component;
+        parentComponents[i].registerComponent(component.getName(), component);
+      }
+      waitUntilAllDone();
+    }
   }
 
   private static final class ControllableComponent implements HealthMonitorable {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/ComponentTreeListener.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/ComponentTreeListener.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.health;
+
+import java.util.Optional;
+
+/**
+ * Listener to changes in "graph" of monitored components. Primary use case is to export the graph
+ * to a human-readable format (such as grafana).
+ */
+public interface ComponentTreeListener extends AutoCloseable {
+
+  /**
+   * Register a node in the graph. If the node has a parent, its parent-child relationship must be
+   * registered before registering the node. Using the method {@link
+   * ComponentTreeListener#registerNode(HealthMonitorable, Optional)} is preferred.
+   *
+   * @param component
+   */
+  void registerNode(HealthMonitorable component);
+
+  /**
+   * Register a new node, together with its relationship with its parent.
+   *
+   * @param component
+   * @param parent
+   */
+  default void registerNode(final HealthMonitorable component, final Optional<String> parent) {
+    parent.ifPresent(p -> registerRelationship(component.getName(), p));
+    registerNode(component);
+  }
+
+  void unregisterNode(HealthMonitorable component);
+
+  /**
+   * Register a relationship between a child and its parent. It must be called before registering
+   * the child
+   */
+  void registerRelationship(String child, String parent);
+
+  /** Unregister a relationship between a child and its parent */
+  void unregisterRelationship(String child, String parent);
+
+  static ComponentTreeListener noop() {
+    return new ComponentTreeListener() {
+      @Override
+      public void registerNode(final HealthMonitorable component) {}
+
+      @Override
+      public void unregisterNode(final HealthMonitorable component) {}
+
+      @Override
+      public void registerRelationship(final String child, final String parent) {}
+
+      @Override
+      public void unregisterRelationship(final String child, final String parent) {}
+
+      @Override
+      public void close() throws Exception {}
+    };
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
@@ -21,22 +21,31 @@ public interface HealthMonitor extends HealthMonitorable {
 
   /**
    * Add a component name to be monitored. The component will be marked not healthy until the
-   * component is registered using {@link #registerComponent(String, HealthMonitorable)}
+   * component is registered using {@link #registerComponent(HealthMonitorable)}.
+   *
+   * <p>The component name must be consistent with the value returned by the method {@link
+   * HealthMonitorable#getName()}
    */
   void monitorComponent(String componentName);
 
   /**
-   * Stop monitoring the component.
+   * Register the component to be monitored.
    *
-   * @param componentName
+   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
+   * component
+   *
+   * @param component to register
    */
-  void removeComponent(String componentName);
+  void registerComponent(final HealthMonitorable component);
 
   /**
-   * Register the component to be monitored
+   * Stop monitoring the component.
    *
-   * @param componentName
-   * @param component
+   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
+   * component
+   *
+   * @param component to be removed
    */
-  void registerComponent(String componentName, HealthMonitorable component);
+  void removeComponent(final HealthMonitorable component);
+
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
@@ -23,7 +23,7 @@ public interface HealthMonitorable {
 
   /**
    * Used by a HealthMonitor to get the health status of this component, typically invoked
-   * periodically.
+   * periodically. Implementation should be thread safe
    *
    * @return health status
    */

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
@@ -76,6 +76,16 @@ public record HealthReport(
     return new HealthReport(component, HealthStatus.DEAD, null, Map.of());
   }
 
+  public static HealthReport fromStatus(
+      final HealthStatus status, final HealthMonitorable component) {
+    return switch (status) {
+      case HEALTHY -> HealthReport.healthy(component);
+      case UNHEALTHY -> HealthReport.unhealthy(component);
+      case DEAD -> HealthReport.dead(component);
+      case null -> HealthReport.unknown(component.getName());
+    };
+  }
+
   public boolean isHealthy() {
     return status == HealthStatus.HEALTHY;
   }


### PR DESCRIPTION
## Description
A new class `HealthTreeMetrics` has been added that exports the health status of each component with micrometer.

Each component is registered with an "actor-like" path (e.g.  `Broker-0/partition-1/StreamProcessor`).
Exported metrics as an example:
```
zeebe_broker_health_nodes{id="Broker-0",partition="none",path="Broker-0"} 1.0
zeebe_broker_health_nodes{id="Exporter-1",partition="1",path="Broker-0/Partition-1/Exporter-1"} 1.0
zeebe_broker_health_nodes{id="Partition-1",partition="1",path="Broker-0/Partition-1"} 1.0
zeebe_broker_health_nodes{id="SnapshotDirector-1",partition="1",path="Broker-0/Partition-1/SnapshotDirector-1"} 1.0
zeebe_broker_health_nodes{id="StreamProcessor-1",partition="1",path="Broker-0/Partition-1/StreamProcessor-1"} 1.0
zeebe_broker_health_nodes{id="ZeebePartition-1",partition="1",path="Broker-0/Partition-1/ZeebePartition-1"} 1.0
zeebe_broker_health_nodes{id="ZeebePartition-1",partition="none",path="Broker-0/ZeebePartition-1"} 1.0
zeebe_broker_health_nodes{id="raft-partition-partition-1",partition="1",path="Broker-0/Partition-1/raft-partition-partition-1"} 1.0
```

Due to [Prometheus fixed number of tags](https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html#_limitation_on_same_name_with_different_set_of_tag_keys), even metrics that don't have a partition must have the "partition" label, which is filled with the value "none".


Moreover, `PrometheusRegistrythrowExceptionOnRegistrationFailure();` is called at startup so that an exception is thrown if metrics are registerd with an invalid number of labels.

An example of a grafana dashboard that I created with a "Stat timeline" visualization:
![image](https://github.com/user-attachments/assets/8224949e-bd85-4385-95c2-5f82496ed758)

> [!IMPORTANT]  
>  Note that the names of the components will change with this PR #24669
> One of the "fixes" that the PR introduce will also avoid having these two lines with the same id:
```
zeebe_broker_health_nodes{id="ZeebePartition-1",partition="1",path="Broker-0/Partition-1/ZeebePartition-1"} 1.0
zeebe_broker_health_nodes{id="ZeebePartition-1",partition="none",path="Broker-0/ZeebePartition-1"} 1.0
```
This is caused by having the actorName of `ZeebePartition` equal to the name the `ZeebePartitionHealth` component registers with.

I would first merge #24669  and then merge this one, verifying the output again. Then I can also add it to the dashboards.

## Related issues

closes #24296 
