### PR TITLE
test: add test coverage - escalation boundary events migration

### DIFF
--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_1.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.6.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -21,9 +21,9 @@
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>Flow_0qko2kt</bpmn:incoming>
+      <bpmn:incoming>Flow_1nlysp1</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Gateway_3" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
@@ -44,9 +44,9 @@
     <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_18wek8y" sourceRef="Gateway_1" targetRef="checkPayment" />
-    <bpmn:parallelGateway id="Gateway_1">
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+    <bpmn:sequenceFlow id="Flow_18wek8y" sourceRef="Gateway_2" targetRef="checkPayment" />
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>Flow_16t2gpe</bpmn:incoming>
       <bpmn:outgoing>Flow_18wek8y</bpmn:outgoing>
       <bpmn:outgoing>Flow_1clcikd</bpmn:outgoing>
       <bpmn:outgoing>Flow_1lf6gyt</bpmn:outgoing>
@@ -57,13 +57,7 @@
       <bpmn:outgoing>Flow_0u36x7t</bpmn:outgoing>
       <bpmn:outgoing>Flow_1f1rfgt</bpmn:outgoing>
       <bpmn:outgoing>Flow_1waofjt</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1eim29b</bpmn:outgoing>
-      <bpmn:outgoing>Flow_08q3qdg</bpmn:outgoing>
-      <bpmn:outgoing>Flow_17wkkw8</bpmn:outgoing>
-      <bpmn:outgoing>Flow_13sckg7</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0jv6wo5</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_0qko2kt" sourceRef="Gateway_2" targetRef="EndEvent_1" />
     <bpmn:endEvent id="Event_2">
       <bpmn:incoming>Flow_14ee2ym</bpmn:incoming>
     </bpmn:endEvent>
@@ -107,10 +101,10 @@
     <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_2" />
     <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting" targetRef="Event_3" />
     <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting" targetRef="Event_4" />
-    <bpmn:sequenceFlow id="Flow_1clcikd" sourceRef="Gateway_1" targetRef="TaskA" />
-    <bpmn:sequenceFlow id="Flow_1lf6gyt" sourceRef="Gateway_1" targetRef="TaskB" />
-    <bpmn:sequenceFlow id="Flow_0vrcdpx" sourceRef="Gateway_1" targetRef="TaskC" />
-    <bpmn:parallelGateway id="Gateway_2">
+    <bpmn:sequenceFlow id="Flow_1clcikd" sourceRef="Gateway_2" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_1lf6gyt" sourceRef="Gateway_2" targetRef="TaskB" />
+    <bpmn:sequenceFlow id="Flow_0vrcdpx" sourceRef="Gateway_2" targetRef="TaskC" />
+    <bpmn:parallelGateway id="Gateway_3">
       <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
       <bpmn:incoming>Flow_18qdbnx</bpmn:incoming>
       <bpmn:incoming>Flow_1i7pkzb</bpmn:incoming>
@@ -121,16 +115,11 @@
       <bpmn:incoming>Flow_001yqxb</bpmn:incoming>
       <bpmn:incoming>Flow_0uq9222</bpmn:incoming>
       <bpmn:incoming>Flow_1l6mtqy</bpmn:incoming>
-      <bpmn:incoming>Flow_1ia1hjp</bpmn:incoming>
-      <bpmn:incoming>Flow_0vt5svt</bpmn:incoming>
-      <bpmn:incoming>Flow_1k08s0c</bpmn:incoming>
-      <bpmn:incoming>Flow_19gk47y</bpmn:incoming>
-      <bpmn:incoming>Flow_0nmo857</bpmn:incoming>
-      <bpmn:outgoing>Flow_0qko2kt</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1bo0sui</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_1o99cpi" sourceRef="TaskB" targetRef="TimerIntermediateCatch" />
-    <bpmn:sequenceFlow id="Flow_18qdbnx" sourceRef="TaskC" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_143wmxd" sourceRef="Gateway_1" targetRef="TaskD" />
+    <bpmn:sequenceFlow id="Flow_18qdbnx" sourceRef="TaskC" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_143wmxd" sourceRef="Gateway_2" targetRef="TaskD" />
     <bpmn:endEvent id="Event_5">
       <bpmn:incoming>Flow_093zwcs</bpmn:incoming>
     </bpmn:endEvent>
@@ -141,7 +130,7 @@
       <bpmn:incoming>Flow_143wmxd</bpmn:incoming>
       <bpmn:outgoing>Flow_1i7pkzb</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1i7pkzb" sourceRef="TaskD" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_1i7pkzb" sourceRef="TaskD" targetRef="Gateway_3" />
     <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
@@ -161,10 +150,10 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1M</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0yq74mw" sourceRef="TimerIntermediateCatch" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0e569q0" sourceRef="TaskA" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_08ahq87" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch" />
-    <bpmn:sequenceFlow id="Flow_1wxn661" sourceRef="MessageIntermediateCatch" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0yq74mw" sourceRef="TimerIntermediateCatch" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_0e569q0" sourceRef="TaskA" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_08ahq87" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
+    <bpmn:sequenceFlow id="Flow_1wxn661" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
     <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
@@ -203,8 +192,8 @@
         </bpmn:timerEventDefinition>
       </bpmn:startEvent>
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_1jeea8a" sourceRef="Gateway_1" targetRef="MessageReceiveTask" />
-    <bpmn:sequenceFlow id="Flow_17dl770" sourceRef="MessageReceiveTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_1jeea8a" sourceRef="Gateway_2" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_17dl770" sourceRef="MessageReceiveTask" targetRef="Gateway_3" />
     <bpmn:receiveTask id="MessageReceiveTask" name="Message receive task" messageRef="Message_14us09o">
       <bpmn:incoming>Flow_1jeea8a</bpmn:incoming>
       <bpmn:outgoing>Flow_17dl770</bpmn:outgoing>
@@ -213,8 +202,8 @@
       <bpmn:outgoing>Flow_14ee2ym</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_144v54n" messageRef="Message_0so1os3" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0u36x7t" sourceRef="Gateway_1" targetRef="BusinessRuleTask" />
-    <bpmn:sequenceFlow id="Flow_001yqxb" sourceRef="BusinessRuleTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0u36x7t" sourceRef="Gateway_2" targetRef="BusinessRuleTask" />
+    <bpmn:sequenceFlow id="Flow_001yqxb" sourceRef="BusinessRuleTask" targetRef="Gateway_3" />
     <bpmn:businessRuleTask id="BusinessRuleTask" name="Business rule task">
       <bpmn:extensionElements>
         <zeebe:calledDecision decisionId="invalid" resultVariable="result" />
@@ -222,7 +211,7 @@
       <bpmn:incoming>Flow_0u36x7t</bpmn:incoming>
       <bpmn:outgoing>Flow_001yqxb</bpmn:outgoing>
     </bpmn:businessRuleTask>
-    <bpmn:sequenceFlow id="Flow_1f1rfgt" sourceRef="Gateway_1" targetRef="ScriptTask" />
+    <bpmn:sequenceFlow id="Flow_1f1rfgt" sourceRef="Gateway_2" targetRef="ScriptTask" />
     <bpmn:scriptTask id="ScriptTask" name="Script Task">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="failingTaskWorker" />
@@ -230,7 +219,7 @@
       <bpmn:incoming>Flow_1f1rfgt</bpmn:incoming>
       <bpmn:outgoing>Flow_0uq9222</bpmn:outgoing>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_0uq9222" sourceRef="ScriptTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0uq9222" sourceRef="ScriptTask" targetRef="Gateway_3" />
     <bpmn:sendTask id="SendTask" name="Send Task">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" retries="0" />
@@ -238,11 +227,10 @@
       <bpmn:incoming>Flow_1waofjt</bpmn:incoming>
       <bpmn:outgoing>Flow_1l6mtqy</bpmn:outgoing>
     </bpmn:sendTask>
-    <bpmn:sequenceFlow id="Flow_1waofjt" sourceRef="Gateway_1" targetRef="SendTask" />
-    <bpmn:sequenceFlow id="Flow_1l6mtqy" sourceRef="SendTask" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_1eim29b" sourceRef="Gateway_1" targetRef="ExclusiveGateway" />
+    <bpmn:sequenceFlow id="Flow_1waofjt" sourceRef="Gateway_2" targetRef="SendTask" />
+    <bpmn:sequenceFlow id="Flow_1l6mtqy" sourceRef="SendTask" targetRef="Gateway_3" />
     <bpmn:exclusiveGateway id="ExclusiveGateway" name="Exclusive gateway">
-      <bpmn:incoming>Flow_1eim29b</bpmn:incoming>
+      <bpmn:incoming>Flow_1fo0rfs</bpmn:incoming>
       <bpmn:outgoing>Flow_126yu9s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
@@ -250,13 +238,11 @@
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_1cs756a">
       <bpmn:incoming>Flow_126yu9s</bpmn:incoming>
-      <bpmn:outgoing>Flow_1ia1hjp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_01ogvlh</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1ia1hjp" sourceRef="Gateway_1cs756a" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_08q3qdg" sourceRef="Gateway_1" targetRef="EventBasedGateway" />
     <bpmn:eventBasedGateway id="EventBasedGateway" name="Event based gateway">
       <bpmn:extensionElements />
-      <bpmn:incoming>Flow_08q3qdg</bpmn:incoming>
+      <bpmn:incoming>Flow_0lsyc1w</bpmn:incoming>
       <bpmn:outgoing>Flow_0guz7jv</bpmn:outgoing>
       <bpmn:outgoing>Flow_0v8bsdg</bpmn:outgoing>
     </bpmn:eventBasedGateway>
@@ -278,10 +264,9 @@
     <bpmn:exclusiveGateway id="Gateway_0ftzss1">
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
       <bpmn:incoming>Flow_0j0qeck</bpmn:incoming>
-      <bpmn:outgoing>Flow_0vt5svt</bpmn:outgoing>
+      <bpmn:outgoing>Flow_17m3xiv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_0vt5svt" sourceRef="Gateway_0ftzss1" targetRef="Gateway_2" />
     <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
       <bpmn:sequenceFlow id="Flow_189mrto" sourceRef="SignalStartEvent" targetRef="TaskH" />
       <bpmn:endEvent id="Event_0opmx5v">
@@ -308,22 +293,20 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_0bfr615" sourceRef="SignalBoundaryEvent" targetRef="Event_049m1di" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_17wkkw8" sourceRef="Gateway_1" targetRef="SignalIntermediateThrow" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
-      <bpmn:incoming>Flow_17wkkw8</bpmn:incoming>
+      <bpmn:incoming>Flow_0p5smdr</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0biu2sq" signalRef="Signal_3r9rbp1" />
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
     <bpmn:intermediateCatchEvent id="SignalIntermediateCatch" name="Signal intermediate catch">
       <bpmn:incoming>Flow_1359yom</bpmn:incoming>
-      <bpmn:outgoing>Flow_1k08s0c</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0g97m5r</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_104j77q" />
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_1k08s0c" sourceRef="SignalIntermediateCatch" targetRef="Gateway_2" />
     <bpmn:subProcess id="SubProcess" name="Sub process">
-      <bpmn:incoming>Flow_13sckg7</bpmn:incoming>
-      <bpmn:outgoing>Flow_19gk47y</bpmn:outgoing>
+      <bpmn:incoming>Flow_0jtyhkp</bpmn:incoming>
+      <bpmn:outgoing>Flow_175yfvp</bpmn:outgoing>
       <bpmn:startEvent id="SubProcessStartEvent">
         <bpmn:outgoing>Flow_1w9iwsx</bpmn:outgoing>
       </bpmn:startEvent>
@@ -351,12 +334,9 @@
       </bpmn:endEvent>
       <bpmn:sequenceFlow id="Flow_1w9iwsx" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_13sckg7" sourceRef="Gateway_1" targetRef="SubProcess" />
-    <bpmn:sequenceFlow id="Flow_19gk47y" sourceRef="SubProcess" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0jv6wo5" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess" />
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
-      <bpmn:incoming>Flow_0jv6wo5</bpmn:incoming>
-      <bpmn:outgoing>Flow_0nmo857</bpmn:outgoing>
+      <bpmn:incoming>Flow_1nydbto</bpmn:incoming>
+      <bpmn:outgoing>Flow_13t7yla</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
           <zeebe:loopCharacteristics inputCollection="=[1,2]" />
@@ -383,7 +363,82 @@
       </bpmn:startEvent>
       <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_0nmo857" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_2" />
+    <bpmn:subProcess id="EscalationSubProcess" name="Escalation sub process">
+      <bpmn:incoming>Flow_1e1hjfq</bpmn:incoming>
+      <bpmn:outgoing>Flow_01wk5qr</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1vxuw3v">
+        <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
+      <bpmn:endEvent id="Event_02vrwd0">
+        <bpmn:incoming>Flow_12rxp59</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_12rxp59" sourceRef="Event_0iwm1fq" targetRef="Event_02vrwd0" />
+      <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
+        <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
+        <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1v2o7l5" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
+      <bpmn:serviceTask id="EscalationTask" name="Escalation task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="escalationWorker" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0qxvh80</bpmn:incoming>
+        <bpmn:outgoing>Flow_0bbhalt</bpmn:outgoing>
+      </bpmn:serviceTask>
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1fxsnef" attachedToRef="EscalationSubProcess">
+      <bpmn:outgoing>Flow_0xejz9b</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_16t2gpe" sourceRef="Gateway_1" targetRef="Gateway_2" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_16t2gpe</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0vm1c0b</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_4">
+      <bpmn:incoming>Flow_0vm1c0b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fo0rfs</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0lsyc1w</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0p5smdr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0jtyhkp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1nydbto</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1e1hjfq</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0vm1c0b" sourceRef="Gateway_1" targetRef="Gateway_4" />
+    <bpmn:sequenceFlow id="Flow_1fo0rfs" sourceRef="Gateway_4" targetRef="ExclusiveGateway" />
+    <bpmn:sequenceFlow id="Flow_0lsyc1w" sourceRef="Gateway_4" targetRef="EventBasedGateway" />
+    <bpmn:sequenceFlow id="Flow_0p5smdr" sourceRef="Gateway_4" targetRef="SignalIntermediateThrow" />
+    <bpmn:sequenceFlow id="Flow_0jtyhkp" sourceRef="Gateway_4" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow_1nydbto" sourceRef="Gateway_4" targetRef="MultiInstanceSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1e1hjfq" sourceRef="Gateway_4" targetRef="EscalationSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1dzoyo4" sourceRef="Gateway_5" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_5">
+      <bpmn:incoming>Flow_01ogvlh</bpmn:incoming>
+      <bpmn:incoming>Flow_17m3xiv</bpmn:incoming>
+      <bpmn:incoming>Flow_0g97m5r</bpmn:incoming>
+      <bpmn:incoming>Flow_175yfvp</bpmn:incoming>
+      <bpmn:incoming>Flow_13t7yla</bpmn:incoming>
+      <bpmn:incoming>Flow_01wk5qr</bpmn:incoming>
+      <bpmn:incoming>Flow_0xejz9b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dzoyo4</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_01ogvlh" sourceRef="Gateway_1cs756a" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_17m3xiv" sourceRef="Gateway_0ftzss1" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0g97m5r" sourceRef="SignalIntermediateCatch" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_175yfvp" sourceRef="SubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_13t7yla" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_01wk5qr" sourceRef="EscalationSubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1nlysp1" sourceRef="Gateway_6" targetRef="EndEvent_1" />
+    <bpmn:parallelGateway id="Gateway_6">
+      <bpmn:incoming>Flow_1dzoyo4</bpmn:incoming>
+      <bpmn:incoming>Flow_1bo0sui</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nlysp1</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1bo0sui" sourceRef="Gateway_3" targetRef="Gateway_6" />
+    <bpmn:sequenceFlow id="Flow_0xejz9b" sourceRef="Event_1fxsnef" targetRef="Gateway_5" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -424,550 +479,627 @@
   <bpmn:signal id="Signal_104j77q" name="Signal_2" />
   <bpmn:error id="Error_00pqgg4" name="error" errorCode="error" />
   <bpmn:error id="Error_13vdeq4" name="error" errorCode="error" />
