### PR TITLE
Reject operation from task listener: protocol changes

### DIFF
--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -84,8 +85,9 @@ public final class JobServices<T> extends ApiServices<JobServices<T>> {
   }
 
   public CompletableFuture<JobRecord> completeJob(
-      final long jobKey, final Map<String, Object> variables) {
-    return sendBrokerRequest(new BrokerCompleteJobRequest(jobKey, getDocumentOrEmpty(variables)));
+      final long jobKey, final Map<String, Object> variables, final JobResult result) {
+    return sendBrokerRequest(
+        new BrokerCompleteJobRequest(jobKey, getDocumentOrEmpty(variables), result));
   }
 
   public CompletableFuture<JobRecord> updateJob(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -73,7 +73,6 @@ public final class CompleteJobTest {
         .hasDeadline(job.getDeadline())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-    // TODO assertj-assertions-generator
     assertFalse(recordValue.getResult().isDenied());
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.engine.processing.job;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
@@ -71,9 +69,8 @@ public final class CompleteJobTest {
         .hasType(job.getType())
         .hasRetries(job.getRetries())
         .hasDeadline(job.getDeadline())
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-
-    assertFalse(recordValue.getResult().isDenied());
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasResult(new JobResult().setDenied(false));
   }
 
   @Test
@@ -195,7 +192,9 @@ public final class CompleteJobTest {
     Assertions.assertThat(completedRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(JobIntent.COMPLETED);
-    assertFalse(completedRecord.getValue().getResult().isDenied());
+
+    Assertions.assertThat(completedRecord.getValue())
+            .hasResult(new JobResult().setDenied(false));
   }
 
   @Test
@@ -216,7 +215,9 @@ public final class CompleteJobTest {
     Assertions.assertThat(completedRecord)
         .hasRecordType(RecordType.EVENT)
         .hasIntent(JobIntent.COMPLETED);
-    assertTrue(completedRecord.getValue().getResult().isDenied());
+
+    Assertions.assertThat(completedRecord.getValue())
+            .hasResult(new JobResult().setDenied(true));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/CompleteJobTest.java
@@ -193,8 +193,7 @@ public final class CompleteJobTest {
         .hasRecordType(RecordType.EVENT)
         .hasIntent(JobIntent.COMPLETED);
 
-    Assertions.assertThat(completedRecord.getValue())
-            .hasResult(new JobResult().setDenied(false));
+    Assertions.assertThat(completedRecord.getValue()).hasResult(new JobResult().setDenied(false));
   }
 
   @Test
@@ -216,8 +215,7 @@ public final class CompleteJobTest {
         .hasRecordType(RecordType.EVENT)
         .hasIntent(JobIntent.COMPLETED);
 
-    Assertions.assertThat(completedRecord.getValue())
-            .hasResult(new JobResult().setDenied(true));
+    Assertions.assertThat(completedRecord.getValue()).hasResult(new JobResult().setDenied(true));
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationPropertiesImpl;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
@@ -154,8 +155,18 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerCompleteJobRequest toCompleteJobRequest(
       final CompleteJobRequest grpcRequest) {
+
     return new BrokerCompleteJobRequest(
-        grpcRequest.getJobKey(), ensureJsonSet(grpcRequest.getVariables()));
+        grpcRequest.getJobKey(),
+        ensureJsonSet(grpcRequest.getVariables()),
+        getJobResultOrDefault(grpcRequest));
+  }
+
+  private static JobResult getJobResultOrDefault(final CompleteJobRequest request) {
+    if (request == null) {
+      return new JobResult();
+    }
+    return new JobResult().setDenied(request.getResult().getDenied());
   }
 
   public static BrokerCreateProcessInstanceRequest toCreateProcessInstanceRequest(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -163,8 +163,8 @@ public final class RequestMapper extends RequestUtil {
   }
 
   private static JobResult getJobResultOrDefault(final CompleteJobRequest request) {
-    if (request == null) {
-      return new JobResult();
+    if (!request.hasResult()) {
+      return null;
     }
     return new JobResult().setDenied(request.getResult().getDenied());
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -18,6 +18,15 @@ public class RequestMapperTest {
   private static final String INVALID_VARIABLES =
       "{ \"test\": \"value\", \"error\": \"errorrvalue }";
 
+  // missing closing quote in "denied"
+  private static final String INVALID_RESULT =
+      """
+        {
+          "result": {
+            "denied: true
+        }
+      }""";
+
   // BigInteger larger than 2^64-1
   private static final String BIG_INTEGER =
       "{\"mybigintistoolong\": 123456789012345678901234567890}";
@@ -28,6 +37,16 @@ public class RequestMapperTest {
     assertThatThrownBy(() -> RequestMapper.ensureJsonSet(INVALID_VARIABLES))
         .isInstanceOf(JsonParseException.class)
         .hasMessageContaining("Invalid JSON", INVALID_VARIABLES)
+        .cause()
+        .isInstanceOf(JsonParseException.class);
+  }
+
+  @Test
+  public void shouldThrowHelpfulExceptionIfJsonIsInvalidForResult() {
+    // when + then
+    assertThatThrownBy(() -> RequestMapper.ensureJsonSet(INVALID_RESULT))
+        .isInstanceOf(JsonParseException.class)
+        .hasMessageContaining("Invalid JSON", INVALID_RESULT)
         .cause()
         .isInstanceOf(JsonParseException.class);
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/RequestMapperTest.java
@@ -24,8 +24,9 @@ public class RequestMapperTest {
         {
           "result": {
             "denied: true
+          }
         }
-      }""";
+      """;
 
   // BigInteger larger than 2^64-1
   private static final String BIG_INTEGER =

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
@@ -92,9 +92,9 @@ public final class CompleteJobTest extends GatewayTest {
     final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
 
-    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    final JobRecord jobRecord = brokerRequest.getRequestWriter();
 
-    assertThat(brokerRequestValue.getResult().isDenied()).isTrue();
+    assertThat(jobRecord.getResult().isDenied()).isTrue();
   }
 
   @Test
@@ -117,9 +117,9 @@ public final class CompleteJobTest extends GatewayTest {
     final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
     assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
 
-    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+    final JobRecord jobRecord = brokerRequest.getRequestWriter();
 
-    assertThat(brokerRequestValue.getResult().isDenied()).isFalse();
+    assertThat(jobRecord.getResult().isDenied()).isFalse();
   }
 
   @Test

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/job/CompleteJobTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.gateway.api.util.GatewayTest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CompleteJobResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -69,5 +70,80 @@ public final class CompleteJobTest extends GatewayTest {
 
     final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
     MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), "{}");
+  }
+
+  @Test
+  public void shouldMapRequestAndResponseWithResultSetDeniedTrue() {
+    // given
+    final CompleteJobStub stub = new CompleteJobStub();
+    stub.registerWith(brokerClient);
+
+    final JobResult jobResult = JobResult.newBuilder().setDenied(true).build();
+
+    final CompleteJobRequest request =
+        CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).setResult(jobResult).build();
+
+    // when
+    final CompleteJobResponse response = client.completeJob(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
+
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+
+    assertThat(brokerRequestValue.getResult().isDenied()).isTrue();
+  }
+
+  @Test
+  public void shouldMapRequestAndResponseWithResultSetDeniedFalse() {
+    // given
+    final CompleteJobStub stub = new CompleteJobStub();
+    stub.registerWith(brokerClient);
+
+    final JobResult jobResult = JobResult.newBuilder().setDenied(false).build();
+
+    final CompleteJobRequest request =
+        CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).setResult(jobResult).build();
+
+    // when
+    final CompleteJobResponse response = client.completeJob(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
+
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+
+    assertThat(brokerRequestValue.getResult().isDenied()).isFalse();
+  }
+
+  @Test
+  public void shouldMapRequestAndResponseWithResultDeniedNotSet() {
+    // given
+    final CompleteJobStub stub = new CompleteJobStub();
+    stub.registerWith(brokerClient);
+
+    final JobResult jobResult = JobResult.newBuilder().build();
+
+    final CompleteJobRequest request =
+        CompleteJobRequest.newBuilder().setJobKey(stub.getKey()).setResult(jobResult).build();
+
+    // when
+    final CompleteJobResponse response = client.completeJob(request);
+
+    // then
+    assertThat(response).isNotNull();
+
+    final BrokerCompleteJobRequest brokerRequest = brokerClient.getSingleBrokerRequest();
+    assertThat(brokerRequest.getKey()).isEqualTo(stub.getKey());
+
+    final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
+
+    assertThat(brokerRequestValue.getResult().isDenied()).isFalse();
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -101,6 +101,14 @@ message CompleteJobRequest {
   int64 jobKey = 1;
   // a JSON document representing the variables in the current task scope
   string variables = 2;
+  // an object representing results of the completed job
+  optional JobResult result = 3;
+}
+
+message JobResult{
+  // a boolean indicating if worker has denied the reason for the job.
+  // Defaults to false.
+  optional bool denied = 1;
 }
 
 message CompleteJobResponse {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -101,12 +101,15 @@ message CompleteJobRequest {
   int64 jobKey = 1;
   // a JSON document representing the variables in the current task scope
   string variables = 2;
-  // an object representing results of the completed job
+  // The result of the completed job as determined by the worker.
   optional JobResult result = 3;
 }
 
 message JobResult{
-  // a boolean indicating if worker has denied the reason for the job.
+  // Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
+  // For example, a Task Listener can deny the completion of a task by setting this flag to true.
+  // In this example, the completion of a task is represented by a job that the worker can complete as denied.
+  // As a result, the completion request is rejected and the task remains active.
   // Defaults to false.
   optional bool denied = 1;
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4235,11 +4235,12 @@ components:
     JobResult:
       type: object
       nullable: true
-      description: The result of a completed job
+      description: The result of the completed job as determined by the worker.
       properties:
         denied:
           type: boolean
-          description: Indicates if worker has denied the reason for the work. Defaults to false.
+          description: Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example, a Task Listener can deny the completion of a task by setting this flag to true. In this example, the completion of a task is represented by a job that the worker can complete as denied. As a result, the completion request is rejected and the task remains active.
+            Defaults to false.
           nullable: true
     JobUpdateRequest:
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4230,6 +4230,17 @@ components:
           description: The variables to complete the job with.
           type: object
           nullable: true
+        result:
+          $ref: "#/components/schemas/JobResult"
+    JobResult:
+      type: object
+      nullable: true
+      description: The result of a completed job
+      properties:
+        denied:
+          type: boolean
+          description: Indicates if worker has denied the reason for the work. Defaults to false.
+          nullable: true
     JobUpdateRequest:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4239,7 +4239,10 @@ components:
       properties:
         denied:
           type: boolean
-          description: Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For example, a Task Listener can deny the completion of a task by setting this flag to true. In this example, the completion of a task is represented by a job that the worker can complete as denied. As a result, the completion request is rejected and the task remains active.
+          description: Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. >
+            For example, a Task Listener can deny the completion of a task by setting this flag to true. >
+            In this example, the completion of a task is represented by a job that the worker can complete as denied. >
+            As a result, the completion request is rejected and the task remains active.
             Defaults to false.
           nullable: true
     JobUpdateRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -78,6 +78,7 @@ import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationActivateInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceModificationTerminateInstruction;
@@ -224,9 +225,10 @@ public class RequestMapper {
 
   public static CompleteJobRequest toJobCompletionRequest(
       final JobCompletionRequest completionRequest, final long jobKey) {
-
     return new CompleteJobRequest(
-        jobKey, getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables));
+        jobKey,
+        getMapOrEmpty(completionRequest, JobCompletionRequest::getVariables),
+        getJobResultOrDefault(completionRequest));
   }
 
   public static Either<ProblemDetail, UpdateJobRequest> toJobUpdateRequest(
@@ -646,7 +648,22 @@ public class RequestMapper {
 
   private static <R> Map<String, Object> getMapOrEmpty(
       final R request, final Function<R, Map<String, Object>> mapExtractor) {
-    return request == null ? Map.of() : mapExtractor.apply(request);
+    final Map<String, Object> value = request == null ? null : mapExtractor.apply(request);
+    return value == null ? Map.of() : value;
+  }
+
+  private static JobResult getJobResultOrDefault(final JobCompletionRequest request) {
+    if (request == null || request.getResult() == null) {
+      return new JobResult();
+    }
+    return new JobResult()
+        .setDenied(getBooleanOrDefault(request, r -> r.getResult().getDenied(), false));
+  }
+
+  private static <R> boolean getBooleanOrDefault(
+      final R request, final Function<R, Boolean> valueExtractor, final boolean defaultValue) {
+    final Boolean value = request == null ? null : valueExtractor.apply(request);
+    return value == null ? defaultValue : value;
   }
 
   private static <R> String getStringOrEmpty(
@@ -699,7 +716,7 @@ public class RequestMapper {
   public record ErrorJobRequest(
       long jobKey, String errorCode, String errorMessage, Map<String, Object> variables) {}
 
-  public record CompleteJobRequest(long jobKey, Map<String, Object> variables) {}
+  public record CompleteJobRequest(long jobKey, Map<String, Object> variables, JobResult result) {}
 
   public record UpdateJobRequest(long jobKey, UpdateJobChangeset changeset) {}
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -140,7 +140,10 @@ public class JobController {
         () ->
             jobServices
                 .withAuthentication(RequestMapper.getAuthentication())
-                .completeJob(completeJobRequest.jobKey(), completeJobRequest.variables()));
+                .completeJob(
+                    completeJobRequest.jobKey(),
+                    completeJobRequest.variables(),
+                    completeJobRequest.result()));
   }
 
   private CompletableFuture<ResponseEntity<Object>> updateJob(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -325,8 +325,9 @@ public class JobControllerTest extends RestControllerTest {
           {
             "result": {
               "denied": true
+            }
           }
-        }""";
+        """;
 
     // when/then
     webClient
@@ -357,8 +358,9 @@ public class JobControllerTest extends RestControllerTest {
           {
             "result": {
               "denied": false
+            }
           }
-        }""";
+        """;
 
     // when/then
     webClient
@@ -389,8 +391,9 @@ public class JobControllerTest extends RestControllerTest {
           {
             "result": {
               "unknownField": true
+            }
           }
-        }""";
+        """;
 
     // when/then
     webClient
@@ -418,11 +421,12 @@ public class JobControllerTest extends RestControllerTest {
 
     final var request =
         """
-            {
-              "variables": {
-                "foo": "bar"
-              }
-            }""";
+          {
+            "variables": {
+              "foo": "bar"
+            }
+          }
+        """;
 
     // when/then
     webClient
@@ -446,12 +450,13 @@ public class JobControllerTest extends RestControllerTest {
 
     final var request =
         """
-            {
-              "changeset": {
-                "retries": 5,
-                "timeout": 1000
-              }
-            }""";
+          {
+            "changeset": {
+              "retries": 5,
+              "timeout": 1000
+            }
+          }
+        """;
     // when/then
     webClient
         .patch()
@@ -474,11 +479,12 @@ public class JobControllerTest extends RestControllerTest {
 
     final var request =
         """
-            {
-              "changeset": {
-                "retries": 5
-              }
-            }""";
+          {
+            "changeset": {
+              "retries": 5
+            }
+          }
+        """;
     // when/then
     webClient
         .patch()
@@ -525,9 +531,10 @@ public class JobControllerTest extends RestControllerTest {
     // given
     final var request =
         """
-            {
-              "changeset": {}
-            }""";
+          {
+            "changeset": {}
+          }
+        """;
 
     final var expectedBody =
         """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import io.camunda.security.auth.Authentication;
@@ -19,10 +20,13 @@ import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -112,7 +116,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).failJob(1L, 0, "", 0L, null);
+    Mockito.verify(jobServices).failJob(1L, 0, "", 0L, Map.of());
   }
 
   @Test
@@ -295,9 +299,8 @@ public class JobControllerTest extends RestControllerTest {
   @Test
   void shouldCompleteJob() {
     // given
-    when(jobServices.completeJob(anyLong(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
     // when/then
     webClient
         .post()
@@ -308,13 +311,45 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).completeJob(1L, Map.of());
+    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of()), any(JobResult.class));
+  }
+
+  @Test
+  void shouldCompleteJobWithResult() {
+    // given
+    when(jobServices.completeJob(anyLong(), any(), any()))
+        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+    final var request =
+        """
+          {
+            "result": {
+              "denied": true
+          }
+        }""";
+
+    // when/then
+    webClient
+        .post()
+        .uri(JOBS_BASE_URL + "/1/completion")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
+        ArgumentCaptor.forClass(JobResult.class);
+    Mockito.verify(jobServices)
+        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
+    Assertions.assertTrue(jobResultArgumentCaptor.getValue().isDenied());
   }
 
   @Test
   void shouldCompleteJobWithVariables() {
     // given
-    when(jobServices.completeJob(anyLong(), any()))
+    when(jobServices.completeJob(anyLong(), any(), any()))
         .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
     final var request =
@@ -336,7 +371,7 @@ public class JobControllerTest extends RestControllerTest {
         .expectStatus()
         .isNoContent();
 
-    Mockito.verify(jobServices).completeJob(1L, Map.of("foo", "bar"));
+    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -142,7 +142,7 @@ public class UserTaskControllerTest extends RestControllerTest {
         .expectBody()
         .isEmpty();
 
-    Mockito.verify(userTaskServices).completeUserTask(1L, null, "customAction");
+    Mockito.verify(userTaskServices).completeUserTask(1L, Map.of(), "customAction");
   }
 
   @ParameterizedTest

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerCompleteJobRequest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.impl.broker.request;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import org.agrona.DirectBuffer;
@@ -17,10 +18,12 @@ public final class BrokerCompleteJobRequest extends BrokerExecuteCommand<JobReco
 
   private final JobRecord requestDto = new JobRecord();
 
-  public BrokerCompleteJobRequest(final long key, final DirectBuffer variables) {
+  public BrokerCompleteJobRequest(
+      final long key, final DirectBuffer variables, final JobResult result) {
     super(ValueType.JOB, JobIntent.COMPLETE);
     request.setKey(key);
     requestDto.setVariables(variables);
+    requestDto.setResult(result);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -276,7 +276,9 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   }
 
   public JobRecord setResult(final JobResult result) {
-    resultProp.getValue().wrap(result);
+    if (result != null) {
+      resultProp.getValue().wrap(result);
+    }
     return this;
   }
 


### PR DESCRIPTION
## Description

The second PR for [Teach Task Listeners how to reject events](https://github.com/camunda/camunda/issues/23709) issue.
Changes in this PR cover [Operation rejection from Task Listeners: changes to protocol](https://github.com/camunda/camunda/issues/24555) issue.

In this PR:
- Changes to REST and gRPC protocols: introducing JobResult `result` as a part of payload. Currently, `result` contains only one field `denied`: it is a boolean indicating if worker has denied the reason for the job, default value is false.
- Changes to REST controller and `RequestMapper` for REST. Tests to verify the changes added to `JobControllerTest` 
- Corresponding changes to `JobServices` , `RequestMapper` and `BrokerCompleteJobRequest` added as well.
- New tests to cover the changes added to `CompleteJobTest` in engine/processing and `CompleteJobTest` in gateway/api
- Please note, that some tests could not be added as Java Client changes are not covered in this PR and will be added in the next PR for [Operation rejection from Task Listeners: changes to Java Client](https://github.com/camunda/camunda/issues/24556)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24555 
relates #23709
