### PR TITLE
Change reported name of HealthMonitorable and refactor HealthMonitor

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1000,8 +1000,12 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    *
    * @return The server name.
    */
-  @Override
   public String getName() {
+    return name;
+  }
+
+  @Override
+  public String componentName() {
     return name;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -46,6 +46,8 @@ import org.slf4j.LoggerFactory;
 public final class RaftPartition implements Partition, HealthMonitorable {
   private static final Logger LOG = LoggerFactory.getLogger(RaftPartition.class);
   private static final String PARTITION_NAME_FORMAT = "%s-partition-%d";
+  private static final String PARTITION_COMPONENT_NAME_FORMAT = "RaftPartition-%d";
+
   private final PartitionId partitionId;
   private final RaftPartitionConfig config;
   private final File dataDirectory;
@@ -145,7 +147,7 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   }
 
   @Override
-  public String getName() {
+  public String getName(){
     return name();
   }
 
@@ -162,6 +164,10 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   @Override
   public void removeFailureListener(final FailureListener failureListener) {
     server.removeFailureListener(failureListener);
+  }
+
+  public String componentName() {
+    return String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId.id());
   }
 
   /** Closes the partition. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftPartition.java
@@ -147,13 +147,14 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   }
 
   @Override
-  public String getName(){
-    return name();
+  public String componentName() {
+    return String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId.id());
   }
 
   @Override
   public HealthReport getHealthReport() {
-    return server.getHealthReport();
+    // name must be overridden otherwise it equals to name()
+    return server.getHealthReport().withName(componentName());
   }
 
   @Override
@@ -164,10 +165,6 @@ public final class RaftPartition implements Partition, HealthMonitorable {
   @Override
   public void removeFailureListener(final FailureListener failureListener) {
     server.removeFailureListener(failureListener);
-  }
-
-  public String componentName() {
-    return String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId.id());
   }
 
   /** Closes the partition. */

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -193,6 +193,11 @@ public class RaftPartitionServer implements HealthMonitorable {
   }
 
   @Override
+  public String componentName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
   public HealthReport getHealthReport() {
     return server.getContext().getHealthReport();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -692,6 +692,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   @Override
+  public String componentName() {
+    return name;
+  }
+
+  @Override
   public HealthReport getHealthReport() {
     return healthReport;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/PartitionRegistrationStep.java
@@ -39,7 +39,7 @@ public final class PartitionRegistrationStep implements StartupStep<PartitionSta
 
     final var partitionId = context.partitionMetadata().id().id();
     context.diskSpaceUsageMonitor().removeDiskUsageListener(context.zeebePartition());
-    context.brokerHealthCheckService().removeMonitoredPartition(partitionId);
+    context.brokerHealthCheckService().removeMonitoredPartition(context.zeebePartition());
     context.topologyManager().removePartition(partitionId);
 
     result.complete(context);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionRaftListener;
+import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -94,7 +95,6 @@ import org.slf4j.Logger;
  */
 public final class BrokerHealthCheckService extends Actor implements PartitionRaftListener {
 
-  private static final String PARTITION_COMPONENT_NAME_FORMAT = "Partition-%d";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private Map<Integer, Boolean> partitionInstallStatus;
   /* set to true when all partitions are installed. Once set to true, it is never
@@ -114,8 +114,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
         partitions.stream().collect(Collectors.toMap(metadata -> metadata.id().id(), p -> false));
     partitions.forEach(
         metadata ->
-            healthMonitor.monitorComponent(
-                String.format(PARTITION_COMPONENT_NAME_FORMAT, metadata.id().id())));
+            healthMonitor.monitorComponent(ZeebePartition.buildActorName(metadata.id().id())));
   }
 
   public boolean isBrokerReady() {
@@ -164,22 +163,20 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
     healthMonitor.startMonitoring();
   }
 
-  private void registerComponent(final String componentName, final HealthMonitorable component) {
-    actor.run(() -> healthMonitor.registerComponent(componentName, component));
+  private void registerComponent(final HealthMonitorable component) {
+    actor.run(() -> healthMonitor.registerComponent(component));
   }
 
   public void registerMonitoredPartition(final int partitionId, final HealthMonitorable partition) {
-    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
-    registerComponent(componentName, partition);
+    registerComponent(partition);
   }
 
-  public void removeMonitoredPartition(final int partitionId) {
-    final String componentName = String.format(PARTITION_COMPONENT_NAME_FORMAT, partitionId);
-    removeComponent(componentName);
+  public void removeMonitoredPartition(final HealthMonitorable partition) {
+    removeComponent(partition);
   }
 
-  private void removeComponent(final String componentName) {
-    actor.run(() -> healthMonitor.removeComponent(componentName));
+  private void removeComponent(final HealthMonitorable component) {
+    actor.run(() -> healthMonitor.removeComponent(component));
   }
 
   public boolean isBrokerHealthy() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/monitoring/BrokerHealthCheckService.java
@@ -114,7 +114,7 @@ public final class BrokerHealthCheckService extends Actor implements PartitionRa
         partitions.stream().collect(Collectors.toMap(metadata -> metadata.id().id(), p -> false));
     partitions.forEach(
         metadata ->
-            healthMonitor.monitorComponent(ZeebePartition.buildActorName(metadata.id().id())));
+            healthMonitor.monitorComponent(ZeebePartition.componentName(metadata.id().id())));
   }
 
   public boolean isBrokerReady() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartition.java
@@ -43,6 +43,7 @@ public final class ZeebePartition extends Actor
         DiskSpaceUsageListener,
         SnapshotReplicationListener {
 
+  public static final String ACTOR_NAME_PREFIX = "Partition";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
 
   private final StartupProcess<PartitionStartupContext> startupProcess;
@@ -82,15 +83,19 @@ public final class ZeebePartition extends Actor
 
     transition.setConcurrencyControl(actor);
 
-    actorName = buildActorName("ZeebePartition", transitionContext.getPartitionId());
+    actorName = buildActorName(transitionContext.getPartitionId());
     transitionContext.setComponentHealthMonitor(
         new CriticalComponentsHealthMonitor(
-            "Partition-" + transitionContext.getPartitionId(), actor, LOG));
+            ZeebePartition.buildActorName(transitionContext.getPartitionId()), actor, LOG));
     zeebePartitionHealth = new ZeebePartitionHealth(transitionContext.getPartitionId(), transition);
     healthMetrics = new HealthMetrics(transitionContext.getPartitionId());
     healthMetrics.setUnhealthy();
     failureListeners = new ArrayList<>();
     roleMetrics = new RoleMetrics(transitionContext.getPartitionId());
+  }
+
+  public static String buildActorName(final int partitionId) {
+    return buildActorName(ACTOR_NAME_PREFIX, partitionId);
   }
 
   public PartitionAdminAccess getAdminAccess() {
@@ -139,15 +144,11 @@ public final class ZeebePartition extends Actor
   @Override
   protected void onActorStarted() {
     context.getComponentHealthMonitor().startMonitoring();
-    context
-        .getComponentHealthMonitor()
-        .registerComponent(context.getRaftPartition().name(), context.getRaftPartition());
+    context.getComponentHealthMonitor().registerComponent(context.getRaftPartition());
     // Add a component that keep track of health of ZeebePartition. This way
     // criticalComponentsHealthMonitor can monitor the health of ZeebePartition similar to other
     // components.
-    context
-        .getComponentHealthMonitor()
-        .registerComponent(zeebePartitionHealth.getName(), zeebePartitionHealth);
+    context.getComponentHealthMonitor().registerComponent(zeebePartitionHealth);
   }
 
   @Override
@@ -179,8 +180,8 @@ public final class ZeebePartition extends Actor
           closing = true;
 
           removeListeners();
-          context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth.getName());
-          context.getComponentHealthMonitor().removeComponent(context.getRaftPartition().name());
+          context.getComponentHealthMonitor().removeComponent(zeebePartitionHealth);
+          context.getComponentHealthMonitor().removeComponent(context.getRaftPartition());
 
           final var inactiveTransitionFuture = transitionToInactive();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -80,7 +80,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
   }
 
   @Override
-  public String getName() {
+  public String componentName() {
     return name;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionHealth.java
@@ -37,7 +37,7 @@ class ZeebePartitionHealth implements HealthMonitorable {
 
   public ZeebePartitionHealth(
       final int partitionId, final PartitionTransition partitionTransition) {
-    name = "ZeebePartition-" + partitionId;
+    name = "ZeebePartitionHealth-" + partitionId;
     this.partitionTransition = partitionTransition;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/AsyncSnapshotDirector.java
@@ -201,6 +201,11 @@ public final class AsyncSnapshotDirector extends Actor
   }
 
   @Override
+  public String componentName() {
+    return actorName;
+  }
+
+  @Override
   public HealthReport getHealthReport() {
     return healthReport;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -61,7 +61,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     final var director = context.getExporterDirector();
     if (director != null && shouldCloseOnTransition(targetRole, context.getCurrentRole())) {
-      context.getComponentHealthMonitor().removeComponent(director.getName());
+      context.getComponentHealthMonitor().removeComponent(director);
       final ActorFuture<Void> future = director.closeAsync();
       future.onComplete(
           (success, error) -> {
@@ -129,7 +129,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());
 
-    context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+    context.getComponentHealthMonitor().registerComponent(director);
 
     final var startFuture = director.startAsync(context.getActorSchedulingService());
     startFuture.onComplete(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -40,7 +40,6 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
       context.setStreamClock(null);
-      context.getComponentHealthMonitor().removeComponent(logStream.getLogName());
       logStream.close();
       context.setLogStream(null);
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/SnapshotDirectorPartitionTransitionStep.java
@@ -28,7 +28,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
       final var director = context.getSnapshotDirector();
-      context.getComponentHealthMonitor().removeComponent(director.getName());
+      context.getComponentHealthMonitor().removeComponent(director);
       context.getRaftPartition().getServer().removeCommittedEntryListener(director);
       final ActorFuture<Void> future = director.closeAsync();
       future.onComplete(
@@ -79,7 +79,7 @@ public final class SnapshotDirectorPartitionTransitionStep implements PartitionT
           (ok, error) -> {
             if (error == null) {
               context.setSnapshotDirector(director);
-              context.getComponentHealthMonitor().registerComponent(director.getName(), director);
+              context.getComponentHealthMonitor().registerComponent(director);
               if (targetRole == Role.LEADER) {
                 server.addCommittedEntryListener(director);
               }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -65,7 +65,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
 
     if (streamprocessor != null
         && (shouldInstallOnTransition(targetRole, currentRole) || targetRole == Role.INACTIVE)) {
-      context.getComponentHealthMonitor().removeComponent(streamprocessor.getName());
+      context.getComponentHealthMonitor().removeComponent(streamprocessor);
       final ActorFuture<Void> future = streamprocessor.closeAsync();
       future.onComplete(
           (success, error) -> {
@@ -103,9 +103,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
                 streamProcessor.resumeProcessing();
               }
 
-              context
-                  .getComponentHealthMonitor()
-                  .registerComponent(streamProcessor.getName(), streamProcessor);
+              context.getComponentHealthMonitor().registerComponent(streamProcessor);
               future.complete(null);
             } else {
               future.completeExceptionally(err);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -414,7 +414,7 @@ public class ZeebePartitionTest {
 
     // then
     final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
     final var healthReport = captor.getValue().getHealthReport();
     assertThat(healthReport.getStatus()).isEqualTo(HealthStatus.UNHEALTHY);
     assertThat(healthReport.getIssue().message())
@@ -431,7 +431,7 @@ public class ZeebePartitionTest {
     schedulerRule.workUntilDone();
 
     // then
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
 
     final var zeebePartitionHealth = captor.getValue();
     final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
@@ -450,7 +450,7 @@ public class ZeebePartitionTest {
     doNothing().when(failureListener).onFailure(any());
 
     final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
     final var zeebePartitionHealth = captor.getValue();
     zeebePartitionHealth.addFailureListener(failureListener);
 
@@ -478,7 +478,7 @@ public class ZeebePartitionTest {
     doNothing().when(failureListener).onFailure(any());
 
     final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
     final var zeebePartitionHealth = captor.getValue();
     zeebePartitionHealth.addFailureListener(failureListener);
 
@@ -510,7 +510,7 @@ public class ZeebePartitionTest {
     doNothing().when(failureListener).onRecovered(any());
 
     final var captor = ArgumentCaptor.forClass(ZeebePartitionHealth.class);
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
     final var zeebePartitionHealth = captor.getValue();
     zeebePartitionHealth.addFailureListener(failureListener);
 
@@ -539,7 +539,7 @@ public class ZeebePartitionTest {
     schedulerRule.workUntilDone();
 
     // then
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
 
     final var zeebePartitionHealth = captor.getValue();
     final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
@@ -559,7 +559,7 @@ public class ZeebePartitionTest {
     schedulerRule.workUntilDone();
 
     // then
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
 
     final var zeebePartitionHealth = captor.getValue();
     final HealthReport healthReport = zeebePartitionHealth.getHealthReport();
@@ -581,7 +581,7 @@ public class ZeebePartitionTest {
     schedulerRule.workUntilDone();
 
     // then
-    verify(healthMonitor).registerComponent(any(), captor.capture());
+    verify(healthMonitor).registerComponent(captor.capture());
 
     final var zeebePartitionHealth = captor.getValue();
     final HealthReport healthReport = zeebePartitionHealth.getHealthReport();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -57,38 +57,38 @@ public class BrokerAdminServiceEndpointTest {
             "status": "HEALTHY",
             "componentsState": "HEALTHY",
             "children": [
-              {
-                "id": "ZeebePartition-1",
-                "name": "ZeebePartition-1",
-                "status": "HEALTHY",
-                "children": []
-              },
-              {
-                "id": "raft-partition-partition-1",
-                "name": "raft-partition-partition-1",
-                "status": "HEALTHY",
-                "children": []
-              },
-              {
-                "id": "SnapshotDirector-1",
-                "name": "SnapshotDirector-1",
-                "status": "HEALTHY",
-                "children": []
-              },
-              {
-                "id": "StreamProcessor-1",
-                "name": "StreamProcessor-1",
-                "status": "HEALTHY",
-                "children": []
-              },
-              {
-                "id": "Exporter-1",
-                "name": "Exporter-1",
-                "status": "HEALTHY",
-                "children": []
-              }
-            ]
-          }
+                {
+                 "id": "SnapshotDirector-1",
+                 "name": "SnapshotDirector-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "ZeebePartitionHealth-1",
+                 "name": "ZeebePartitionHealth-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "StreamProcessor-1",
+                 "name": "StreamProcessor-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "Exporter-1",
+                 "name": "Exporter-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "RaftPartition-1",
+                 "name": "RaftPartition-1",
+                 "status": "HEALTHY",
+                 "children": []
+               }
+             ]
+           }
         }
       }
       """;
@@ -109,43 +109,43 @@ public class BrokerAdminServiceEndpointTest {
           "modification": {}
         },
         "health": {
-          "id": "Partition-1",
-          "name": "Partition-1",
-          "status": "HEALTHY",
-          "componentsState": "HEALTHY",
-          "children": [
-            {
-              "id": "ZeebePartition-1",
-              "name": "ZeebePartition-1",
-              "status": "HEALTHY",
-              "children": []
-            },
-            {
-              "id": "raft-partition-partition-1",
-              "name": "raft-partition-partition-1",
-              "status": "HEALTHY",
-              "children": []
-            },
-            {
-              "id": "SnapshotDirector-1",
-              "name": "SnapshotDirector-1",
-              "status": "HEALTHY",
-              "children": []
-            },
-            {
-              "id": "StreamProcessor-1",
-              "name": "StreamProcessor-1",
-              "status": "HEALTHY",
-              "children": []
-            },
-            {
-              "id": "Exporter-1",
-              "name": "Exporter-1",
-              "status": "HEALTHY",
-              "children": []
-            }
-          ]
-        }
+             "id": "Partition-1",
+             "name": "Partition-1",
+             "status": "HEALTHY",
+             "componentsState": "HEALTHY",
+             "children": [
+               {
+                 "id": "SnapshotDirector-1",
+                 "name": "SnapshotDirector-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "ZeebePartitionHealth-1",
+                 "name": "ZeebePartitionHealth-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "StreamProcessor-1",
+                 "name": "StreamProcessor-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "Exporter-1",
+                 "name": "Exporter-1",
+                 "status": "HEALTHY",
+                 "children": []
+               },
+               {
+                 "id": "RaftPartition-1",
+                 "name": "RaftPartition-1",
+                 "status": "HEALTHY",
+                 "children": []
+               }
+             ]
+           }
       }
       """;
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -67,9 +67,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public void removeComponent(final String componentName) {
+  public void removeComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
+          final var componentName = component.getName();
           final var monitoredComponent = monitoredComponents.remove(componentName);
           if (monitoredComponent != null) {
             componentHealth.remove(componentName);
@@ -79,9 +80,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public void registerComponent(final String componentName, final HealthMonitorable component) {
+  public void registerComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
+          final var componentName = component.getName();
           final var monitoredComponent = new MonitoredComponent(componentName, component);
           monitoredComponents.put(componentName, monitoredComponent);
           componentHealth.put(componentName, component.getHealthReport());

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitor.java
@@ -67,23 +67,10 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public void removeComponent(final HealthMonitorable component) {
-    actor.run(
-        () -> {
-          final var componentName = component.getName();
-          final var monitoredComponent = monitoredComponents.remove(componentName);
-          if (monitoredComponent != null) {
-            componentHealth.remove(componentName);
-            monitoredComponent.component.removeFailureListener(monitoredComponent);
-          }
-        });
-  }
-
-  @Override
   public void registerComponent(final HealthMonitorable component) {
     actor.run(
         () -> {
-          final var componentName = component.getName();
+          final var componentName = component.componentName();
           final var monitoredComponent = new MonitoredComponent(componentName, component);
           monitoredComponents.put(componentName, monitoredComponent);
           componentHealth.put(componentName, component.getHealthReport());
@@ -94,7 +81,20 @@ public class CriticalComponentsHealthMonitor implements HealthMonitor {
   }
 
   @Override
-  public String getName() {
+  public void removeComponent(final HealthMonitorable component) {
+    actor.run(
+        () -> {
+          final var componentName = component.componentName();
+          final var monitoredComponent = monitoredComponents.remove(componentName);
+          if (monitoredComponent != null) {
+            componentHealth.remove(componentName);
+            monitoredComponent.component.removeFailureListener(monitoredComponent);
+          }
+        });
+  }
+
+  @Override
+  public String componentName() {
     return name;
   }
 

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -267,8 +267,8 @@ public class CriticalComponentsHealthMonitorTest {
     }
 
     @Override
-    public String getName() {
-      return (name != null) ? name : HealthMonitorable.super.getName();
+    public String componentName() {
+      return name;
     }
 
     @Override

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/health/CriticalComponentsHealthMonitorTest.java
@@ -63,8 +63,8 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorComponent() {
     // given
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("test", component);
+    final ControllableComponent component = new ControllableComponent("test");
+    monitor.registerComponent(component);
 
     // when
     waitUntilAllDone();
@@ -86,7 +86,7 @@ public class CriticalComponentsHealthMonitorTest {
   public void shouldRecover() {
     // given
     final ControllableComponent component = new ControllableComponent("test");
-    monitor.registerComponent("test", component);
+    monitor.registerComponent(component);
     waitUntilAllDone();
     component.setUnhealthy();
     waitUntilAllDone();
@@ -103,11 +103,11 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorMultipleComponent() {
     // given
-    final ControllableComponent component1 = new ControllableComponent();
-    final ControllableComponent component2 = new ControllableComponent();
+    final ControllableComponent component1 = new ControllableComponent("test1");
+    final ControllableComponent component2 = new ControllableComponent("test2");
 
-    monitor.registerComponent("test1", component1);
-    monitor.registerComponent("test2", component2);
+    monitor.registerComponent(component1);
+    monitor.registerComponent(component2);
 
     waitUntilAllDone();
     Awaitility.await("component is healthy")
@@ -143,12 +143,12 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldRemoveComponent() {
     // given
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("test", component);
+    final ControllableComponent component = new ControllableComponent("test");
+    monitor.registerComponent(component);
     Awaitility.await().until(() -> monitor.getHealthReport().getStatus() == HealthStatus.HEALTHY);
 
     // when
-    monitor.removeComponent("test");
+    monitor.removeComponent(component);
     waitUntilAllDone();
     component.setUnhealthy();
     waitUntilAllDone();
@@ -160,11 +160,11 @@ public class CriticalComponentsHealthMonitorTest {
   @Test
   public void shouldMonitorComponentDeath() {
     // given
-    final ControllableComponent component1 = new ControllableComponent();
-    final ControllableComponent component2 = new ControllableComponent();
+    final ControllableComponent component1 = new ControllableComponent("comp1");
+    final ControllableComponent component2 = new ControllableComponent("comp2");
 
-    monitor.registerComponent("comp1", component1);
-    monitor.registerComponent("comp2", component2);
+    monitor.registerComponent(component1);
+    monitor.registerComponent(component2);
     waitUntilAllDone();
 
     // when/then
@@ -195,13 +195,13 @@ public class CriticalComponentsHealthMonitorTest {
 
       parentComponents[i] = parentComponent;
       if (i > 0) {
-        parentComponents[i - 1].registerComponent(parentComponent.getName(), parentComponent);
+        parentComponents[i - 1].registerComponent(parentComponent);
       }
 
       for (int j = 0; j < children; j++) {
         final var component = new ControllableComponent("child-at-%d-%d".formatted(i, j));
         components[i][j] = component;
-        parentComponents[i].registerComponent(component.getName(), component);
+        parentComponents[i].registerComponent(component);
       }
     }
     waitUntilAllDone();
@@ -234,8 +234,8 @@ public class CriticalComponentsHealthMonitorTest {
   public void shouldTrackRootIssue() {
     // given
     final var issue = HealthIssue.of(new IllegalStateException(), Instant.ofEpochMilli(19201293L));
-    final ControllableComponent component = new ControllableComponent();
-    monitor.registerComponent("component", component);
+    final ControllableComponent component = new ControllableComponent("component");
+    monitor.registerComponent(component);
     waitUntilAllDone();
 
     // when
@@ -260,10 +260,6 @@ public class CriticalComponentsHealthMonitorTest {
     private final Set<FailureListener> failureListeners = new HashSet<>();
     private volatile HealthReport healthReport;
     private final String name;
-
-    public ControllableComponent() {
-      this(null);
-    }
 
     public ControllableComponent(final String name) {
       this.name = name;

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -463,6 +463,11 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   @Override
+  public String componentName() {
+    return actorName;
+  }
+
+  @Override
   public HealthReport getHealthReport() {
     final var instant =
         ActorClock.current() != null ? ActorClock.current().instant() : Instant.now();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
@@ -24,15 +24,15 @@ public interface HealthMonitor extends HealthMonitorable {
    * component is registered using {@link #registerComponent(HealthMonitorable)}.
    *
    * <p>The component name must be consistent with the value returned by the method {@link
-   * HealthMonitorable#getName()}
+   * HealthMonitorable#componentName()} ()}
    */
   void monitorComponent(String componentName);
 
   /**
    * Register the component to be monitored.
    *
-   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
-   * component
+   * <p>The implementation must use the {@link HealthMonitorable#componentName()} field to identify
+   * a component
    *
    * @param component to register
    */
@@ -41,8 +41,8 @@ public interface HealthMonitor extends HealthMonitorable {
   /**
    * Stop monitoring the component.
    *
-   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
-   * component
+   * <p>The implementation must use the {@link HealthMonitorable#componentName()} field to identify
+   * a component
    *
    * @param component to be removed
    */

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitor.java
@@ -21,22 +21,30 @@ public interface HealthMonitor extends HealthMonitorable {
 
   /**
    * Add a component name to be monitored. The component will be marked not healthy until the
-   * component is registered using {@link #registerComponent(String, HealthMonitorable)}
+   * component is registered using {@link #registerComponent(HealthMonitorable)}.
+   *
+   * <p>The component name must be consistent with the value returned by the method {@link
+   * HealthMonitorable#getName()}
    */
   void monitorComponent(String componentName);
 
   /**
-   * Stop monitoring the component.
+   * Register the component to be monitored.
    *
-   * @param componentName
+   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
+   * component
+   *
+   * @param component to register
    */
-  void removeComponent(String componentName);
+  void registerComponent(final HealthMonitorable component);
 
   /**
-   * Register the component to be monitored
+   * Stop monitoring the component.
    *
-   * @param componentName
-   * @param component
+   * <p>The implementation must use the {@link HealthMonitorable#getName()} field to identify a
+   * component
+   *
+   * @param component to be removed
    */
-  void registerComponent(String componentName, HealthMonitorable component);
+  void removeComponent(final HealthMonitorable component);
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthMonitorable.java
@@ -12,14 +12,11 @@ public interface HealthMonitorable {
 
   /**
    * Used by a HealthMonitor to get the name of this component. Most `HealthMonitorable`s override
-   * this method to return their actor name. If they don't override the method, the name of the
-   * class is returned.
+   * this method to return their actor name.
    *
    * @return the name of this component
    */
-  default String getName() {
-    return getClass().getSimpleName();
-  }
+  String componentName();
 
   /**
    * Used by a HealthMonitor to get the health status of this component, typically invoked

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/health/HealthReport.java
@@ -45,7 +45,7 @@ public record HealthReport(
       final HealthStatus status,
       final HealthIssue issue,
       final Map<String, HealthReport> children) {
-    this(component.getName(), status, issue, children);
+    this(component.componentName(), status, issue, children);
   }
 
   public static Optional<HealthReport> fromChildrenStatus(
@@ -114,5 +114,9 @@ public record HealthReport(
 
   public HealthReport withIssue(final Throwable e, final Instant since) {
     return new HealthReport(componentName, status, HealthIssue.of(e, since), children);
+  }
+
+  public HealthReport withName(final String name) {
+    return new HealthReport(name, status, issue, children);
   }
 }


### PR DESCRIPTION
## Description

- Change the name of `ZeebePartitionHealth` and `RaftPartition`, so that the displayed name in Health functionalities is more consistent
-  refactor `HealthMonitor` to use the `HealthMonitorable`'s name instead of a separated string

Before:
```json
"health": {
    "id": "Partition-1",
    "name": "Partition-1",
    "status": "HEALTHY",
    "componentsState": "HEALTHY",
    "children": [
      {
        "id": "ZeebePartition-1",
        "name": "ZeebePartition-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "raft-partition-partition-1",
        "name": "raft-partition-partition-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "SnapshotDirector-1",
        "name": "SnapshotDirector-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "StreamProcessor-1",
        "name": "StreamProcessor-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "Exporter-1",
        "name": "Exporter-1",
        "status": "HEALTHY",
        "children": []
      }
    ]
  }
```



After:
```json
"health": {
    "id": "Partition-1",
    "name": "Partition-1",
    "status": "HEALTHY",
    "componentsState": "HEALTHY",
    "children": [
      {
        "id": "SnapshotDirector-1",
        "name": "SnapshotDirector-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "ZeebePartitionHealth-1",
        "name": "ZeebePartitionHealth-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "StreamProcessor-1",
        "name": "StreamProcessor-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "Exporter-1",
        "name": "Exporter-1",
        "status": "HEALTHY",
        "children": []
      },
      {
        "id": "RaftPartition-1",
        "name": "RaftPartition-1",
        "status": "HEALTHY",
        "children": []
      }
    ]
  }
```