+  <bpmn:escalation id="Escalation_1v2o7l5" name="Escalation_1" escalationCode="123" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessMigration">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="175" y="120" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="157" y="156" width="73" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
-        <dc:Bounds x="440" y="98" width="100" height="80" />
+        <dc:Bounds x="440" y="160" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
-        <dc:Bounds x="773" y="98" width="100" height="80" />
+        <dc:Bounds x="773" y="160" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="609" y="175" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="600" y="147" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="584" y="322" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1p3ovhb_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="305" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="562" y="647" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="562" y="797" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="562" y="957" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
+        <dc:Bounds x="440" y="532" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
+        <dc:Bounds x="440" y="694" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
+        <dc:Bounds x="440" y="854" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="562" y="1117" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
+        <dc:Bounds x="440" y="1014" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
+        <dc:Bounds x="722" y="444" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="696" y="487" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
+        <dc:Bounds x="742" y="716" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="715" y="760" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="440" y="1212" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_068k72z_di" bpmnElement="BusinessRuleTask">
+        <dc:Bounds x="440" y="1322" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c02rbz_di" bpmnElement="ScriptTask">
+        <dc:Bounds x="440" y="1432" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0t0kboe_di" bpmnElement="SendTask">
+        <dc:Bounds x="440" y="1542" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="92" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="128" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1nphcyi_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="305" y="85" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1bflyvp_di" bpmnElement="Gateway_3">
+        <dc:Bounds x="945" y="1557" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+        <dc:Bounds x="1205" y="175" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1207" y="233" width="47" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
+        <dc:Bounds x="1445" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway">
+        <dc:Bounds x="1205" y="285" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1159" y="326" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB">
+        <dc:Bounds x="1412" y="292" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1400" y="335" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB">
+        <dc:Bounds x="1412" y="392" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1400" y="435" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
+        <dc:Bounds x="1585" y="285" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
+        <dc:Bounds x="1212" y="502" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1200" y="545" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch">
+        <dc:Bounds x="1412" y="502" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1386" y="545" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1gkqj5u_di" bpmnElement="Gateway_4">
+        <dc:Bounds x="1035" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1tdy0d3_di" bpmnElement="Gateway_5">
+        <dc:Bounds x="1675" y="1557" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="1462" y="120" width="36" height="36" />
+        <dc:Bounds x="2182" y="1652" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="609" y="113" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="600" y="85" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
-        <dc:Bounds x="584" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1p3ovhb_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="305" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
-        <dc:Bounds x="562" y="585" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
-        <dc:Bounds x="562" y="735" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
-        <dc:Bounds x="562" y="895" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
-        <dc:Bounds x="440" y="470" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
-        <dc:Bounds x="440" y="632" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
-        <dc:Bounds x="440" y="792" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bflyvp_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="945" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
-        <dc:Bounds x="562" y="1055" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
-        <dc:Bounds x="440" y="952" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
-        <dc:Bounds x="722" y="382" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="696" y="425" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
-        <dc:Bounds x="742" y="654" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="715" y="698" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1490" y="290" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="1752" y="372" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="1610" y="350" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="1530" y="372" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1512" y="415" width="73" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="1566" y="390" />
-        <di:waypoint x="1610" y="390" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="1710" y="390" />
-        <di:waypoint x="1752" y="390" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1490" y="540" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="1752" y="622" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="1610" y="600" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="1530" y="622" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1507" y="665" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="1566" y="640" />
-        <di:waypoint x="1610" y="640" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="1710" y="640" />
-        <di:waypoint x="1752" y="640" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
-        <dc:Bounds x="440" y="1150" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_068k72z_di" bpmnElement="BusinessRuleTask">
-        <dc:Bounds x="440" y="1260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1c02rbz_di" bpmnElement="ScriptTask">
-        <dc:Bounds x="440" y="1370" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0t0kboe_di" bpmnElement="SendTask">
-        <dc:Bounds x="440" y="1480" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
-        <dc:Bounds x="465" y="1595" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="465" y="1653" width="50" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
-        <dc:Bounds x="705" y="1595" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway">
-        <dc:Bounds x="465" y="1705" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="417" y="1746" width="65" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB">
-        <dc:Bounds x="672" y="1712" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="658" y="1755" width="64" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB">
-        <dc:Bounds x="672" y="1812" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="660" y="1855" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
-        <dc:Bounds x="845" y="1705" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1490" y="790" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="1782" y="872" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="1620" y="850" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="1530" y="872" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1506" y="915" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="1782" y="942" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="1672" y="912" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1650" y="955" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="1566" y="890" />
-        <di:waypoint x="1620" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="1720" y="890" />
-        <di:waypoint x="1782" y="890" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="1690" y="948" />
-        <di:waypoint x="1690" y="960" />
-        <di:waypoint x="1782" y="960" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
-        <dc:Bounds x="472" y="1922" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="460" y="1965" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch">
-        <dc:Bounds x="672" y="1922" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="646" y="1965" width="90" height="27" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_1j4ljfk_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="1675" y="1645" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lb6pou_di" bpmnElement="SubProcess" isExpanded="true">
-        <dc:Bounds x="382" y="2030" width="423" height="350" />
+        <dc:Bounds x="1122" y="610" width="423" height="350" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1v2yf5g" bpmnElement="SubProcessStartEvent">
-        <dc:Bounds x="459" y="2072" width="36" height="36" />
+        <dc:Bounds x="1199" y="652" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1d78vu4_di" bpmnElement="ErrorEndEvent">
+        <dc:Bounds x="1412" y="652" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0cqp75h_di" bpmnElement="ErrorEventSubProcess" isExpanded="true">
-        <dc:Bounds x="420" y="2153" width="350" height="200" />
+        <dc:Bounds x="1160" y="733" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_157z1vz_di" bpmnElement="ErrorStartEvent">
-        <dc:Bounds x="460" y="2235" width="36" height="36" />
+        <dc:Bounds x="1200" y="815" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="439" y="2278" width="79" height="14" />
+          <dc:Bounds x="1179" y="858" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_07uk0ug_di" bpmnElement="Event_07uk0ug">
-        <dc:Bounds x="672" y="2235" width="36" height="36" />
+        <dc:Bounds x="1412" y="815" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0csidym_di" bpmnElement="TaskG">
-        <dc:Bounds x="530" y="2213" width="100" height="80" />
+        <dc:Bounds x="1270" y="793" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1ic0jav_di" bpmnElement="Flow_1ic0jav">
-        <di:waypoint x="496" y="2253" />
-        <di:waypoint x="530" y="2253" />
+        <di:waypoint x="1236" y="833" />
+        <di:waypoint x="1270" y="833" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dsa3rn_di" bpmnElement="Flow_1dsa3rn">
-        <di:waypoint x="630" y="2253" />
-        <di:waypoint x="672" y="2253" />
+        <di:waypoint x="1370" y="833" />
+        <di:waypoint x="1412" y="833" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1d78vu4_di" bpmnElement="ErrorEndEvent">
-        <dc:Bounds x="672" y="2072" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1w9iwsx_di" bpmnElement="Flow_1w9iwsx">
-        <di:waypoint x="495" y="2090" />
-        <di:waypoint x="672" y="2090" />
+        <di:waypoint x="1235" y="670" />
+        <di:waypoint x="1412" y="670" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
-        <dc:Bounds x="459" y="2440" width="350" height="200" />
+        <dc:Bounds x="1199" y="1020" width="350" height="200" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
-        <dc:Bounds x="499" y="2522" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
-        <dc:Bounds x="739" y="2522" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask">
-        <dc:Bounds x="587" y="2500" width="100" height="80" />
+        <dc:Bounds x="1327" y="1080" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
+        <dc:Bounds x="1479" y="1102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
+        <dc:Bounds x="1239" y="1102" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
-        <di:waypoint x="535" y="2540" />
-        <di:waypoint x="587" y="2540" />
+        <di:waypoint x="1275" y="1120" />
+        <di:waypoint x="1327" y="1120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
-        <di:waypoint x="687" y="2540" />
-        <di:waypoint x="739" y="2540" />
+        <di:waypoint x="1427" y="1120" />
+        <di:waypoint x="1479" y="1120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+        <dc:Bounds x="1199" y="1270" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02vrwd0_di" bpmnElement="Event_02vrwd0">
+        <dc:Bounds x="1492" y="1352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f62b1z_di" bpmnElement="Event_0iwm1fq">
+        <dc:Bounds x="1422" y="1352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vxuw3v_di" bpmnElement="Event_1vxuw3v">
+        <dc:Bounds x="1222" y="1352" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14net6k_di" bpmnElement="EscalationTask">
+        <dc:Bounds x="1290" y="1330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_12rxp59_di" bpmnElement="Flow_12rxp59">
+        <di:waypoint x="1458" y="1370" />
+        <di:waypoint x="1492" y="1370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bbhalt_di" bpmnElement="Flow_0bbhalt">
+        <di:waypoint x="1390" y="1370" />
+        <di:waypoint x="1422" y="1370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qxvh80_di" bpmnElement="Flow_0qxvh80">
+        <di:waypoint x="1258" y="1370" />
+        <di:waypoint x="1290" y="1370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1840" y="200" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="2102" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="1960" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="1880" y="282" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1864" y="325" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="2060" y="300" />
+        <di:waypoint x="2102" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="1916" y="300" />
+        <di:waypoint x="1960" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1840" y="450" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="2102" y="532" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="1960" y="510" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="1880" y="532" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1857" y="575" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="2060" y="550" />
+        <di:waypoint x="2102" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="1916" y="550" />
+        <di:waypoint x="1960" y="550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1840" y="700" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="2132" y="782" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="1970" y="760" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="1880" y="782" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1856" y="825" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="2132" y="852" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="2022" y="822" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2000" y="865" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="2070" y="800" />
+        <di:waypoint x="2132" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="1916" y="800" />
+        <di:waypoint x="1970" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="2040" y="858" />
+        <di:waypoint x="2040" y="870" />
+        <di:waypoint x="2132" y="870" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
-        <dc:Bounds x="492" y="532" width="36" height="36" />
+        <dc:Bounds x="492" y="594" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="442" y="559" width="56" height="27" />
+          <dc:Bounds x="442" y="621" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
-        <dc:Bounds x="492" y="1014" width="36" height="36" />
+        <dc:Bounds x="492" y="1076" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="442" y="1049" width="56" height="27" />
+          <dc:Bounds x="442" y="1111" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
-        <dc:Bounds x="492" y="854" width="36" height="36" />
+        <dc:Bounds x="492" y="916" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="434" y="889" width="71" height="27" />
+          <dc:Bounds x="434" y="951" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
-        <dc:Bounds x="492" y="694" width="36" height="36" />
+        <dc:Bounds x="492" y="756" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="417" y="726" width="86" height="14" />
+          <dc:Bounds x="417" y="788" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
-        <di:waypoint x="211" y="138" />
-        <di:waypoint x="305" y="138" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="873" y="138" />
-        <di:waypoint x="945" y="138" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="337.5" y="227" width="90" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="540" y="138" />
-        <di:waypoint x="609" y="138" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="54.5" y="227" width="0" height="12" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="634" y="163" />
-        <di:waypoint x="634" y="260" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="590" y="188" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="Event_1fxsnef">
+        <dc:Bounds x="1362" y="1452" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="584" y="300" />
-        <di:waypoint x="490" y="300" />
-        <di:waypoint x="490" y="178" />
+        <di:waypoint x="584" y="362" />
+        <di:waypoint x="490" y="362" />
+        <di:waypoint x="490" y="240" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="659" y="138" />
-        <di:waypoint x="773" y="138" />
+      <bpmndi:BPMNEdge id="Flow_18wek8y_di" bpmnElement="Flow_18wek8y">
+        <di:waypoint x="355" y="200" />
+        <di:waypoint x="440" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
+        <di:waypoint x="540" y="200" />
+        <di:waypoint x="609" y="200" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="706" y="117" width="21" height="14" />
+          <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18wek8y_di" bpmnElement="Flow_18wek8y">
-        <di:waypoint x="355" y="138" />
-        <di:waypoint x="440" y="138" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
+        <di:waypoint x="659" y="200" />
+        <di:waypoint x="773" y="200" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="706" y="179" width="21" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qko2kt_di" bpmnElement="Flow_0qko2kt">
-        <di:waypoint x="995" y="138" />
-        <di:waypoint x="1462" y="138" />
+      <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
+        <di:waypoint x="873" y="200" />
+        <di:waypoint x="970" y="200" />
+        <di:waypoint x="970" y="1557" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="337.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
-        <di:waypoint x="510" y="568" />
-        <di:waypoint x="510" y="603" />
-        <di:waypoint x="562" y="603" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
+        <di:waypoint x="634" y="225" />
+        <di:waypoint x="634" y="322" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="590" y="250" width="41" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
-        <di:waypoint x="510" y="730" />
-        <di:waypoint x="510" y="753" />
-        <di:waypoint x="562" y="753" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
-        <di:waypoint x="510" y="890" />
-        <di:waypoint x="510" y="913" />
-        <di:waypoint x="562" y="913" />
+      <bpmndi:BPMNEdge id="Flow_16t2gpe_di" bpmnElement="Flow_16t2gpe">
+        <di:waypoint x="330" y="135" />
+        <di:waypoint x="330" y="175" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1clcikd_di" bpmnElement="Flow_1clcikd">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="510" />
-        <di:waypoint x="440" y="510" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="572" />
+        <di:waypoint x="440" y="572" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1lf6gyt_di" bpmnElement="Flow_1lf6gyt">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="672" />
-        <di:waypoint x="440" y="672" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="734" />
+        <di:waypoint x="440" y="734" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vrcdpx_di" bpmnElement="Flow_0vrcdpx">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="832" />
-        <di:waypoint x="440" y="832" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o99cpi_di" bpmnElement="Flow_1o99cpi">
-        <di:waypoint x="540" y="672" />
-        <di:waypoint x="742" y="672" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18qdbnx_di" bpmnElement="Flow_18qdbnx">
-        <di:waypoint x="540" y="832" />
-        <di:waypoint x="970" y="832" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="894" />
+        <di:waypoint x="440" y="894" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_143wmxd_di" bpmnElement="Flow_143wmxd">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="992" />
-        <di:waypoint x="440" y="992" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1i7pkzb_di" bpmnElement="Flow_1i7pkzb">
-        <di:waypoint x="540" y="992" />
-        <di:waypoint x="970" y="992" />
-        <di:waypoint x="970" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
-        <di:waypoint x="510" y="1050" />
-        <di:waypoint x="510" y="1073" />
-        <di:waypoint x="562" y="1073" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0yq74mw_di" bpmnElement="Flow_0yq74mw">
-        <di:waypoint x="778" y="672" />
-        <di:waypoint x="970" y="672" />
-        <di:waypoint x="970" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0e569q0_di" bpmnElement="Flow_0e569q0">
-        <di:waypoint x="540" y="510" />
-        <di:waypoint x="970" y="510" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="1054" />
+        <di:waypoint x="440" y="1054" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08ahq87_di" bpmnElement="Flow_08ahq87">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="400" />
-        <di:waypoint x="722" y="400" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wxn661_di" bpmnElement="Flow_1wxn661">
-        <di:waypoint x="758" y="400" />
-        <di:waypoint x="970" y="400" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="462" />
+        <di:waypoint x="722" y="462" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1jeea8a_di" bpmnElement="Flow_1jeea8a">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1190" />
-        <di:waypoint x="440" y="1190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17dl770_di" bpmnElement="Flow_17dl770">
-        <di:waypoint x="540" y="1190" />
-        <di:waypoint x="970" y="1190" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="1252" />
+        <di:waypoint x="440" y="1252" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0u36x7t_di" bpmnElement="Flow_0u36x7t">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1300" />
-        <di:waypoint x="440" y="1300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_001yqxb_di" bpmnElement="Flow_001yqxb">
-        <di:waypoint x="540" y="1300" />
-        <di:waypoint x="970" y="1300" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="1362" />
+        <di:waypoint x="440" y="1362" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1f1rfgt_di" bpmnElement="Flow_1f1rfgt">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1410" />
-        <di:waypoint x="440" y="1410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0uq9222_di" bpmnElement="Flow_0uq9222">
-        <di:waypoint x="540" y="1410" />
-        <di:waypoint x="970" y="1410" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="1472" />
+        <di:waypoint x="440" y="1472" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1waofjt_di" bpmnElement="Flow_1waofjt">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1520" />
-        <di:waypoint x="440" y="1520" />
+        <di:waypoint x="330" y="225" />
+        <di:waypoint x="330" y="1582" />
+        <di:waypoint x="440" y="1582" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
+        <di:waypoint x="510" y="630" />
+        <di:waypoint x="510" y="665" />
+        <di:waypoint x="562" y="665" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
+        <di:waypoint x="510" y="792" />
+        <di:waypoint x="510" y="815" />
+        <di:waypoint x="562" y="815" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
+        <di:waypoint x="510" y="952" />
+        <di:waypoint x="510" y="975" />
+        <di:waypoint x="562" y="975" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e569q0_di" bpmnElement="Flow_0e569q0">
+        <di:waypoint x="540" y="572" />
+        <di:waypoint x="970" y="572" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1o99cpi_di" bpmnElement="Flow_1o99cpi">
+        <di:waypoint x="540" y="734" />
+        <di:waypoint x="742" y="734" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18qdbnx_di" bpmnElement="Flow_18qdbnx">
+        <di:waypoint x="540" y="894" />
+        <di:waypoint x="970" y="894" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="510" y="1112" />
+        <di:waypoint x="510" y="1135" />
+        <di:waypoint x="562" y="1135" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i7pkzb_di" bpmnElement="Flow_1i7pkzb">
+        <di:waypoint x="540" y="1054" />
+        <di:waypoint x="970" y="1054" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wxn661_di" bpmnElement="Flow_1wxn661">
+        <di:waypoint x="758" y="462" />
+        <di:waypoint x="970" y="462" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yq74mw_di" bpmnElement="Flow_0yq74mw">
+        <di:waypoint x="778" y="734" />
+        <di:waypoint x="970" y="734" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17dl770_di" bpmnElement="Flow_17dl770">
+        <di:waypoint x="540" y="1252" />
+        <di:waypoint x="970" y="1252" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_001yqxb_di" bpmnElement="Flow_001yqxb">
+        <di:waypoint x="540" y="1362" />
+        <di:waypoint x="970" y="1362" />
+        <di:waypoint x="970" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uq9222_di" bpmnElement="Flow_0uq9222">
+        <di:waypoint x="540" y="1472" />
+        <di:waypoint x="970" y="1472" />
+        <di:waypoint x="970" y="1557" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l6mtqy_di" bpmnElement="Flow_1l6mtqy">
-        <di:waypoint x="540" y="1520" />
-        <di:waypoint x="970" y="1520" />
-        <di:waypoint x="970" y="163" />
+        <di:waypoint x="540" y="1582" />
+        <di:waypoint x="945" y="1582" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1eim29b_di" bpmnElement="Flow_1eim29b">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1620" />
-        <di:waypoint x="465" y="1620" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
-        <di:waypoint x="515" y="1620" />
-        <di:waypoint x="705" y="1620" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="110" />
+        <di:waypoint x="305" y="110" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="602" y="1602" width="16" height="14" />
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ia1hjp_di" bpmnElement="Flow_1ia1hjp">
-        <di:waypoint x="755" y="1620" />
-        <di:waypoint x="970" y="1620" />
-        <di:waypoint x="970" y="163" />
+      <bpmndi:BPMNEdge id="Flow_0vm1c0b_di" bpmnElement="Flow_0vm1c0b">
+        <di:waypoint x="345" y="100" />
+        <di:waypoint x="1060" y="100" />
+        <di:waypoint x="1060" y="175" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08q3qdg_di" bpmnElement="Flow_08q3qdg">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1730" />
-        <di:waypoint x="465" y="1730" />
+      <bpmndi:BPMNEdge id="Flow_1bo0sui_di" bpmnElement="Flow_1bo0sui">
+        <di:waypoint x="970" y="1607" />
+        <di:waypoint x="970" y="1670" />
+        <di:waypoint x="1675" y="1670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fo0rfs_di" bpmnElement="Flow_1fo0rfs">
+        <di:waypoint x="1085" y="200" />
+        <di:waypoint x="1205" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
+        <di:waypoint x="1255" y="200" />
+        <di:waypoint x="1445" y="200" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1342" y="182" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01ogvlh_di" bpmnElement="Flow_01ogvlh">
+        <di:waypoint x="1495" y="200" />
+        <di:waypoint x="1700" y="200" />
+        <di:waypoint x="1700" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lsyc1w_di" bpmnElement="Flow_0lsyc1w">
+        <di:waypoint x="1060" y="225" />
+        <di:waypoint x="1060" y="310" />
+        <di:waypoint x="1205" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
-        <di:waypoint x="515" y="1730" />
-        <di:waypoint x="672" y="1730" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
-        <di:waypoint x="708" y="1730" />
-        <di:waypoint x="845" y="1730" />
+        <di:waypoint x="1255" y="310" />
+        <di:waypoint x="1412" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
-        <di:waypoint x="490" y="1755" />
-        <di:waypoint x="490" y="1830" />
-        <di:waypoint x="672" y="1830" />
+        <di:waypoint x="1230" y="335" />
+        <di:waypoint x="1230" y="410" />
+        <di:waypoint x="1412" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
+        <di:waypoint x="1448" y="310" />
+        <di:waypoint x="1585" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
-        <di:waypoint x="708" y="1830" />
-        <di:waypoint x="870" y="1830" />
-        <di:waypoint x="870" y="1755" />
+        <di:waypoint x="1448" y="410" />
+        <di:waypoint x="1610" y="410" />
+        <di:waypoint x="1610" y="335" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vt5svt_di" bpmnElement="Flow_0vt5svt">
-        <di:waypoint x="895" y="1730" />
-        <di:waypoint x="970" y="1730" />
-        <di:waypoint x="970" y="163" />
+      <bpmndi:BPMNEdge id="Flow_17m3xiv_di" bpmnElement="Flow_17m3xiv">
+        <di:waypoint x="1635" y="310" />
+        <di:waypoint x="1700" y="310" />
+        <di:waypoint x="1700" y="1557" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17wkkw8_di" bpmnElement="Flow_17wkkw8">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="1940" />
-        <di:waypoint x="472" y="1940" />
+      <bpmndi:BPMNEdge id="Flow_0p5smdr_di" bpmnElement="Flow_0p5smdr">
+        <di:waypoint x="1060" y="225" />
+        <di:waypoint x="1060" y="520" />
+        <di:waypoint x="1212" y="520" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
-        <di:waypoint x="508" y="1940" />
-        <di:waypoint x="672" y="1940" />
+        <di:waypoint x="1248" y="520" />
+        <di:waypoint x="1412" y="520" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1k08s0c_di" bpmnElement="Flow_1k08s0c">
-        <di:waypoint x="708" y="1940" />
-        <di:waypoint x="970" y="1940" />
-        <di:waypoint x="970" y="163" />
+      <bpmndi:BPMNEdge id="Flow_0g97m5r_di" bpmnElement="Flow_0g97m5r">
+        <di:waypoint x="1448" y="520" />
+        <di:waypoint x="1700" y="520" />
+        <di:waypoint x="1700" y="1557" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13sckg7_di" bpmnElement="Flow_13sckg7">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="2205" />
-        <di:waypoint x="382" y="2205" />
+      <bpmndi:BPMNEdge id="Flow_0jtyhkp_di" bpmnElement="Flow_0jtyhkp">
+        <di:waypoint x="1060" y="225" />
+        <di:waypoint x="1060" y="785" />
+        <di:waypoint x="1122" y="785" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19gk47y_di" bpmnElement="Flow_19gk47y">
-        <di:waypoint x="805" y="2205" />
-        <di:waypoint x="970" y="2205" />
-        <di:waypoint x="970" y="163" />
+      <bpmndi:BPMNEdge id="Flow_1nydbto_di" bpmnElement="Flow_1nydbto">
+        <di:waypoint x="1060" y="225" />
+        <di:waypoint x="1060" y="1120" />
+        <di:waypoint x="1199" y="1120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jv6wo5_di" bpmnElement="Flow_0jv6wo5">
-        <di:waypoint x="330" y="163" />
-        <di:waypoint x="330" y="2540" />
-        <di:waypoint x="459" y="2540" />
+      <bpmndi:BPMNEdge id="Flow_1e1hjfq_di" bpmnElement="Flow_1e1hjfq">
+        <di:waypoint x="1060" y="225" />
+        <di:waypoint x="1060" y="1370" />
+        <di:waypoint x="1199" y="1370" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nmo857_di" bpmnElement="Flow_0nmo857">
-        <di:waypoint x="809" y="2540" />
-        <di:waypoint x="970" y="2540" />
-        <di:waypoint x="970" y="163" />
+      <bpmndi:BPMNEdge id="Flow_175yfvp_di" bpmnElement="Flow_175yfvp">
+        <di:waypoint x="1545" y="785" />
+        <di:waypoint x="1700" y="785" />
+        <di:waypoint x="1700" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13t7yla_di" bpmnElement="Flow_13t7yla">
+        <di:waypoint x="1549" y="1120" />
+        <di:waypoint x="1700" y="1120" />
+        <di:waypoint x="1700" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01wk5qr_di" bpmnElement="Flow_01wk5qr">
+        <di:waypoint x="1549" y="1370" />
+        <di:waypoint x="1700" y="1370" />
+        <di:waypoint x="1700" y="1557" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dzoyo4_di" bpmnElement="Flow_1dzoyo4">
+        <di:waypoint x="1700" y="1607" />
+        <di:waypoint x="1700" y="1645" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nlysp1_di" bpmnElement="Flow_1nlysp1">
+        <di:waypoint x="1725" y="1670" />
+        <di:waypoint x="2182" y="1670" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xejz9b_di" bpmnElement="Flow_0xejz9b">
+        <di:waypoint x="1380" y="1488" />
+        <di:waypoint x="1380" y="1582" />
+        <di:waypoint x="1675" y="1582" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_2.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -14,7 +14,7 @@
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
+      <bpmn:incoming>Flow_0whnivt</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -44,7 +44,7 @@
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Activity_0ae6k1y" />
-    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Gateway_3" />
     <bpmn:serviceTask id="Activity_0ae6k1y" name="Notify Customer">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="notifyCustomer" />
