### PR TITLE
feat: add authorization checks on decision instance GET endpoint

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.auth;
+
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.CREATE;
+import static io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum.READ_INSTANCE;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DECISION_DEFINITION;
+import static io.camunda.zeebe.client.protocol.rest.ResourceTypeEnum.DEPLOYMENT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.application.Profile;
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
+import io.camunda.it.utils.ZeebeClientTestFactory.Authenticated;
+import io.camunda.it.utils.ZeebeClientTestFactory.Permissions;
+import io.camunda.it.utils.ZeebeClientTestFactory.User;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.search.response.DecisionInstance;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.function.Executable;
+
+@TestInstance(Lifecycle.PER_CLASS)
+class DecisionInstanceAuthorizationIT {
+
+  private static final String DECISION_DEFINITION_ID_1 = "decision_1";
+  private static final String DECISION_DEFINITION_ID_2 = "test_qa";
+  private static final String ADMIN = "admin";
+  private static final String RESTRICTED = "restricted-user";
+  private static final User ADMIN_USER =
+      new User(
+          ADMIN,
+          "password",
+          List.of(
+              new Permissions(DEPLOYMENT, CREATE, List.of("*")),
+              new Permissions(DECISION_DEFINITION, CREATE, List.of("*")),
+              new Permissions(DECISION_DEFINITION, READ_INSTANCE, List.of("*"))));
+  private static final User RESTRICTED_USER =
+      new User(
+          RESTRICTED,
+          "password",
+          List.of(
+              new Permissions(
+                  DECISION_DEFINITION, READ_INSTANCE, List.of(DECISION_DEFINITION_ID_1))));
+
+  @RegisterExtension
+  static final BrokerWithCamundaExporterITInvocationProvider PROVIDER =
+      new BrokerWithCamundaExporterITInvocationProvider()
+          .withAdditionalProfiles(Profile.AUTH_BASIC)
+          .withAuthorizationsEnabled()
+          .withUsers(ADMIN_USER, RESTRICTED_USER);
+
+  private boolean initialized;
+
+  @BeforeEach
+  void setUp(@Authenticated(ADMIN) final ZeebeClient adminClient) {
+    if (!initialized) {
+      final List<String> decisions = List.of("decision_model.dmn", "decision_model_1.dmn");
+      decisions.stream()
+          .flatMap(
+              decision ->
+                  deployResource(adminClient, String.format("decisions/%s", decision))
+                      .getDecisions()
+                      .stream())
+          .forEach(decision -> evaluateDecision(adminClient, decision.getDecisionKey()));
+      waitForDecisionsToBeEvaluated(adminClient, decisions.size());
+      initialized = true;
+    }
+  }
+
+  @TestTemplate
+  void searchShouldReturnAuthorizedDecisionInstances(
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // when
+    final var decisionInstances = userClient.newDecisionInstanceQuery().send().join().items();
+
+    // then
+    assertThat(decisionInstances).hasSize(1);
+    assertThat(decisionInstances.stream().map(DecisionInstance::getDecisionDefinitionId).toList())
+        .containsOnly(DECISION_DEFINITION_ID_1);
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionInstance(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionInstanceKey = getDecisionInstanceKey(adminClient, DECISION_DEFINITION_ID_2);
+
+    // when
+    final Executable executeGet =
+        () -> userClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
+
+    // then
+    final var problemException = assertThrows(ProblemException.class, executeGet);
+    assertThat(problemException.code()).isEqualTo(403);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'DECISION_DEFINITION'");
+  }
+
+  @TestTemplate
+  void getByKeyShouldReturnAuthorizedDecisionDefinition(
+      @Authenticated(ADMIN) final ZeebeClient adminClient,
+      @Authenticated(RESTRICTED) final ZeebeClient userClient) {
+    // given
+    final var decisionInstanceKey = getDecisionInstanceKey(adminClient, DECISION_DEFINITION_ID_1);
+
+    // when
+    final var decisionInstance =
+        userClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
+
+    // then
+    assertThat(decisionInstance).isNotNull();
+    assertThat(decisionInstance.getDecisionDefinitionId()).isEqualTo(DECISION_DEFINITION_ID_1);
+  }
+
+  private long getDecisionInstanceKey(final ZeebeClient client, final String decisionDefinitionId) {
+    return client
+        .newDecisionInstanceQuery()
+        .filter(f -> f.decisionDefinitionId(decisionDefinitionId))
+        .send()
+        .join()
+        .items()
+        .getFirst()
+        .getDecisionInstanceKey();
+  }
+
+  private DeploymentEvent deployResource(final ZeebeClient zeebeClient, final String resourceName) {
+    return zeebeClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .send()
+        .join();
+  }
+
+  private static EvaluateDecisionResponse evaluateDecision(
+      final ZeebeClient zeebeClient, final long decisionKey) {
+    return zeebeClient
+        .newEvaluateDecisionCommand()
+        .decisionKey(decisionKey)
+        .variables("{\"input1\": \"A\"}")
+        .send()
+        .join();
+  }
+
+  private void waitForDecisionsToBeEvaluated(
+      final ZeebeClient zeebeClient, final int expectedCount) {
+    Awaitility.await("should deploy decision definitions and import in Operate")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = zeebeClient.newDecisionInstanceQuery().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -738,8 +738,6 @@ class DecisionQueryTest {
     // then
     assertThat(problemException.code()).isEqualTo(404);
     assertThat(problemException.details().getDetail())
-        .isEqualTo(
-            "Decision Instance with decisionInstanceKey=%d not found"
-                .formatted(decisionInstanceKey));
+        .isEqualTo("Decision instance with key %d not found".formatted(decisionInstanceKey));
   }
 }

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -19,11 +19,10 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
-import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import java.util.function.Function;
 
 public final class DecisionInstanceServices
     extends SearchQueryService<
@@ -54,13 +53,19 @@ public final class DecisionInstanceServices
    */
   @Override
   public SearchQueryResult<DecisionInstanceEntity> search(final DecisionInstanceQuery query) {
-    return baseSearch(
-        q ->
-            q.filter(query.filter())
-                .sort(query.sort())
-                .page(query.page())
-                .resultConfig(
-                    ofNullable(query.resultConfig()).orElseGet(this::defaultSearchResultConfig)));
+    return decisionInstanceSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.decisionDefinition().readInstance())))
+        .searchDecisionInstances(
+            decisionInstanceSearchQuery(
+                q ->
+                    q.filter(query.filter())
+                        .sort(query.sort())
+                        .page(query.page())
+                        .resultConfig(
+                            ofNullable(query.resultConfig())
+                                .orElseGet(this::defaultSearchResultConfig))));
   }
 
   /**
@@ -73,26 +78,20 @@ public final class DecisionInstanceServices
    *     once
    */
   public DecisionInstanceEntity getByKey(final long decisionInstanceKey) {
-    final var result = baseSearch(q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey)));
-    if (result.total() < 1) {
-      throw new NotFoundException(
-          "Decision Instance with decisionInstanceKey=%d not found".formatted(decisionInstanceKey));
-    } else if (result.total() > 1) {
-      throw new CamundaSearchException(
-          String.format(
-              "Found Decision Definition with key %d more than once", decisionInstanceKey));
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
+    final var result =
+        decisionInstanceSearchClient
+            .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+            .searchDecisionInstances(
+                decisionInstanceSearchQuery(
+                    q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey))));
+    final var decisionInstanceEntity =
+        getSingleResultOrThrow(result, decisionInstanceKey, "Decision instance");
+    final var authorization = Authorization.of(a -> a.decisionDefinition().readInstance());
+    if (!securityContextProvider.isAuthorized(
+        decisionInstanceEntity.decisionId(), authentication, authorization)) {
+      throw new ForbiddenException(authorization);
     }
