### PR TITLE
fix: throw correct error instead of InternalError

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
@@ -39,5 +39,9 @@ public sealed interface ClusterConfigurationRequestFailedException {
     public InternalError(final Throwable cause) {
       super(cause);
     }
+
+    public InternalError(final String message) {
+      super(message);
+    }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -107,7 +107,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                         // the default coordinator
                         failFuture(
                             future,
-                            new InternalError(
+                            new ClusterConfigurationRequestFailedException.InternalError(
                                 String.format(
                                     "Cannot process request to change the configuration. The broker '%s' is not the coordinator.",
                                     localMemberId)));


### PR DESCRIPTION
## Description
`InternalError` was thrown by mistake (which extends `VirtualMachineError` and could case the VM to terminate.
Correct error is now thrown