@@ -102,9 +102,9 @@
     <bpmn:sequenceFlow id="Flow_14ee2ym" sourceRef="MessageInterrupting" targetRef="Event_2" />
     <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting" targetRef="Event_3" />
     <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting" targetRef="Event_4" />
-    <bpmn:sequenceFlow id="Flow_0ngsahl" sourceRef="Gateway_1" targetRef="checkPayment" />
-    <bpmn:parallelGateway id="Gateway_1">
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+    <bpmn:sequenceFlow id="Flow_0ngsahl" sourceRef="Gateway_2" targetRef="checkPayment" />
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>Flow_1d2ue2p</bpmn:incoming>
       <bpmn:outgoing>Flow_0ngsahl</bpmn:outgoing>
       <bpmn:outgoing>Flow_05ul9v8</bpmn:outgoing>
       <bpmn:outgoing>Flow_0jjil6z</bpmn:outgoing>
@@ -115,19 +115,14 @@
       <bpmn:outgoing>Flow_1wwq56a</bpmn:outgoing>
       <bpmn:outgoing>Flow_12z0a1t</bpmn:outgoing>
       <bpmn:outgoing>Flow_0nv5dxr</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1w3h29f</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1lx7h0o</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1ggtty0</bpmn:outgoing>
-      <bpmn:outgoing>Flow_030xtpk</bpmn:outgoing>
-      <bpmn:outgoing>Flow_17bv8lx</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_05ul9v8" sourceRef="Gateway_1" targetRef="TaskA" />
-    <bpmn:sequenceFlow id="Flow_0jjil6z" sourceRef="Gateway_1" targetRef="TaskB" />
-    <bpmn:sequenceFlow id="Flow_1rzqxuo" sourceRef="Gateway_1" targetRef="TaskC" />
-    <bpmn:sequenceFlow id="Flow_1xou7mm" sourceRef="Gateway_2" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_05ul9v8" sourceRef="Gateway_2" targetRef="TaskA" />
+    <bpmn:sequenceFlow id="Flow_0jjil6z" sourceRef="Gateway_2" targetRef="TaskB" />
+    <bpmn:sequenceFlow id="Flow_1rzqxuo" sourceRef="Gateway_2" targetRef="TaskC" />
+    <bpmn:sequenceFlow id="Flow_1xou7mm" sourceRef="Gateway_3" targetRef="Gateway_6" />
     <bpmn:sequenceFlow id="Flow_0vp8yz2" sourceRef="TaskB" targetRef="TimerIntermediateCatch" />
-    <bpmn:sequenceFlow id="Flow_0bqerrc" sourceRef="TaskC" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_1bdhdkt" sourceRef="Gateway_1" targetRef="TaskD" />
+    <bpmn:sequenceFlow id="Flow_0bqerrc" sourceRef="TaskC" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_1bdhdkt" sourceRef="Gateway_2" targetRef="TaskD" />
     <bpmn:serviceTask id="TaskD" name="Task D">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
@@ -135,7 +130,7 @@
       <bpmn:incoming>Flow_1bdhdkt</bpmn:incoming>
       <bpmn:outgoing>Flow_0hx3trf</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0hx3trf" sourceRef="TaskD" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0hx3trf" sourceRef="TaskD" targetRef="Gateway_3" />
     <bpmn:boundaryEvent id="TimerNonInterrupting" name="Timer non-interrupting" cancelActivity="false" attachedToRef="TaskD">
       <bpmn:outgoing>Flow_093zwcs</bpmn:outgoing>
       <bpmn:timerEventDefinition id="TimerEventDefinition_0lpluww">
@@ -143,7 +138,7 @@
       </bpmn:timerEventDefinition>
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting" targetRef="Event_5" />
-    <bpmn:parallelGateway id="Gateway_2">
+    <bpmn:parallelGateway id="Gateway_3">
       <bpmn:incoming>Flow_0zx0zzd</bpmn:incoming>
       <bpmn:incoming>Flow_0bqerrc</bpmn:incoming>
       <bpmn:incoming>Flow_0hx3trf</bpmn:incoming>
@@ -154,14 +149,9 @@
       <bpmn:incoming>Flow_0i4gdab</bpmn:incoming>
       <bpmn:incoming>Flow_0u2azlm</bpmn:incoming>
       <bpmn:incoming>Flow_1smm1xg</bpmn:incoming>
-      <bpmn:incoming>Flow_0ziqt8h</bpmn:incoming>
-      <bpmn:incoming>Flow_06rofsk</bpmn:incoming>
-      <bpmn:incoming>Flow_0i6qn1g</bpmn:incoming>
-      <bpmn:incoming>Flow_0teqyyg</bpmn:incoming>
-      <bpmn:incoming>Flow_0hb1y3g</bpmn:incoming>
       <bpmn:outgoing>Flow_1xou7mm</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_1bvocj3" sourceRef="TimerIntermediateCatch" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_1bvocj3" sourceRef="TimerIntermediateCatch" targetRef="Gateway_3" />
     <bpmn:intermediateCatchEvent id="MessageIntermediateCatch" name="Message intermediate catch">
       <bpmn:incoming>Flow_13205bp</bpmn:incoming>
       <bpmn:outgoing>Flow_0lwoyt0</bpmn:outgoing>
@@ -174,9 +164,9 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1Y</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0qh5pp6" sourceRef="TaskA" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_13205bp" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch" />
-    <bpmn:sequenceFlow id="Flow_0lwoyt0" sourceRef="MessageIntermediateCatch" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0qh5pp6" sourceRef="TaskA" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_13205bp" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch" />
+    <bpmn:sequenceFlow id="Flow_0lwoyt0" sourceRef="MessageIntermediateCatch" targetRef="Gateway_3" />
     <bpmn:subProcess id="MessageEventSubProcess" name="Message event sub process" triggeredByEvent="true">
       <bpmn:endEvent id="Event_13rtwuo">
         <bpmn:incoming>Flow_006eqia</bpmn:incoming>
@@ -219,10 +209,10 @@
       <bpmn:incoming>Flow_10qe08j</bpmn:incoming>
       <bpmn:outgoing>Flow_170beuy</bpmn:outgoing>
     </bpmn:receiveTask>
-    <bpmn:sequenceFlow id="Flow_10qe08j" sourceRef="Gateway_1" targetRef="MessageReceiveTask" />
-    <bpmn:sequenceFlow id="Flow_170beuy" sourceRef="MessageReceiveTask" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_1wwq56a" sourceRef="Gateway_1" targetRef="BusinessRuleTask" />
-    <bpmn:sequenceFlow id="Flow_0i4gdab" sourceRef="BusinessRuleTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_10qe08j" sourceRef="Gateway_2" targetRef="MessageReceiveTask" />
+    <bpmn:sequenceFlow id="Flow_170beuy" sourceRef="MessageReceiveTask" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_1wwq56a" sourceRef="Gateway_2" targetRef="BusinessRuleTask" />
+    <bpmn:sequenceFlow id="Flow_0i4gdab" sourceRef="BusinessRuleTask" targetRef="Gateway_3" />
     <bpmn:businessRuleTask id="BusinessRuleTask" name="Business rule task">
       <bpmn:extensionElements>
         <zeebe:calledDecision decisionId="invalid2" resultVariable="result" />
@@ -230,8 +220,8 @@
       <bpmn:incoming>Flow_1wwq56a</bpmn:incoming>
       <bpmn:outgoing>Flow_0i4gdab</bpmn:outgoing>
     </bpmn:businessRuleTask>
-    <bpmn:sequenceFlow id="Flow_12z0a1t" sourceRef="Gateway_1" targetRef="ScriptTask" />
-    <bpmn:sequenceFlow id="Flow_0u2azlm" sourceRef="ScriptTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_12z0a1t" sourceRef="Gateway_2" targetRef="ScriptTask" />
+    <bpmn:sequenceFlow id="Flow_0u2azlm" sourceRef="ScriptTask" targetRef="Gateway_3" />
     <bpmn:scriptTask id="ScriptTask" name="Script task">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="failingTaskWorker" retries="0" />
@@ -239,8 +229,8 @@
       <bpmn:incoming>Flow_12z0a1t</bpmn:incoming>
       <bpmn:outgoing>Flow_0u2azlm</bpmn:outgoing>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_0nv5dxr" sourceRef="Gateway_1" targetRef="SendTask" />
-    <bpmn:sequenceFlow id="Flow_1smm1xg" sourceRef="SendTask" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0nv5dxr" sourceRef="Gateway_2" targetRef="SendTask" />
+    <bpmn:sequenceFlow id="Flow_1smm1xg" sourceRef="SendTask" targetRef="Gateway_3" />
     <bpmn:sendTask id="SendTask" name="Send Task">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="foo" />
@@ -249,15 +239,15 @@
       <bpmn:outgoing>Flow_1smm1xg</bpmn:outgoing>
     </bpmn:sendTask>
     <bpmn:exclusiveGateway id="ExclusiveGateway" name="Exclusive gateway">
-      <bpmn:incoming>Flow_1w3h29f</bpmn:incoming>
+      <bpmn:incoming>Flow_00qgj15</bpmn:incoming>
       <bpmn:outgoing>Flow_126yu9s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:exclusiveGateway id="Gateway_1cs756a">
       <bpmn:incoming>Flow_126yu9s</bpmn:incoming>
-      <bpmn:outgoing>Flow_0ziqt8h</bpmn:outgoing>
+      <bpmn:outgoing>Flow_186ylgv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:eventBasedGateway id="EventBasedGateway" name="Event based gateway">
-      <bpmn:incoming>Flow_1lx7h0o</bpmn:incoming>
+      <bpmn:incoming>Flow_1h7gcpa</bpmn:incoming>
       <bpmn:outgoing>Flow_0guz7jv</bpmn:outgoing>
       <bpmn:outgoing>Flow_0v8bsdg</bpmn:outgoing>
     </bpmn:eventBasedGateway>
@@ -276,7 +266,7 @@
     <bpmn:exclusiveGateway id="Gateway_0ftzss1">
       <bpmn:incoming>Flow_0j0qeck</bpmn:incoming>
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
-      <bpmn:outgoing>Flow_06rofsk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0brqydf</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway" targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
@@ -285,23 +275,17 @@
     <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway" targetRef="MessageIntermediateCatchB" />
     <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB" targetRef="Gateway_0ftzss1" />
     <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_1w3h29f" sourceRef="Gateway_1" targetRef="ExclusiveGateway" />
