### PR TITLE
Align permission types with permissions document

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -8,7 +8,7 @@
 package io.camunda.it.auth;
 
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
-import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_INSTANCE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,14 +48,14 @@ class DecisionInstanceAuthorizationIT {
           List.of(
               new Permissions(DEPLOYMENT, CREATE, List.of("*")),
               new Permissions(DECISION_DEFINITION, CREATE, List.of("*")),
-              new Permissions(DECISION_DEFINITION, READ_INSTANCE, List.of("*"))));
+              new Permissions(DECISION_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
   private static final User RESTRICTED_USER =
       new User(
           RESTRICTED,
           "password",
           List.of(
               new Permissions(
-                  DECISION_DEFINITION, READ_INSTANCE, List.of(DECISION_DEFINITION_ID_1))));
+                  DECISION_DEFINITION, READ_PROCESS_INSTANCE, List.of(DECISION_DEFINITION_ID_1))));
 
   @RegisterExtension
   static final BrokerWithCamundaExporterITInvocationProvider PROVIDER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.auth;
 
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE_DECISION_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
@@ -47,7 +48,7 @@ class DecisionInstanceAuthorizationIT {
           "password",
           List.of(
               new Permissions(DEPLOYMENT, CREATE, List.of("*")),
-              new Permissions(DECISION_DEFINITION, CREATE, List.of("*")),
+              new Permissions(DECISION_DEFINITION, CREATE_DECISION_INSTANCE, List.of("*")),
               new Permissions(DECISION_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
   private static final User RESTRICTED_USER =
       new User(
@@ -110,7 +111,7 @@ class DecisionInstanceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'DECISION_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'DECISION_DEFINITION'");
   }
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -9,7 +9,7 @@ package io.camunda.it.auth;
 
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ;
-import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_INSTANCE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,17 +47,19 @@ class ProcessInstanceAuthorizationIT {
               new Permissions(DEPLOYMENT, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, CREATE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of("*"))));
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
   private static final User USER1_USER =
       new User(
           USER1,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of(PROCESS_ID_1))));
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID_1))));
   private static final User USER2_USER =
       new User(
           USER2,
           "password",
-          List.of(new Permissions(PROCESS_DEFINITION, READ_INSTANCE, List.of(PROCESS_ID_2))));
+          List.of(
+              new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of(PROCESS_ID_2))));
 
   @RegisterExtension
   static final BrokerWithCamundaExporterITInvocationProvider PROVIDER =

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/ProcessInstanceAuthorizationIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.auth;
 
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ;
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
@@ -45,7 +46,7 @@ class ProcessInstanceAuthorizationIT {
           "password",
           List.of(
               new Permissions(DEPLOYMENT, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_PROCESS_INSTANCE, List.of("*"))));
   private static final User USER1_USER =
@@ -121,7 +122,7 @@ class ProcessInstanceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 
   @TestTemplate
@@ -166,7 +167,7 @@ class ProcessInstanceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 
   @TestTemplate
@@ -207,7 +208,7 @@ class ProcessInstanceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 
   @TestTemplate
