### PR TITLE
[Backport stable/8.6] fix: cancel user tasks on instance modification

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.auth.impl.TenantAuthorizationCheckerImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior.ActivatedElementKeys;
@@ -143,6 +144,7 @@ public final class ProcessInstanceModificationModifyProcessor
   private final CatchEventBehavior catchEventBehavior;
   private final ElementActivationBehavior elementActivationBehavior;
   private final VariableBehavior variableBehavior;
+  private final BpmnUserTaskBehavior userTaskBehavior;
 
   public ProcessInstanceModificationModifyProcessor(
       final Writers writers,
@@ -159,6 +161,7 @@ public final class ProcessInstanceModificationModifyProcessor
     catchEventBehavior = bpmnBehaviors.catchEventBehavior();
     elementActivationBehavior = bpmnBehaviors.elementActivationBehavior();
     variableBehavior = bpmnBehaviors.variableBehavior();
+    userTaskBehavior = bpmnBehaviors.userTaskBehavior();
   }
 
   @Override
@@ -699,6 +702,7 @@ public final class ProcessInstanceModificationModifyProcessor
       elementInstancesToTerminate.push(currentElement);
 
       jobBehavior.cancelJob(currentElement);
+      userTaskBehavior.cancelUserTask(currentElement);
       incidentBehavior.resolveIncidents(elementInstanceKey);
       catchEventBehavior.unsubscribeFromEvents(elementInstanceKey);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserTaskRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/UserTaskRecordStream.java
@@ -26,4 +26,8 @@ public class UserTaskRecordStream
   public UserTaskRecordStream withProcessInstanceKey(final long processInstanceKey) {
     return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
   }
+
+  public UserTaskRecordStream withElementId(final String elementId) {
+    return valueFilter(v -> v.getElementId().equals(elementId));
+  }
 }


### PR DESCRIPTION
# Description
Backport of #24673 to `stable/8.6`.

relates to #24672
original author: @tmetzke