-    <bpmn:sequenceFlow id="Flow_1lx7h0o" sourceRef="Gateway_1" targetRef="EventBasedGateway" />
-    <bpmn:sequenceFlow id="Flow_0ziqt8h" sourceRef="Gateway_1cs756a" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_06rofsk" sourceRef="Gateway_0ftzss1" targetRef="Gateway_2" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
-      <bpmn:incoming>Flow_1ggtty0</bpmn:incoming>
+      <bpmn:incoming>Flow_0mmpytv</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0biu2sq" signalRef="Signal_0pin92p" />
     </bpmn:intermediateThrowEvent>
     <bpmn:intermediateCatchEvent id="SignalIntermediateCatch" name="Signal intermediate catch">
       <bpmn:incoming>Flow_1359yom</bpmn:incoming>
-      <bpmn:outgoing>Flow_0i6qn1g</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1yhf88z</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_18ev63b" />
     </bpmn:intermediateCatchEvent>
     <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch" />
-    <bpmn:sequenceFlow id="Flow_1ggtty0" sourceRef="Gateway_1" targetRef="SignalIntermediateThrow" />
-    <bpmn:sequenceFlow id="Flow_0i6qn1g" sourceRef="SignalIntermediateCatch" targetRef="Gateway_2" />
     <bpmn:subProcess id="SignalEventSubProcess" name="Signal event sub process" triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
@@ -329,8 +313,8 @@
       <bpmn:sequenceFlow id="Flow_0bfr615" sourceRef="SignalBoundaryEvent" targetRef="Event_049m1di" />
     </bpmn:subProcess>
     <bpmn:subProcess id="SubProcess" name="Sub process">
-      <bpmn:incoming>Flow_030xtpk</bpmn:incoming>
-      <bpmn:outgoing>Flow_0teqyyg</bpmn:outgoing>
+      <bpmn:incoming>Flow_0t4qsgg</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fet2uy</bpmn:outgoing>
       <bpmn:endEvent id="ErrorEndEvent">
         <bpmn:incoming>Flow_04fbdug</bpmn:incoming>
         <bpmn:errorEventDefinition id="ErrorEventDefinition_1oyfpff" errorRef="Error_0or6j8h" />
@@ -358,11 +342,9 @@
       </bpmn:subProcess>
       <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_030xtpk" sourceRef="Gateway_1" targetRef="SubProcess" />
-    <bpmn:sequenceFlow id="Flow_0teqyyg" sourceRef="SubProcess" targetRef="Gateway_2" />
     <bpmn:subProcess id="MultiInstanceSubProcess" name="Multi instance sub process">
-      <bpmn:incoming>Flow_17bv8lx</bpmn:incoming>
-      <bpmn:outgoing>Flow_0hb1y3g</bpmn:outgoing>
+      <bpmn:incoming>Flow_0s7xnsc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1bit3gk</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
           <zeebe:loopCharacteristics inputCollection="=[1,2,3,4]" />
@@ -389,8 +371,81 @@
       <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask" />
       <bpmn:sequenceFlow id="Flow_10r7wrx" sourceRef="MultiInstanceTask" targetRef="Event_0lqkl4x" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_17bv8lx" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess" />
-    <bpmn:sequenceFlow id="Flow_0hb1y3g" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_2" />
+    <bpmn:subProcess id="EscalationSubProcess" name="Escalation sub process">
+      <bpmn:incoming>Flow_1fmviig</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tjifq7</bpmn:outgoing>
+      <bpmn:endEvent id="Event_02vrwd0">
+        <bpmn:incoming>Flow_12rxp59</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
+        <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
+        <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_0aipw8x" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:startEvent id="Event_1vxuw3v">
+        <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="EscalationTask" name="Escalation task">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="escalationWorker" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0qxvh80</bpmn:incoming>
+        <bpmn:outgoing>Flow_0bbhalt</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_12rxp59" sourceRef="Event_0iwm1fq" targetRef="Event_02vrwd0" />
+      <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
+      <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_1fxsnef" attachedToRef="EscalationSubProcess">
+      <bpmn:outgoing>Flow_1pu67u8</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1v2o7l5" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1d2ue2p" sourceRef="Gateway_1" targetRef="Gateway_2" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1d2ue2p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_00b9dxt</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_4">
+      <bpmn:incoming>Flow_00b9dxt</bpmn:incoming>
+      <bpmn:outgoing>Flow_00qgj15</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1h7gcpa</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0mmpytv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0t4qsgg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0s7xnsc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1fmviig</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_00b9dxt" sourceRef="Gateway_1" targetRef="Gateway_4" />
+    <bpmn:sequenceFlow id="Flow_00qgj15" sourceRef="Gateway_4" targetRef="ExclusiveGateway" />
+    <bpmn:sequenceFlow id="Flow_1h7gcpa" sourceRef="Gateway_4" targetRef="EventBasedGateway" />
+    <bpmn:sequenceFlow id="Flow_0mmpytv" sourceRef="Gateway_4" targetRef="SignalIntermediateThrow" />
+    <bpmn:sequenceFlow id="Flow_0t4qsgg" sourceRef="Gateway_4" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow_0s7xnsc" sourceRef="Gateway_4" targetRef="MultiInstanceSubProcess" />
+    <bpmn:sequenceFlow id="Flow_1fmviig" sourceRef="Gateway_4" targetRef="EscalationSubProcess" />
+    <bpmn:parallelGateway id="Gateway_5">
+      <bpmn:incoming>Flow_1pu67u8</bpmn:incoming>
+      <bpmn:incoming>Flow_0tjifq7</bpmn:incoming>
+      <bpmn:incoming>Flow_1bit3gk</bpmn:incoming>
+      <bpmn:incoming>Flow_1fet2uy</bpmn:incoming>
+      <bpmn:incoming>Flow_1yhf88z</bpmn:incoming>
+      <bpmn:incoming>Flow_0brqydf</bpmn:incoming>
+      <bpmn:incoming>Flow_186ylgv</bpmn:incoming>
+      <bpmn:outgoing>Flow_19y2492</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1pu67u8" sourceRef="Event_1fxsnef" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0tjifq7" sourceRef="EscalationSubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1bit3gk" sourceRef="MultiInstanceSubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1fet2uy" sourceRef="SubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1yhf88z" sourceRef="SignalIntermediateCatch" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0brqydf" sourceRef="Gateway_0ftzss1" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_186ylgv" sourceRef="Gateway_1cs756a" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0whnivt" sourceRef="Gateway_6" targetRef="EndEvent_1" />
+    <bpmn:sequenceFlow id="Flow_19y2492" sourceRef="Gateway_5" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_6">
+      <bpmn:incoming>Flow_1xou7mm</bpmn:incoming>
+      <bpmn:incoming>Flow_19y2492</bpmn:incoming>
+      <bpmn:outgoing>Flow_0whnivt</bpmn:outgoing>
+    </bpmn:parallelGateway>
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -438,556 +493,635 @@
   <bpmn:signal id="Signal_18ev63b" name="Signal_4" />
   <bpmn:error id="Error_0or6j8h" name="error" errorCode="error" />
   <bpmn:error id="Error_0guddpc" name="error2" errorCode="error2" />