-  }
-
-  private SearchQueryResult<DecisionInstanceEntity> baseSearch(
-      final Function<DecisionInstanceQuery.Builder, ObjectBuilder<DecisionInstanceQuery>> fn) {
-    return decisionInstanceSearchClient
-        .withSecurityContext(
-            securityContextProvider.provideSecurityContext(
-                authentication, Authorization.of(a -> a.decisionDefinition().readInstance())))
-        .searchDecisionInstances(decisionInstanceSearchQuery(fn));
+    return decisionInstanceEntity;
   }
 
   /**

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -8,6 +8,7 @@
 package io.camunda.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -18,24 +19,32 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 
 class DecisionInstanceServiceTest {
 
   private DecisionInstanceServices services;
   private DecisionInstanceSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
 
   @BeforeEach
   public void before() {
     client = mock(DecisionInstanceSearchClient.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    authentication = mock(Authentication.class);
     services =
         new DecisionInstanceServices(
-            mock(BrokerClient.class), mock(SecurityContextProvider.class), client, null);
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
   }
 
   @Test
@@ -59,10 +68,18 @@ class DecisionInstanceServiceTest {
   void shouldGetDecisionInstanceByKey() {
     // given
     final Long decisionInstanceKey = 1L;
+    final var decisionDefinitionKey = "dd1";
     final var result = mock(SearchQueryResult.class);
     when(result.total()).thenReturn(1L);
-    when(result.items()).thenReturn(List.of(mock(DecisionInstanceEntity.class)));
+    final var decisionInstanceEntity = mock(DecisionInstanceEntity.class);
+    when(decisionInstanceEntity.decisionId()).thenReturn(decisionDefinitionKey);
+    when(result.items()).thenReturn(List.of(decisionInstanceEntity));
     when(client.searchDecisionInstances(any())).thenReturn(result);
+    when(securityContextProvider.isAuthorized(
+            decisionDefinitionKey,
+            authentication,
+            Authorization.of(a -> a.decisionDefinition().readInstance())))
+        .thenReturn(true);
 
     // when
     services.getByKey(decisionInstanceKey);
@@ -97,5 +114,32 @@ class DecisionInstanceServiceTest {
                         .page(p -> p.size(20))
                         .resultConfig(
                             r -> r.includeEvaluatedInputs(false).includeEvaluatedOutputs(false))));
+  }
+
+  @Test
+  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionDefinition() {
+    // given
+    final Long decisionInstanceKey = 1L;
+    final var decisionDefinitionKey = "dd1";
+    final var result = mock(SearchQueryResult.class);
+    when(result.total()).thenReturn(1L);
+    final var decisionInstanceEntity = mock(DecisionInstanceEntity.class);
+    when(decisionInstanceEntity.decisionId()).thenReturn(decisionDefinitionKey);
+    when(result.items()).thenReturn(List.of(decisionInstanceEntity));
+    when(client.searchDecisionInstances(any())).thenReturn(result);
+    when(securityContextProvider.isAuthorized(
+            decisionDefinitionKey,
+            authentication,
+            Authorization.of(a -> a.decisionDefinition().readInstance())))
+        .thenReturn(false);
+
+    // when
+    final Executable executable = () -> services.getByKey(decisionInstanceKey);
+
+    // then
+    final var exception = assertThrows(ForbiddenException.class, executable);
+    assertThat(exception.getMessage())
+        .isEqualTo(
+            "Unauthorized to perform operation 'READ_INSTANCE' on resource 'DECISION_DEFINITION'");
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryController.java
@@ -12,6 +12,7 @@ import io.camunda.service.DecisionInstanceServices;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionInstanceGetQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionInstanceSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.DecisionInstanceSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
@@ -48,7 +49,9 @@ public class DecisionInstanceQueryController {
     try {
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionInstanceGetQueryResponse(
-              decisionInstanceServices.getByKey(decisionInstanceKey)));
+              decisionInstanceServices
+                  .withAuthentication(RequestMapper.getAuthentication())
+                  .getByKey(decisionInstanceKey)));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
     }
@@ -57,7 +60,10 @@ public class DecisionInstanceQueryController {
   private ResponseEntity<DecisionInstanceSearchQueryResponse> search(
       final DecisionInstanceQuery query) {
     try {
-      final var decisionInstances = decisionInstanceServices.search(query);
+      final var decisionInstances =
+          decisionInstanceServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .search(query);
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionInstanceSearchQueryResponse(decisionInstances));
     } catch (final Exception e) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds `DECISION_DEFINITION_READ_INSTANCE` permission check on
```
GET /decision-instances/{decisionInstanceKey}
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/23180
