### PR TITLE
ci: switch e2e tests to run on chrome

### DIFF
--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -38,7 +38,7 @@ permissions:
 jobs:
   e2e-tests-sm:
     name: E2E tests sm
-    runs-on: gcp-core-4-default
+    runs-on: ubuntu-latest
     timeout-minutes: 120
 
     steps:
@@ -61,14 +61,6 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-
-      - name: Install firefox deps
-        run: |
-          sudo apt-get update && sudo apt-get install
-          sudo apt-get install -y xvfb bzip2 packagekit-gtk3-module libasound2
-
-      - name: Install firefox
-        uses: browser-actions/setup-firefox@v1
 
       - name: Build frontend
         uses: ./.github/actions/build-frontend

--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -44,7 +44,7 @@
     "e2e": "testcafe -c 3 chrome e2e/sm-tests/*.js --disable-screenshots",
     "e2e:ci:headless": "testcafe -c 3 chrome:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:ci:cloud:headless": "testcafe chrome:headless e2e/cloud-tests/smokeTest.js -e",
-    "e2e:ci:sm:headless": "testcafe -c 3 firefox:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
+    "e2e:ci:sm:headless": "testcafe -c 3 chrome:headless e2e/sm-tests/*.js -e --disable-screenshots --assertion-timeout 40000 -q attemptLimit=3,successThreshold=1",
     "e2e:cloud": "testcafe chrome e2e/cloud-tests/smokeTest.js",
     "eject": "react-scripts eject",
     "postinstall": "node scripts/wireModules && patch-package",


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
The e2e tests were timing out a lot. sometimes, they take a really long time.
I tried switching them to run on Chrome on github runners and they seems to be much faster and more stable.
I ran them 5 times and they all succeeded.

We used to run the e2e tests on firefox because testcafe used to get stuck on chrome with no obvious error. Since this does not happen anymore after we updated testcafe, it is good to go back to chrome.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