+  <bpmn:escalation id="Escalation_1v2o7l5" name="Escalation_1" escalationCode="123" />
+  <bpmn:escalation id="Escalation_0aipw8x" name="Escalation_1" escalationCode="123" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessMigration">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="175" y="120" width="36" height="36" />
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="400" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="569" y="193" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="157" y="156" width="73" height="14" />
+          <dc:Bounds x="559" y="169" width="69" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
-        <dc:Bounds x="400" y="98" width="100" height="80" />
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="544" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
+        <dc:Bounds x="690" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
+        <dc:Bounds x="840" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="522" y="692" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="522" y="842" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="522" y="1002" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="522" y="1162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
+        <dc:Bounds x="400" y="577" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
+        <dc:Bounds x="400" y="739" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
+        <dc:Bounds x="400" y="899" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0qdsa34_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="285" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
+        <dc:Bounds x="400" y="1059" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
+        <dc:Bounds x="662" y="482" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="635" y="526" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
+        <dc:Bounds x="742" y="761" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="718" y="804" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
+        <dc:Bounds x="400" y="1230" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dxxg7h_di" bpmnElement="BusinessRuleTask">
+        <dc:Bounds x="400" y="1350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0de0r29_di" bpmnElement="ScriptTask">
+        <dc:Bounds x="400" y="1470" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1f4kynw_di" bpmnElement="SendTask">
+        <dc:Bounds x="400" y="1590" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="92" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="128" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gmp7q3_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="285" y="85" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1c7u8wl_di" bpmnElement="Gateway_3">
+        <dc:Bounds x="975" y="1605" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0sjq8dt_di" bpmnElement="Gateway_4">
+        <dc:Bounds x="1085" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
+        <dc:Bounds x="1355" y="275" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1357" y="333" width="47" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
+        <dc:Bounds x="1595" y="275" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway">
+        <dc:Bounds x="1355" y="385" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1309" y="426" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB">
+        <dc:Bounds x="1562" y="392" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1550" y="435" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB">
+        <dc:Bounds x="1562" y="492" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1550" y="535" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
+        <dc:Bounds x="1735" y="385" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
+        <dc:Bounds x="1362" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1350" y="635" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch">
+        <dc:Bounds x="1562" y="592" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1536" y="635" width="90" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0o7tedy_di" bpmnElement="Gateway_5">
+        <dc:Bounds x="1805" y="1605" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_10o6pf2_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="1805" y="1705" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="1062" y="120" width="36" height="36" />
+        <dc:Bounds x="2432" y="1712" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="569" y="113" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="560" y="85" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
-        <dc:Bounds x="544" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
-        <dc:Bounds x="690" y="98" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
-        <dc:Bounds x="840" y="98" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
-        <dc:Bounds x="522" y="612" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
-        <dc:Bounds x="522" y="762" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
-        <dc:Bounds x="522" y="922" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
-        <dc:Bounds x="522" y="1082" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA">
-        <dc:Bounds x="400" y="497" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB">
-        <dc:Bounds x="400" y="659" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC">
-        <dc:Bounds x="400" y="819" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0qdsa34_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="285" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD">
-        <dc:Bounds x="400" y="979" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1c7u8wl_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="975" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch">
-        <dc:Bounds x="662" y="402" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="635" y="446" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch">
-        <dc:Bounds x="742" y="681" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="718" y="724" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1080" y="240" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="1342" y="322" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
-        <dc:Bounds x="1200" y="300" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="1120" y="322" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1104" y="365" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="1300" y="340" />
-        <di:waypoint x="1342" y="340" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="1156" y="340" />
-        <di:waypoint x="1200" y="340" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1080" y="490" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="1342" y="572" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
-        <dc:Bounds x="1200" y="550" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="1120" y="572" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1097" y="615" width="83" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="1300" y="590" />
-        <di:waypoint x="1342" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="1156" y="590" />
-        <di:waypoint x="1200" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask">
-        <dc:Bounds x="400" y="1150" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0dxxg7h_di" bpmnElement="BusinessRuleTask">
-        <dc:Bounds x="400" y="1270" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0de0r29_di" bpmnElement="ScriptTask">
-        <dc:Bounds x="400" y="1390" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1f4kynw_di" bpmnElement="SendTask">
-        <dc:Bounds x="400" y="1510" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway" isMarkerVisible="true">
-        <dc:Bounds x="425" y="1625" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="427" y="1683" width="47" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
-        <dc:Bounds x="665" y="1625" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway">
-        <dc:Bounds x="425" y="1735" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="379" y="1776" width="62" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB">
-        <dc:Bounds x="632" y="1742" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="620" y="1785" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB">
-        <dc:Bounds x="632" y="1842" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="620" y="1885" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
-        <dc:Bounds x="805" y="1735" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
-        <dc:Bounds x="432" y="1942" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="420" y="1985" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch">
-        <dc:Bounds x="632" y="1942" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="606" y="1985" width="90" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
-        <dc:Bounds x="1080" y="740" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="1372" y="822" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="1210" y="800" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="1120" y="822" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1096" y="865" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="1372" y="892" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
-        <dc:Bounds x="1262" y="862" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1240" y="905" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="1310" y="840" />
-        <di:waypoint x="1372" y="840" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="1156" y="840" />
-        <di:waypoint x="1210" y="840" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="1280" y="898" />
-        <di:waypoint x="1280" y="910" />
-        <di:waypoint x="1372" y="910" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
-        <dc:Bounds x="350" y="2050" width="423" height="350" />
+        <dc:Bounds x="1280" y="700" width="423" height="350" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0q4nhhk" bpmnElement="ErrorEndEvent">
-        <dc:Bounds x="640" y="2092" width="36" height="36" />
+        <dc:Bounds x="1570" y="742" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0avpv6s" bpmnElement="SubProcessStartEvent">
-        <dc:Bounds x="427" y="2092" width="36" height="36" />
+        <dc:Bounds x="1357" y="742" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0bd9v5k" bpmnElement="ErrorEventSubProcess" isExpanded="true">
-        <dc:Bounds x="388" y="2173" width="350" height="200" />
+        <dc:Bounds x="1318" y="823" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0zghnh1" bpmnElement="ErrorStartEvent">
-        <dc:Bounds x="428" y="2255" width="36" height="36" />
+        <dc:Bounds x="1358" y="905" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="407" y="2298" width="79" height="14" />
+          <dc:Bounds x="1337" y="948" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07uzu84" bpmnElement="Event_12yeu6m">
-        <dc:Bounds x="640" y="2255" width="36" height="36" />
+        <dc:Bounds x="1570" y="905" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1cc07mn" bpmnElement="TaskG">
-        <dc:Bounds x="498" y="2233" width="100" height="80" />
+        <dc:Bounds x="1428" y="883" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_14n5b9f" bpmnElement="Flow_1nc8qvq">
-        <di:waypoint x="464" y="2273" />
-        <di:waypoint x="498" y="2273" />
+        <di:waypoint x="1394" y="923" />
+        <di:waypoint x="1428" y="923" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_03b1wgz" bpmnElement="Flow_1n6hwxq">
-        <di:waypoint x="598" y="2273" />
-        <di:waypoint x="640" y="2273" />
+        <di:waypoint x="1528" y="923" />
+        <di:waypoint x="1570" y="923" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_14dxxs3" bpmnElement="Flow_04fbdug">
-        <di:waypoint x="463" y="2110" />
-        <di:waypoint x="640" y="2110" />
+        <di:waypoint x="1393" y="760" />
+        <di:waypoint x="1570" y="760" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess" isExpanded="true">
-        <dc:Bounds x="475" y="2460" width="350" height="200" />
+        <dc:Bounds x="1405" y="1110" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
-        <dc:Bounds x="515" y="2542" width="36" height="36" />
+        <dc:Bounds x="1445" y="1192" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
-        <dc:Bounds x="755" y="2542" width="36" height="36" />
+        <dc:Bounds x="1685" y="1192" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask">
-        <dc:Bounds x="603" y="2520" width="100" height="80" />
+        <dc:Bounds x="1533" y="1170" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
-        <di:waypoint x="551" y="2560" />
-        <di:waypoint x="603" y="2560" />
+        <di:waypoint x="1481" y="1210" />
+        <di:waypoint x="1533" y="1210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
-        <di:waypoint x="703" y="2560" />
-        <di:waypoint x="755" y="2560" />
+        <di:waypoint x="1633" y="1210" />
+        <di:waypoint x="1685" y="1210" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
-        <dc:Bounds x="452" y="1041" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+        <dc:Bounds x="1405" y="1370" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02vrwd0_di" bpmnElement="Event_02vrwd0">
+        <dc:Bounds x="1698" y="1452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f62b1z_di" bpmnElement="Event_0iwm1fq">
+        <dc:Bounds x="1628" y="1452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vxuw3v_di" bpmnElement="Event_1vxuw3v">
+        <dc:Bounds x="1428" y="1452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14net6k_di" bpmnElement="EscalationTask">
+        <dc:Bounds x="1496" y="1430" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_12rxp59_di" bpmnElement="Flow_12rxp59">
+        <di:waypoint x="1664" y="1470" />
+        <di:waypoint x="1698" y="1470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bbhalt_di" bpmnElement="Flow_0bbhalt">
+        <di:waypoint x="1596" y="1470" />
+        <di:waypoint x="1628" y="1470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qxvh80_di" bpmnElement="Flow_0qxvh80">
+        <di:waypoint x="1464" y="1470" />
+        <di:waypoint x="1496" y="1470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1980" y="300" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="2242" y="382" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE">
+        <dc:Bounds x="2100" y="360" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="2020" y="382" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="402" y="1076" width="56" height="27" />
+          <dc:Bounds x="2004" y="425" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
-        <dc:Bounds x="452" y="881" width="36" height="36" />
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="2200" y="400" />
+        <di:waypoint x="2242" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="2056" y="400" />
+        <di:waypoint x="2100" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1980" y="550" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="2242" y="632" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF">
+        <dc:Bounds x="2100" y="610" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="2020" y="632" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="394" y="916" width="71" height="27" />
+          <dc:Bounds x="1997" y="675" width="83" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="2200" y="650" />
+        <di:waypoint x="2242" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="2056" y="650" />
+        <di:waypoint x="2100" y="650" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess" isExpanded="true">
+        <dc:Bounds x="1980" y="800" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="2272" y="882" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="2110" y="860" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="2020" y="882" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1996" y="925" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="2272" y="952" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoundaryEvent">
+        <dc:Bounds x="2162" y="922" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2140" y="965" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="2210" y="900" />
+        <di:waypoint x="2272" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="2056" y="900" />
+        <di:waypoint x="2110" y="900" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="2180" y="958" />
+        <di:waypoint x="2180" y="970" />
+        <di:waypoint x="2272" y="970" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
+        <dc:Bounds x="452" y="639" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="402" y="666" width="56" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting">
-        <dc:Bounds x="452" y="721" width="36" height="36" />
+        <dc:Bounds x="452" y="801" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="377" y="753" width="86" height="14" />
+          <dc:Bounds x="377" y="833" width="86" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting">
-        <dc:Bounds x="452" y="559" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting">
+        <dc:Bounds x="452" y="961" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="402" y="586" width="56" height="27" />
+          <dc:Bounds x="394" y="996" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
-        <di:waypoint x="211" y="138" />
-        <di:waypoint x="285" y="138" />
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting">
+        <dc:Bounds x="452" y="1121" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+          <dc:Bounds x="402" y="1156" width="56" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="Event_1fxsnef">
+        <dc:Bounds x="1568" y="1552" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="544" y="380" />
+        <di:waypoint x="450" y="380" />
+        <di:waypoint x="450" y="258" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ngsahl_di" bpmnElement="Flow_0ngsahl">
+        <di:waypoint x="335" y="218" />
+        <di:waypoint x="400" y="218" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="500" y="138" />
-        <di:waypoint x="569" y="138" />
+        <di:waypoint x="500" y="218" />
+        <di:waypoint x="569" y="218" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="594" y="163" />
-        <di:waypoint x="594" y="260" />
+        <di:waypoint x="594" y="243" />
+        <di:waypoint x="594" y="340" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="550" y="188" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="544" y="300" />
-        <di:waypoint x="450" y="300" />
-        <di:waypoint x="450" y="178" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="17" y="389" width="0" height="12" />
+          <dc:Bounds x="550" y="268" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="619" y="138" />
-        <di:waypoint x="690" y="138" />
+        <di:waypoint x="619" y="218" />
+        <di:waypoint x="690" y="218" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="639" y="117" width="21" height="14" />
+          <dc:Bounds x="639" y="197" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="790" y="138" />
-        <di:waypoint x="840" y="138" />
+        <di:waypoint x="790" y="218" />
+        <di:waypoint x="840" y="218" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="337.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zx0zzd_di" bpmnElement="Flow_0zx0zzd">
-        <di:waypoint x="940" y="138" />
-        <di:waypoint x="975" y="138" />
+        <di:waypoint x="940" y="218" />
+        <di:waypoint x="1000" y="218" />
+        <di:waypoint x="1000" y="1605" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
-        <di:waypoint x="470" y="595" />
-        <di:waypoint x="470" y="630" />
-        <di:waypoint x="522" y="630" />
+        <di:waypoint x="470" y="675" />
+        <di:waypoint x="470" y="710" />
+        <di:waypoint x="522" y="710" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
-        <di:waypoint x="470" y="757" />
-        <di:waypoint x="470" y="780" />
-        <di:waypoint x="522" y="780" />
+        <di:waypoint x="470" y="837" />
+        <di:waypoint x="470" y="860" />
+        <di:waypoint x="522" y="860" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
-        <di:waypoint x="470" y="917" />
-        <di:waypoint x="470" y="940" />
-        <di:waypoint x="522" y="940" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ngsahl_di" bpmnElement="Flow_0ngsahl">
-        <di:waypoint x="335" y="138" />
-        <di:waypoint x="400" y="138" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05ul9v8_di" bpmnElement="Flow_05ul9v8">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="537" />
-        <di:waypoint x="400" y="537" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jjil6z_di" bpmnElement="Flow_0jjil6z">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="699" />
-        <di:waypoint x="400" y="699" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1rzqxuo_di" bpmnElement="Flow_1rzqxuo">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="859" />
-        <di:waypoint x="400" y="859" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
-        <di:waypoint x="1025" y="138" />
-        <di:waypoint x="1062" y="138" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
-        <di:waypoint x="500" y="699" />
-        <di:waypoint x="742" y="699" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bqerrc_di" bpmnElement="Flow_0bqerrc">
-        <di:waypoint x="500" y="859" />
-        <di:waypoint x="1000" y="859" />
-        <di:waypoint x="1000" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bdhdkt_di" bpmnElement="Flow_1bdhdkt">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1019" />
-        <di:waypoint x="400" y="1019" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hx3trf_di" bpmnElement="Flow_0hx3trf">
-        <di:waypoint x="500" y="1019" />
-        <di:waypoint x="1000" y="1019" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="470" y="997" />
+        <di:waypoint x="470" y="1020" />
+        <di:waypoint x="522" y="1020" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
-        <di:waypoint x="470" y="1077" />
-        <di:waypoint x="470" y="1100" />
-        <di:waypoint x="522" y="1100" />
+        <di:waypoint x="470" y="1157" />
+        <di:waypoint x="470" y="1180" />
+        <di:waypoint x="522" y="1180" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bvocj3_di" bpmnElement="Flow_1bvocj3">
-        <di:waypoint x="778" y="699" />
-        <di:waypoint x="1000" y="699" />
-        <di:waypoint x="1000" y="163" />
+      <bpmndi:BPMNEdge id="Flow_05ul9v8_di" bpmnElement="Flow_05ul9v8">
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="617" />
+        <di:waypoint x="400" y="617" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qh5pp6_di" bpmnElement="Flow_0qh5pp6">
-        <di:waypoint x="500" y="537" />
-        <di:waypoint x="1000" y="537" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="500" y="617" />
+        <di:waypoint x="1000" y="617" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jjil6z_di" bpmnElement="Flow_0jjil6z">
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="779" />
+        <di:waypoint x="400" y="779" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vp8yz2_di" bpmnElement="Flow_0vp8yz2">
+        <di:waypoint x="500" y="779" />
+        <di:waypoint x="742" y="779" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rzqxuo_di" bpmnElement="Flow_1rzqxuo">
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="939" />
+        <di:waypoint x="400" y="939" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bqerrc_di" bpmnElement="Flow_0bqerrc">
+        <di:waypoint x="500" y="939" />
+        <di:waypoint x="1000" y="939" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d2ue2p_di" bpmnElement="Flow_1d2ue2p">
+        <di:waypoint x="310" y="135" />
+        <di:waypoint x="310" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bdhdkt_di" bpmnElement="Flow_1bdhdkt">
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="1099" />
+        <di:waypoint x="400" y="1099" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_13205bp_di" bpmnElement="Flow_13205bp">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="420" />
-        <di:waypoint x="662" y="420" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0lwoyt0_di" bpmnElement="Flow_0lwoyt0">
-        <di:waypoint x="698" y="420" />
-        <di:waypoint x="1000" y="420" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="500" />
+        <di:waypoint x="662" y="500" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10qe08j_di" bpmnElement="Flow_10qe08j">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1190" />
-        <di:waypoint x="400" y="1190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_170beuy_di" bpmnElement="Flow_170beuy">
-        <di:waypoint x="500" y="1190" />
-        <di:waypoint x="1000" y="1190" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="1270" />
+        <di:waypoint x="400" y="1270" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wwq56a_di" bpmnElement="Flow_1wwq56a">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1310" />
-        <di:waypoint x="400" y="1310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0i4gdab_di" bpmnElement="Flow_0i4gdab">
-        <di:waypoint x="500" y="1310" />
-        <di:waypoint x="1000" y="1310" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="1390" />
+        <di:waypoint x="400" y="1390" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12z0a1t_di" bpmnElement="Flow_12z0a1t">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1430" />
-        <di:waypoint x="400" y="1430" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0u2azlm_di" bpmnElement="Flow_0u2azlm">
-        <di:waypoint x="500" y="1430" />
-        <di:waypoint x="1000" y="1430" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="1510" />
+        <di:waypoint x="400" y="1510" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0nv5dxr_di" bpmnElement="Flow_0nv5dxr">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1550" />
-        <di:waypoint x="400" y="1550" />
+        <di:waypoint x="310" y="243" />
+        <di:waypoint x="310" y="1630" />
+        <di:waypoint x="400" y="1630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hx3trf_di" bpmnElement="Flow_0hx3trf">
+        <di:waypoint x="500" y="1099" />
+        <di:waypoint x="1000" y="1099" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lwoyt0_di" bpmnElement="Flow_0lwoyt0">
+        <di:waypoint x="698" y="500" />
+        <di:waypoint x="1000" y="500" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bvocj3_di" bpmnElement="Flow_1bvocj3">
+        <di:waypoint x="778" y="779" />
+        <di:waypoint x="1000" y="779" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_170beuy_di" bpmnElement="Flow_170beuy">
+        <di:waypoint x="500" y="1270" />
+        <di:waypoint x="1000" y="1270" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i4gdab_di" bpmnElement="Flow_0i4gdab">
+        <di:waypoint x="500" y="1390" />
+        <di:waypoint x="1000" y="1390" />
+        <di:waypoint x="1000" y="1605" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u2azlm_di" bpmnElement="Flow_0u2azlm">
+        <di:waypoint x="500" y="1510" />
+        <di:waypoint x="1000" y="1510" />
+        <di:waypoint x="1000" y="1605" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1smm1xg_di" bpmnElement="Flow_1smm1xg">
-        <di:waypoint x="500" y="1550" />
-        <di:waypoint x="1000" y="1550" />
-        <di:waypoint x="1000" y="163" />
+        <di:waypoint x="500" y="1630" />
+        <di:waypoint x="975" y="1630" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
-        <di:waypoint x="475" y="1650" />
-        <di:waypoint x="665" y="1650" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="110" />
+        <di:waypoint x="285" y="110" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="562" y="1632" width="16" height="14" />
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00b9dxt_di" bpmnElement="Flow_00b9dxt">
+        <di:waypoint x="335" y="110" />
+        <di:waypoint x="1110" y="110" />
+        <di:waypoint x="1110" y="193" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xou7mm_di" bpmnElement="Flow_1xou7mm">
+        <di:waypoint x="1000" y="1655" />
+        <di:waypoint x="1000" y="1730" />
+        <di:waypoint x="1805" y="1730" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00qgj15_di" bpmnElement="Flow_00qgj15">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="300" />
+        <di:waypoint x="1355" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h7gcpa_di" bpmnElement="Flow_1h7gcpa">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="410" />
+        <di:waypoint x="1355" y="410" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mmpytv_di" bpmnElement="Flow_0mmpytv">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="610" />
+        <di:waypoint x="1362" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t4qsgg_di" bpmnElement="Flow_0t4qsgg">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="875" />
+        <di:waypoint x="1280" y="875" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s7xnsc_di" bpmnElement="Flow_0s7xnsc">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="1210" />
+        <di:waypoint x="1405" y="1210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fmviig_di" bpmnElement="Flow_1fmviig">
+        <di:waypoint x="1110" y="243" />
+        <di:waypoint x="1110" y="1470" />
+        <di:waypoint x="1405" y="1470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
+        <di:waypoint x="1405" y="300" />
+        <di:waypoint x="1595" y="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1492" y="282" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_186ylgv_di" bpmnElement="Flow_186ylgv">
+        <di:waypoint x="1645" y="300" />
+        <di:waypoint x="1830" y="300" />
+        <di:waypoint x="1830" y="1605" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
-        <di:waypoint x="475" y="1760" />
-        <di:waypoint x="632" y="1760" />
+        <di:waypoint x="1405" y="410" />
+        <di:waypoint x="1562" y="410" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
-        <di:waypoint x="450" y="1785" />
-        <di:waypoint x="450" y="1860" />
-        <di:waypoint x="632" y="1860" />
+        <di:waypoint x="1380" y="435" />
+        <di:waypoint x="1380" y="510" />
+        <di:waypoint x="1562" y="510" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
-        <di:waypoint x="668" y="1760" />
-        <di:waypoint x="805" y="1760" />
+        <di:waypoint x="1598" y="410" />
+        <di:waypoint x="1735" y="410" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
-        <di:waypoint x="668" y="1860" />
-        <di:waypoint x="830" y="1860" />
-        <di:waypoint x="830" y="1785" />
+        <di:waypoint x="1598" y="510" />
+        <di:waypoint x="1760" y="510" />
+        <di:waypoint x="1760" y="435" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1w3h29f_di" bpmnElement="Flow_1w3h29f">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1650" />
-        <di:waypoint x="425" y="1650" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lx7h0o_di" bpmnElement="Flow_1lx7h0o">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1760" />
-        <di:waypoint x="425" y="1760" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ziqt8h_di" bpmnElement="Flow_0ziqt8h">
-        <di:waypoint x="715" y="1650" />
-        <di:waypoint x="1000" y="1650" />
-        <di:waypoint x="1000" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06rofsk_di" bpmnElement="Flow_06rofsk">
-        <di:waypoint x="855" y="1760" />
-        <di:waypoint x="1000" y="1760" />
-        <di:waypoint x="1000" y="163" />
+      <bpmndi:BPMNEdge id="Flow_0brqydf_di" bpmnElement="Flow_0brqydf">
+        <di:waypoint x="1785" y="410" />
+        <di:waypoint x="1830" y="410" />
+        <di:waypoint x="1830" y="1605" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
-        <di:waypoint x="468" y="1960" />
-        <di:waypoint x="632" y="1960" />
+        <di:waypoint x="1398" y="610" />
+        <di:waypoint x="1562" y="610" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ggtty0_di" bpmnElement="Flow_1ggtty0">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="1960" />
-        <di:waypoint x="432" y="1960" />
+      <bpmndi:BPMNEdge id="Flow_1yhf88z_di" bpmnElement="Flow_1yhf88z">
+        <di:waypoint x="1598" y="610" />
+        <di:waypoint x="1830" y="610" />
+        <di:waypoint x="1830" y="1605" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0i6qn1g_di" bpmnElement="Flow_0i6qn1g">
-        <di:waypoint x="668" y="1960" />
-        <di:waypoint x="1000" y="1960" />
-        <di:waypoint x="1000" y="163" />
+      <bpmndi:BPMNEdge id="Flow_1pu67u8_di" bpmnElement="Flow_1pu67u8">
+        <di:waypoint x="1586" y="1588" />
+        <di:waypoint x="1586" y="1630" />
+        <di:waypoint x="1805" y="1630" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_030xtpk_di" bpmnElement="Flow_030xtpk">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="2225" />
-        <di:waypoint x="350" y="2225" />
+      <bpmndi:BPMNEdge id="Flow_0tjifq7_di" bpmnElement="Flow_0tjifq7">
+        <di:waypoint x="1755" y="1470" />
+        <di:waypoint x="1830" y="1470" />
+        <di:waypoint x="1830" y="1605" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0teqyyg_di" bpmnElement="Flow_0teqyyg">
-        <di:waypoint x="773" y="2225" />
-        <di:waypoint x="1000" y="2225" />
-        <di:waypoint x="1000" y="163" />
+      <bpmndi:BPMNEdge id="Flow_1bit3gk_di" bpmnElement="Flow_1bit3gk">
+        <di:waypoint x="1755" y="1210" />
+        <di:waypoint x="1830" y="1210" />
+        <di:waypoint x="1830" y="1605" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17bv8lx_di" bpmnElement="Flow_17bv8lx">
-        <di:waypoint x="310" y="163" />
-        <di:waypoint x="310" y="2560" />
-        <di:waypoint x="475" y="2560" />
+      <bpmndi:BPMNEdge id="Flow_1fet2uy_di" bpmnElement="Flow_1fet2uy">
+        <di:waypoint x="1703" y="875" />
+        <di:waypoint x="1830" y="875" />
+        <di:waypoint x="1830" y="1605" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hb1y3g_di" bpmnElement="Flow_0hb1y3g">
-        <di:waypoint x="825" y="2560" />
-        <di:waypoint x="1000" y="2560" />
-        <di:waypoint x="1000" y="163" />
+      <bpmndi:BPMNEdge id="Flow_19y2492_di" bpmnElement="Flow_19y2492">
+        <di:waypoint x="1830" y="1655" />
+        <di:waypoint x="1830" y="1705" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0whnivt_di" bpmnElement="Flow_0whnivt">
+        <di:waypoint x="1855" y="1730" />
+        <di:waypoint x="2432" y="1730" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.27.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.28.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
   <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -14,7 +14,7 @@
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_1">
-      <bpmn:incoming>Flow_1ibxab9</bpmn:incoming>
+      <bpmn:incoming>Flow_1tyhemw</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -52,7 +52,7 @@
       <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
       <bpmn:outgoing>Flow_0zx0zzd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="checkDeliveryState2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="checkDeliveryState2" targetRef="Gateway_3" />
     <bpmn:serviceTask id="checkDeliveryState2" name="Check delivery state 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkDelivery" />
@@ -124,14 +124,14 @@
     <bpmn:sequenceFlow id="Flow_1ym4tee" sourceRef="TimerInterrupting2" targetRef="Event_3" />
     <bpmn:sequenceFlow id="Flow_0b5y250" sourceRef="MessageNonInterrupting2" targetRef="Event_4" />
     <bpmn:sequenceFlow id="Flow_093zwcs" sourceRef="TimerNonInterrupting2" targetRef="Event_5" />
-    <bpmn:sequenceFlow id="Flow_0s77slh" sourceRef="Gateway_1" targetRef="checkPayment2" />
-    <bpmn:sequenceFlow id="Flow_1umsz4s" sourceRef="Gateway_1" targetRef="TaskA2" />
-    <bpmn:sequenceFlow id="Flow_19twklg" sourceRef="Gateway_1" targetRef="TaskB2" />
-    <bpmn:sequenceFlow id="Flow_0fyja5s" sourceRef="Gateway_1" targetRef="TaskC2" />
-    <bpmn:sequenceFlow id="Flow_1478njt" sourceRef="Gateway_1" targetRef="TaskD2" />
-    <bpmn:sequenceFlow id="Flow_1ibxab9" sourceRef="Gateway_2" targetRef="EndEvent_1" />
-    <bpmn:parallelGateway id="Gateway_1">
-      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+    <bpmn:sequenceFlow id="Flow_0s77slh" sourceRef="Gateway_2" targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="Flow_1umsz4s" sourceRef="Gateway_2" targetRef="TaskA2" />
+    <bpmn:sequenceFlow id="Flow_19twklg" sourceRef="Gateway_2" targetRef="TaskB2" />
+    <bpmn:sequenceFlow id="Flow_0fyja5s" sourceRef="Gateway_2" targetRef="TaskC2" />
+    <bpmn:sequenceFlow id="Flow_1478njt" sourceRef="Gateway_2" targetRef="TaskD2" />
+    <bpmn:sequenceFlow id="Flow_1ibxab9" sourceRef="Gateway_3" targetRef="Gateway_6" />
+    <bpmn:parallelGateway id="Gateway_2">
+      <bpmn:incoming>Flow_13zdve9</bpmn:incoming>
       <bpmn:outgoing>Flow_0s77slh</bpmn:outgoing>
       <bpmn:outgoing>Flow_1umsz4s</bpmn:outgoing>
       <bpmn:outgoing>Flow_19twklg</bpmn:outgoing>
