### PR TITLE
[Backport stable/8.5] fix: throw correct error instead of InternalError

### DIFF
--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestFailedException.java
@@ -37,5 +37,9 @@ public sealed interface TopologyRequestFailedException {
     public InternalError(final Throwable cause) {
       super(cause);
     }
+
+    public InternalError(final String message) {
+      super(message);
+    }
   }
 }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -103,7 +103,7 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
                         // the default coordinator
                         failFuture(
                             future,
-                            new InternalError(
+                            new TopologyRequestFailedException.InternalError(
                                 String.format(
                                     "Cannot process request to change the topology. The broker '%s' is not the coordinator.",
                                     localMemberId)));


### PR DESCRIPTION
# Description
Backport of #24680 to `stable/8.5`.

relates to 
original author: @entangled90