### PR TITLE
fix: Determine Commercial License status for invalid licenses

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/license/CamundaLicense.java
@@ -74,6 +74,12 @@ public class CamundaLicense {
   private void validateLicense(final String licenseStr) {
     try {
       final LicenseKey licenseKey = getLicenseKey(licenseStr);
+
+      isCommercial = licenseKey.isCommercial();
+      if (licenseKey.getValidUntil() != null) {
+        expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+      }
+
       licenseKey.validate(); // this method logs the license status
 
       licenseType = LicenseType.get(licenseKey.getProperties().get("licenseType"));
@@ -83,10 +89,6 @@ public class CamundaLicense {
             "Expected a valid licenseType property on the Camunda License, but none were found.");
         isValid = false;
       } else {
-        isCommercial = licenseKey.isCommercial();
-        if (licenseKey.getValidUntil() != null) {
-          expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
-        }
         isValid = true;
       }
 

--- a/service/src/main/java/io/camunda/service/license/CamundaLicense.java
+++ b/service/src/main/java/io/camunda/service/license/CamundaLicense.java
@@ -71,6 +71,12 @@ public class CamundaLicense {
   private void validateLicense(final String licenseStr) {
     try {
       final LicenseKey licenseKey = getLicenseKey(licenseStr);
+
+      isCommercial = licenseKey.isCommercial();
+      if (licenseKey.getValidUntil() != null) {
+        expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
+      }
+
       licenseKey.validate(); // this method logs the license status
 
       licenseType = LicenseType.get(licenseKey.getProperties().get("licenseType"));
@@ -80,10 +86,6 @@ public class CamundaLicense {
             "Expected a valid licenseType property on the Camunda License, but none were found.");
         isValid = false;
       } else {
-        isCommercial = licenseKey.isCommercial();
-        if (licenseKey.getValidUntil() != null) {
-          expiresAt = licenseKey.getValidUntil().toInstant().atOffset(ZoneOffset.UTC);
-        }
         isValid = true;
       }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In the case of an invalid license, commerical status of the license still needs to be read so that it can be passed to the front end for proper display 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