@@ -142,13 +142,8 @@
       <bpmn:outgoing>Flow_1235n4i</bpmn:outgoing>
       <bpmn:outgoing>Flow_192dswa</bpmn:outgoing>
       <bpmn:outgoing>Flow_14gbl4m</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1ixacpg</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0796mcu</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0t0hay3</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0hc14mk</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0xxd8dc</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:parallelGateway id="Gateway_2">
+    <bpmn:parallelGateway id="Gateway_3">
       <bpmn:incoming>Flow_0hxjz3q</bpmn:incoming>
       <bpmn:incoming>Flow_159gm2j</bpmn:incoming>
       <bpmn:incoming>Flow_0279afj</bpmn:incoming>
@@ -159,16 +154,11 @@
       <bpmn:incoming>Flow_1xg3tdz</bpmn:incoming>
       <bpmn:incoming>Flow_1epls0w</bpmn:incoming>
       <bpmn:incoming>Flow_0vlhghj</bpmn:incoming>
-      <bpmn:incoming>Flow_060zyko</bpmn:incoming>
-      <bpmn:incoming>Flow_0i5udyk</bpmn:incoming>
-      <bpmn:incoming>Flow_06eifq9</bpmn:incoming>
-      <bpmn:incoming>Flow_1brhss6</bpmn:incoming>
-      <bpmn:incoming>Flow_1mxprri</bpmn:incoming>
       <bpmn:outgoing>Flow_1ibxab9</bpmn:outgoing>
     </bpmn:parallelGateway>
     <bpmn:sequenceFlow id="Flow_0lyxcbw" sourceRef="TaskB2" targetRef="TimerIntermediateCatch2" />
-    <bpmn:sequenceFlow id="Flow_159gm2j" sourceRef="TaskC2" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0279afj" sourceRef="TaskD2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_159gm2j" sourceRef="TaskC2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_0279afj" sourceRef="TaskD2" targetRef="Gateway_3" />
     <bpmn:intermediateCatchEvent id="MessageIntermediateCatch2" name="Message intermediate catch 2">
       <bpmn:incoming>Flow_0kfelct</bpmn:incoming>
       <bpmn:outgoing>Flow_1j5fksj</bpmn:outgoing>
@@ -181,10 +171,10 @@
         <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">P1M</bpmn:timeDuration>
       </bpmn:timerEventDefinition>
     </bpmn:intermediateCatchEvent>
-    <bpmn:sequenceFlow id="Flow_0s3pyc8" sourceRef="TimerIntermediateCatch2" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0kfelct" sourceRef="Gateway_1" targetRef="MessageIntermediateCatch2" />
-    <bpmn:sequenceFlow id="Flow_1j5fksj" sourceRef="MessageIntermediateCatch2" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0aheimq" sourceRef="TaskA2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_0s3pyc8" sourceRef="TimerIntermediateCatch2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_0kfelct" sourceRef="Gateway_2" targetRef="MessageIntermediateCatch2" />
+    <bpmn:sequenceFlow id="Flow_1j5fksj" sourceRef="MessageIntermediateCatch2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_0aheimq" sourceRef="TaskA2" targetRef="Gateway_3" />
     <bpmn:subProcess id="TimerEventSubProcess2" name="Timer event sub process 2" triggeredByEvent="true">
       <bpmn:endEvent id="Event_0lk89tk">
         <bpmn:incoming>Flow_1rrwh6x</bpmn:incoming>
@@ -227,8 +217,8 @@
       <bpmn:incoming>Flow_00bezny</bpmn:incoming>
       <bpmn:outgoing>Flow_16drwmj</bpmn:outgoing>
     </bpmn:receiveTask>
-    <bpmn:sequenceFlow id="Flow_00bezny" sourceRef="Gateway_1" targetRef="MessageReceiveTask2" />
-    <bpmn:sequenceFlow id="Flow_16drwmj" sourceRef="MessageReceiveTask2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_00bezny" sourceRef="Gateway_2" targetRef="MessageReceiveTask2" />
+    <bpmn:sequenceFlow id="Flow_16drwmj" sourceRef="MessageReceiveTask2" targetRef="Gateway_3" />
     <bpmn:businessRuleTask id="BusinessRuleTask2" name="Business rule task 2">
       <bpmn:extensionElements>
         <zeebe:calledDecision decisionId="invalid2" resultVariable="result" />
@@ -236,10 +226,10 @@
       <bpmn:incoming>Flow_1235n4i</bpmn:incoming>
       <bpmn:outgoing>Flow_1xg3tdz</bpmn:outgoing>
     </bpmn:businessRuleTask>
-    <bpmn:sequenceFlow id="Flow_1235n4i" sourceRef="Gateway_1" targetRef="BusinessRuleTask2" />
-    <bpmn:sequenceFlow id="Flow_1xg3tdz" sourceRef="BusinessRuleTask2" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_192dswa" sourceRef="Gateway_1" targetRef="ScriptTask2" />
-    <bpmn:sequenceFlow id="Flow_1epls0w" sourceRef="ScriptTask2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_1235n4i" sourceRef="Gateway_2" targetRef="BusinessRuleTask2" />
+    <bpmn:sequenceFlow id="Flow_1xg3tdz" sourceRef="BusinessRuleTask2" targetRef="Gateway_3" />
+    <bpmn:sequenceFlow id="Flow_192dswa" sourceRef="Gateway_2" targetRef="ScriptTask2" />
+    <bpmn:sequenceFlow id="Flow_1epls0w" sourceRef="ScriptTask2" targetRef="Gateway_3" />
     <bpmn:scriptTask id="ScriptTask2" name="Script task 2">
       <bpmn:extensionElements>
         <zeebe:script expression="=1" resultVariable="scriptResult" />
@@ -247,8 +237,8 @@
       <bpmn:incoming>Flow_192dswa</bpmn:incoming>
       <bpmn:outgoing>Flow_1epls0w</bpmn:outgoing>
     </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_14gbl4m" sourceRef="Gateway_1" targetRef="SendTask2" />
-    <bpmn:sequenceFlow id="Flow_0vlhghj" sourceRef="SendTask2" targetRef="Gateway_2" />
+    <bpmn:sequenceFlow id="Flow_14gbl4m" sourceRef="Gateway_2" targetRef="SendTask2" />
+    <bpmn:sequenceFlow id="Flow_0vlhghj" sourceRef="SendTask2" targetRef="Gateway_3" />
     <bpmn:sendTask id="SendTask2" name="Send Task 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="failingTaskWorker" />
@@ -257,15 +247,15 @@
       <bpmn:outgoing>Flow_0vlhghj</bpmn:outgoing>
     </bpmn:sendTask>
     <bpmn:exclusiveGateway id="ExclusiveGateway2" name="Exclusive gateway 2">
-      <bpmn:incoming>Flow_1ixacpg</bpmn:incoming>
+      <bpmn:incoming>Flow_0ncb1sr</bpmn:incoming>
       <bpmn:outgoing>Flow_126yu9s</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:exclusiveGateway id="Gateway_1cs756a">
       <bpmn:incoming>Flow_126yu9s</bpmn:incoming>
-      <bpmn:outgoing>Flow_060zyko</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1qp2ewy</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:eventBasedGateway id="EventBasedGateway2" name="Event based gateway 2">
-      <bpmn:incoming>Flow_0796mcu</bpmn:incoming>
+      <bpmn:incoming>Flow_06rnibw</bpmn:incoming>
       <bpmn:outgoing>Flow_0guz7jv</bpmn:outgoing>
       <bpmn:outgoing>Flow_0v8bsdg</bpmn:outgoing>
     </bpmn:eventBasedGateway>
@@ -284,7 +274,7 @@
     <bpmn:exclusiveGateway id="Gateway_0ftzss1">
       <bpmn:incoming>Flow_0j0qeck</bpmn:incoming>
       <bpmn:incoming>Flow_17zq5s0</bpmn:incoming>
-      <bpmn:outgoing>Flow_0i5udyk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0u9dvrj</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_126yu9s" name="&#60; 0" sourceRef="ExclusiveGateway2" targetRef="Gateway_1cs756a">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=unknownVariable &lt; 0</bpmn:conditionExpression>
@@ -293,23 +283,17 @@
     <bpmn:sequenceFlow id="Flow_0v8bsdg" sourceRef="EventBasedGateway2" targetRef="MessageIntermediateCatchB2" />
     <bpmn:sequenceFlow id="Flow_0j0qeck" sourceRef="TimerIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
     <bpmn:sequenceFlow id="Flow_17zq5s0" sourceRef="MessageIntermediateCatchB2" targetRef="Gateway_0ftzss1" />
-    <bpmn:sequenceFlow id="Flow_1ixacpg" sourceRef="Gateway_1" targetRef="ExclusiveGateway2" />
-    <bpmn:sequenceFlow id="Flow_0796mcu" sourceRef="Gateway_1" targetRef="EventBasedGateway2" />
-    <bpmn:sequenceFlow id="Flow_060zyko" sourceRef="Gateway_1cs756a" targetRef="Gateway_2" />
-    <bpmn:sequenceFlow id="Flow_0i5udyk" sourceRef="Gateway_0ftzss1" targetRef="Gateway_2" />
     <bpmn:intermediateThrowEvent id="SignalIntermediateThrow" name="Signal intermediate throw">
-      <bpmn:incoming>Flow_0t0hay3</bpmn:incoming>
+      <bpmn:incoming>Flow_041w5kk</bpmn:incoming>
       <bpmn:outgoing>Flow_1359yom</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0biu2sq" signalRef="Signal_1jnksul" />
     </bpmn:intermediateThrowEvent>
     <bpmn:intermediateCatchEvent id="SignalIntermediateCatch2" name="Signal intermediate catch 2">
       <bpmn:incoming>Flow_1359yom</bpmn:incoming>
-      <bpmn:outgoing>Flow_06eifq9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_04ta31i</bpmn:outgoing>
       <bpmn:signalEventDefinition id="SignalEventDefinition_0wy1une" signalRef="Signal_0j5das4" />
     </bpmn:intermediateCatchEvent>
     <bpmn:sequenceFlow id="Flow_1359yom" sourceRef="SignalIntermediateThrow" targetRef="SignalIntermediateCatch2" />
-    <bpmn:sequenceFlow id="Flow_0t0hay3" sourceRef="Gateway_1" targetRef="SignalIntermediateThrow" />
-    <bpmn:sequenceFlow id="Flow_06eifq9" sourceRef="SignalIntermediateCatch2" targetRef="Gateway_2" />
     <bpmn:subProcess id="SignalEventSubProcess2" name="Signal event sub process 2" triggeredByEvent="true">
       <bpmn:endEvent id="Event_0opmx5v">
         <bpmn:incoming>Flow_1tl6j8a</bpmn:incoming>
@@ -337,8 +321,8 @@
       <bpmn:sequenceFlow id="Flow_0bfr615" sourceRef="SignalBoudaryEvent2" targetRef="Event_049m1di" />
     </bpmn:subProcess>
     <bpmn:subProcess id="SubProcess" name="Sub process">
-      <bpmn:incoming>Flow_0hc14mk</bpmn:incoming>
-      <bpmn:outgoing>Flow_1brhss6</bpmn:outgoing>
+      <bpmn:incoming>Flow_14xnbyk</bpmn:incoming>
+      <bpmn:outgoing>Flow_06bvbdi</bpmn:outgoing>
       <bpmn:endEvent id="ErrorEndEvent">
         <bpmn:incoming>Flow_04fbdug</bpmn:incoming>
         <bpmn:errorEventDefinition id="ErrorEventDefinition_1oyfpff" errorRef="Error_0or6j8h" />
@@ -366,11 +350,9 @@
       </bpmn:subProcess>
       <bpmn:sequenceFlow id="Flow_04fbdug" sourceRef="SubProcessStartEvent" targetRef="ErrorEndEvent" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_0hc14mk" sourceRef="Gateway_1" targetRef="SubProcess" />
-    <bpmn:sequenceFlow id="Flow_1brhss6" sourceRef="SubProcess" targetRef="Gateway_2" />
     <bpmn:subProcess id="MultiInstanceSubProcess2" name="Multi instance sub process 2">
-      <bpmn:incoming>Flow_0xxd8dc</bpmn:incoming>
-      <bpmn:outgoing>Flow_1mxprri</bpmn:outgoing>
+      <bpmn:incoming>Flow_0nfno00</bpmn:incoming>
+      <bpmn:outgoing>Flow_0up5li4</bpmn:outgoing>
       <bpmn:multiInstanceLoopCharacteristics>
         <bpmn:extensionElements>
           <zeebe:loopCharacteristics inputCollection="=[1]" />
@@ -397,8 +379,81 @@
       <bpmn:sequenceFlow id="Flow_00irh9p" sourceRef="Event_1b83nzw" targetRef="MultiInstanceTask2" />
       <bpmn:sequenceFlow id="Flow_10r7wrx" sourceRef="MultiInstanceTask2" targetRef="Event_0lqkl4x" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_0xxd8dc" sourceRef="Gateway_1" targetRef="MultiInstanceSubProcess2" />
-    <bpmn:sequenceFlow id="Flow_1mxprri" sourceRef="MultiInstanceSubProcess2" targetRef="Gateway_2" />
+    <bpmn:subProcess id="EscalationSubProcess" name="Escalation sub process 2">
+      <bpmn:incoming>Flow_0ykwgtn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xc7gwl</bpmn:outgoing>
+      <bpmn:endEvent id="Event_02vrwd0">
+        <bpmn:incoming>Flow_12rxp59</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:intermediateThrowEvent id="Event_0iwm1fq">
+        <bpmn:incoming>Flow_0bbhalt</bpmn:incoming>
+        <bpmn:outgoing>Flow_12rxp59</bpmn:outgoing>
+        <bpmn:escalationEventDefinition id="EscalationEventDefinition_0a4p2il" escalationRef="Escalation_1fppfbl" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:startEvent id="Event_1vxuw3v">
+        <bpmn:outgoing>Flow_0qxvh80</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="EscalationTask" name="Escalation task 2">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="escalationWorker" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_0qxvh80</bpmn:incoming>
+        <bpmn:outgoing>Flow_0bbhalt</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_12rxp59" sourceRef="Event_0iwm1fq" targetRef="Event_02vrwd0" />
+      <bpmn:sequenceFlow id="Flow_0bbhalt" sourceRef="EscalationTask" targetRef="Event_0iwm1fq" />
+      <bpmn:sequenceFlow id="Flow_0qxvh80" sourceRef="Event_1vxuw3v" targetRef="EscalationTask" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="EscalationEvent" name="Escalation event" attachedToRef="EscalationSubProcess">
+      <bpmn:outgoing>Flow_19stf58</bpmn:outgoing>
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_164va8l" escalationRef="Escalation_1fppfbl" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_13zdve9" sourceRef="Gateway_1" targetRef="Gateway_2" />
+    <bpmn:parallelGateway id="Gateway_1">
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:outgoing>Flow_13zdve9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rs7xob</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_4">
+      <bpmn:incoming>Flow_1rs7xob</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ncb1sr</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06rnibw</bpmn:outgoing>
+      <bpmn:outgoing>Flow_041w5kk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14xnbyk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0nfno00</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ykwgtn</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1rs7xob" sourceRef="Gateway_1" targetRef="Gateway_4" />
+    <bpmn:sequenceFlow id="Flow_0ncb1sr" sourceRef="Gateway_4" targetRef="ExclusiveGateway2" />
+    <bpmn:sequenceFlow id="Flow_06rnibw" sourceRef="Gateway_4" targetRef="EventBasedGateway2" />
+    <bpmn:sequenceFlow id="Flow_041w5kk" sourceRef="Gateway_4" targetRef="SignalIntermediateThrow" />
+    <bpmn:sequenceFlow id="Flow_14xnbyk" sourceRef="Gateway_4" targetRef="SubProcess" />
+    <bpmn:sequenceFlow id="Flow_0nfno00" sourceRef="Gateway_4" targetRef="MultiInstanceSubProcess2" />
+    <bpmn:sequenceFlow id="Flow_0ykwgtn" sourceRef="Gateway_4" targetRef="EscalationSubProcess" />
+    <bpmn:parallelGateway id="Gateway_5">
+      <bpmn:incoming>Flow_1qp2ewy</bpmn:incoming>
+      <bpmn:incoming>Flow_0u9dvrj</bpmn:incoming>
+      <bpmn:incoming>Flow_04ta31i</bpmn:incoming>
+      <bpmn:incoming>Flow_06bvbdi</bpmn:incoming>
+      <bpmn:incoming>Flow_0up5li4</bpmn:incoming>
+      <bpmn:incoming>Flow_0xc7gwl</bpmn:incoming>
+      <bpmn:incoming>Flow_19stf58</bpmn:incoming>
+      <bpmn:outgoing>Flow_1c49dph</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1qp2ewy" sourceRef="Gateway_1cs756a" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0u9dvrj" sourceRef="Gateway_0ftzss1" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_04ta31i" sourceRef="SignalIntermediateCatch2" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_06bvbdi" sourceRef="SubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0up5li4" sourceRef="MultiInstanceSubProcess2" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_0xc7gwl" sourceRef="EscalationSubProcess" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_19stf58" sourceRef="EscalationEvent" targetRef="Gateway_5" />
+    <bpmn:sequenceFlow id="Flow_1tyhemw" sourceRef="Gateway_6" targetRef="EndEvent_1" />
+    <bpmn:parallelGateway id="Gateway_6">
+      <bpmn:incoming>Flow_1ibxab9</bpmn:incoming>
+      <bpmn:incoming>Flow_1c49dph</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tyhemw</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1c49dph" sourceRef="Gateway_5" targetRef="Gateway_6" />
   </bpmn:process>
   <bpmn:message id="Message_0so1os3" name="Message_1">
     <bpmn:extensionElements>
