### PR TITLE
[Backport stable/8.6] fix: throw correct error instead of InternalError

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestFailedException.java
@@ -39,5 +39,9 @@ public sealed interface ClusterConfigurationRequestFailedException {
     public InternalError(final Throwable cause) {
       super(cause);
     }
+
+    public InternalError(final String message) {
+      super(message);
+    }
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImpl.java
@@ -106,7 +106,7 @@ public class ConfigurationChangeCoordinatorImpl implements ConfigurationChangeCo
                         // the default coordinator
                         failFuture(
                             future,
-                            new InternalError(
+                            new ClusterConfigurationRequestFailedException.InternalError(
                                 String.format(
                                     "Cannot process request to change the configuration. The broker '%s' is not the coordinator.",
                                     localMemberId)));


### PR DESCRIPTION
# Description
Backport of #24680 to `stable/8.6`.

relates to 
original author: @entangled90