@@ -252,7 +253,7 @@ class ProcessInstanceAuthorizationIT {
     assertThat(problemException.code()).isEqualTo(403);
     assertThat(problemException.details().getDetail())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 
   private long getProcessInstanceKey(final ZeebeClient zeebeClient, final String processId) {

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/UserTaskAuthorizationIT.java
@@ -8,6 +8,7 @@
 package io.camunda.it.auth;
 
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE_PROCESS_INSTANCE;
 import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_USER_TASK;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
 import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
@@ -44,7 +45,7 @@ class UserTaskAuthorizationIT {
           "password",
           List.of(
               new Permissions(DEPLOYMENT, CREATE, List.of("*")),
-              new Permissions(PROCESS_DEFINITION, CREATE, List.of("*")),
+              new Permissions(PROCESS_DEFINITION, CREATE_PROCESS_INSTANCE, List.of("*")),
               new Permissions(PROCESS_DEFINITION, READ_USER_TASK, List.of("*"))));
   private static final User USER1_USER =
       new User(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/DecisionInstanceAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/DecisionInstanceAuthorizationQueryTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -24,7 +24,7 @@ public class DecisionInstanceAuthorizationQueryTransformer
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceKeys) {
-    if (resourceType == DECISION_DEFINITION && permissionType == READ_INSTANCE) {
+    if (resourceType == DECISION_DEFINITION && permissionType == READ_PROCESS_INSTANCE) {
       return stringTerms("decisionId", resourceKeys);
     }
     throw new IllegalArgumentException(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/FlowNodeInstanceAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/FlowNodeInstanceAuthorizationQueryTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -24,7 +24,7 @@ public class FlowNodeInstanceAuthorizationQueryTransformer
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceKeys) {
-    if (resourceType == PROCESS_DEFINITION && permissionType == READ_INSTANCE) {
+    if (resourceType == PROCESS_DEFINITION && permissionType == READ_PROCESS_INSTANCE) {
       return stringTerms("bpmnProcessId", resourceKeys);
     }
     throw new IllegalArgumentException(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/IncidentAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/IncidentAuthorizationQueryTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -23,7 +23,7 @@ public class IncidentAuthorizationQueryTransformer implements AuthorizationQuery
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceKeys) {
-    if (resourceType == PROCESS_DEFINITION && permissionType == READ_INSTANCE) {
+    if (resourceType == PROCESS_DEFINITION && permissionType == READ_PROCESS_INSTANCE) {
       return stringTerms("bpmnProcessId", resourceKeys);
     }
     throw new IllegalArgumentException(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/ProcessInstanceAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/ProcessInstanceAuthorizationQueryTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -23,7 +23,7 @@ public class ProcessInstanceAuthorizationQueryTransformer implements Authorizati
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceKeys) {
-    if (resourceType == PROCESS_DEFINITION && permissionType == READ_INSTANCE) {
+    if (resourceType == PROCESS_DEFINITION && permissionType == READ_PROCESS_INSTANCE) {
       return stringTerms("bpmnProcessId", resourceKeys);
     }
     throw new IllegalArgumentException(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/VariableAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/VariableAuthorizationQueryTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.auth;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -23,7 +23,7 @@ public class VariableAuthorizationQueryTransformer implements AuthorizationQuery
       final AuthorizationResourceType resourceType,
       final PermissionType permissionType,
       final List<String> resourceKeys) {
-    if (resourceType == PROCESS_DEFINITION && permissionType == READ_INSTANCE) {
+    if (resourceType == PROCESS_DEFINITION && permissionType == READ_PROCESS_INSTANCE) {
       return stringTerms("bpmnProcessId", resourceKeys);
     }
     throw new IllegalArgumentException(

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -15,7 +15,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.R
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.TENANT;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.USER;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_INSTANCE;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_PROCESS_INSTANCE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ_USER_TASK;
 
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
@@ -77,7 +77,7 @@ public record Authorization(AuthorizationResourceType resourceType, PermissionTy
     }
 
     public Builder readInstance() {
-      return permissionType(READ_INSTANCE);
+      return permissionType(READ_PROCESS_INSTANCE);
     }
 
     public Builder readUserTask() {

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
@@ -9,10 +9,17 @@ package io.camunda.zeebe.protocol.record.value;
 
 public enum PermissionType {
   CREATE,
+  CREATE_PROCESS_INSTANCE,
+  CREATE_DECISION_INSTANCE,
+
   READ,
   READ_PROCESS_INSTANCE,
   READ_USER_TASK,
+
   UPDATE,
+  UPDATE_PROCESS_INSTANCE,
+  UPDATE_USER_TASK,
+
   DELETE,
   DELETE_PROCESS,
   DELETE_DRD,

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.protocol.record.value;
 public enum PermissionType {
   CREATE,
   READ,
-  READ_INSTANCE,
+  READ_PROCESS_INSTANCE,
   READ_USER_TASK,
   UPDATE,
   DELETE,

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -140,6 +140,6 @@ class DecisionInstanceServiceTest {
     final var exception = assertThrows(ForbiddenException.class, executable);
     assertThat(exception.getMessage())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'DECISION_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'DECISION_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
@@ -95,6 +95,6 @@ public final class FlowNodeInstanceServiceTest {
     final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
     assertThat(exception.getMessage())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -95,6 +95,6 @@ public final class IncidentServiceTest {
     final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
     assertThat(exception.getMessage())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -124,7 +124,7 @@ public final class ProcessInstanceServiceTest {
     final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
     assertThat(exception.getMessage())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 
   private void authorizeProcessReadInstance(final boolean authorize, final String processId) {

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -108,6 +108,6 @@ public class VariableServiceTest {
     final var exception = assertThrowsExactly(ForbiddenException.class, executeGetByKey);
     assertThat(exception.getMessage())
         .isEqualTo(
-            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'PROCESS_DEFINITION'");
+            "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -68,7 +68,9 @@ public class DecisionEvaluationEvaluteProcessor
       final var decisionId = bufferAsString(decision.getDecisionId());
       final var authRequest =
           new AuthorizationRequest(
-                  command, AuthorizationResourceType.DECISION_DEFINITION, PermissionType.CREATE)
+                  command,
+                  AuthorizationResourceType.DECISION_DEFINITION,
+                  PermissionType.CREATE_DECISION_INSTANCE)
               .addResourceId(decisionId);
 
       if (!authCheckBehavior.isAuthorized(authRequest)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -85,7 +85,9 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
 
     final var authRequest =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(incident.getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(authRequest)) {
       final var reason =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DefaultJobCommandPreconditionGuard.java
@@ -75,7 +75,9 @@ public final class DefaultJobCommandPreconditionGuard {
       final TypedRecord<JobRecord> command, final JobRecord job) {
     final var request =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(job.getBpmnProcessId());
 
     if (authCheckBehavior.isAuthorized(request)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -96,7 +96,9 @@ final class JobBatchCollector {
     final var authorizedProcessIds =
         authCheckBehavior.getAuthorizedResourceIdentifiers(
             new AuthorizationRequest(
-                record, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE));
+                record,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE));
 
     jobState.forEachActivatableJobs(
         value.getTypeBuffer(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -203,7 +203,9 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       final TypedRecord<JobRecord> command, final JobRecord job) {
     final var request =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(job.getBpmnProcessId());
 
     if (authCheckBehavior.isAuthorized(request)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -58,7 +58,9 @@ public class JobUpdateBehaviour {
       final TypedRecord<JobRecord> command, final JobRecord job) {
     final var authRequest =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(job.getBpmnProcessId());
 
     if (!authCheckBehavior.isAuthorized(authRequest)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationCorrelateProcessor.java
@@ -172,8 +172,8 @@ public final class MessageCorrelationCorrelateProcessor
             subscription -> {
               final PermissionType permissionType =
                   subscription.isStartEventSubscription()
-                      ? PermissionType.CREATE
-                      : PermissionType.UPDATE;
+                      ? PermissionType.CREATE_PROCESS_INSTANCE
+                      : PermissionType.UPDATE_PROCESS_INSTANCE;
 
               request.set(
                   new AuthorizationRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCancelProcessor.java
@@ -93,7 +93,9 @@ public final class ProcessInstanceCancelProcessor
 
     final var request =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(elementInstance.getValue().getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(request)) {
       final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceCreationCreateProcessor.java
@@ -142,7 +142,9 @@ public final class ProcessInstanceCreationCreateProcessor
     final var processId = bufferAsString(deployedProcess.getBpmnProcessId());
     final var request =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.CREATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.CREATE_PROCESS_INSTANCE)
             .addResourceId(processId);
 
     if (authCheckBehavior.isAuthorized(request)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -121,7 +121,9 @@ public class ProcessInstanceMigrationMigrateProcessor
 
     final var authorizationRequest =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(processInstance.getValue().getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(authorizationRequest)) {
       final var errorMessage =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -193,7 +193,9 @@ public final class ProcessInstanceModificationModifyProcessor
 
     final var authRequest =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(processInstance.getValue().getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(authRequest)) {
       final String reason =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -124,7 +124,10 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
       final TypedRecord<SignalRecord> command,
       final boolean isStartEvent,
       final SignalSubscriptionRecord subscriptionRecord) {
-    final var permissionType = isStartEvent ? PermissionType.CREATE : PermissionType.UPDATE;
+    final var permissionType =
+        isStartEvent
+            ? PermissionType.CREATE_PROCESS_INSTANCE
+            : PermissionType.UPDATE_PROCESS_INSTANCE;
     final var authRequest =
         new AuthorizationRequest(
                 command, AuthorizationResourceType.PROCESS_DEFINITION, permissionType)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -81,7 +81,9 @@ public class UserTaskCommandPreconditionChecker {
 
     final var authRequest =
         new AuthorizationRequest(
-                command, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                command,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_USER_TASK)
             .addResourceId(persistedRecord.getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(authRequest)) {
       return Either.left(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/variable/VariableDocumentUpdateProcessor.java
@@ -66,7 +66,9 @@ public final class VariableDocumentUpdateProcessor
 
     final var authRequest =
         new AuthorizationRequest(
-                record, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.UPDATE)
+                record,
+                AuthorizationResourceType.PROCESS_DEFINITION,
+                PermissionType.UPDATE_PROCESS_INSTANCE)
             .addResourceId(scope.getValue().getBpmnProcessId());
     if (!authCheckBehavior.isAuthorized(authRequest)) {
       final var reason =

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3748,7 +3748,7 @@ components:
       enum:
         - CREATE
         - READ
-        - READ_INSTANCE
+        - READ_PROCESS_INSTANCE
         - READ_USER_TASK
         - UPDATE
         - DELETE

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3747,10 +3747,14 @@ components:
       description: Specifies the type of permissions.
       enum:
         - CREATE
+        - CREATE_PROCESS_INSTANCE
+        - CREATE_DECISION_INSTANCE
         - READ
         - READ_PROCESS_INSTANCE
         - READ_USER_TASK
         - UPDATE
+        - UPDATE_PROCESS_INSTANCE
+        - UPDATE_USER_TASK
         - DELETE
         - DELETE_PROCESS
         - DELETE_DRD

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -355,7 +355,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                   "type": "about:blank",
                   "title": "io.camunda.service.exception.ForbiddenException",
                   "status": 403,
-                  "detail": "Unauthorized to perform operation 'READ_INSTANCE' on resource 'DECISION_DEFINITION'",
+                  "detail": "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'DECISION_DEFINITION'",
                   "instance": "/v2/decision-instances/123"
                 }""");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/DecisionEvaluationEvaluateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/DecisionEvaluationEvaluateAuthorizationIT.java
@@ -95,7 +95,9 @@ public class DecisionEvaluationEvaluateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.DECISION_DEFINITION, PermissionTypeEnum.CREATE, List.of(DECISION_ID)));
+            ResourceTypeEnum.DECISION_DEFINITION,
+            PermissionTypeEnum.CREATE_DECISION_INSTANCE,
+            List.of(DECISION_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -134,7 +136,7 @@ public class DecisionEvaluationEvaluateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'DECISION_DEFINITION' with decision id '%s'",
+              "Unauthorized to perform operation 'CREATE_DECISION_INSTANCE' on resource 'DECISION_DEFINITION' with decision id '%s'",
               DECISION_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/IncidentResolveAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/IncidentResolveAuthorizationIT.java
@@ -99,7 +99,9 @@ public class IncidentResolveAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -130,7 +132,7 @@ public class IncidentResolveAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobBatchActivateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobBatchActivateAuthorizationIT.java
@@ -114,7 +114,7 @@ public class JobBatchActivateAuthorizationIT {
         password,
         new Permissions(
             ResourceTypeEnum.PROCESS_DEFINITION,
-            PermissionTypeEnum.UPDATE,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
             List.of(processId1, processId2)));
 
     try (final var client = authUtil.createClient(username, password)) {
@@ -144,7 +144,9 @@ public class JobBatchActivateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(processId1)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(processId1)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobCompleteAuthorizationIT.java
@@ -114,7 +114,9 @@ public class JobCompleteAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
     final var processInstanceKey =
         defaultUserClient
             .newCreateInstanceCommand()
@@ -168,7 +170,7 @@ public class JobCompleteAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobFailAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobFailAuthorizationIT.java
@@ -112,7 +112,9 @@ public class JobFailAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -140,7 +142,7 @@ public class JobFailAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/JobUpdateAuthorizationIT.java
@@ -113,7 +113,9 @@ public class JobUpdateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -141,7 +143,7 @@ public class JobUpdateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/MessageCorrelationCorrelateAuthorizationIT.java
@@ -124,7 +124,9 @@ public class MessageCorrelationCorrelateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -167,7 +169,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }
@@ -196,7 +198,9 @@ public class MessageCorrelationCorrelateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -235,7 +239,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }
@@ -249,7 +253,9 @@ public class MessageCorrelationCorrelateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
     final var unauthorizedProcessId = "unauthorizedProcessId";
     final var resourceName = "unauthorizedProcess.xml";
     final var deploymentKey =
@@ -281,7 +287,7 @@ public class MessageCorrelationCorrelateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               unauthorizedProcessId);
 
       final var deploymentPosition =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCancelAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCancelAuthorizationIT.java
@@ -95,7 +95,7 @@ public class ProcessInstanceCancelAuthorizationIT {
   }
 
   @Test
-  void shouldBeAuthorizedToCreateInstanceWithUser() {
+  void shouldBeAuthorizedToCancelInstanceWithUser() {
     // given
     final var processInstanceEvent =
         defaultUserClient
@@ -110,7 +110,9 @@ public class ProcessInstanceCancelAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -126,7 +128,7 @@ public class ProcessInstanceCancelAuthorizationIT {
   }
 
   @Test
-  void shouldBeUnauthorizedToCreateInstanceIfNoPermissions() {
+  void shouldBeUnauthorizedToCancelInstanceIfNoPermissions() {
     // given
     final var processInstanceEvent =
         defaultUserClient
@@ -150,7 +152,7 @@ public class ProcessInstanceCancelAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCreateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceCreateAuthorizationIT.java
@@ -107,7 +107,9 @@ public class ProcessInstanceCreateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -126,7 +128,9 @@ public class ProcessInstanceCreateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -160,7 +164,7 @@ public class ProcessInstanceCreateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION'");
+              "Unauthorized to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION'");
     }
   }
 
@@ -187,7 +191,7 @@ public class ProcessInstanceCreateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceMigrationMigrateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceMigrationMigrateAuthorizationIT.java
@@ -140,7 +140,9 @@ public class ProcessInstanceMigrationMigrateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when migrate to a non-existing process as authorization checks should fail first
@@ -190,7 +192,7 @@ public class ProcessInstanceMigrationMigrateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceModificationModifyAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/ProcessInstanceModificationModifyAuthorizationIT.java
@@ -110,7 +110,9 @@ public class ProcessInstanceModificationModifyAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -149,7 +151,7 @@ public class ProcessInstanceModificationModifyAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/SignalBroadcastAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/SignalBroadcastAuthorizationIT.java
@@ -110,9 +110,13 @@ public class SignalBroadcastAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)),
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)),
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when
@@ -142,7 +146,7 @@ public class SignalBroadcastAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'CREATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'CREATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }
@@ -156,7 +160,9 @@ public class SignalBroadcastAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.CREATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.CREATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
     final var processInstanceKey = createProcessInstance();
 
     try (final var client = authUtil.createClient(username, password)) {
@@ -169,7 +175,7 @@ public class SignalBroadcastAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
 
       assertThat(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskAssignAuthorizationIT.java
@@ -112,7 +112,9 @@ public class UserTaskAssignAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_USER_TASK,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -154,7 +156,7 @@ public class UserTaskAssignAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskClaimAuthorizationIT.java
@@ -107,7 +107,9 @@ public class UserTaskClaimAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_USER_TASK,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -139,7 +141,7 @@ public class UserTaskClaimAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskCompleteAuthorizationIT.java
@@ -106,7 +106,9 @@ public class UserTaskCompleteAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_USER_TASK,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -137,7 +139,7 @@ public class UserTaskCompleteAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/UserTaskUpdateAuthorizationIT.java
@@ -107,7 +107,9 @@ public class UserTaskUpdateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_USER_TASK,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -139,7 +141,7 @@ public class UserTaskUpdateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/VariableDocumentUpdateAuthorizationIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/VariableDocumentUpdateAuthorizationIT.java
@@ -105,7 +105,9 @@ public class VariableDocumentUpdateAuthorizationIT {
         username,
         password,
         new Permissions(
-            ResourceTypeEnum.PROCESS_DEFINITION, PermissionTypeEnum.UPDATE, List.of(PROCESS_ID)));
+            ResourceTypeEnum.PROCESS_DEFINITION,
+            PermissionTypeEnum.UPDATE_PROCESS_INSTANCE,
+            List.of(PROCESS_ID)));
 
     try (final var client = authUtil.createClient(username, password)) {
       // when then
@@ -142,7 +144,7 @@ public class VariableDocumentUpdateAuthorizationIT {
           .hasMessageContaining("title: UNAUTHORIZED")
           .hasMessageContaining("status: 401")
           .hasMessageContaining(
-              "Unauthorized to perform operation 'UPDATE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
+              "Unauthorized to perform operation 'UPDATE_PROCESS_INSTANCE' on resource 'PROCESS_DEFINITION' with BPMN process id '%s'",
               PROCESS_ID);
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

[Link to document (internal)](https://docs.google.com/document/d/1ikxw9ARCv-MBwASnj7WhW5uHCndCRk2B35xi-cB2N0M/edit?tab=t.0)

This PR changes the permissionTypes of the authorization checks we're doing in Zeebe and aligns them with what's written in the document.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24612 
