### PR TITLE
feat: Add h2 ITests for rdbms + make CamundaRdbmsInvocationContextPro…

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -256,6 +263,12 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>jdbc</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/util/CamundaRdbmsTestApplication.java
@@ -35,16 +35,33 @@ public final class CamundaRdbmsTestApplication
     return this;
   }
 
+  public CamundaRdbmsTestApplication withRdbms() {
+    super.withProperty("camunda.database.type", "rdbms")
+        .withProperty("logging.level.io.camunda.db.rdbms", "DEBUG")
+        .withProperty("logging.level.org.mybatis", "DEBUG");
+    return this;
+  }
+
+  public CamundaRdbmsTestApplication withH2() {
+    super.withProperty(
+            "spring.datasource.url", "jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL")
+        .withProperty("spring.datasource.driver-class-name", "org.h2.Driver")
+        .withProperty("spring.datasource.username", "sa")
+        .withProperty("spring.datasource.password", "");
+    return this;
+  }
+
   @Override
   public CamundaRdbmsTestApplication start() {
-    LOGGER.info("Start database container '{}'...", databaseContainer.getContainerInfo());
-    databaseContainer.start();
+    if (databaseContainer != null) {
+      LOGGER.info("Start database container '{}'...", databaseContainer.getContainerInfo());
+      databaseContainer.start();
 
-    if (databaseContainer instanceof final JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
-      super.withProperty("camunda.database.type", "rdbms")
-          .withProperty("spring.datasource.url", jdbcDatabaseContainer.getJdbcUrl())
-          .withProperty("spring.datasource.username", jdbcDatabaseContainer.getUsername())
-          .withProperty("spring.datasource.password", jdbcDatabaseContainer.getPassword());
+      if (databaseContainer instanceof final JdbcDatabaseContainer<?> jdbcDatabaseContainer) {
+        super.withProperty("spring.datasource.url", jdbcDatabaseContainer.getJdbcUrl())
+            .withProperty("spring.datasource.username", jdbcDatabaseContainer.getUsername())
+            .withProperty("spring.datasource.password", jdbcDatabaseContainer.getPassword());
+      }
     }
 
     LOGGER.info("Start spring application ...");
@@ -55,8 +72,10 @@ public final class CamundaRdbmsTestApplication
   public void close() {
     LOGGER.info("Stop spring application ...");
     super.stop();
-    LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
-    databaseContainer.close();
+    if (databaseContainer != null) {
+      LOGGER.info("Stop database container '{}'...", databaseContainer.getContainerInfo());
+      databaseContainer.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
Add h2 ITests for rdbms + make CamundaRdbmsInvocationContextProviderExtension configurable in tests

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

#24593  
