### PR TITLE
feat: store metadata of newly created deployments

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -143,7 +143,7 @@ public final class DeploymentCreateProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<DeploymentRecord> command) {
-    if (deploymentState.getStoredDeploymentRecord(command.getKey()) != null) {
+    if (deploymentState.hasStoredDeploymentRecord(command.getKey())) {
       // we already processed this deployment, so we can ignore it
       distributionBehavior.acknowledgeCommand(command);
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -146,6 +146,8 @@ public final class DeploymentCreateProcessor
     if (deploymentState.hasStoredDeploymentRecord(command.getKey())) {
       // we already processed this deployment, so we can ignore it
       distributionBehavior.acknowledgeCommand(command);
+      rejectionWriter.appendRejection(
+          command, RejectionType.ALREADY_EXISTS, "Deployment already exists");
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV1Applier.java
@@ -12,12 +12,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 
-public class DeploymentCreatedApplier
+public class DeploymentCreatedV1Applier
     implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
 
   private final MutableDeploymentState mutableDeploymentState;
 
-  public DeploymentCreatedApplier(final MutableDeploymentState mutableDeploymentState) {
+  public DeploymentCreatedV1Applier(final MutableDeploymentState mutableDeploymentState) {
     this.mutableDeploymentState = mutableDeploymentState;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV2Applier.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+
+public class DeploymentCreatedV2Applier
+    implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+
+  @Override
+  public void applyState(final long key, final DeploymentRecord value) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV2Applier.java
@@ -8,12 +8,20 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 
 public class DeploymentCreatedV2Applier
     implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentCreatedV2Applier(final MutableDeploymentState deploymentState) {
+    this.deploymentState = deploymentState;
+  }
 
   @Override
-  public void applyState(final long key, final DeploymentRecord value) {}
+  public void applyState(final long key, final DeploymentRecord value) {
+    deploymentState.storeDeploymentRecord(key, value);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV3Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentCreatedV3Applier.java
@@ -12,11 +12,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 
-public class DeploymentCreatedV2Applier
+public class DeploymentCreatedV3Applier
     implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
   private final MutableDeploymentState deploymentState;
 
-  public DeploymentCreatedV2Applier(final MutableDeploymentState deploymentState) {
+  public DeploymentCreatedV3Applier(final MutableDeploymentState deploymentState) {
     this.deploymentState = deploymentState;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -153,7 +153,7 @@ public final class EventAppliers implements EventApplier {
 
     register(
         DeploymentIntent.CREATED, 1, new DeploymentCreatedV1Applier(state.getDeploymentState()));
-    register(DeploymentIntent.CREATED, 2, NOOP_EVENT_APPLIER);
+    register(DeploymentIntent.CREATED, 2, new DeploymentCreatedV2Applier());
     register(
         DeploymentIntent.DISTRIBUTED,
         new DeploymentDistributedApplier(state.getProcessState(), state.getDecisionState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -151,7 +151,8 @@ public final class EventAppliers implements EventApplier {
         DeploymentDistributionIntent.COMPLETED,
         new DeploymentDistributionCompletedApplier(state.getDeploymentState()));
 
-    register(DeploymentIntent.CREATED, 1, new DeploymentCreatedApplier(state.getDeploymentState()));
+    register(
+        DeploymentIntent.CREATED, 1, new DeploymentCreatedV1Applier(state.getDeploymentState()));
     register(DeploymentIntent.CREATED, 2, NOOP_EVENT_APPLIER);
     register(
         DeploymentIntent.DISTRIBUTED,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -153,8 +153,9 @@ public final class EventAppliers implements EventApplier {
 
     register(
         DeploymentIntent.CREATED, 1, new DeploymentCreatedV1Applier(state.getDeploymentState()));
+    register(DeploymentIntent.CREATED, 2, NOOP_EVENT_APPLIER);
     register(
-        DeploymentIntent.CREATED, 2, new DeploymentCreatedV2Applier(state.getDeploymentState()));
+        DeploymentIntent.CREATED, 3, new DeploymentCreatedV3Applier(state.getDeploymentState()));
     register(
         DeploymentIntent.DISTRIBUTED,
         new DeploymentDistributedApplier(state.getProcessState(), state.getDecisionState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -153,7 +153,8 @@ public final class EventAppliers implements EventApplier {
 
     register(
         DeploymentIntent.CREATED, 1, new DeploymentCreatedV1Applier(state.getDeploymentState()));
-    register(DeploymentIntent.CREATED, 2, new DeploymentCreatedV2Applier());
+    register(
+        DeploymentIntent.CREATED, 2, new DeploymentCreatedV2Applier(state.getDeploymentState()));
     register(
         DeploymentIntent.DISTRIBUTED,
         new DeploymentDistributedApplier(state.getProcessState(), state.getDecisionState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -106,6 +106,12 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
+  public boolean hasStoredDeploymentRecord(final long deploymentKey) {
+    this.deploymentKey.wrapLong(deploymentKey);
+    return deploymentRawColumnFamily.exists(this.deploymentKey);
+  }
+
+  @Override
   public DeploymentRecord getStoredDeploymentRecord(final long key) {
     deploymentKey.wrapLong(key);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
@@ -30,6 +30,12 @@ public interface DeploymentState {
    */
   boolean hasPendingDeploymentDistribution(long deploymentKey, int partitionId);
 
+  /**
+   * Returns true when there is a deployment record stored for the given deployment key. Similar to
+   * {@link #getStoredDeploymentRecord(long)} but doesn't return the record.
+   */
+  boolean hasStoredDeploymentRecord(long deploymentKey);
+
   DeploymentRecord getStoredDeploymentRecord(long deploymentKey);
 
   void foreachPendingDeploymentDistribution(PendingDeploymentVisitor pendingDeploymentVisitor);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -46,7 +46,8 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.PROCESS_CACHE_DIGEST_BY_ID,
           ZbColumnFamilies.PROCESS_DEFINITION_KEY_BY_PROCESS_ID_AND_DEPLOYMENT_KEY,
           ZbColumnFamilies.MESSAGE_STATS,
-          ZbColumnFamilies.MIGRATIONS_STATE);
+          ZbColumnFamilies.MIGRATIONS_STATE,
+          ZbColumnFamilies.DEPLOYMENT_RAW);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -116,6 +116,30 @@ public class DeploymentStateTest {
   }
 
   @Test
+  public void shouldReturnFalseWhenCheckingIfNonExistingDeploymentExists() {
+    // given
+
+    // when
+    final var hasStoredDeploymentRecord = deploymentState.hasStoredDeploymentRecord(1);
+
+    // then
+    assertThat(hasStoredDeploymentRecord).isFalse();
+  }
+
+  @Test
+  public void shouldReturnTrueWhenCheckingIfExistingDeploymentExists() {
+    // given
+    final var deployment = createDeployment();
+    deploymentState.storeDeploymentRecord(1, deployment);
+
+    // when
+    final var hasStoredDeploymentRecord = deploymentState.hasStoredDeploymentRecord(1);
+
+    // then
+    assertThat(hasStoredDeploymentRecord).isTrue();
+  }
+
+  @Test
   public void shouldRemoveDeploymentIdempotent() {
     // given
 


### PR DESCRIPTION
This creates a new applier for the Deployment/Created event that actually stores the record in the state. The records only contains the resource metadata.

Because we don't want to overwrite deployments, the processor now checks whether a deployment already exists before handling a distributed Deployment/Create command. If it does, we simply write a rejection.
This also means that we no longer re-create the resources needlessly, so that's a small performance win too.

:thought_balloon: I wasn't sure what to do about the old deployment handling where we remove the deployment from the state once fully distributed. This mechanism is no longer used since we switched to generalized command distribution but the code for it is still there, so there's a chance that we can still remove deployments. Could we remove the old processors/appliers now?

closes #24683
