### PR TITLE
refactor: ensure task manager is retry-able and test-able

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -73,6 +73,9 @@ public class CamundaExporter implements Exporter {
     ConfigValidator.validate(configuration);
     context.setFilter(new CamundaExporterRecordFilter());
     metrics = new CamundaExporterMetrics(context.getMeterRegistry());
+    clientAdapter = ClientAdapter.of(configuration);
+    provider.init(configuration, clientAdapter.getExporterEntityCacheProvider());
+
     taskManager =
         BackgroundTaskManager.create(
             context.getPartitionId(),
@@ -87,10 +90,6 @@ public class CamundaExporter implements Exporter {
   @Override
   public void open(final Controller controller) {
     this.controller = controller;
-    clientAdapter = ClientAdapter.of(configuration);
-
-    provider.init(configuration, clientAdapter.getExporterEntityCacheProvider());
-
     final var searchEngineClient = clientAdapter.getSearchEngineClient();
     final var schemaManager =
         new SchemaManager(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 public class CamundaExporter implements Exporter {
   private static final Logger LOG = LoggerFactory.getLogger(CamundaExporter.class);
 
-  private Context context;
   private Controller controller;
   private ExporterConfiguration configuration;
   private ClientAdapter clientAdapter;
@@ -69,7 +68,6 @@ public class CamundaExporter implements Exporter {
 
   @Override
   public void configure(final Context context) {
-    this.context = context;
     logger = context.getLogger();
     configuration = context.getConfiguration().instantiate(ExporterConfiguration.class);
     ConfigValidator.validate(configuration);
@@ -167,7 +165,7 @@ public class CamundaExporter implements Exporter {
 
   private ExporterBatchWriter createBatchWriter() {
     final var builder = ExporterBatchWriter.Builder.begin();
-    provider.getExportHandlers().stream().forEach(builder::withHandler);
+    provider.getExportHandlers().forEach(builder::withHandler);
     return builder.build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -11,8 +11,6 @@ import static java.util.Map.entry;
 
 import io.camunda.exporter.cache.ExporterEntityCacheImpl;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
-import io.camunda.exporter.cache.form.CachedFormEntity;
-import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.handlers.AuthorizationHandler;
@@ -96,15 +94,14 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   private Map<Class<? extends IndexTemplateDescriptor>, IndexTemplateDescriptor>
       templateDescriptorsMap;
 
-  private Set<ExportHandler> exportHandlers;
-  private boolean isElasticsearch;
+  private Set<ExportHandler<?, ?>> exportHandlers;
 
   @Override
   public void init(
       final ExporterConfiguration configuration,
       final ExporterEntityCacheProvider entityCacheProvider) {
     final var globalPrefix = configuration.getIndex().getPrefix();
-    isElasticsearch =
+    final var isElasticsearch =
         ConnectionTypes.from(configuration.getConnect().getType())
             .equals(ConnectionTypes.ELASTICSEARCH);
 
@@ -150,13 +147,13 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             entry(GroupIndex.class, new GroupIndex(globalPrefix, isElasticsearch)));
 
     final var processCache =
-        new ExporterEntityCacheImpl<Long, CachedProcessEntity>(
+        new ExporterEntityCacheImpl<>(
             10000,
             entityCacheProvider.getProcessCacheLoader(
                 indexDescriptorsMap.get(ProcessIndex.class).getFullQualifiedName(), new XMLUtil()));
 
     final var formCache =
-        new ExporterEntityCacheImpl<String, CachedFormEntity>(
+        new ExporterEntityCacheImpl<>(
             10000,
             entityCacheProvider.getFormCacheLoader(
                 indexDescriptorsMap.get(FormIndex.class).getFullQualifiedName()));
@@ -269,7 +266,7 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
   }
 
   @Override
-  public Set<ExportHandler> getExportHandlers() {
+  public Set<ExportHandler<?, ?>> getExportHandlers() {
     // Register all handlers here
     return exportHandlers;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterResourceProvider.java
@@ -45,5 +45,5 @@ public interface ExporterResourceProvider {
   /**
    * @return A {@link Set} of {@link ExportHandler} to be registered with the exporter
    */
-  Set<ExportHandler> getExportHandlers();
+  Set<ExportHandler<?, ?>> getExportHandlers();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -14,7 +14,6 @@ import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import io.camunda.exporter.tasks.archiver.ArchiverJob;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
 import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ElasticsearchRepository;
@@ -30,6 +29,7 @@ import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,21 +40,32 @@ import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 
 public final class BackgroundTaskManager implements CloseableSilently {
+
+  // TODO: consider making this configurable
+  private static final int MAX_BACKGROUND_THREADS = 3;
   private final int partitionId;
   private final ArchiverRepository repository;
   private final Logger logger;
   private final ScheduledExecutorService executor;
+  private final List<BackgroundTask> tasks;
+  private final ArchiverConfiguration config;
+
+  private int submittedTasks = 0;
 
   @VisibleForTesting
   BackgroundTaskManager(
       final int partitionId,
       final @WillCloseWhenClosed ArchiverRepository repository,
       final Logger logger,
-      final @WillCloseWhenClosed ScheduledExecutorService executor) {
+      final @WillCloseWhenClosed ScheduledExecutorService executor,
+      final List<BackgroundTask> tasks,
+      final ArchiverConfiguration config) {
     this.partitionId = partitionId;
     this.repository = Objects.requireNonNull(repository, "must specify a repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
+    this.tasks = Objects.requireNonNull(tasks, "must specify tasks");
+    this.config = Objects.requireNonNull(config, "must specify a config");
   }
 
   @Override
@@ -73,12 +84,24 @@ public final class BackgroundTaskManager implements CloseableSilently {
         repository);
   }
 
-  private void start(final ArchiverConfiguration config, final ArchiverJob... jobs) {
-    logger.debug("Starting {} archiver jobs", jobs.length);
-    for (final ArchiverJob job : jobs) {
+  public void start() {
+    // make sure this is retry-able, as this is called in the exporter's open phase, which can be
+    // retried; in this case, we don't want to resubmit previously submitted tasks
+    final var unsubmittedTasks = tasks.size() - submittedTasks;
+    if (unsubmittedTasks == 0) {
+      return;
+    }
+
+    logger.debug(
+        "Starting {} background tasks (with {} previously submitted tasks out of {} tasks)",
+        unsubmittedTasks,
+        submittedTasks,
+        tasks.size());
+    for (; submittedTasks < tasks.size(); submittedTasks++) {
+      final var task = tasks.get(submittedTasks);
       executor.submit(
           new ReschedulingTask(
-              job, config.getRolloverBatchSize(), config.getDelayBetweenRuns(), executor, logger));
+              task, config.getRolloverBatchSize(), config.getDelayBetweenRuns(), executor, logger));
     }
   }
 
@@ -94,21 +117,19 @@ public final class BackgroundTaskManager implements CloseableSilently {
             .name("exporter-" + exporterId + "-p" + partitionId + "-tasks-", 0)
             .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(logger))
             .factory();
-    final var executor = defaultExecutor(threadFactory, partitionId);
+    final var executor = defaultExecutor(threadFactory);
     final var repository =
         createRepository(config, resourceProvider, partitionId, executor, metrics, logger);
-    final var archiver = new BackgroundTaskManager(partitionId, repository, logger, executor);
-    final var processInstanceJob =
-        createProcessInstanceJob(metrics, logger, resourceProvider, repository, executor);
+    final List<BackgroundTask> tasks = new ArrayList<>();
+
+    tasks.add(createProcessInstanceJob(metrics, logger, resourceProvider, repository, executor));
     if (partitionId == START_PARTITION_ID) {
-      final var batchOperationJob =
-          createBatchOperationJob(metrics, logger, resourceProvider, repository, executor);
-      archiver.start(config.getArchiver(), processInstanceJob, batchOperationJob);
-    } else {
-      archiver.start(config.getArchiver(), processInstanceJob);
+      tasks.add(createBatchOperationJob(metrics, logger, resourceProvider, repository, executor));
     }
 
-    return archiver;
+    executor.setCorePoolSize(Math.min(tasks.size(), MAX_BACKGROUND_THREADS));
+    return new BackgroundTaskManager(
+        partitionId, repository, logger, executor, tasks, config.getArchiver());
   }
 
   private static ProcessInstancesArchiverJob createProcessInstanceJob(
@@ -153,11 +174,8 @@ public final class BackgroundTaskManager implements CloseableSilently {
         executor);
   }
 
-  private static ScheduledThreadPoolExecutor defaultExecutor(
-      final ThreadFactory threadFactory, final int partitionId) {
-    // if we are present on partition 1, we need to have 2 threads to handle both jobs
-    final var executor =
-        new ScheduledThreadPoolExecutor(partitionId == START_PARTITION_ID ? 2 : 1, threadFactory);
+  private static ScheduledThreadPoolExecutor defaultExecutor(final ThreadFactory threadFactory) {
+    final var executor = new ScheduledThreadPoolExecutor(0, threadFactory);
     executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     executor.setRemoveOnCancelPolicy(true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/CamundaExporterHandlerIT.java
@@ -431,6 +431,7 @@ public class CamundaExporterHandlerIT {
     return provider.getExportHandlers().stream()
         .filter(handler -> handler.getClass().equals(handlerClass))
         .findFirst()
+        .map(handler -> (ExportHandler<S, T>) handler)
         .orElseThrow();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -10,25 +10,93 @@ package io.camunda.exporter.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.agrona.collections.MutableInteger;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 
 @AutoCloseResources
 final class BackgroundTaskManagerTest {
-  @AutoCloseResource // ensures we always reap the thread no matter what
-  private final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+  @AutoCloseResource(closeMethod = "shutdownNow")
+  private final ScheduledThreadPoolExecutor executor =
+      Mockito.spy(new ScheduledThreadPoolExecutor(1));
+
+  @Nested
+  final class StartTest {
+    private final BackgroundTaskManager archiver =
+        new BackgroundTaskManager(
+            1,
+            new NoopArchiverRepository(),
+            LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
+            executor,
+            // return unfinished futures to have a deterministic count of submitted tasks
+            List.of(CompletableFuture::new, CompletableFuture::new),
+            new ArchiverConfiguration());
+
+    @Test
+    void shouldNotResubmitTasksOnStart() {
+      // given
+      archiver.start();
+
+      // when
+      archiver.start();
+
+      // then - we can't use `getTaskCount()` because that's an approximation of the number of tasks
+      // and it may be wrong at times, as per the docs
+      Mockito.verify(executor, Mockito.times(2)).submit(Mockito.any(Runnable.class));
+    }
+
+    @Test
+    void shouldResubmitUnsubmittedTasksOnStart() {
+      // given
+      final var count = new MutableInteger();
+      Mockito.doAnswer(
+              inv -> {
+                final var invocation = count.getAndIncrement();
+                // fail on the second call
+                if (invocation == 1) {
+                  throw new RuntimeException("fail");
+                }
+
+                return inv.callRealMethod();
+              })
+          .when(executor)
+          .submit(Mockito.any(Runnable.class));
+      assertThatCode(archiver::start)
+          .as("throws on the second task submission")
+          .isInstanceOf(RuntimeException.class);
+      Mockito.verify(executor, Mockito.times(2)).submit(Mockito.any(Runnable.class));
+
+      // when
+      archiver.start();
+
+      // we can't use `getTaskCount()` because that's an approximation of the number of tasks
+      // and it may be wrong at times, as per the docs
+      // then - we actually expect 3 submit calls, since the second one initially failed, and we're
+      // now re-submitting it again
+      Mockito.verify(executor, Mockito.times(3)).submit(Mockito.any(Runnable.class));
+    }
+  }
 
   @Nested
   final class CloseTest {
     private final CloseableRepository repository = new CloseableRepository();
     private final BackgroundTaskManager archiver =
         new BackgroundTaskManager(
-            1, repository, LoggerFactory.getLogger(BackgroundTaskManagerTest.class), executor);
+            1,
+            repository,
+            LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
+            executor,
+            List.of(),
+            new ArchiverConfiguration());
 
     @Test
     void shouldCloseExecutorOnClose() {


### PR DESCRIPTION
## Description

By passing the tasks to the manager at construction time, and not immediately starting it, we can improve how it will be handled in the exporter's open phase if that gets retried, and make sure it is retried in a safe way (e.g. do not resubmit the same task). That way, we ensure there is not the same task running twice which could cause concurrency issues.

Additionally, this will make it easier to unit and integration test, because we can now control when and how the tasks are executed, and have better introspection into the background task manager.

## Related issues

related to #24095
