### PR TITLE
Handle potential null aggregate

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -44,13 +44,13 @@ public class BatchOperationArchiverJob implements ArchiverJob {
   public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
 
     if (archiveBatch != null) {
-      logger.debug("Following batch operations are found for archiving: {}", archiveBatch);
+      logger.trace("Following batch operations are found for archiving: {}", archiveBatch);
 
       return moveBatch(archiveBatch.finishDate(), archiveBatch.ids())
           .thenApplyAsync(FunctionUtil.peek(metrics::batchOperationsArchived), executor);
     }
 
-    logger.debug("Nothing to archive");
+    logger.trace("Nothing to archive");
     return CompletableFuture.completedFuture(0);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
@@ -208,9 +208,12 @@ public final class ElasticsearchRepository implements ArchiverRepository {
   }
 
   private ArchiveBatch createArchiveBatch(final SubmitResponse<?> search) {
-    final List<DateHistogramBucket> buckets =
-        search.response().aggregations().get(DATES_AGG).dateHistogram().buckets().array();
+    final var aggregate = search.response().aggregations().get(DATES_AGG);
+    if (aggregate == null) {
+      return null;
+    }
 
+    final List<DateHistogramBucket> buckets = aggregate.dateHistogram().buckets().array();
     if (buckets.isEmpty()) {
       return null;
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
@@ -207,9 +207,12 @@ public final class OpenSearchRepository implements ArchiverRepository {
   }
 
   private ArchiveBatch createArchiveBatch(final SearchResponse<?> search) {
-    final List<DateHistogramBucket> buckets =
-        search.aggregations().get(DATES_AGG).dateHistogram().buckets().array();
+    final var aggregation = search.aggregations().get(DATES_AGG);
+    if (aggregation == null) {
+      return null;
+    }
 
+    final List<DateHistogramBucket> buckets = aggregation.dateHistogram().buckets().array();
     if (buckets.isEmpty()) {
       return null;
     }


### PR DESCRIPTION
## Description

There seems to be a race condition where sometimes the aggregation returned is null. This only happens when there is nothing in the indices (i.e. nothing to archive). I couldn't verify if this is actually expected (as it's not documented anywhere) - and since sometimes it's just an empty aggregation (instead of null), it's hard to say.

That said, it seems low impact, and worth just adding a check.

I also added a tiny commit, lowering the log level in `BatchOperationArchiverJob` (as it was logged often). Seemed overkill to open another PR for that :smile: 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
