### PR TITLE
feat: support decisionInstances in rdbms #23266

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -8,6 +8,7 @@
 package io.camunda.db.rdbms;
 
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
@@ -22,6 +23,7 @@ public class RdbmsService {
 
   private final RdbmsWriterFactory rdbmsWriterFactory;
   private final DecisionDefinitionReader decisionDefinitionReader;
+  private final DecisionInstanceReader decisionInstanceReader;
   private final DecisionRequirementsReader decisionRequirementsReader;
   private final FlowNodeInstanceReader flowNodeInstanceReader;
   private final ProcessDefinitionReader processDefinitionReader;
@@ -32,6 +34,7 @@ public class RdbmsService {
   public RdbmsService(
       final RdbmsWriterFactory rdbmsWriterFactory,
       final DecisionDefinitionReader decisionDefinitionReader,
+      final DecisionInstanceReader decisionInstanceReader,
       final DecisionRequirementsReader decisionRequirementsReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
@@ -41,6 +44,7 @@ public class RdbmsService {
     this.rdbmsWriterFactory = rdbmsWriterFactory;
     this.decisionRequirementsReader = decisionRequirementsReader;
     this.decisionDefinitionReader = decisionDefinitionReader;
+    this.decisionInstanceReader = decisionInstanceReader;
     this.flowNodeInstanceReader = flowNodeInstanceReader;
     this.processDefinitionReader = processDefinitionReader;
     this.processInstanceReader = processInstanceReader;
@@ -50,6 +54,10 @@ public class RdbmsService {
 
   public DecisionDefinitionReader getDecisionDefinitionReader() {
     return decisionDefinitionReader;
+  }
+
+  public DecisionInstanceReader getDecisionInstanceReader() {
+    return decisionInstanceReader;
   }
 
   public DecisionRequirementsReader getDecisionRequirementsReader() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionInstanceDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/DecisionInstanceDbQuery.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.domain;
+
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record DecisionInstanceDbQuery(
+    DecisionInstanceFilter filter, DbQuerySorting<DecisionInstanceEntity> sort, DbQueryPage page) {
+
+  public static DecisionInstanceDbQuery of(
+      final Function<DecisionInstanceDbQuery.Builder, ObjectBuilder<DecisionInstanceDbQuery>> fn) {
+    return fn.apply(new DecisionInstanceDbQuery.Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<DecisionInstanceDbQuery> {
+
+    private static final DecisionInstanceFilter EMPTY_FILTER =
+        FilterBuilders.decisionInstance().build();
+
+    private DecisionInstanceFilter filter;
+    private DbQuerySorting<DecisionInstanceEntity> sort;
+    private DbQueryPage page;
+
+    public Builder filter(final DecisionInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder sort(final DbQuerySorting<DecisionInstanceEntity> value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<DecisionInstanceFilter.Builder, ObjectBuilder<DecisionInstanceFilter>> fn) {
+      return filter(FilterBuilders.decisionInstance(fn));
+    }
+
+    public Builder sort(
+        final Function<
+                DbQuerySorting.Builder<DecisionInstanceEntity>,
+                ObjectBuilder<DbQuerySorting<DecisionInstanceEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
+    }
+
+    @Override
+    public DecisionInstanceDbQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new DecisionInstanceDbQuery(filter, sort, page);
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.read.service;
+
+import io.camunda.db.rdbms.read.domain.DecisionInstanceDbQuery;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
+import io.camunda.db.rdbms.sql.columns.DecisionInstanceSearchColumn;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedInput;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceInputEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputEntity;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.result.DecisionInstanceQueryResultConfig;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DecisionInstanceReader extends AbstractEntityReader<DecisionInstanceEntity> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DecisionInstanceReader.class);
+
+  private final DecisionInstanceMapper decisionInstanceMapper;
+
+  public DecisionInstanceReader(final DecisionInstanceMapper decisionInstanceMapper) {
+    super(DecisionInstanceSearchColumn::findByProperty);
+    this.decisionInstanceMapper = decisionInstanceMapper;
+  }
+
+  public Optional<DecisionInstanceEntity> findOne(final String decisionInstanceId) {
+    LOG.trace("[RDBMS DB] Search for decision instance with key {}", decisionInstanceId);
+    final var result =
+        search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(f -> f.decisionInstanceIds(decisionInstanceId))
+                        .resultConfig(
+                            r -> r.includeEvaluatedInputs(true).includeEvaluatedOutputs(true))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
+  }
+
+  public SearchQueryResult<DecisionInstanceEntity> search(final DecisionInstanceQuery query) {
+    final var dbSort = convertSort(query.sort(), DecisionInstanceSearchColumn.DECISION_INSTANCE_ID);
+    final var dbQuery =
+        DecisionInstanceDbQuery.of(
+            b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
+
+    LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
+    final var totalHits = decisionInstanceMapper.count(dbQuery);
+    final var hits = enhanceEntities(decisionInstanceMapper.search(dbQuery), query.resultConfig());
+
+    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+  }
+
+  /**
+   * Based on the result config, re batch-load here additional data (input, output values) with one
+   * SQL each (if enabled).
+   */
+  private List<DecisionInstanceEntity> enhanceEntities(
+      final List<DecisionInstanceEntity> intermediateResult,
+      final DecisionInstanceQueryResultConfig resultConfig) {
+    if (intermediateResult.isEmpty()) {
+      return intermediateResult;
+    }
+
+    if (resultConfig == null
+        || (!resultConfig.includeEvaluatedInputs() && !resultConfig.includeEvaluatedOutputs())) {
+      return intermediateResult;
+    }
+
+    final Map<String, List<EvaluatedInput>> inputs = new HashMap<>();
+    final Map<String, List<EvaluatedOutput>> outputs = new HashMap<>();
+    final List<String> keys =
+        intermediateResult.stream().map(DecisionInstanceEntity::decisionInstanceId).toList();
+    if (resultConfig.includeEvaluatedInputs()) {
+      inputs.putAll(
+          decisionInstanceMapper.loadInputs(keys).stream()
+              .collect(Collectors.groupingBy(EvaluatedInput::decisionInstanceId)));
+    }
+    if (resultConfig.includeEvaluatedOutputs()) {
+      outputs.putAll(
+          decisionInstanceMapper.loadOutputs(keys).stream()
+              .collect(Collectors.groupingBy(EvaluatedOutput::decisionInstanceId)));
+    }
+
+    return intermediateResult.stream()
+        .map(
+            entity ->
+                entity.toBuilder()
+                    .evaluatedInputs(
+                        mapInputList(inputs.getOrDefault(entity.decisionInstanceId(), List.of())))
+                    .evaluatedOutputs(
+                        mapOutputList(outputs.getOrDefault(entity.decisionInstanceId(), List.of())))
+                    .build())
+        .toList();
+  }
+
+  private List<DecisionInstanceInputEntity> mapInputList(final List<EvaluatedInput> inputList) {
+    return inputList.stream()
+        .map(i -> new DecisionInstanceInputEntity(i.id(), i.name(), i.value()))
+        .toList();
+  }
+
+  private List<DecisionInstanceOutputEntity> mapOutputList(final List<EvaluatedOutput> outputList) {
+    return outputList.stream()
+        .map(
+            o ->
+                new DecisionInstanceOutputEntity(
+                    o.id(), o.name(), o.value(), o.ruleId(), o.ruleIndex()))
+        .toList();
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/DecisionInstanceMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql;
+
+import io.camunda.db.rdbms.read.domain.DecisionInstanceDbQuery;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import java.util.List;
+
+public interface DecisionInstanceMapper {
+
+  void insert(DecisionInstanceDbModel decisionInstance);
+
+  Long count(DecisionInstanceDbQuery filter);
+
+  List<DecisionInstanceEntity> search(DecisionInstanceDbQuery filter);
+
+  List<DecisionInstanceDbModel.EvaluatedInput> loadInputs(List<String> decisionInstanceIds);
+
+  List<DecisionInstanceDbModel.EvaluatedOutput> loadOutputs(List<String> decisionInstanceIds);
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/DecisionInstanceSearchColumn.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.function.Function;
+
+public enum DecisionInstanceSearchColumn implements SearchColumn<DecisionInstanceEntity> {
+  DECISION_INSTANCE_ID("decisionInstanceId", DecisionInstanceEntity::decisionInstanceId),
+  DECISION_INSTANCE_KEY("decisionInstanceKey", DecisionInstanceEntity::decisionInstanceKey),
+  PROCESS_DEFINITION_KEY("processDefinitionKey", DecisionInstanceEntity::processDefinitionKey),
+  DECISION_DEFINITION_NAME(
+      "decisionDefinitionName", DecisionInstanceEntity::decisionDefinitionName),
+  DECISION_DEFINITION_ID("decisionDefinitionId", DecisionInstanceEntity::decisionDefinitionId),
+  DECISION_DEFINITION_KEY("decisionDefinitionKey", DecisionInstanceEntity::decisionDefinitionKey),
+  DECISION_DEFINITION_VERSION(
+      "decisionDefinitionVersion", DecisionInstanceEntity::decisionDefinitionVersion),
+  DECISION_DEFINITION_TYPE(
+      "decisionDefinitionType", DecisionInstanceEntity::decisionDefinitionType),
+  TENANT_ID("tenantId", DecisionInstanceEntity::tenantId),
+  EVALUATION_DATE(
+      "evaluationDate", DecisionInstanceEntity::evaluationDate, DateUtil::fuzzyToOffsetDateTime),
+  STATE("state", DecisionInstanceEntity::state),
+  RESULT("result", DecisionInstanceEntity::result),
+  EVALUATION_FAILURE("evaluationFailure", DecisionInstanceEntity::evaluationFailure);
+
+  private final String property;
+  private final Function<DecisionInstanceEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  DecisionInstanceSearchColumn(
+      final String property, final Function<DecisionInstanceEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  DecisionInstanceSearchColumn(
+      final String property,
+      final Function<DecisionInstanceEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final DecisionInstanceEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static DecisionInstanceSearchColumn findByProperty(final String property) {
+    for (final DecisionInstanceSearchColumn column : DecisionInstanceSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriter.java
@@ -9,6 +9,7 @@ package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
+import io.camunda.db.rdbms.write.service.DecisionInstanceWriter;
 import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
@@ -21,6 +22,7 @@ public class RdbmsWriter {
 
   private final ExecutionQueue executionQueue;
   private final DecisionDefinitionWriter decisionDefinitionWriter;
+  private final DecisionInstanceWriter decisionInstanceWriter;
   private final DecisionRequirementsWriter decisionRequirementsWriter;
   private final ExporterPositionService exporterPositionService;
   private final FlowNodeInstanceWriter flowNodeInstanceWriter;
@@ -34,6 +36,7 @@ public class RdbmsWriter {
     this.executionQueue = executionQueue;
     this.exporterPositionService = exporterPositionService;
     decisionDefinitionWriter = new DecisionDefinitionWriter(executionQueue);
+    decisionInstanceWriter = new DecisionInstanceWriter(executionQueue);
     decisionRequirementsWriter = new DecisionRequirementsWriter(executionQueue);
     flowNodeInstanceWriter = new FlowNodeInstanceWriter(executionQueue);
     processDefinitionWriter = new ProcessDefinitionWriter(executionQueue);
@@ -44,6 +47,10 @@ public class RdbmsWriter {
 
   public DecisionDefinitionWriter getDecisionDefinitionWriter() {
     return decisionDefinitionWriter;
+  }
+
+  public DecisionInstanceWriter getDecisionInstanceWriter() {
+    return decisionInstanceWriter;
   }
 
   public DecisionRequirementsWriter getDecisionRequirementsWriter() {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/DecisionInstanceDbModel.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.domain;
+
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.function.Function;
+
+public record DecisionInstanceDbModel(
+    String decisionInstanceId,
+    Long decisionInstanceKey,
+    DecisionInstanceState state,
+    OffsetDateTime evaluationDate,
+    String evaluationFailure,
+    String result,
+    Long flowNodeInstanceKey,
+    String flowNodeId,
+    Long processInstanceKey,
+    Long processDefinitionKey,
+    String processDefinitionId,
+    Long decisionDefinitionKey,
+    String decisionDefinitionId,
+    Long decisionRequirementsKey,
+    String decisionRequirementsId,
+    Long rootDecisionDefinitionKey,
+    DecisionDefinitionType decisionType,
+    String tenantId,
+    List<EvaluatedInput> evaluatedInputs,
+    List<EvaluatedOutput> evaluatedOutputs) {
+
+  public static DecisionInstanceDbModel of(
+      final Function<Builder, ObjectBuilder<DecisionInstanceDbModel>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder implements ObjectBuilder<DecisionInstanceDbModel> {
+
+    private String decisionInstanceId;
+    private Long decisionInstanceKey;
+    private DecisionInstanceState state;
+    private OffsetDateTime evaluationDate;
+    private String evaluationFailure;
+    private String result;
+    private Long flowNodeInstanceKey;
+    private String flowNodeId;
+    private Long processInstanceKey;
+    private Long processDefinitionKey;
+    private String processDefinitionId;
+    private Long decisionDefinitionKey;
+    private String decisionDefinitionId;
+    private Long decisionRequirementsKey;
+    private String decisionRequirementsId;
+    private Long rootDecisionDefinitionKey;
+    private DecisionDefinitionType decisionType;
+    private String tenantId;
+    private List<EvaluatedInput> evaluatedInputs;
+    private List<EvaluatedOutput> evaluatedOutputs;
+
+    public Builder decisionInstanceId(final String value) {
+      decisionInstanceId = value;
+      return this;
+    }
+
+    public Builder decisionInstanceKey(final Long value) {
+      decisionInstanceKey = value;
+      return this;
+    }
+
+    public Builder state(final DecisionInstanceState value) {
+      state = value;
+      return this;
+    }
+
+    public Builder evaluationDate(final OffsetDateTime value) {
+      evaluationDate = value;
+      return this;
+    }
+
+    public Builder evaluationFailure(final String value) {
+      evaluationFailure = value;
+      return this;
+    }
+
+    public Builder result(final String value) {
+      result = value;
+      return this;
+    }
+
+    public Builder flowNodeInstanceKey(final Long value) {
+      flowNodeInstanceKey = value;
+      return this;
+    }
+
+    public Builder flowNodeId(final String value) {
+      flowNodeId = value;
+      return this;
+    }
+
+    public Builder processInstanceKey(final Long value) {
+      processInstanceKey = value;
+      return this;
+    }
+
+    public Builder processDefinitionKey(final Long value) {
+      processDefinitionKey = value;
+      return this;
+    }
+
+    public Builder processDefinitionId(final String value) {
+      processDefinitionId = value;
+      return this;
+    }
+
+    public Builder decisionDefinitionKey(final Long value) {
+      decisionDefinitionKey = value;
+      return this;
+    }
+
+    public Builder decisionDefinitionId(final String value) {
+      decisionDefinitionId = value;
+      return this;
+    }
+
+    public Builder decisionRequirementsKey(final Long value) {
+      decisionRequirementsKey = value;
+      return this;
+    }
+
+    public Builder decisionRequirementsId(final String value) {
+      decisionRequirementsId = value;
+      return this;
+    }
+
+    public Builder rootDecisionDefinitionKey(final Long value) {
+      rootDecisionDefinitionKey = value;
+      return this;
+    }
+
+    public Builder decisionType(final DecisionDefinitionType value) {
+      decisionType = value;
+      return this;
+    }
+
+    public Builder tenantId(final String value) {
+      tenantId = value;
+      return this;
+    }
+
+    public Builder evaluatedInputs(final List<EvaluatedInput> value) {
+      evaluatedInputs = value;
+      return this;
+    }
+
+    public Builder evaluatedOutputs(final List<EvaluatedOutput> value) {
+      evaluatedOutputs = value;
+      return this;
+    }
+
+    @Override
+    public DecisionInstanceDbModel build() {
+      return new DecisionInstanceDbModel(
+          decisionInstanceId,
+          decisionInstanceKey,
+          state,
+          evaluationDate,
+          evaluationFailure,
+          result,
+          flowNodeInstanceKey,
+          flowNodeId,
+          processInstanceKey,
+          processDefinitionKey,
+          processDefinitionId,
+          decisionDefinitionKey,
+          decisionDefinitionId,
+          decisionRequirementsKey,
+          decisionRequirementsId,
+          rootDecisionDefinitionKey,
+          decisionType,
+          tenantId,
+          evaluatedInputs,
+          evaluatedOutputs);
+    }
+  }
+
+  public record EvaluatedInput(String decisionInstanceId, String id, String name, String value) {}
+
+  public record EvaluatedOutput(
+      String decisionInstanceId,
+      String id,
+      String name,
+      String value,
+      String ruleId,
+      Integer ruleIndex) {}
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ContextType.java
@@ -10,6 +10,7 @@ package io.camunda.db.rdbms.write.queue;
 public enum ContextType {
   EXPORTER_POSITION,
   DECISION_DEFINITION,
+  DECISION_INSTANCE,
   PROCESS_DEFINITION,
   PROCESS_INSTANCE,
   FLOW_NODE,

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/service/DecisionInstanceWriter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.service;
+
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+
+public class DecisionInstanceWriter {
+
+  private final ExecutionQueue executionQueue;
+
+  public DecisionInstanceWriter(final ExecutionQueue executionQueue) {
+    this.executionQueue = executionQueue;
+  }
+
+  public void create(final DecisionInstanceDbModel decisionInstance) {
+    executionQueue.executeInQueue(
+        new QueueItem(
+            ContextType.DECISION_INSTANCE,
+            decisionInstance.decisionInstanceKey(),
+            "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insert",
+            decisionInstance));
+    if (decisionInstance.evaluatedInputs() != null
+        && !decisionInstance.evaluatedInputs().isEmpty()) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.DECISION_INSTANCE,
+              decisionInstance.decisionInstanceKey(),
+              "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertInput",
+              decisionInstance));
+    }
+    if (decisionInstance.evaluatedOutputs() != null
+        && !decisionInstance.evaluatedOutputs().isEmpty()) {
+      executionQueue.executeInQueue(
+          new QueueItem(
+              ContextType.DECISION_INSTANCE,
+              decisionInstance.decisionInstanceKey(),
+              "io.camunda.db.rdbms.sql.DecisionInstanceMapper.insertOutput",
+              decisionInstance));
+    }
+  }
+}

--- a/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
+++ b/db/rdbms/src/main/resources/db/changelog/rdbms-support/changesets/create_engine.xml
@@ -196,4 +196,64 @@
     </createIndex>
   </changeSet>
 
+  <changeSet id="create_decision_instance_table" author="cthiel">
+    <createTable tableName="DECISION_INSTANCE">
+      <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)" >
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="DECISION_INSTANCE_KEY" type="BIGINT" />
+      <column name="PROCESS_INSTANCE_KEY" type="BIGINT" />
+      <column name="PROCESS_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="PROCESS_DEFINITION_KEY" type="BIGINT" />
+      <column name="DECISION_DEFINITION_ID" type="VARCHAR(255)" />
+      <column name="DECISION_DEFINITION_KEY" type="BIGINT" />
+      <column name="DECISION_REQUIREMENTS_ID" type="VARCHAR(255)" />
+      <column name="DECISION_REQUIREMENTS_KEY" type="BIGINT" />
+      <column name="FLOW_NODE_ID" type="VARCHAR(255)" />
+      <column name="FLOW_NODE_INSTANCE_KEY" type="BIGINT" />
+      <column name="ROOT_DECISION_DEFINITION_KEY" type="BIGINT" />
+      <column name="EVALUATION_DATE" type="TIMESTAMP WITH TIME ZONE(3)" />
+      <column name="TYPE" type="VARCHAR(255)" />
+      <column name="STATE" type="VARCHAR(255)" />
+      <column name="RESULT" type="VARCHAR(255)" />
+      <column name="EVALUATION_FAILURE" type="VARCHAR(255)" />
+      <column name="TENANT_ID" type="VARCHAR(255)" />
+    </createTable>
+
+    <modifySql dbms="mariadb">
+      <!-- MariaDB doesn't support TIMESTAMP WITH TIME ZONE, but its TIMESTAMP type has already a time zone -->
+      <replace replace="TIMESTAMP WITH TIME ZONE" with="TIMESTAMP"/>
+    </modifySql>
+  </changeSet>
+
+  <changeSet id="create_decision_instance_input_table" author="cthiel">
+    <createTable tableName="DECISION_INSTANCE_INPUT">
+      <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="INPUT_ID" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="INPUT_NAME" type="VARCHAR(255)" />
+      <column name="INPUT_VALUE" type="VARCHAR(4000)" />
+    </createTable>
+    <!-- No additional index for DECISION_INSTANCE_KEY needed -->
+  </changeSet>
+
+  <changeSet id="create_decision_instance_output_table" author="cthiel">
+    <createTable tableName="DECISION_INSTANCE_OUTPUT">
+      <column name="DECISION_INSTANCE_ID" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="OUTPUT_ID" type="VARCHAR(255)">
+        <constraints primaryKey="true"/>
+      </column>
+      <column name="OUTPUT_NAME" type="VARCHAR(255)" />
+      <column name="OUTPUT_VALUE" type="VARCHAR(4000)" />
+      <column name="RULE_ID" type="VARCHAR(255)" />
+      <column name="RULE_INDEX" type="SMALLINT" />
+    </createTable>
+    <!-- No additional index for DECISION_INSTANCE_KEY needed -->
+  </changeSet>
+
 </databaseChangeLog>

--- a/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/DecisionInstanceMapper.xml
@@ -1,0 +1,269 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+  ~ one or more contributor license agreements. See the NOTICE file distributed
+  ~ with this work for additional information regarding copyright ownership.
+  ~ Licensed under the Camunda License 1.0. You may not use this file
+  ~ except in compliance with the Camunda License 1.0.
+  -->
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="io.camunda.db.rdbms.sql.DecisionInstanceMapper">
+
+  <select id="count" resultType="java.lang.Long">
+    SELECT COUNT(*)
+    FROM DECISION_INSTANCE di
+    LEFT JOIN DECISION_DEFINITION dd ON (di.DECISION_DEFINITION_KEY = dd.DECISION_DEFINITION_KEY)
+    <include refid="io.camunda.db.rdbms.sql.DecisionInstanceMapper.searchFilter"/>
+  </select>
+
+  <!-- default search statement for databases supporting LIMIT/OFFSET-->
+  <select id="search" parameterType="io.camunda.db.rdbms.read.domain.DecisionInstanceDbQuery"
+    resultMap="io.camunda.db.rdbms.sql.DecisionInstanceMapper.searchResultMap">
+    SELECT * FROM (
+    SELECT di.DECISION_INSTANCE_ID,
+    di.DECISION_INSTANCE_KEY,
+    di.PROCESS_INSTANCE_KEY,
+    di.PROCESS_DEFINITION_ID,
+    di.PROCESS_DEFINITION_KEY,
+    di.DECISION_DEFINITION_KEY,
+    di.DECISION_DEFINITION_ID,
+    di.STATE,
+    di.TYPE, /* TODO really save it there? */
+    di.EVALUATION_DATE,
+    di.RESULT,
+    di.EVALUATION_FAILURE,
+    di.TENANT_ID,
+    NULL AS EVALUATED_INPUTS,
+    NULL AS EVALUATED_OUTPUTS,
+    dd.NAME AS DECISION_DEFINITION_NAME,
+    dd.VERSION AS DECISION_DEFINITION_VERSION
+    FROM DECISION_INSTANCE di
+    LEFT JOIN DECISION_DEFINITION dd ON (di.DECISION_DEFINITION_KEY = dd.DECISION_DEFINITION_KEY)
+    <include refid="io.camunda.db.rdbms.sql.DecisionInstanceMapper.searchFilter"/>
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
+  </select>
+
+  <sql id="searchFilter">
+    WHERE 1 = 1
+    <!-- basic filters -->
+    <if
+      test="filter.decisionInstanceIds != null and !filter.decisionInstanceIds.isEmpty()">
+      AND di.DECISION_INSTANCE_ID IN
+      <foreach collection="filter.decisionInstanceIds" item="key" open="(" close=")" separator=", ">
+        #{key}
+      </foreach>
+    </if>
+    <if
+      test="filter.decisionInstanceKeys != null and !filter.decisionInstanceKeys.isEmpty()">
+      AND di.DECISION_INSTANCE_KEY IN
+      <foreach collection="filter.decisionInstanceKeys" item="key" open="(" close=")" separator=", ">
+        #{key}
+      </foreach>
+    </if>
+    <if test="filter.processInstanceKeys != null and !filter.processInstanceKeys.isEmpty()">
+      AND di.PROCESS_INSTANCE_KEY IN
+      <foreach collection="filter.processInstanceKeys" item="key" open="(" close=")" separator=", ">
+        #{key}
+      </foreach>
+    </if>
+    <if test="filter.processDefinitionKeys != null and !filter.processDefinitionKeys.isEmpty()">
+      AND di.PROCESS_DEFINITION_KEY IN
+      <foreach collection="filter.processDefinitionKeys" item="key" open="(" close=")" separator=", ">
+        #{key}
+      </foreach>
+    </if>
+    <if test="filter.states != null and !filter.states.isEmpty()">
+      AND di.STATE IN
+      <foreach collection="filter.states" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.evaluationFailures != null and !filter.evaluationFailures.isEmpty()">
+      AND di.EVALUATION_FAILURE IN
+      <foreach collection="filter.evaluationFailures" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionDefinitionIds != null and !filter.decisionDefinitionIds.isEmpty()">
+      AND di.DECISION_DEFINITION_ID IN
+      <foreach collection="filter.decisionDefinitionIds" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionDefinitionNames != null and !filter.decisionDefinitionNames.isEmpty()">
+      AND dd.NAME IN
+      <foreach collection="filter.decisionDefinitionNames" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <if
+      test="filter.decisionDefinitionVersions != null and !filter.decisionDefinitionVersions.isEmpty()">
+      AND dd.VERSION IN
+      <foreach collection="filter.decisionDefinitionVersions" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <if test="filter.decisionTypes != null and !filter.decisionTypes.isEmpty()">
+      AND di.TYPE IN
+      <foreach collection="filter.decisionTypes" item="value" open="(" close=")" separator=", ">
+        #{value}
+      </foreach>
+    </if>
+    <!--    TODO: Check if useful https://github.com/camunda/camunda/issues/22842
+    <if test="filter.tenantIds != null and !filter.tenantIds.isEmpty()">
+          AND di.TENANT_ID
+          <foreach collection="filter.tenantIds" item="value" open="(" close=")">
+            #{value}
+          </foreach>
+        </if>-->
+    <if
+      test="filter.evaluationDateOperations != null and !filter.evaluationDateOperations.isEmpty()">
+      <foreach collection="filter.evaluationDateOperations" item="operation">
+        AND di.EVALUATION_DATE
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+    <if
+      test="filter.decisionDefinitionKeyOperations != null and !filter.decisionDefinitionKeyOperations.isEmpty()">
+      <foreach collection="filter.decisionDefinitionKeyOperations" item="operation">
+        AND di.DECISION_DEFINITION_KEY
+        <include refid="io.camunda.db.rdbms.sql.Commons.operationCondition"/>
+      </foreach>
+    </if>
+  </sql>
+
+  <resultMap id="searchResultMap" type="io.camunda.search.entities.DecisionInstanceEntity">
+    <constructor>
+      <idArg column="DECISION_INSTANCE_ID" javaType="java.lang.String"/>
+      <arg column="DECISION_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="STATE"
+        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionInstanceState"/>
+      <arg column="EVALUATION_DATE" javaType="java.time.OffsetDateTime"/>
+      <arg column="EVALUATION_FAILURE" javaType="java.lang.String"/>
+      <arg column="PROCESS_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <arg column="PROCESS_INSTANCE_KEY" javaType="java.lang.Long"/>
+      <arg column="TENANT_ID" javaType="java.lang.String"/>
+      <arg column="DECISION_DEFINITION_ID" javaType="java.lang.String"/>
+      <arg column="DECISION_DEFINITION_KEY" javaType="java.lang.Long"/>
+      <arg column="DECISION_DEFINITION_NAME" javaType="java.lang.String"/>
+      <arg column="DECISION_DEFINITION_VERSION" javaType="java.lang.Integer"/>
+      <arg column="TYPE"
+        javaType="io.camunda.search.entities.DecisionInstanceEntity$DecisionDefinitionType"/>
+      <arg column="RESULT" javaType="java.lang.String"/>
+      <!-- The list is loaded separately (optional). But we still need a value (NULL) here.
+       we use the ObjectTypeHandler because no other typeHandler can map NULL to List -->
+      <arg column="EVALUATED_INPUTS" javaType="java.util.List"
+        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+      <arg column="EVALUATED_OUTPUTS" javaType="java.util.List"
+        typeHandler="org.apache.ibatis.type.ObjectTypeHandler"/>
+    </constructor>
+  </resultMap>
+
+  <insert
+    id="insert"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
+    flushCache="true">
+    INSERT INTO DECISION_INSTANCE (DECISION_INSTANCE_ID,
+                                   DECISION_INSTANCE_KEY,
+                                   PROCESS_INSTANCE_KEY,
+                                   PROCESS_DEFINITION_KEY,
+                                   PROCESS_DEFINITION_ID,
+                                   DECISION_DEFINITION_KEY,
+                                   DECISION_DEFINITION_ID,
+                                   DECISION_REQUIREMENTS_KEY,
+                                   DECISION_REQUIREMENTS_ID,
+                                   FLOW_NODE_INSTANCE_KEY,
+                                   FLOW_NODE_ID,
+                                   ROOT_DECISION_DEFINITION_KEY,
+                                   TYPE,
+                                   STATE,
+                                   EVALUATION_DATE,
+                                   RESULT,
+                                   EVALUATION_FAILURE)
+    VALUES (#{decisionInstanceId}, #{decisionInstanceKey}, #{processInstanceKey},
+            #{processDefinitionKey}, #{processDefinitionId},
+            #{decisionDefinitionKey}, #{decisionDefinitionId},
+            #{decisionRequirementsKey}, #{decisionRequirementsId},
+            #{flowNodeInstanceKey}, #{flowNodeId},
+            #{rootDecisionDefinitionKey},
+            #{decisionType}, #{state},
+            #{evaluationDate, jdbcType=TIMESTAMP}, #{result}, #{evaluationFailure})
+  </insert>
+
+  <insert
+    id="insertInput"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
+    flushCache="true">
+    INSERT INTO DECISION_INSTANCE_INPUT (DECISION_INSTANCE_ID, INPUT_ID, INPUT_NAME, INPUT_VALUE)
+    VALUES
+    <foreach collection="evaluatedInputs" item="item" separator=", ">
+      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value})
+    </foreach>
+  </insert>
+
+  <!-- create select statement for decision instance input -->
+  <select id="loadInputs" parameterType="list"
+    resultMap="io.camunda.db.rdbms.sql.DecisionInstanceMapper.evaluatedInputResultMap">
+    SELECT
+    DECISION_INSTANCE_ID,
+    INPUT_ID,
+    INPUT_NAME,
+    INPUT_VALUE
+    FROM DECISION_INSTANCE_INPUT
+    WHERE DECISION_INSTANCE_ID IN (<foreach collection="list" item="id" separator=", ">
+    #{id}</foreach>)
+  </select>
+
+  <resultMap id="evaluatedInputResultMap"
+    type="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel$EvaluatedInput">
+    <constructor>
+      <idArg column="DECISION_INSTANCE_ID" javaType="java.lang.String"/>
+      <idArg column="INPUT_ID" javaType="java.lang.String"/>
+      <arg column="INPUT_NAME" javaType="java.lang.String"/>
+      <arg column="INPUT_VALUE" javaType="java.lang.String"/>
+    </constructor>
+  </resultMap>
+
+  <insert
+    id="insertOutput"
+    parameterType="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel"
+    flushCache="true">
+    INSERT INTO DECISION_INSTANCE_OUTPUT
+    (DECISION_INSTANCE_ID, OUTPUT_ID, OUTPUT_NAME, OUTPUT_VALUE, RULE_ID, RULE_INDEX) VALUES
+    <foreach collection="evaluatedOutputs" item="item" separator=", ">
+      (#{decisionInstanceId}, #{item.id}, #{item.name}, #{item.value}, #{item.ruleId},
+      #{item.ruleIndex})
+    </foreach>
+  </insert>
+
+  <select id="loadOutputs" parameterType="list"
+    resultMap="io.camunda.db.rdbms.sql.DecisionInstanceMapper.evaluatedOutputResultMap">
+    SELECT
+    DECISION_INSTANCE_ID,
+    OUTPUT_ID,
+    OUTPUT_NAME,
+    OUTPUT_VALUE,
+    RULE_ID,
+    RULE_INDEX
+    FROM DECISION_INSTANCE_OUTPUT
+    WHERE DECISION_INSTANCE_ID IN (<foreach collection="list" item="id" separator=", ">
+    #{id}</foreach>)
+  </select>
+
+  <resultMap id="evaluatedOutputResultMap"
+    type="io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel$EvaluatedOutput">
+    <constructor>
+      <idArg column="DECISION_INSTANCE_ID" javaType="java.lang.String"/>
+      <idArg column="OUTPUT_ID" javaType="java.lang.String"/>
+      <arg column="OUTPUT_NAME" javaType="java.lang.String"/>
+      <arg column="OUTPUT_VALUE" javaType="java.lang.String"/>
+      <arg column="RULE_ID" javaType="java.lang.String"/>
+      <arg column="RULE_INDEX" javaType="java.lang.Integer"/>
+    </constructor>
+  </resultMap>
+
+</mapper>

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/MyBatisConfiguration.java
@@ -8,6 +8,7 @@
 package io.camunda.application.commons.rdbms;
 
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -83,6 +84,12 @@ public class MyBatisConfiguration {
   public MapperFactoryBean<DecisionDefinitionMapper> decisionDefinitionMapper(
       final SqlSessionFactory sqlSessionFactory) {
     return createMapperFactoryBean(sqlSessionFactory, DecisionDefinitionMapper.class);
+  }
+
+  @Bean
+  public MapperFactoryBean<DecisionInstanceMapper> decisionInstanceMapper(
+      final SqlSessionFactory sqlSessionFactory) {
+    return createMapperFactoryBean(sqlSessionFactory, DecisionInstanceMapper.class);
   }
 
   @Bean

--- a/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rdbms/RdbmsConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.application.commons.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.read.service.DecisionDefinitionReader;
+import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
 import io.camunda.db.rdbms.read.service.DecisionRequirementsReader;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.read.service.ProcessDefinitionReader;
@@ -16,6 +17,7 @@ import io.camunda.db.rdbms.read.service.ProcessInstanceReader;
 import io.camunda.db.rdbms.read.service.UserTaskReader;
 import io.camunda.db.rdbms.read.service.VariableReader;
 import io.camunda.db.rdbms.sql.DecisionDefinitionMapper;
+import io.camunda.db.rdbms.sql.DecisionInstanceMapper;
 import io.camunda.db.rdbms.sql.DecisionRequirementsMapper;
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
@@ -44,6 +46,12 @@ public class RdbmsConfiguration {
   public DecisionDefinitionReader decisionDefinitionReader(
       final DecisionDefinitionMapper decisionDefinitionMapper) {
     return new DecisionDefinitionReader(decisionDefinitionMapper);
+  }
+
+  @Bean
+  public DecisionInstanceReader decisionInstanceReader(
+      final DecisionInstanceMapper decisionInstanceMapper) {
+    return new DecisionInstanceReader(decisionInstanceMapper);
   }
 
   @Bean
@@ -87,6 +95,7 @@ public class RdbmsConfiguration {
       final RdbmsWriterFactory rdbmsWriterFactory,
       final VariableReader variableReader,
       final DecisionDefinitionReader decisionDefinitionReader,
+      final DecisionInstanceReader decisionInstanceReader,
       final DecisionRequirementsReader decisionRequirementsReader,
       final FlowNodeInstanceReader flowNodeInstanceReader,
       final ProcessDefinitionReader processDefinitionReader,
@@ -95,6 +104,7 @@ public class RdbmsConfiguration {
     return new RdbmsService(
         rdbmsWriterFactory,
         decisionDefinitionReader,
+        decisionInstanceReader,
         decisionRequirementsReader,
         flowNodeInstanceReader,
         processDefinitionReader,

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisioninstance;
+
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstance;
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
+import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.sort.DecisionInstanceSort;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import org.assertj.core.data.TemporalUnitWithinOffset;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionInstanceIT {
+
+  public static final Long PARTITION_ID = 0L;
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @TestTemplate
+  public void shouldSaveAndFindDecisionInstanceById(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceReader decisionInstanceReader = rdbmsService.getDecisionInstanceReader();
+
+    final var original = DecisionInstanceFixtures.createRandomized(b -> b);
+    createAndSaveDecisionInstance(rdbmsWriter, original);
+    final var actual = decisionInstanceReader.findOne(original.decisionInstanceId()).orElseThrow();
+
+    assertThat(actual).isNotNull();
+    assertThat(actual.decisionInstanceId()).isEqualTo(original.decisionInstanceId());
+    assertThat(actual.decisionInstanceKey()).isEqualTo(original.decisionInstanceKey());
+    assertThat(actual.processDefinitionKey()).isEqualTo(original.processDefinitionKey());
+    assertThat(actual.decisionDefinitionId()).isEqualTo(original.decisionDefinitionId());
+    assertThat(actual.state()).isEqualTo(original.state());
+    assertThat(actual.evaluationDate())
+        .isCloseTo(original.evaluationDate(), new TemporalUnitWithinOffset(1, ChronoUnit.MILLIS));
+    assertThat(actual.evaluationFailure()).isEqualTo(original.evaluationFailure());
+    assertThat(actual.result()).isEqualTo(original.result());
+    assertThat(actual.decisionDefinitionType()).isEqualTo(original.decisionType());
+    assertThat(actual.evaluatedInputs()).hasSize(original.evaluatedInputs().size());
+    assertThat(actual.evaluatedInputs()).hasSize(original.evaluatedInputs().size());
+    assertThat(actual.evaluatedOutputs()).hasSize(original.evaluatedOutputs().size());
+  }
+
+  @TestTemplate
+  public void shouldFindAllDecisionInstancePaged(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceReader decisionInstanceReader = rdbmsService.getDecisionInstanceReader();
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriter, b -> b);
+    createAndSaveRandomDecisionInstances(
+        rdbmsWriter, b -> b.decisionDefinitionKey(decisionDefinition.decisionDefinitionKey()));
+
+    final var searchResult =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.decisionDefinitionKeys(
+                                    decisionDefinition.decisionDefinitionKey()))
+                        .sort(s -> s.evaluationDate().asc().decisionDefinitionName().asc())
+                        .page(p -> p.from(0).size(5))));
+
+    assertThat(searchResult).isNotNull();
+    assertThat(searchResult.total()).isEqualTo(20);
+    assertThat(searchResult.items()).hasSize(5);
+
+    final var lastInstance = searchResult.items().getLast();
+    assertThat(searchResult.sortValues()).hasSize(3);
+    assertThat(searchResult.sortValues())
+        .containsExactly(
+            lastInstance.evaluationDate(),
+            lastInstance.decisionDefinitionName(),
+            lastInstance.decisionInstanceId());
+  }
+
+  @TestTemplate
+  public void shouldFindDecisionInstanceWithFullFilter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceReader decisionInstanceReader = rdbmsService.getDecisionInstanceReader();
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriter, b -> b);
+    createAndSaveRandomDecisionInstances(rdbmsWriter);
+    final var instance =
+        createAndSaveRandomDecisionInstance(
+            rdbmsWriter,
+            b ->
+                b.decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
+                    .decisionDefinitionId(decisionDefinition.decisionDefinitionId()));
+    final var searchResult =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(
+                            f ->
+                                f.decisionInstanceKeys(instance.decisionInstanceKey())
+                                    .decisionDefinitionIds(instance.decisionDefinitionId())
+                                    .decisionDefinitionNames(decisionDefinition.name())
+                                    .processDefinitionKeys(instance.processDefinitionKey())
+                                    .states(instance.state())
+                                    .decisionTypes(instance.decisionType())
+                                    .processInstanceKeys(instance.processInstanceKey())
+                                    .evaluationFailures(instance.evaluationFailure())
+                                    .evaluationDateOperations(
+                                        List.of(
+                                            Operation.gt(
+                                                instance.evaluationDate().minusSeconds(1)))))
+                        .sort(s -> s)
+                        .page(p -> p.from(0).size(5))));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionInstanceId())
+        .isEqualTo(instance.decisionInstanceId());
+  }
+
+  @TestTemplate
+  public void shouldFindDecisionInstanceWithSearchAfter(
+      final CamundaRdbmsTestApplication testApplication) {
+    final RdbmsService rdbmsService = testApplication.getRdbmsService();
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceReader decisionInstanceReader = rdbmsService.getDecisionInstanceReader();
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveRandomDecisionDefinition(rdbmsWriter, b -> b);
+    createAndSaveRandomDecisionInstances(
+        rdbmsWriter,
+        b ->
+            b.decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
+                .decisionDefinitionId(decisionDefinition.decisionDefinitionId()));
+    final var sort =
+        DecisionInstanceSort.of(
+            s ->
+                s.decisionDefinitionName()
+                    .asc()
+                    .decisionDefinitionVersion()
+                    .asc()
+                    .evaluationDate()
+                    .desc());
+    final var searchResult =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(
+                            f -> f.decisionDefinitionIds(decisionDefinition.decisionDefinitionId()))
+                        .sort(sort)
+                        .page(p -> p.from(0).size(20))));
+
+    final var instanceAfter = searchResult.items().get(9);
+    final var nextPage =
+        decisionInstanceReader.search(
+            DecisionInstanceQuery.of(
+                b ->
+                    b.filter(
+                            f -> f.decisionDefinitionIds(decisionDefinition.decisionDefinitionId()))
+                        .sort(sort)
+                        .page(
+                            p ->
+                                p.size(5)
+                                    .searchAfter(
+                                        new Object[] {
+                                          instanceAfter.decisionDefinitionName(),
+                                          instanceAfter.decisionDefinitionVersion(),
+                                          instanceAfter.evaluationDate(),
+                                          instanceAfter.decisionInstanceId()
+                                        }))));
+
+    assertThat(nextPage.total()).isEqualTo(20);
+    assertThat(nextPage.items()).hasSize(5);
+    assertThat(nextPage.items()).isEqualTo(searchResult.items().subList(10, 15));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSortIT.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisioninstance;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
+import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.sort.DecisionInstanceSort;
+import io.camunda.search.sort.DecisionInstanceSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.Comparator;
+import java.util.function.Function;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("rdbms")
+@ExtendWith(CamundaRdbmsInvocationContextProviderExtension.class)
+public class DecisionInstanceSortIT {
+
+  public static final Long PARTITION_ID = 0L;
+
+  @TestTemplate
+  public void shouldSortByDecisionInstanceIdAsc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionInstanceId().asc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionInstanceId));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionInstanceIdDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionInstanceId().desc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionInstanceId).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionInstanceKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionInstanceKey().asc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionInstanceKey));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionInstanceKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionInstanceKey().desc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionInstanceKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionKeyAsc(
+      final CamundaRdbmsTestApplication testApplication) {
+    // TODO this makes no sense since builder.decisionDefinitionKey sets the field to "decisionId"
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionId().asc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionDefinitionId));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionKeyDesc(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionKey().desc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionDefinitionKey).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionName(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionName().asc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionDefinitionName));
+  }
+
+  @TestTemplate
+  public void shouldSortByDecisionDefinitionVersion(
+      final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.decisionDefinitionVersion().asc(),
+        Comparator.comparing(DecisionInstanceEntity::decisionDefinitionVersion));
+  }
+
+  @TestTemplate
+  public void shouldSortByEvaluationDate(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.evaluationDate().asc(),
+        Comparator.comparing(DecisionInstanceEntity::evaluationDate));
+  }
+
+  @TestTemplate
+  public void shouldSortByEvaluationDateDesc(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.evaluationDate().desc(),
+        Comparator.comparing(DecisionInstanceEntity::evaluationDate).reversed());
+  }
+
+  @TestTemplate
+  public void shouldSortByState(final CamundaRdbmsTestApplication testApplication) {
+    testSorting(
+        testApplication.getRdbmsService(),
+        b -> b.state().asc(),
+        Comparator.comparing(DecisionInstanceEntity::state));
+  }
+
+  private void testSorting(
+      final RdbmsService rdbmsService,
+      final Function<Builder, ObjectBuilder<DecisionInstanceSort>> sortBuilder,
+      final Comparator<DecisionInstanceEntity> comparator) {
+    final RdbmsWriter rdbmsWriter = rdbmsService.createWriter(PARTITION_ID);
+    final DecisionInstanceReader reader = rdbmsService.getDecisionInstanceReader();
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveDecisionDefinition(rdbmsWriter, b -> b);
+    final var processDefinitionKey = nextKey();
+    createAndSaveRandomDecisionInstances(
+        rdbmsWriter,
+        b ->
+            b.processDefinitionKey(processDefinitionKey)
+                .decisionDefinitionId(decisionDefinition.decisionDefinitionId())
+                .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey()));
+
+    final var searchResult =
+        reader
+            .search(
+                new DecisionInstanceQuery(
+                    new DecisionInstanceFilter.Builder()
+                        .processDefinitionKeys(processDefinitionKey)
+                        .build(),
+                    DecisionInstanceSort.of(sortBuilder),
+                    SearchQueryPage.of(b -> b),
+                    null))
+            .items();
+
+    assertThat(searchResult).hasSize(20);
+    assertThat(searchResult).isSortedAccordingTo(comparator);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceSpecificFilterIT.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.decisioninstance;
+
+import static io.camunda.it.rdbms.db.fixtures.CommonFixtures.nextKey;
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveDecisionInstance;
+import static io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures.createAndSaveRandomDecisionInstances;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.application.commons.rdbms.RdbmsConfiguration;
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.read.service.DecisionInstanceReader;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.it.rdbms.db.fixtures.DecisionDefinitionFixtures;
+import io.camunda.it.rdbms.db.fixtures.DecisionInstanceFixtures;
+import io.camunda.it.rdbms.db.util.RdbmsTestConfiguration;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.search.filter.DecisionInstanceFilter;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.sort.DecisionInstanceSort;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigurationPackage;
+import org.springframework.boot.test.autoconfigure.data.jdbc.DataJdbcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+
+@Tag("rdbms")
+@DataJdbcTest
+@ContextConfiguration(classes = {RdbmsTestConfiguration.class, RdbmsConfiguration.class})
+@AutoConfigurationPackage
+@TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
+public class DecisionInstanceSpecificFilterIT {
+
+  public static final OffsetDateTime NOW = OffsetDateTime.now();
+
+  @Autowired private RdbmsService rdbmsService;
+
+  @Autowired private DecisionInstanceReader decisionInstanceReader;
+
+  private RdbmsWriter rdbmsWriter;
+
+  @BeforeEach
+  public void beforeAll() {
+    rdbmsWriter = rdbmsService.createWriter(0L);
+
+    final var decisionDefinitionKey = nextKey();
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveDecisionDefinition(
+            rdbmsWriter,
+            b ->
+                b.decisionDefinitionKey(decisionDefinitionKey)
+                    .decisionDefinitionId("decision" + decisionDefinitionKey)
+                    .name("Decision " + decisionDefinitionKey));
+    createAndSaveRandomDecisionInstances(
+        rdbmsWriter,
+        b ->
+            b.state(DecisionInstanceState.UNSPECIFIED)
+                .decisionType(DecisionDefinitionType.UNSPECIFIED)
+                .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
+                .decisionDefinitionId(decisionDefinition.decisionDefinitionId()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("shouldFindDecisionInstanceWithSpecificFilterParameters")
+  public void shouldFindDecisionInstanceWithSpecificFilter(final DecisionInstanceFilter filter) {
+    final var decisionDefinitionKey = 100L;
+
+    final var decisionDefinition =
+        DecisionDefinitionFixtures.createAndSaveDecisionDefinition(
+            rdbmsWriter,
+            b ->
+                b.decisionDefinitionKey(decisionDefinitionKey)
+                    .decisionDefinitionId("decision-" + decisionDefinitionKey)
+                    .name("Decision " + decisionDefinitionKey));
+    createAndSaveDecisionInstance(
+        rdbmsWriter,
+        DecisionInstanceFixtures.createRandomized(
+            b ->
+                b.decisionInstanceId("42-1")
+                    .decisionInstanceKey(42L)
+                    .flowNodeId("unique-flowNode-42")
+                    .processInstanceKey(123L)
+                    .processDefinitionId("unique-process-124")
+                    .processDefinitionKey(124L)
+                    .state(DecisionInstanceState.EVALUATED)
+                    .decisionType(DecisionDefinitionType.DECISION_TABLE)
+                    .decisionDefinitionKey(decisionDefinition.decisionDefinitionKey())
+                    .decisionDefinitionId(decisionDefinition.decisionDefinitionId())
+                    .evaluationFailure("failure-42")
+                    .result("result-42")));
+
+    final var searchResult =
+        decisionInstanceReader.search(
+            new DecisionInstanceQuery(
+                filter,
+                DecisionInstanceSort.of(b -> b),
+                SearchQueryPage.of(b -> b.from(0).size(5)),
+                null));
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().decisionInstanceId()).isEqualTo("42-1");
+  }
+
+  static List<DecisionInstanceFilter> shouldFindDecisionInstanceWithSpecificFilterParameters() {
+    return List.of(
+        DecisionInstanceFilter.of(b -> b.decisionInstanceIds("42-1")),
+        DecisionInstanceFilter.of(b -> b.decisionInstanceKeys(42L)),
+        DecisionInstanceFilter.of(b -> b.processInstanceKeys(123L)),
+        DecisionInstanceFilter.of(b -> b.processDefinitionKeys(124L)),
+        DecisionInstanceFilter.of(
+            b -> b.decisionDefinitionKeyOperations(List.of(Operation.eq(100L)))),
+        DecisionInstanceFilter.of(b -> b.decisionDefinitionIds("decision-100")),
+        DecisionInstanceFilter.of(b -> b.states(DecisionInstanceState.EVALUATED)),
+        DecisionInstanceFilter.of(b -> b.decisionTypes(DecisionDefinitionType.DECISION_TABLE)),
+        DecisionInstanceFilter.of(b -> b.evaluationFailures("failure-42")),
+        DecisionInstanceFilter.of(b -> b.decisionDefinitionNames("Decision 100")));
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/CommonFixtures.java
@@ -16,7 +16,7 @@ public class CommonFixtures {
 
   public static final OffsetDateTime NOW = OffsetDateTime.now();
   protected static final Random RANDOM = new Random(System.nanoTime());
-  private static final AtomicLong ID_COUNTER = new AtomicLong();
+  private static final AtomicLong ID_COUNTER = new AtomicLong(54321L);
 
   public static Long nextKey() {
     return ID_COUNTER.incrementAndGet();

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionDefinitionFixtures.java
@@ -41,6 +41,16 @@ public final class DecisionDefinitionFixtures extends CommonFixtures {
         rdbmsWriter, b -> b.decisionDefinitionId(nextStringId()));
   }
 
+  public static DecisionDefinitionDbModel createAndSaveRandomDecisionDefinition(
+      final RdbmsWriter rdbmsWriter,
+      final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>
+          builderFunction) {
+    final var definition = DecisionDefinitionFixtures.createRandomized(builderFunction);
+    rdbmsWriter.getDecisionDefinitionWriter().create(definition);
+    rdbmsWriter.flush();
+    return definition;
+  }
+
   public static void createAndSaveRandomDecisionDefinitions(
       final RdbmsWriter rdbmsWriter,
       final Function<DecisionDefinitionDbModelBuilder, DecisionDefinitionDbModelBuilder>

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/DecisionInstanceFixtures.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.rdbms.db.fixtures;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedInput;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+public final class DecisionInstanceFixtures extends CommonFixtures {
+
+  private DecisionInstanceFixtures() {}
+
+  public static DecisionInstanceDbModel createRandomized(
+      final Function<DecisionInstanceDbModel.Builder, DecisionInstanceDbModel.Builder>
+          builderFunction) {
+    final var decisionInstanceKey = nextKey();
+    final var decisionInstanceId = decisionInstanceKey + "-1";
+    final var builder =
+        new DecisionInstanceDbModel.Builder()
+            .decisionInstanceId(decisionInstanceId)
+            .decisionInstanceKey(decisionInstanceKey)
+            .processInstanceKey(nextKey())
+            .processDefinitionKey(nextKey())
+            .processDefinitionId("process-" + RANDOM.nextInt(10000))
+            .flowNodeInstanceKey(nextKey())
+            .flowNodeId("flow-node-" + RANDOM.nextInt(10000))
+            .decisionRequirementsKey(nextKey())
+            .decisionRequirementsId("requirements-" + RANDOM.nextInt(10000))
+            .decisionDefinitionKey(nextKey())
+            .decisionDefinitionId("decision-" + RANDOM.nextInt(1000))
+            .evaluationDate(NOW.plus(RANDOM.nextInt(), ChronoUnit.MILLIS))
+            .result("result-" + RANDOM.nextInt(10000))
+            .evaluationFailure("failure-" + RANDOM.nextInt(10000))
+            .decisionType(randomEnum(DecisionInstanceEntity.DecisionDefinitionType.class))
+            .tenantId("tenant-" + RANDOM.nextInt(10000))
+            .state(randomEnum(DecisionInstanceEntity.DecisionInstanceState.class))
+            .evaluatedInputs(randomInputs(decisionInstanceId))
+            .evaluatedOutputs(randomOutputs(decisionInstanceId));
+
+    return builderFunction.apply(builder).build();
+  }
+
+  private static List<EvaluatedInput> randomInputs(final String id) {
+    return IntStream.range(0, RANDOM.nextInt(5) + 5)
+        .boxed()
+        .map(i -> new EvaluatedInput(id, "input-" + i, "Input " + i, Integer.toString(i)))
+        .toList();
+  }
+
+  private static List<EvaluatedOutput> randomOutputs(final String id) {
+    return IntStream.range(0, RANDOM.nextInt(5) + 5)
+        .boxed()
+        .map(
+            i ->
+                new EvaluatedOutput(
+                    id, "input-" + i, "Input " + i, Integer.toString(i), "rule-" + i, i))
+        .toList();
+  }
+
+  public static void createAndSaveRandomDecisionInstances(final RdbmsWriter rdbmsWriter) {
+    createAndSaveRandomDecisionInstances(rdbmsWriter, b -> b);
+  }
+
+  public static DecisionInstanceDbModel createAndSaveRandomDecisionInstance(
+      final RdbmsWriter rdbmsWriter,
+      final Function<DecisionInstanceDbModel.Builder, DecisionInstanceDbModel.Builder>
+          builderFunction) {
+    final var instance = createRandomized(builderFunction);
+    rdbmsWriter.getDecisionInstanceWriter().create(instance);
+    rdbmsWriter.flush();
+    return instance;
+  }
+
+  public static void createAndSaveRandomDecisionInstances(
+      final RdbmsWriter rdbmsWriter,
+      final Function<DecisionInstanceDbModel.Builder, DecisionInstanceDbModel.Builder>
+          builderFunction) {
+    for (int i = 0; i < 20; i++) {
+      rdbmsWriter
+          .getDecisionInstanceWriter()
+          .create(DecisionInstanceFixtures.createRandomized(builderFunction));
+    }
+
+    rdbmsWriter.flush();
+  }
+
+  public static void createAndSaveDecisionInstance(
+      final RdbmsWriter rdbmsWriter, final DecisionInstanceDbModel pecisionInstance) {
+    createAndSaveDecisionInstances(rdbmsWriter, List.of(pecisionInstance));
+  }
+
+  public static void createAndSaveDecisionInstances(
+      final RdbmsWriter rdbmsWriter, final List<DecisionInstanceDbModel> pecisionInstanceList) {
+    for (final DecisionInstanceDbModel pecisionInstance : pecisionInstanceList) {
+      rdbmsWriter.getDecisionInstanceWriter().create(pecisionInstance);
+    }
+    rdbmsWriter.flush();
+  }
+}

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -115,8 +115,10 @@ public class RdbmsSearchClient
 
   @Override
   public SearchQueryResult<DecisionInstanceEntity> searchDecisionInstances(
-      final DecisionInstanceQuery filter) {
-    return null;
+      final DecisionInstanceQuery query) {
+    LOG.debug("[RDBMS Search Client] Search for decisionInstances: {}", query);
+
+    return rdbmsService.getDecisionInstanceReader().search(query);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.search.entities;
 
+import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -27,6 +28,147 @@ public record DecisionInstanceEntity(
     String result,
     List<DecisionInstanceInputEntity> evaluatedInputs,
     List<DecisionInstanceOutputEntity> evaluatedOutputs) {
+
+  public Builder toBuilder() {
+    return new Builder()
+        .decisionInstanceId(decisionInstanceId)
+        .decisionInstanceKey(decisionInstanceKey)
+        .state(state)
+        .evaluationDate(evaluationDate)
+        .evaluationFailure(evaluationFailure)
+        .processDefinitionKey(processDefinitionKey)
+        .processInstanceKey(processInstanceKey)
+        .decisionDefinitionKey(decisionDefinitionKey)
+        .decisionDefinitionId(decisionDefinitionId)
+        .decisionDefinitionName(decisionDefinitionName)
+        .decisionDefinitionVersion(decisionDefinitionVersion)
+        .decisionDefinitionType(decisionDefinitionType)
+        .tenantId(tenantId)
+        .result(result)
+        .evaluatedInputs(evaluatedInputs)
+        .evaluatedOutputs(evaluatedOutputs);
+  }
+
+  public static class Builder implements ObjectBuilder<DecisionInstanceEntity> {
+
+    private String decisionInstanceId;
+    private Long decisionInstanceKey;
+    private DecisionInstanceState state;
+    private OffsetDateTime evaluationDate;
+    private String evaluationFailure;
+    private Long processDefinitionKey;
+    private Long processInstanceKey;
+    private String tenantId;
+    private String decisionDefinitionId;
+    private Long decisionDefinitionKey;
+    private String decisionDefinitionName;
+    private Integer decisionDefinitionVersion;
+    private DecisionDefinitionType decisionDefinitionType;
+    private String result;
+    private List<DecisionInstanceInputEntity> evaluatedInputs;
+    private List<DecisionInstanceOutputEntity> evaluatedOutputs;
+
+    public Builder decisionInstanceId(String decisionInstanceId) {
+      this.decisionInstanceId = decisionInstanceId;
+      return this;
+    }
+
+    public Builder decisionInstanceKey(Long decisionInstanceKey) {
+      this.decisionInstanceKey = decisionInstanceKey;
+      return this;
+    }
+
+    public Builder state(DecisionInstanceState state) {
+      this.state = state;
+      return this;
+    }
+
+    public Builder evaluationDate(OffsetDateTime evaluationDate) {
+      this.evaluationDate = evaluationDate;
+      return this;
+    }
+
+    public Builder evaluationFailure(String evaluationFailure) {
+      this.evaluationFailure = evaluationFailure;
+      return this;
+    }
+
+    public Builder processDefinitionKey(Long processDefinitionKey) {
+      this.processDefinitionKey = processDefinitionKey;
+      return this;
+    }
+
+    public Builder processInstanceKey(Long processInstanceKey) {
+      this.processInstanceKey = processInstanceKey;
+      return this;
+    }
+
+    public Builder tenantId(String tenantId) {
+      this.tenantId = tenantId;
+      return this;
+    }
+
+    public Builder decisionDefinitionId(String decisionDefinitionId) {
+      this.decisionDefinitionId = decisionDefinitionId;
+      return this;
+    }
+
+    public Builder decisionDefinitionKey(Long decisionDefinitionKey) {
+      this.decisionDefinitionKey = decisionDefinitionKey;
+      return this;
+    }
+
+    public Builder decisionDefinitionName(String decisionDefinitionName) {
+      this.decisionDefinitionName = decisionDefinitionName;
+      return this;
+    }
+
+    public Builder decisionDefinitionVersion(Integer decisionDefinitionVersion) {
+      this.decisionDefinitionVersion = decisionDefinitionVersion;
+      return this;
+    }
+
+    public Builder decisionDefinitionType(DecisionDefinitionType decisionDefinitionType) {
+      this.decisionDefinitionType = decisionDefinitionType;
+      return this;
+    }
+
+    public Builder result(String result) {
+      this.result = result;
+      return this;
+    }
+
+    public Builder evaluatedInputs(List<DecisionInstanceInputEntity> evaluatedInputs) {
+      this.evaluatedInputs = evaluatedInputs;
+      return this;
+    }
+
+    public Builder evaluatedOutputs(List<DecisionInstanceOutputEntity> evaluatedOutputs) {
+      this.evaluatedOutputs = evaluatedOutputs;
+      return this;
+    }
+
+    @Override
+    public DecisionInstanceEntity build() {
+      return new DecisionInstanceEntity(
+          decisionInstanceId,
+          decisionInstanceKey,
+          state,
+          evaluationDate,
+          evaluationFailure,
+          processDefinitionKey,
+          processInstanceKey,
+          tenantId,
+          decisionDefinitionId,
+          decisionDefinitionKey,
+          decisionDefinitionName,
+          decisionDefinitionVersion,
+          decisionDefinitionType,
+          result,
+          evaluatedInputs,
+          evaluatedOutputs);
+    }
+  }
 
   public record DecisionInstanceInputEntity(String inputId, String inputName, String inputValue) {}
 

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
@@ -19,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.function.Function;
 
 public record DecisionInstanceFilter(
     List<Long> decisionInstanceKeys,
@@ -35,6 +36,11 @@ public record DecisionInstanceFilter(
     List<DecisionDefinitionType> decisionTypes,
     List<String> tenantIds)
     implements FilterBase {
+
+  public static DecisionInstanceFilter of(
+      final Function<DecisionInstanceFilter.Builder, ObjectBuilder<DecisionInstanceFilter>> fn) {
+    return FilterBuilders.decisionInstance(fn);
+  }
 
   public static final class Builder implements ObjectBuilder<DecisionInstanceFilter> {
 

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/DecisionInstanceExportHandler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedInput;
+import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
+import io.camunda.db.rdbms.write.service.DecisionInstanceWriter;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
+import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedDecisionValue;
+import io.camunda.zeebe.protocol.record.value.EvaluatedInputValue;
+import io.camunda.zeebe.protocol.record.value.MatchedRuleValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DecisionInstanceExportHandler
+    implements RdbmsExportHandler<DecisionEvaluationRecordValue> {
+
+  private final DecisionInstanceWriter decisionInstanceWriter;
+
+  public DecisionInstanceExportHandler(final DecisionInstanceWriter decisionInstanceWriter) {
+    this.decisionInstanceWriter = decisionInstanceWriter;
+  }
+
+  @Override
+  public boolean canExport(final Record<DecisionEvaluationRecordValue> record) {
+    return record.getValueType() == ValueType.DECISION_EVALUATION
+        && record.getIntent() == DecisionEvaluationIntent.EVALUATED;
+  }
+
+  @Override
+  public void export(final Record<DecisionEvaluationRecordValue> record) {
+    final DecisionEvaluationRecordValue value = record.getValue();
+
+    int index = 1;
+    for (index = 1; index <= value.getEvaluatedDecisions().size(); index++) {
+      final EvaluatedDecisionValue evaluatedDecision = value.getEvaluatedDecisions().get(index - 1);
+      final DecisionInstanceDbModel decisionInstance = map(record, evaluatedDecision, index);
+      decisionInstanceWriter.create(decisionInstance);
+    }
+  }
+
+  // TODO move to common exporter util module #24002
+  private DecisionInstanceState getState(
+      final Record<DecisionEvaluationRecordValue> record,
+      final DecisionEvaluationRecordValue decisionEvaluation,
+      final int i) {
+    if (record.getIntent().name().equals(DecisionEvaluationIntent.FAILED.name())
+        && i == decisionEvaluation.getEvaluatedDecisions().size()) {
+      return DecisionInstanceState.FAILED;
+    } else {
+      return DecisionInstanceState.EVALUATED;
+    }
+  }
+
+  private DecisionInstanceDbModel map(
+      final Record<DecisionEvaluationRecordValue> record,
+      final EvaluatedDecisionValue evaluatedDecision,
+      final int index) {
+    final DecisionEvaluationRecordValue value = record.getValue();
+    final var state = getState(record, value, index);
+    final var key = record.getKey();
+    final var id = record.getKey() + "-" + index;
+
+    return new DecisionInstanceDbModel.Builder()
+        .decisionInstanceId(id)
+        .decisionInstanceKey(key)
+        .decisionDefinitionKey(evaluatedDecision.getDecisionKey())
+        .decisionDefinitionId(evaluatedDecision.getDecisionId())
+        .evaluationDate(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .processDefinitionKey(value.getProcessDefinitionKey())
+        .processDefinitionId(value.getBpmnProcessId())
+        .processInstanceKey(value.getProcessInstanceKey())
+        .decisionRequirementsKey(value.getDecisionRequirementsKey())
+        .decisionRequirementsId(value.getDecisionRequirementsId())
+        .flowNodeInstanceKey(value.getElementInstanceKey())
+        .flowNodeId(value.getElementId())
+        .rootDecisionDefinitionKey(evaluatedDecision.getDecisionKey())
+        .result(evaluatedDecision.getDecisionOutput())
+        .evaluatedInputs(createEvaluationInputs(id, evaluatedDecision.getEvaluatedInputs()))
+        .evaluatedOutputs(createEvaluationOutputs(id, evaluatedDecision.getMatchedRules()))
+        .state(state)
+        .decisionType(DecisionDefinitionType.fromValue(evaluatedDecision.getDecisionType()))
+        .evaluationFailure(
+            state == DecisionInstanceState.FAILED ? value.getEvaluationFailureMessage() : null)
+        .build();
+  }
+
+  private List<EvaluatedInput> createEvaluationInputs(
+      final String id, final List<EvaluatedInputValue> evaluatedInputs) {
+    return evaluatedInputs.stream()
+        .map(
+            input ->
+                new EvaluatedInput(
+                    id, input.getInputId(), input.getInputName(), input.getInputValue()))
+        .collect(Collectors.toList());
+  }
+
+  private List<EvaluatedOutput> createEvaluationOutputs(
+      final String id, final List<MatchedRuleValue> matchedRules) {
+    final List<EvaluatedOutput> outputs = new ArrayList<>();
+    matchedRules.forEach(
+        rule ->
+            outputs.addAll(
+                rule.getEvaluatedOutputs().stream()
+                    .map(
+                        output ->
+                            new EvaluatedOutput(
+                                id,
+                                output.getOutputId(),
+                                output.getOutputName(),
+                                output.getOutputValue(),
+                                rule.getRuleId(),
+                                rule.getRuleIndex()))
+                    .toList()));
+    return outputs;
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -132,6 +132,9 @@ public class RdbmsExporter implements Exporter {
         List.of(
             new DecisionRequirementsExportHandler(rdbmsWriter.getDecisionRequirementsWriter())));
     registeredHandlers.put(
+        ValueType.DECISION_EVALUATION,
+        List.of(new DecisionInstanceExportHandler(rdbmsWriter.getDecisionInstanceWriter())));
+    registeredHandlers.put(
         ValueType.PROCESS_INSTANCE,
         List.of(
             new ProcessInstanceExportHandler(rdbmsWriter.getProcessInstanceWriter()),


### PR DESCRIPTION
## Description

Extends the RDBMS reach client by DecisionInstances
- save the exported instances
- saves evaluated inputs and evaluated outputs in separate tables

closes #23266