@@ -451,573 +506,655 @@
   <bpmn:signal id="Signal_0j5das4" name="Signal_6" />
   <bpmn:error id="Error_0or6j8h" name="error" errorCode="error" />
   <bpmn:error id="Error_0guddpc" name="error2" errorCode="error2" />
+  <bpmn:escalation id="Escalation_1v2o7l5" name="Escalation_1" escalationCode="123" />
+  <bpmn:escalation id="Escalation_0aipw8x" name="Escalation_1" escalationCode="123" />
+  <bpmn:escalation id="Escalation_1fppfbl" name="Escalation_2" escalationCode="234" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newOrderProcessMigration">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="175" y="120" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="158" y="156" width="73" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment2">
-        <dc:Bounds x="360" y="98" width="100" height="80" />
+        <dc:Bounds x="360" y="168" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="529" y="183" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="519" y="159" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment2">
+        <dc:Bounds x="504" y="330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles2">
+        <dc:Bounds x="650" y="168" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="notifyCustomer2">
+        <dc:Bounds x="800" y="168" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="checkDeliveryState2">
+        <dc:Bounds x="950" y="168" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
+        <dc:Bounds x="482" y="682" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
+        <dc:Bounds x="482" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
+        <dc:Bounds x="482" y="992" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA2">
+        <dc:Bounds x="360" y="567" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB2">
+        <dc:Bounds x="360" y="729" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC2">
+        <dc:Bounds x="360" y="889" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
+        <dc:Bounds x="482" y="1152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD2">
+        <dc:Bounds x="360" y="1049" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_176evz4_di" bpmnElement="Gateway_2">
+        <dc:Bounds x="265" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch2">
+        <dc:Bounds x="772" y="472" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="745" y="520" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch2">
+        <dc:Bounds x="772" y="751" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="745" y="795" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask2">
+        <dc:Bounds x="360" y="1220" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0jycym6_di" bpmnElement="BusinessRuleTask2">
+        <dc:Bounds x="360" y="1330" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1iphj8c_di" bpmnElement="ScriptTask2">
+        <dc:Bounds x="360" y="1440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1keytrg_di" bpmnElement="SendTask2">
+        <dc:Bounds x="360" y="1550" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="92" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="128" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0eqh0on_di" bpmnElement="Gateway_1">
+        <dc:Bounds x="265" y="85" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0oxwpws_di" bpmnElement="Gateway_3">
+        <dc:Bounds x="1105" y="1565" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2" isMarkerVisible="true">
+        <dc:Bounds x="1427" y="183" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1427" y="241" width="51" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
+        <dc:Bounds x="1667" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway2">
+        <dc:Bounds x="1427" y="293" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1381" y="334" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
+        <dc:Bounds x="1434" y="520" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1422" y="563" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch2">
+        <dc:Bounds x="1634" y="520" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1608" y="563" width="90" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wjhud9_di" bpmnElement="Gateway_4">
+        <dc:Bounds x="1275" y="183" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB2">
+        <dc:Bounds x="1596" y="300" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1584" y="343" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB2">
+        <dc:Bounds x="1596" y="400" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1584" y="443" width="61" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
+        <dc:Bounds x="1712" y="293" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_06z2xtb_di" bpmnElement="Gateway_5">
+        <dc:Bounds x="1905" y="1565" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_1">
-        <dc:Bounds x="1192" y="120" width="36" height="36" />
+        <dc:Bounds x="2122" y="1662" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="529" y="113" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="520" y="85" width="69" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Gateway_1bqc3xm_di" bpmnElement="Gateway_6">
+        <dc:Bounds x="1905" y="1655" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment2">
-        <dc:Bounds x="504" y="260" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles2">
-        <dc:Bounds x="650" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="notifyCustomer2">
-        <dc:Bounds x="800" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="checkDeliveryState2">
-        <dc:Bounds x="950" y="98" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1q5nldo_di" bpmnElement="Event_2">
-        <dc:Bounds x="482" y="612" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0c40wzp_di" bpmnElement="Event_3">
-        <dc:Bounds x="482" y="762" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_14gulzq_di" bpmnElement="Event_4">
-        <dc:Bounds x="482" y="922" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0lb6rcr_di" bpmnElement="TaskA2">
-        <dc:Bounds x="360" y="497" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_12bglfo_di" bpmnElement="TaskB2">
-        <dc:Bounds x="360" y="659" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0epoqda_di" bpmnElement="TaskC2">
-        <dc:Bounds x="360" y="819" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ptwud8_di" bpmnElement="Event_5">
-        <dc:Bounds x="482" y="1082" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1pu1nmm_di" bpmnElement="TaskD2">
-        <dc:Bounds x="360" y="979" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_176evz4_di" bpmnElement="Gateway_1">
-        <dc:Bounds x="265" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0oxwpws_di" bpmnElement="Gateway_2">
-        <dc:Bounds x="1105" y="113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0bkpnr3_di" bpmnElement="MessageIntermediateCatch2">
-        <dc:Bounds x="772" y="402" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="450" width="90" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1wu1wpo_di" bpmnElement="TimerIntermediateCatch2">
-        <dc:Bounds x="772" y="681" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="725" width="90" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="1230" y="460" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
-        <dc:Bounds x="1492" y="542" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
-        <dc:Bounds x="1350" y="520" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
-        <dc:Bounds x="1270" y="542" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1247" y="585" width="83" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
-        <di:waypoint x="1450" y="560" />
-        <di:waypoint x="1492" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
-        <di:waypoint x="1306" y="560" />
-        <di:waypoint x="1350" y="560" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="1230" y="210" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
-        <dc:Bounds x="1492" y="292" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
-        <dc:Bounds x="1350" y="270" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
-        <dc:Bounds x="1270" y="292" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1254" y="335" width="70" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
-        <di:waypoint x="1450" y="310" />
-        <di:waypoint x="1492" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
-        <di:waypoint x="1306" y="310" />
-        <di:waypoint x="1350" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0jap8wu_di" bpmnElement="MessageReceiveTask2">
-        <dc:Bounds x="360" y="1150" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0jycym6_di" bpmnElement="BusinessRuleTask2">
-        <dc:Bounds x="360" y="1260" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1iphj8c_di" bpmnElement="ScriptTask2">
-        <dc:Bounds x="360" y="1370" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1keytrg_di" bpmnElement="SendTask2">
-        <dc:Bounds x="360" y="1480" width="100" height="80" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05lm5ha_di" bpmnElement="ExclusiveGateway2" isMarkerVisible="true">
-        <dc:Bounds x="385" y="1605" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="385" y="1663" width="51" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1cs756a_di" bpmnElement="Gateway_1cs756a" isMarkerVisible="true">
-        <dc:Bounds x="625" y="1605" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0wr1vef_di" bpmnElement="EventBasedGateway2">
-        <dc:Bounds x="385" y="1715" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="339" y="1756" width="62" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0pur8kj_di" bpmnElement="TimerIntermediateCatchB2">
-        <dc:Bounds x="592" y="1722" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="580" y="1765" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1cxzp2c_di" bpmnElement="MessageIntermediateCatchB2">
-        <dc:Bounds x="592" y="1822" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="580" y="1865" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ftzss1_di" bpmnElement="Gateway_0ftzss1" isMarkerVisible="true">
-        <dc:Bounds x="765" y="1715" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1ymwb5r_di" bpmnElement="SignalIntermediateThrow">
-        <dc:Bounds x="392" y="1942" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="380" y="1985" width="61" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0jx4kbd_di" bpmnElement="SignalIntermediateCatch2">
-        <dc:Bounds x="592" y="1942" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="566" y="1985" width="90" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2" isExpanded="true">
-        <dc:Bounds x="1230" y="710" width="350" height="200" />
-        <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
-        <dc:Bounds x="1522" y="792" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
-        <dc:Bounds x="1360" y="770" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
-        <dc:Bounds x="1270" y="792" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1246" y="835" width="85" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
-        <dc:Bounds x="1522" y="862" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
-        <dc:Bounds x="1412" y="832" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1392" y="875" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
-        <di:waypoint x="1460" y="810" />
-        <di:waypoint x="1522" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
-        <di:waypoint x="1306" y="810" />
-        <di:waypoint x="1360" y="810" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
-        <di:waypoint x="1430" y="868" />
-        <di:waypoint x="1430" y="880" />
-        <di:waypoint x="1522" y="880" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="BPMNShape_0p68nmi" bpmnElement="SubProcess" isExpanded="true">
-        <dc:Bounds x="310" y="2050" width="423" height="350" />
+        <dc:Bounds x="1402" y="628" width="423" height="350" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0q4nhhk" bpmnElement="ErrorEndEvent">
-        <dc:Bounds x="600" y="2092" width="36" height="36" />
+        <dc:Bounds x="1692" y="670" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0avpv6s" bpmnElement="SubProcessStartEvent">
-        <dc:Bounds x="387" y="2092" width="36" height="36" />
+        <dc:Bounds x="1479" y="670" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0bd9v5k" bpmnElement="ErrorEventSubProcess" isExpanded="true">
-        <dc:Bounds x="348" y="2173" width="350" height="200" />
+        <dc:Bounds x="1440" y="751" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0zghnh1" bpmnElement="ErrorStartEvent">
-        <dc:Bounds x="388" y="2255" width="36" height="36" />
+        <dc:Bounds x="1480" y="833" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="367" y="2298" width="79" height="14" />
+          <dc:Bounds x="1459" y="876" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_07uzu84" bpmnElement="Event_12yeu6m">
-        <dc:Bounds x="600" y="2255" width="36" height="36" />
+        <dc:Bounds x="1692" y="833" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_1cc07mn" bpmnElement="TaskG">
-        <dc:Bounds x="458" y="2233" width="100" height="80" />
+        <dc:Bounds x="1550" y="811" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="BPMNEdge_14n5b9f" bpmnElement="Flow_1nc8qvq">
-        <di:waypoint x="424" y="2273" />
-        <di:waypoint x="458" y="2273" />
+        <di:waypoint x="1516" y="851" />
+        <di:waypoint x="1550" y="851" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_03b1wgz" bpmnElement="Flow_1n6hwxq">
-        <di:waypoint x="558" y="2273" />
-        <di:waypoint x="600" y="2273" />
+        <di:waypoint x="1650" y="851" />
+        <di:waypoint x="1692" y="851" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="BPMNEdge_14dxxs3" bpmnElement="Flow_04fbdug">
-        <di:waypoint x="423" y="2110" />
-        <di:waypoint x="600" y="2110" />
+        <di:waypoint x="1515" y="688" />
+        <di:waypoint x="1692" y="688" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_1ms6g9k_di" bpmnElement="MultiInstanceSubProcess2" isExpanded="true">
-        <dc:Bounds x="510" y="2440" width="350" height="200" />
+        <dc:Bounds x="1412" y="1018" width="350" height="200" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1b83nzw_di" bpmnElement="Event_1b83nzw">
-        <dc:Bounds x="550" y="2522" width="36" height="36" />
+        <dc:Bounds x="1452" y="1100" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0lqkl4x_di" bpmnElement="Event_0lqkl4x">
-        <dc:Bounds x="790" y="2522" width="36" height="36" />
+        <dc:Bounds x="1692" y="1100" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0j5j3d3_di" bpmnElement="MultiInstanceTask2">
-        <dc:Bounds x="638" y="2500" width="100" height="80" />
+        <dc:Bounds x="1540" y="1078" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_00irh9p_di" bpmnElement="Flow_00irh9p">
-        <di:waypoint x="586" y="2540" />
-        <di:waypoint x="638" y="2540" />
+        <di:waypoint x="1488" y="1118" />
+        <di:waypoint x="1540" y="1118" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10r7wrx_di" bpmnElement="Flow_10r7wrx">
-        <di:waypoint x="738" y="2540" />
-        <di:waypoint x="790" y="2540" />
+        <di:waypoint x="1640" y="1118" />
+        <di:waypoint x="1692" y="1118" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting2">
-        <dc:Bounds x="412" y="1041" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_17jsa42_di" bpmnElement="EscalationSubProcess" isExpanded="true">
+        <dc:Bounds x="1412" y="1248" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_02vrwd0_di" bpmnElement="Event_02vrwd0">
+        <dc:Bounds x="1705" y="1330" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1f62b1z_di" bpmnElement="Event_0iwm1fq">
+        <dc:Bounds x="1635" y="1330" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1vxuw3v_di" bpmnElement="Event_1vxuw3v">
+        <dc:Bounds x="1435" y="1330" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14net6k_di" bpmnElement="EscalationTask">
+        <dc:Bounds x="1503" y="1308" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_12rxp59_di" bpmnElement="Flow_12rxp59">
+        <di:waypoint x="1671" y="1348" />
+        <di:waypoint x="1705" y="1348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bbhalt_di" bpmnElement="Flow_0bbhalt">
+        <di:waypoint x="1603" y="1348" />
+        <di:waypoint x="1635" y="1348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qxvh80_di" bpmnElement="Flow_0qxvh80">
+        <di:waypoint x="1471" y="1348" />
+        <di:waypoint x="1503" y="1348" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0cz53c2_di" bpmnElement="TimerEventSubProcess2" isExpanded="true">
+        <dc:Bounds x="2070" y="430" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lk89tk_di" bpmnElement="Event_0lk89tk">
+        <dc:Bounds x="2332" y="512" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x898wf_di" bpmnElement="TaskF2">
+        <dc:Bounds x="2190" y="490" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_01ol322_di" bpmnElement="TimerStartEvent">
+        <dc:Bounds x="2110" y="512" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="358" y="1076" width="65" height="27" />
+          <dc:Bounds x="2087" y="555" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting2">
-        <dc:Bounds x="412" y="881" width="36" height="36" />
+      <bpmndi:BPMNEdge id="Flow_1rrwh6x_di" bpmnElement="Flow_1rrwh6x">
+        <di:waypoint x="2290" y="530" />
+        <di:waypoint x="2332" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0eemr1n_di" bpmnElement="Flow_0eemr1n">
+        <di:waypoint x="2146" y="530" />
+        <di:waypoint x="2190" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0tgxt6v_di" bpmnElement="MessageEventSubProcess2" isExpanded="true">
+        <dc:Bounds x="2070" y="180" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_13rtwuo_di" bpmnElement="Event_13rtwuo">
+        <dc:Bounds x="2332" y="262" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9lzza_di" bpmnElement="TaskE2">
+        <dc:Bounds x="2190" y="240" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1t7lt05_di" bpmnElement="MessageStartEvent">
+        <dc:Bounds x="2110" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="354" y="916" width="71" height="27" />
+          <dc:Bounds x="2094" y="305" width="70" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_006eqia_di" bpmnElement="Flow_006eqia">
+        <di:waypoint x="2290" y="280" />
+        <di:waypoint x="2332" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7mn63_di" bpmnElement="Flow_1f7mn63">
+        <di:waypoint x="2146" y="280" />
+        <di:waypoint x="2190" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1s001x5_di" bpmnElement="SignalEventSubProcess2" isExpanded="true">
+        <dc:Bounds x="2070" y="680" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0opmx5v_di" bpmnElement="Event_0opmx5v">
+        <dc:Bounds x="2362" y="762" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v214gi_di" bpmnElement="TaskH">
+        <dc:Bounds x="2200" y="740" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1u3z80h_di" bpmnElement="SignalStartEvent">
+        <dc:Bounds x="2110" y="762" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2086" y="805" width="85" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_049m1di_di" bpmnElement="Event_049m1di">
+        <dc:Bounds x="2362" y="832" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ch2r7b_di" bpmnElement="SignalBoudaryEvent2">
+        <dc:Bounds x="2252" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2232" y="845" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1tl6j8a_di" bpmnElement="Flow_1tl6j8a">
+        <di:waypoint x="2300" y="780" />
+        <di:waypoint x="2362" y="780" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_189mrto_di" bpmnElement="Flow_189mrto">
+        <di:waypoint x="2146" y="780" />
+        <di:waypoint x="2200" y="780" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bfr615_di" bpmnElement="Flow_0bfr615">
+        <di:waypoint x="2270" y="838" />
+        <di:waypoint x="2270" y="850" />
+        <di:waypoint x="2362" y="850" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting2">
+        <dc:Bounds x="412" y="629" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="358" y="656" width="65" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qunf6g_di" bpmnElement="TimerInterrupting2">
-        <dc:Bounds x="412" y="721" width="36" height="36" />
+        <dc:Bounds x="412" y="791" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="337" y="753" width="86" height="27" />
+          <dc:Bounds x="337" y="823" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0ebm1nl_di" bpmnElement="MessageInterrupting2">
-        <dc:Bounds x="412" y="559" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0uzff2d_di" bpmnElement="MessageNonInterrupting2">
+        <dc:Bounds x="412" y="951" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="358" y="586" width="65" height="27" />
+          <dc:Bounds x="354" y="986" width="71" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
-        <di:waypoint x="211" y="138" />
-        <di:waypoint x="265" y="138" />
+      <bpmndi:BPMNShape id="Event_09ic20e_di" bpmnElement="TimerNonInterrupting2">
+        <dc:Bounds x="412" y="1111" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+          <dc:Bounds x="358" y="1146" width="65" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0jexdxm_di" bpmnElement="EscalationEvent">
+        <dc:Bounds x="1575" y="1430" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1553" y="1473" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="504" y="370" />
+        <di:waypoint x="410" y="370" />
+        <di:waypoint x="410" y="248" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s77slh_di" bpmnElement="Flow_0s77slh">
+        <di:waypoint x="315" y="208" />
+        <di:waypoint x="360" y="208" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
-        <di:waypoint x="460" y="138" />
-        <di:waypoint x="529" y="138" />
+        <di:waypoint x="460" y="208" />
+        <di:waypoint x="529" y="208" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="54.5" y="227" width="0" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
-        <di:waypoint x="554" y="163" />
-        <di:waypoint x="554" y="260" />
+        <di:waypoint x="554" y="233" />
+        <di:waypoint x="554" y="330" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="510" y="188" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
-        <di:waypoint x="504" y="300" />
-        <di:waypoint x="410" y="300" />
-        <di:waypoint x="410" y="178" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="17" y="389" width="0" height="12" />
+          <dc:Bounds x="510" y="258" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
-        <di:waypoint x="579" y="138" />
-        <di:waypoint x="650" y="138" />
+        <di:waypoint x="579" y="208" />
+        <di:waypoint x="650" y="208" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="599" y="117" width="21" height="14" />
+          <dc:Bounds x="599" y="187" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_19klrd3_di" bpmnElement="SequenceFlow_19klrd3">
-        <di:waypoint x="750" y="138" />
-        <di:waypoint x="800" y="138" />
+        <di:waypoint x="750" y="208" />
+        <di:waypoint x="800" y="208" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="337.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zx0zzd_di" bpmnElement="Flow_0zx0zzd">
-        <di:waypoint x="900" y="138" />
-        <di:waypoint x="950" y="138" />
+        <di:waypoint x="900" y="208" />
+        <di:waypoint x="950" y="208" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0hxjz3q_di" bpmnElement="Flow_0hxjz3q">
-        <di:waypoint x="1050" y="138" />
-        <di:waypoint x="1105" y="138" />
+        <di:waypoint x="1050" y="208" />
+        <di:waypoint x="1130" y="208" />
+        <di:waypoint x="1130" y="1565" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14ee2ym_di" bpmnElement="Flow_14ee2ym">
-        <di:waypoint x="430" y="595" />
-        <di:waypoint x="430" y="630" />
-        <di:waypoint x="482" y="630" />
+        <di:waypoint x="430" y="665" />
+        <di:waypoint x="430" y="700" />
+        <di:waypoint x="482" y="700" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ym4tee_di" bpmnElement="Flow_1ym4tee">
-        <di:waypoint x="430" y="757" />
-        <di:waypoint x="430" y="780" />
-        <di:waypoint x="482" y="780" />
+        <di:waypoint x="430" y="827" />
+        <di:waypoint x="430" y="850" />
+        <di:waypoint x="482" y="850" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0b5y250_di" bpmnElement="Flow_0b5y250">
-        <di:waypoint x="430" y="917" />
-        <di:waypoint x="430" y="940" />
-        <di:waypoint x="482" y="940" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
-        <di:waypoint x="430" y="1077" />
-        <di:waypoint x="430" y="1100" />
-        <di:waypoint x="482" y="1100" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0s77slh_di" bpmnElement="Flow_0s77slh">
-        <di:waypoint x="315" y="138" />
-        <di:waypoint x="360" y="138" />
+        <di:waypoint x="430" y="987" />
+        <di:waypoint x="430" y="1010" />
+        <di:waypoint x="482" y="1010" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1umsz4s_di" bpmnElement="Flow_1umsz4s">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="537" />
-        <di:waypoint x="360" y="537" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19twklg_di" bpmnElement="Flow_19twklg">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="699" />
-        <di:waypoint x="360" y="699" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fyja5s_di" bpmnElement="Flow_0fyja5s">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="859" />
-        <di:waypoint x="360" y="859" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1478njt_di" bpmnElement="Flow_1478njt">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1019" />
-        <di:waypoint x="360" y="1019" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
-        <di:waypoint x="1155" y="138" />
-        <di:waypoint x="1192" y="138" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
-        <di:waypoint x="460" y="699" />
-        <di:waypoint x="772" y="699" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_159gm2j_di" bpmnElement="Flow_159gm2j">
-        <di:waypoint x="460" y="859" />
-        <di:waypoint x="1130" y="859" />
-        <di:waypoint x="1130" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0279afj_di" bpmnElement="Flow_0279afj">
-        <di:waypoint x="460" y="1019" />
-        <di:waypoint x="1130" y="1019" />
-        <di:waypoint x="1130" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0s3pyc8_di" bpmnElement="Flow_0s3pyc8">
-        <di:waypoint x="808" y="699" />
-        <di:waypoint x="1130" y="699" />
-        <di:waypoint x="1130" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kfelct_di" bpmnElement="Flow_0kfelct">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="420" />
-        <di:waypoint x="772" y="420" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1j5fksj_di" bpmnElement="Flow_1j5fksj">
-        <di:waypoint x="808" y="420" />
-        <di:waypoint x="1130" y="420" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="607" />
+        <di:waypoint x="360" y="607" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0aheimq_di" bpmnElement="Flow_0aheimq">
-        <di:waypoint x="460" y="537" />
-        <di:waypoint x="1130" y="537" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="460" y="607" />
+        <di:waypoint x="1130" y="607" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19twklg_di" bpmnElement="Flow_19twklg">
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="769" />
+        <di:waypoint x="360" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lyxcbw_di" bpmnElement="Flow_0lyxcbw">
+        <di:waypoint x="460" y="769" />
+        <di:waypoint x="772" y="769" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fyja5s_di" bpmnElement="Flow_0fyja5s">
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="929" />
+        <di:waypoint x="360" y="929" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_159gm2j_di" bpmnElement="Flow_159gm2j">
+        <di:waypoint x="460" y="929" />
+        <di:waypoint x="1130" y="929" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_093zwcs_di" bpmnElement="Flow_093zwcs">
+        <di:waypoint x="430" y="1147" />
+        <di:waypoint x="430" y="1170" />
+        <di:waypoint x="482" y="1170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1478njt_di" bpmnElement="Flow_1478njt">
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="1089" />
+        <di:waypoint x="360" y="1089" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0279afj_di" bpmnElement="Flow_0279afj">
+        <di:waypoint x="460" y="1089" />
+        <di:waypoint x="1130" y="1089" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13zdve9_di" bpmnElement="Flow_13zdve9">
+        <di:waypoint x="290" y="135" />
+        <di:waypoint x="290" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kfelct_di" bpmnElement="Flow_0kfelct">
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="490" />
+        <di:waypoint x="772" y="490" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_00bezny_di" bpmnElement="Flow_00bezny">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1190" />
-        <di:waypoint x="360" y="1190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16drwmj_di" bpmnElement="Flow_16drwmj">
-        <di:waypoint x="460" y="1190" />
-        <di:waypoint x="1130" y="1190" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="1260" />
+        <di:waypoint x="360" y="1260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1235n4i_di" bpmnElement="Flow_1235n4i">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1300" />
-        <di:waypoint x="360" y="1300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xg3tdz_di" bpmnElement="Flow_1xg3tdz">
-        <di:waypoint x="460" y="1300" />
-        <di:waypoint x="1130" y="1300" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="1370" />
+        <di:waypoint x="360" y="1370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_192dswa_di" bpmnElement="Flow_192dswa">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1410" />
-        <di:waypoint x="360" y="1410" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1epls0w_di" bpmnElement="Flow_1epls0w">
-        <di:waypoint x="460" y="1410" />
-        <di:waypoint x="1130" y="1410" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="1480" />
+        <di:waypoint x="360" y="1480" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14gbl4m_di" bpmnElement="Flow_14gbl4m">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1520" />
-        <di:waypoint x="360" y="1520" />
+        <di:waypoint x="290" y="233" />
+        <di:waypoint x="290" y="1590" />
+        <di:waypoint x="360" y="1590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j5fksj_di" bpmnElement="Flow_1j5fksj">
+        <di:waypoint x="808" y="490" />
+        <di:waypoint x="1130" y="490" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0s3pyc8_di" bpmnElement="Flow_0s3pyc8">
+        <di:waypoint x="808" y="769" />
+        <di:waypoint x="1130" y="769" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16drwmj_di" bpmnElement="Flow_16drwmj">
+        <di:waypoint x="460" y="1260" />
+        <di:waypoint x="1130" y="1260" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xg3tdz_di" bpmnElement="Flow_1xg3tdz">
+        <di:waypoint x="460" y="1370" />
+        <di:waypoint x="1130" y="1370" />
+        <di:waypoint x="1130" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1epls0w_di" bpmnElement="Flow_1epls0w">
+        <di:waypoint x="460" y="1480" />
+        <di:waypoint x="1130" y="1480" />
+        <di:waypoint x="1130" y="1565" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vlhghj_di" bpmnElement="Flow_0vlhghj">
-        <di:waypoint x="460" y="1520" />
-        <di:waypoint x="1130" y="1520" />
-        <di:waypoint x="1130" y="163" />
+        <di:waypoint x="460" y="1590" />
+        <di:waypoint x="1105" y="1590" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
-        <di:waypoint x="435" y="1630" />
-        <di:waypoint x="625" y="1630" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="110" />
+        <di:waypoint x="265" y="110" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="522" y="1612" width="16" height="14" />
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rs7xob_di" bpmnElement="Flow_1rs7xob">
+        <di:waypoint x="315" y="110" />
+        <di:waypoint x="1300" y="110" />
+        <di:waypoint x="1300" y="183" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ibxab9_di" bpmnElement="Flow_1ibxab9">
+        <di:waypoint x="1130" y="1615" />
+        <di:waypoint x="1130" y="1680" />
+        <di:waypoint x="1905" y="1680" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ncb1sr_di" bpmnElement="Flow_0ncb1sr">
+        <di:waypoint x="1325" y="208" />
+        <di:waypoint x="1427" y="208" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126yu9s_di" bpmnElement="Flow_126yu9s">
+        <di:waypoint x="1477" y="208" />
+        <di:waypoint x="1667" y="208" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1564" y="190" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qp2ewy_di" bpmnElement="Flow_1qp2ewy">
+        <di:waypoint x="1717" y="208" />
+        <di:waypoint x="1930" y="208" />
+        <di:waypoint x="1930" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06rnibw_di" bpmnElement="Flow_06rnibw">
+        <di:waypoint x="1300" y="233" />
+        <di:waypoint x="1300" y="318" />
+        <di:waypoint x="1427" y="318" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0guz7jv_di" bpmnElement="Flow_0guz7jv">
-        <di:waypoint x="435" y="1740" />
-        <di:waypoint x="592" y="1740" />
+        <di:waypoint x="1477" y="318" />
+        <di:waypoint x="1596" y="318" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0v8bsdg_di" bpmnElement="Flow_0v8bsdg">
-        <di:waypoint x="410" y="1765" />
-        <di:waypoint x="410" y="1840" />
-        <di:waypoint x="592" y="1840" />
+        <di:waypoint x="1452" y="343" />
+        <di:waypoint x="1452" y="418" />
+        <di:waypoint x="1596" y="418" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
-        <di:waypoint x="628" y="1740" />
-        <di:waypoint x="765" y="1740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
-        <di:waypoint x="628" y="1840" />
-        <di:waypoint x="790" y="1840" />
-        <di:waypoint x="790" y="1765" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ixacpg_di" bpmnElement="Flow_1ixacpg">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1630" />
-        <di:waypoint x="385" y="1630" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0796mcu_di" bpmnElement="Flow_0796mcu">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1740" />
-        <di:waypoint x="385" y="1740" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_060zyko_di" bpmnElement="Flow_060zyko">
-        <di:waypoint x="675" y="1630" />
-        <di:waypoint x="1130" y="1630" />
-        <di:waypoint x="1130" y="163" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0i5udyk_di" bpmnElement="Flow_0i5udyk">
-        <di:waypoint x="815" y="1740" />
-        <di:waypoint x="1130" y="1740" />
-        <di:waypoint x="1130" y="163" />
+      <bpmndi:BPMNEdge id="Flow_041w5kk_di" bpmnElement="Flow_041w5kk">
+        <di:waypoint x="1300" y="233" />
+        <di:waypoint x="1300" y="538" />
+        <di:waypoint x="1434" y="538" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1359yom_di" bpmnElement="Flow_1359yom">
-        <di:waypoint x="428" y="1960" />
-        <di:waypoint x="592" y="1960" />
+        <di:waypoint x="1470" y="538" />
+        <di:waypoint x="1634" y="538" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0t0hay3_di" bpmnElement="Flow_0t0hay3">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="1960" />
-        <di:waypoint x="392" y="1960" />
+      <bpmndi:BPMNEdge id="Flow_04ta31i_di" bpmnElement="Flow_04ta31i">
+        <di:waypoint x="1670" y="538" />
+        <di:waypoint x="1930" y="538" />
+        <di:waypoint x="1930" y="1565" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06eifq9_di" bpmnElement="Flow_06eifq9">
-        <di:waypoint x="628" y="1960" />
-        <di:waypoint x="1130" y="1960" />
-        <di:waypoint x="1130" y="163" />
+      <bpmndi:BPMNEdge id="Flow_14xnbyk_di" bpmnElement="Flow_14xnbyk">
+        <di:waypoint x="1300" y="233" />
+        <di:waypoint x="1300" y="803" />
+        <di:waypoint x="1402" y="803" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hc14mk_di" bpmnElement="Flow_0hc14mk">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="2225" />
-        <di:waypoint x="310" y="2225" />
+      <bpmndi:BPMNEdge id="Flow_0nfno00_di" bpmnElement="Flow_0nfno00">
+        <di:waypoint x="1300" y="233" />
+        <di:waypoint x="1300" y="1118" />
+        <di:waypoint x="1412" y="1118" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1brhss6_di" bpmnElement="Flow_1brhss6">
-        <di:waypoint x="733" y="2225" />
-        <di:waypoint x="1130" y="2225" />
-        <di:waypoint x="1130" y="163" />
+      <bpmndi:BPMNEdge id="Flow_0ykwgtn_di" bpmnElement="Flow_0ykwgtn">
+        <di:waypoint x="1300" y="233" />
+        <di:waypoint x="1300" y="1348" />
+        <di:waypoint x="1412" y="1348" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0xxd8dc_di" bpmnElement="Flow_0xxd8dc">
-        <di:waypoint x="290" y="163" />
-        <di:waypoint x="290" y="2540" />
-        <di:waypoint x="510" y="2540" />
+      <bpmndi:BPMNEdge id="Flow_0j0qeck_di" bpmnElement="Flow_0j0qeck">
+        <di:waypoint x="1632" y="318" />
+        <di:waypoint x="1712" y="318" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mxprri_di" bpmnElement="Flow_1mxprri">
-        <di:waypoint x="860" y="2540" />
-        <di:waypoint x="1130" y="2540" />
-        <di:waypoint x="1130" y="163" />
+      <bpmndi:BPMNEdge id="Flow_17zq5s0_di" bpmnElement="Flow_17zq5s0">
+        <di:waypoint x="1632" y="418" />
+        <di:waypoint x="1737" y="418" />
+        <di:waypoint x="1737" y="343" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0u9dvrj_di" bpmnElement="Flow_0u9dvrj">
+        <di:waypoint x="1762" y="318" />
+        <di:waypoint x="1930" y="318" />
+        <di:waypoint x="1930" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06bvbdi_di" bpmnElement="Flow_06bvbdi">
+        <di:waypoint x="1825" y="803" />
+        <di:waypoint x="1930" y="803" />
+        <di:waypoint x="1930" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0up5li4_di" bpmnElement="Flow_0up5li4">
+        <di:waypoint x="1762" y="1118" />
+        <di:waypoint x="1930" y="1118" />
+        <di:waypoint x="1930" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xc7gwl_di" bpmnElement="Flow_0xc7gwl">
+        <di:waypoint x="1762" y="1348" />
+        <di:waypoint x="1930" y="1348" />
+        <di:waypoint x="1930" y="1565" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19stf58_di" bpmnElement="Flow_19stf58">
+        <di:waypoint x="1593" y="1466" />
+        <di:waypoint x="1593" y="1590" />
+        <di:waypoint x="1905" y="1590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1c49dph_di" bpmnElement="Flow_1c49dph">
+        <di:waypoint x="1930" y="1615" />
+        <di:waypoint x="1930" y="1655" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tyhemw_di" bpmnElement="Flow_1tyhemw">
+        <di:waypoint x="1955" y="1680" />
+        <di:waypoint x="2122" y="1680" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
## Description

This PR adds E2E test coverage to ensure the migration works.
Mapping tasks inside sub processes with an escalation boundary event was already possible. 

The layout in the process definition files was updated due to readability reasons, which caused the big diff

Before:

![image](https://github.com/user-attachments/assets/0b9b43ba-5277-4c9c-bfa4-e74c48c25c75)

After:

![image](https://github.com/user-attachments/assets/08374e5b-35ca-4184-9e83-35bec4abe24c)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24628 

Link to the test case: 
[User Can Migrate successfully a process with escalation boundary events](https://camunda.testrail.com/index.php?/cases/view/535967)
