### PR TITLE
feat: add endpoint for role deletion

### DIFF
--- a/service/src/main/java/io/camunda/service/RoleServices.java
+++ b/service/src/main/java/io/camunda/service/RoleServices.java
@@ -20,6 +20,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerRoleUpdateRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.role.BrokerRoleCreateRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.role.BrokerRoleDeleteRequest;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -71,5 +72,9 @@ public class RoleServices extends SearchQueryService<RoleServices, RoleQuery, Ro
         .items()
         .stream()
         .findFirst();
+  }
+
+  public CompletableFuture<RoleRecord> deleteRole(final long roleKey) {
+    return sendBrokerRequest(new BrokerRoleDeleteRequest(roleKey));
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2011,7 +2011,33 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-
+    delete:
+      tags:
+        - Role
+      operationId: deleteRole
+      summary: Delete role
+      description: Deletes the role with the given key.
+      parameters:
+        - name: roleKey
+          in: path
+          required: true
+          description: The key of the role to delete.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "204":
+          description: The role was deleted successfully.
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          description: The role with the roleKey was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /roles/search:
     post:
       tags:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleController.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -70,5 +71,14 @@ public class RoleController {
             roleServices
                 .withAuthentication(RequestMapper.getAuthentication())
                 .updateRole(updateRoleRequest.roleKey(), updateRoleRequest.name()));
+  }
+
+  @DeleteMapping(
+      path = "/{roleKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> deleteRole(@PathVariable final long roleKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            roleServices.withAuthentication(RequestMapper.getAuthentication()).deleteRole(roleKey));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleControllerTest.java
@@ -181,4 +181,27 @@ public class RoleControllerTest extends RestControllerTest {
 
     verify(roleServices, times(1)).updateRole(roleKey, roleName);
   }
+
+  @Test
+  void deleteRoleShouldReturnNoContent() {
+    // given
+    final long roleKey = 100L;
+
+    final var roleRecord = new RoleRecord().setRoleKey(roleKey);
+
+    when(roleServices.deleteRole(roleKey))
+        .thenReturn(CompletableFuture.completedFuture(roleRecord));
+
+    // when
+    webClient
+        .delete()
+        .uri("%s/%s".formatted(ROLE_BASE_URL, roleKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(roleServices, times(1)).deleteRole(roleKey);
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/role/BrokerRoleDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/role/BrokerRoleDeleteRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request.role;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerRoleDeleteRequest extends BrokerExecuteCommand<RoleRecord> {
+  private final RoleRecord requestDto = new RoleRecord();
+
+  public BrokerRoleDeleteRequest(final long key) {
+    super(ValueType.ROLE, RoleIntent.DELETE);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+    setRoleKey(key);
+  }
+
+  public BrokerRoleDeleteRequest setRoleKey(final long roleKey) {
+    requestDto.setRoleKey(roleKey);
+    return this;
+  }
+
+  @Override
+  public RoleRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected RoleRecord toResponseDto(final DirectBuffer buffer) {
+    final var response = new RoleRecord();
+    response.wrap(buffer);
+    return response;
+  }
+}


### PR DESCRIPTION
Builds on https://github.com/camunda/camunda/pull/24418

## Description

This PR implements `DELETE /v2/roles/{roleKey}` as part of #22389.

Closes #24578
