### PR TITLE
fix: revert common datetime format and improve deserializer

### DIFF
--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -15,7 +15,7 @@ public class ConnectConfiguration {
 
   private static final String DATABASE_TYPE_DEFAULT = "elasticsearch";
   private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
-  private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSXX";
+  private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
   private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
   private static final String URL_DEFAULT = "http://localhost:9200";
 


### PR DESCRIPTION
## Description

The previously defined date time format is used for writing data and reading it. This must not change as the exported data changes compared to previous versions otherwise.

The date deserializer is made more robust so it can read the defined format but also those produced by writers that don't use the `ConnectConfiguration` but a plain `OffsetDatetime::toString` directly, using a colon-based offset format, potentially using 'Z'.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24218 
