### PR TITLE
fix: Use Decision Instance Primary Key in GET Endpoint

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -1033,13 +1033,13 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
   DecisionInstanceQuery newDecisionInstanceQuery();
 
   /**
-   * Retrieves a decision instance by key.
+   * Retrieves a decision instance by id.
    *
    * <pre>
-   * long decisionInstanceKey = ...;
+   * String decisionInstanceKey = ...;
    *
    * zeebeClient
-   * .newDecisionInstanceGetQuery(decisionInstanceKey)
+   * .newDecisionInstanceGetQuery(decisionInstanceId)
    * .send();
    * </pre>
    *
@@ -1049,11 +1049,11 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * warning is removed, anything described below may not yet have taken effect, and the interface
    * and its description are subject to change.</strong>
    *
-   * @param decisionInstanceKey
+   * @param decisionInstanceId
    * @return a builder for the request to get a decision instance
    */
   @ExperimentalApi("https://github.com/camunda/camunda/issues/20596")
-  DecisionInstanceGetRequest newDecisionInstanceGetRequest(long decisionInstanceKey);
+  DecisionInstanceGetRequest newDecisionInstanceGetRequest(String decisionInstanceId);
 
   /*
    * Executes a search request to query decision definitions.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/DecisionInstanceFilter.java
@@ -27,6 +27,9 @@ public interface DecisionInstanceFilter extends SearchRequestFilter {
   /** Filter by decisionInstanceKey */
   DecisionInstanceFilter decisionInstanceKey(long decisionInstanceKey);
 
+  /** Filter by decisionInstanceId */
+  DecisionInstanceFilter decisionInstanceId(String decisionInstanceId);
+
   /** Filter by state */
   DecisionInstanceFilter state(DecisionInstanceState state);
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstance.java
@@ -27,6 +27,11 @@ public interface DecisionInstance {
   long getDecisionInstanceKey();
 
   /**
+   * @return the id of the decision instance
+   */
+  String getDecisionInstanceId();
+
+  /**
    * @return the state of the decision instance
    */
   DecisionInstanceState getState();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/DecisionInstance.java
@@ -27,7 +27,7 @@ public interface DecisionInstance {
   long getDecisionInstanceKey();
 
   /**
-   * @return the id of the decision instance
+   * @return the ID of the decision instance
    */
   String getDecisionInstanceId();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/sort/DecisionInstanceSort.java
@@ -22,6 +22,9 @@ public interface DecisionInstanceSort extends SearchRequestSort<DecisionInstance
   /** Sort by decisionInstanceKey */
   DecisionInstanceSort decisionInstanceKey();
 
+  /** Sort by decisionInstanceId */
+  DecisionInstanceSort decisionInstanceId();
+
   /** Sort by state */
   DecisionInstanceSort state();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -673,8 +673,8 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public DecisionInstanceGetRequest newDecisionInstanceGetRequest(final long decisionInstanceKey) {
-    return new DecisionInstanceGetRequestImpl(httpClient, jsonMapper, decisionInstanceKey);
+  public DecisionInstanceGetRequest newDecisionInstanceGetRequest(final String decisionInstanceId) {
+    return new DecisionInstanceGetRequestImpl(httpClient, jsonMapper, decisionInstanceId);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DecisionInstanceGetRequestImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/fetch/DecisionInstanceGetRequestImpl.java
@@ -33,14 +33,14 @@ public class DecisionInstanceGetRequestImpl implements DecisionInstanceGetReques
   private final JsonMapper jsonMapper;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final long decisionInstanceKey;
+  private final String decisionInstanceId;
 
   public DecisionInstanceGetRequestImpl(
-      final HttpClient httpClient, final JsonMapper jsonMapper, final long decisionInstanceKey) {
+      final HttpClient httpClient, final JsonMapper jsonMapper, final String decisionInstanceId) {
     this.httpClient = httpClient;
     this.jsonMapper = jsonMapper;
     httpRequestConfig = httpClient.newRequestConfig();
-    this.decisionInstanceKey = decisionInstanceKey;
+    this.decisionInstanceId = decisionInstanceId;
   }
 
   @Override
@@ -53,7 +53,7 @@ public class DecisionInstanceGetRequestImpl implements DecisionInstanceGetReques
   public ZeebeFuture<DecisionInstance> send() {
     final HttpZeebeFuture<DecisionInstance> result = new HttpZeebeFuture<>();
     httpClient.get(
-        String.format("/decision-instances/%d", decisionInstanceKey),
+        String.format("/decision-instances/%s", decisionInstanceId),
         httpRequestConfig.build(),
         DecisionInstanceGetQueryResponse.class,
         resp -> new DecisionInstanceImpl(resp, jsonMapper),

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/DecisionInstanceFilterImpl.java
@@ -44,6 +44,12 @@ public class DecisionInstanceFilterImpl
   }
 
   @Override
+  public DecisionInstanceFilter decisionInstanceId(final String decisionInstanceId) {
+    filter.decisionInstanceId(decisionInstanceId);
+    return this;
+  }
+
+  @Override
   public DecisionInstanceFilter state(final DecisionInstanceState state) {
     final DecisionInstanceStateEnum stateEnum;
     switch (state) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/DecisionInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/DecisionInstanceImpl.java
@@ -36,6 +36,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
 
   @JsonIgnore private final JsonMapper jsonMapper;
   private final long decisionInstanceKey;
+  private final String decisionInstanceId;
   private final DecisionInstanceState state;
   private final String evaluationDate;
   private final String evaluationFailure;
@@ -54,6 +55,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
     this(
         jsonMapper,
         item.getDecisionInstanceKey(),
+        item.getDecisionInstanceId(),
         toDecisionInstanceState(item.getState()),
         item.getEvaluationDate(),
         item.getEvaluationFailure(),
@@ -74,6 +76,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
     this(
         jsonMapper,
         item.getDecisionInstanceKey(),
+        item.getDecisionInstanceId(),
         toDecisionInstanceState(item.getState()),
         item.getEvaluationDate(),
         item.getEvaluationFailure(),
@@ -96,6 +99,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   public DecisionInstanceImpl(
       final JsonMapper jsonMapper,
       final long decisionInstanceKey,
+      final String decisionInstanceId,
       final DecisionInstanceState state,
       final String evaluationDate,
       final String evaluationFailure,
@@ -111,6 +115,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
       final List<MatchedDecisionRule> matchedRules) {
     this.jsonMapper = jsonMapper;
     this.decisionInstanceKey = decisionInstanceKey;
+    this.decisionInstanceId = decisionInstanceId;
     this.state = state;
     this.evaluationDate = evaluationDate;
     this.evaluationFailure = evaluationFailure;
@@ -167,6 +172,11 @@ public class DecisionInstanceImpl implements DecisionInstance {
   @Override
   public long getDecisionInstanceKey() {
     return decisionInstanceKey;
+  }
+
+  @Override
+  public String getDecisionInstanceId() {
+    return decisionInstanceId;
   }
 
   @Override
@@ -243,6 +253,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
   public int hashCode() {
     return Objects.hash(
         decisionInstanceKey,
+        decisionInstanceId,
         state,
         evaluationDate,
         evaluationFailure,
@@ -271,6 +282,7 @@ public class DecisionInstanceImpl implements DecisionInstance {
         && decisionKey == that.decisionKey
         && decisionDefinitionVersion == that.decisionDefinitionVersion
         && state == that.state
+        && Objects.equals(decisionInstanceId, that.decisionInstanceId)
         && Objects.equals(evaluationDate, that.evaluationDate)
         && Objects.equals(evaluationFailure, that.evaluationFailure)
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/sort/DecisionInstanceSortImpl.java
@@ -32,6 +32,11 @@ public class DecisionInstanceSortImpl extends SearchQuerySortBase<DecisionInstan
   }
 
   @Override
+  public DecisionInstanceSort decisionInstanceId() {
+    return field("decisionInstanceId");
+  }
+
+  @Override
   public DecisionInstanceSort state() {
     return field("state");
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/GetDecisionInstanceTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/GetDecisionInstanceTest.java
@@ -27,12 +27,12 @@ public final class GetDecisionInstanceTest extends ClientRestTest {
   @Test
   void shouldGetDecisionInstance() {
     // when
-    final long decisionInstanceKey = 1L;
-    client.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
+    final String decisionInstanceId = "1-1";
+    client.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then
     final LoggedRequest request = gatewayService.getLastRequest();
-    assertThat(request.getUrl()).isEqualTo("/v2/decision-instances/" + decisionInstanceKey);
+    assertThat(request.getUrl()).isEqualTo("/v2/decision-instances/" + decisionInstanceId);
     assertThat(request.getMethod()).isEqualTo(RequestMethod.GET);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/DecisionInstanceAuthorizationIT.java
@@ -96,15 +96,15 @@ class DecisionInstanceAuthorizationIT {
   }
 
   @TestTemplate
-  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionInstance(
+  void getByIdShouldReturnForbiddenForUnauthorizedDecisionInstance(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
-    final var decisionInstanceKey = getDecisionInstanceKey(adminClient, DECISION_DEFINITION_ID_2);
+    final var decisionInstanceId = getDecisionInstanceId(adminClient, DECISION_DEFINITION_ID_2);
 
     // when
     final Executable executeGet =
-        () -> userClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
+        () -> userClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then
     final var problemException = assertThrows(ProblemException.class, executeGet);
@@ -115,22 +115,23 @@ class DecisionInstanceAuthorizationIT {
   }
 
   @TestTemplate
-  void getByKeyShouldReturnAuthorizedDecisionDefinition(
+  void getByIdShouldReturnAuthorizedDecisionDefinition(
       @Authenticated(ADMIN) final ZeebeClient adminClient,
       @Authenticated(RESTRICTED) final ZeebeClient userClient) {
     // given
-    final var decisionInstanceKey = getDecisionInstanceKey(adminClient, DECISION_DEFINITION_ID_1);
+    final var decisionInstanceId = getDecisionInstanceId(adminClient, DECISION_DEFINITION_ID_1);
 
     // when
     final var decisionInstance =
-        userClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
+        userClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
 
     // then
     assertThat(decisionInstance).isNotNull();
     assertThat(decisionInstance.getDecisionDefinitionId()).isEqualTo(DECISION_DEFINITION_ID_1);
   }
 
-  private long getDecisionInstanceKey(final ZeebeClient client, final String decisionDefinitionId) {
+  private String getDecisionInstanceId(
+      final ZeebeClient client, final String decisionDefinitionId) {
     return client
         .newDecisionInstanceQuery()
         .filter(f -> f.decisionDefinitionId(decisionDefinitionId))
@@ -138,7 +139,7 @@ class DecisionInstanceAuthorizationIT {
         .join()
         .items()
         .getFirst()
-        .getDecisionInstanceKey();
+        .getDecisionInstanceId();
   }
 
   private DeploymentEvent deployResource(final ZeebeClient zeebeClient, final String resourceName) {

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionInstanceQueryTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
+import io.camunda.zeebe.client.api.search.response.DecisionDefinitionType;
+import io.camunda.zeebe.client.api.search.response.DecisionInstance;
+import io.camunda.zeebe.client.api.search.response.DecisionInstanceState;
+import io.camunda.zeebe.client.protocol.rest.BasicLongFilterProperty;
+import io.camunda.zeebe.client.protocol.rest.DateTimeFilterProperty;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@TestInstance(Lifecycle.PER_CLASS)
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
+class DecisionInstanceQueryTest {
+
+  private static final String DECISION_DEFINITION_ID_1 = "decision_1";
+  private static final String DECISION_DEFINITION_ID_2 = "invoiceAssignApprover";
+  // evaluated decisions mapped by decision definition id
+  private final Map<String, EvaluateDecisionResponse> evaluatedDecisions = new HashMap<>();
+  private boolean initialized;
+
+  @BeforeEach
+  void setUp(final ZeebeClient zeebeClient) {
+    if (!initialized) {
+
+      List.of("decision_model.dmn", "invoiceBusinessDecisions_v_1.dmn")
+          .forEach(
+              dmn ->
+                  deployResource(zeebeClient, String.format("decisions/%s", dmn)).getDecisions());
+      evaluatedDecisions.put(
+          DECISION_DEFINITION_ID_1,
+          evaluateDecision(
+              zeebeClient, DECISION_DEFINITION_ID_1, "{\"age\": 20, \"income\": 20000}"));
+      evaluatedDecisions.put(
+          DECISION_DEFINITION_ID_2,
+          evaluateDecision(
+              zeebeClient,
+              DECISION_DEFINITION_ID_2,
+              "{\"amount\": 100, \"invoiceCategory\": \"Misc\"}"));
+      waitForDecisionsToBeEvaluated(
+          zeebeClient,
+          evaluatedDecisions.values().stream()
+              .mapToInt(v -> v.getEvaluatedDecisions().size())
+              .sum());
+      initialized = true;
+    }
+  }
+
+  @TestTemplate
+  public void shouldRetrieveAllDecisionInstances(final ZeebeClient zeebeClient) {
+    // when
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .sort(b -> b.decisionInstanceKey().asc())
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(3);
+
+    assertThat(
+            result.items().stream()
+                .map(DecisionInstance::getDecisionInstanceKey)
+                .collect(Collectors.toSet()))
+        .containsExactlyElementsOf(
+            evaluatedDecisions.values().stream()
+                .map(EvaluateDecisionResponse::getDecisionInstanceKey)
+                .collect(Collectors.toSet()));
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByDecisionDefinitionKey(final ZeebeClient zeebeClient) {
+    // when
+    final long decisionDefinitionKey =
+        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionKey();
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.decisionDefinitionKey(decisionDefinitionKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst().getDecisionDefinitionKey())
+        .isEqualTo(decisionDefinitionKey);
+    assertThat(result.items().getFirst().getDecisionInstanceKey())
+        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByDecisionKeyFilterIn(final ZeebeClient zeebeClient) {
+    // when
+    final long decisionDefinitionKey =
+        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionKey();
+    final BasicLongFilterProperty filter = new BasicLongFilterProperty();
+    filter.set$In(List.of(Long.MAX_VALUE, decisionDefinitionKey));
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.decisionDefinitionKey(filter))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().getFirst().getDecisionDefinitionKey())
+        .isEqualTo(decisionDefinitionKey);
+    assertThat(result.items().getFirst().getDecisionInstanceKey())
+        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByDecisionInstanceKey(final ZeebeClient zeebeClient) {
+    // when
+    final long decisionInstanceKey =
+        evaluatedDecisions.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.decisionInstanceKey(decisionInstanceKey))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(2);
+    assertThat(result.items().getFirst().getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+    assertThat(result.items().getLast().getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByStateAndType(final ZeebeClient zeebeClient) {
+    // when
+    final DecisionInstanceState state = DecisionInstanceState.EVALUATED;
+    final DecisionDefinitionType type = DecisionDefinitionType.DECISION_TABLE;
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.state(state).decisionDefinitionType(type))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(3);
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByEvaluationDate(final ZeebeClient zeebeClient) {
+    // given
+    final var allResult =
+        zeebeClient.newDecisionInstanceQuery().page(p -> p.limit(1)).send().join();
+    final var di = allResult.items().getFirst();
+
+    // when
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(f -> f.evaluationDate(OffsetDateTime.parse(di.getEvaluationDate())))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getDecisionInstanceKey())
+        .isEqualTo(di.getDecisionInstanceKey());
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGt(
+      final ZeebeClient zeebeClient) {
+    // given
+    final var allResult =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .sort(s -> s.evaluationDate().asc())
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var di = allResult.items().getFirst();
+    final DateTimeFilterProperty filter = new DateTimeFilterProperty();
+    filter.set$Gt(di.getEvaluationDate());
+
+    // when
+    final var result =
+        zeebeClient.newDecisionInstanceQuery().filter(f -> f.evaluationDate(filter)).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(2);
+    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
+    assertThat(result.items())
+        .extracting("evaluationDate", String.class)
+        .allMatch(date -> requestDate.isBefore(OffsetDateTime.parse(date)));
+    assertThat(result.items())
+        .extracting("decisionInstanceKey", Long.class)
+        .noneMatch(key -> di.getDecisionInstanceKey() == key);
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGte(
+      final ZeebeClient zeebeClient) {
+    // given
+    final var allResult =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .sort(s -> s.evaluationDate().asc())
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var di = allResult.items().getFirst();
+    final DateTimeFilterProperty filter = new DateTimeFilterProperty();
+    filter.set$Gte(di.getEvaluationDate());
+
+    // when
+    final var result =
+        zeebeClient.newDecisionInstanceQuery().filter(f -> f.evaluationDate(filter)).send().join();
+
+    // then
+    assertThat(result.items()).hasSize(3);
+    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
+    assertThat(result.items())
+        .extracting("evaluationDate", String.class)
+        .allMatch(date -> !OffsetDateTime.parse(date).isBefore(requestDate));
+    assertThat(result.items())
+        .extracting("decisionInstanceKey", Long.class)
+        .anyMatch(key -> di.getDecisionInstanceKey() == key);
+  }
+
+  @TestTemplate
+  public void shouldRetrieveDecisionInstanceByDmnDecisionIdAndDecisionVersion(
+      final ZeebeClient zeebeClient) {
+    // when
+    final String dmnDecisionId = evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionId();
+    final int decisionVersion =
+        evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionVersion();
+    final var result =
+        zeebeClient
+            .newDecisionInstanceQuery()
+            .filter(
+                f ->
+                    f.decisionDefinitionId(dmnDecisionId)
+                        .decisionDefinitionVersion(decisionVersion))
+            .send()
+            .join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().get(0).getDecisionInstanceKey())
+        .isEqualTo(evaluatedDecisions.get(DECISION_DEFINITION_ID_1).getDecisionInstanceKey());
+  }
+
+  @TestTemplate
+  void shouldGetDecisionInstance(final ZeebeClient zeebeClient) {
+    // when
+    final long decisionInstanceKey =
+        evaluatedDecisions.get(DECISION_DEFINITION_ID_2).getDecisionInstanceKey();
+    final var decisionInstanceId = "%d-%d".formatted(decisionInstanceKey, 1);
+    final var result = zeebeClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join();
+
+    // then
+    assertThat(result.getDecisionInstanceId()).isEqualTo(decisionInstanceId);
+    assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
+  }
+
+  @TestTemplate
+  void shouldReturn404ForNotFoundDecisionInstance(final ZeebeClient zeebeClient) {
+    // when
+    final var decisionInstanceId = "not-existing";
+    final var problemException =
+        assertThrows(
+            ProblemException.class,
+            () -> zeebeClient.newDecisionInstanceGetRequest(decisionInstanceId).send().join());
+    // then
+    assertThat(problemException.code()).isEqualTo(404);
+    assertThat(problemException.details().getDetail())
+        .isEqualTo("Decision instance with key %s not found".formatted(decisionInstanceId));
+  }
+
+  private DeploymentEvent deployResource(final ZeebeClient zeebeClient, final String resourceName) {
+    return zeebeClient
+        .newDeployResourceCommand()
+        .addResourceFromClasspath(resourceName)
+        .send()
+        .join();
+  }
+
+  private EvaluateDecisionResponse evaluateDecision(
+      final ZeebeClient zeebeClient, final String decisionDefinitionId, final String variables) {
+    return zeebeClient
+        .newEvaluateDecisionCommand()
+        .decisionId(decisionDefinitionId)
+        .variables(variables)
+        .send()
+        .join();
+  }
+
+  private void waitForDecisionsToBeEvaluated(
+      final ZeebeClient zeebeClient, final int expectedCount) {
+    Awaitility.await("should deploy decision definitions and import in Operate")
+        .atMost(Duration.ofSeconds(15))
+        .ignoreExceptions() // Ignore exceptions and continue retrying
+        .untilAsserted(
+            () -> {
+              final var result = zeebeClient.newDecisionInstanceQuery().send().join();
+              assertThat(result.items().size()).isEqualTo(expectedCount);
+            });
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/DecisionQueryTest.java
@@ -16,21 +16,14 @@ import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.client.api.response.Decision;
 import io.camunda.zeebe.client.api.response.DecisionRequirements;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
-import io.camunda.zeebe.client.api.response.EvaluateDecisionResponse;
 import io.camunda.zeebe.client.api.search.response.DecisionDefinition;
-import io.camunda.zeebe.client.api.search.response.DecisionDefinitionType;
-import io.camunda.zeebe.client.api.search.response.DecisionInstance;
-import io.camunda.zeebe.client.api.search.response.DecisionInstanceState;
 import io.camunda.zeebe.client.impl.search.response.DecisionDefinitionImpl;
-import io.camunda.zeebe.client.protocol.rest.BasicLongFilterProperty;
-import io.camunda.zeebe.client.protocol.rest.DateTimeFilterProperty;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -49,7 +42,6 @@ class DecisionQueryTest {
   private static final List<Decision> DEPLOYED_DECISIONS = new ArrayList<>();
   private static final List<DecisionRequirements> DEPLOYED_DECISION_REQUIREMENTS =
       new ArrayList<>();
-  private static final List<EvaluateDecisionResponse> EVALUATED_DECISIONS = new ArrayList<>();
   private static ZeebeClient zeebeClient;
 
   @TestZeebe(initMethod = "initTestStandaloneCamunda")
@@ -76,21 +68,12 @@ class DecisionQueryTest {
     assertThat(DEPLOYED_DECISIONS.size()).isEqualTo(3);
     assertThat(DEPLOYED_DECISION_REQUIREMENTS.size()).isEqualTo(3);
     waitForDecisionsBeingExported();
-
-    EVALUATED_DECISIONS.addAll(
-        DEPLOYED_DECISIONS.stream()
-            .map(Decision::getDecisionKey)
-            .map(k -> evaluateDecision(k))
-            .toList());
-    assertThat(EVALUATED_DECISIONS.size()).isEqualTo(3);
-    waitForDecisionInstancesBeingExported();
   }
 
   @AfterAll
   static void afterAll() {
     DEPLOYED_DECISIONS.clear();
     DEPLOYED_DECISION_REQUIREMENTS.clear();
-    EVALUATED_DECISIONS.clear();
   }
 
   @Test
@@ -114,7 +97,7 @@ class DecisionQueryTest {
   }
 
   @Test
-  void shouldRetrieveByDecisionKey() {
+  void shouldSearchDecisionDefinitionsByDecisionDefinitionKey() {
     // when
     final long decisionKey = DEPLOYED_DECISIONS.get(0).getDecisionKey();
     final var result =
@@ -500,196 +483,6 @@ class DecisionQueryTest {
     assertThat(resultBefore.items().getFirst().getDecisionRequirementsKey()).isEqualTo(key);
   }
 
-  @Test
-  public void shouldRetrieveAllDecisionInstances() {
-    // when
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .sort(b -> b.decisionInstanceKey().asc())
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(3);
-    assertThat(result.items().stream().map(DecisionInstance::getDecisionInstanceKey).toList())
-        .isEqualTo(
-            EVALUATED_DECISIONS.stream()
-                .map(EvaluateDecisionResponse::getDecisionInstanceKey)
-                .sorted()
-                .toList());
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByDecisionKey() {
-    // when
-    final long decisionKey = DEPLOYED_DECISIONS.get(0).getDecisionKey();
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(f -> f.decisionDefinitionKey(decisionKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().get(0).getDecisionDefinitionKey()).isEqualTo(decisionKey);
-    assertThat(result.items().get(0).getDecisionInstanceKey())
-        .isEqualTo(EVALUATED_DECISIONS.get(0).getDecisionInstanceKey());
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByDecisionKeyFilterIn() {
-    // when
-    final long decisionKey = DEPLOYED_DECISIONS.get(0).getDecisionKey();
-    final BasicLongFilterProperty filter = new BasicLongFilterProperty();
-    filter.set$In(List.of(Long.MAX_VALUE, decisionKey));
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(f -> f.decisionDefinitionKey(filter))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().get(0).getDecisionDefinitionKey()).isEqualTo(decisionKey);
-    assertThat(result.items().get(0).getDecisionInstanceKey())
-        .isEqualTo(EVALUATED_DECISIONS.get(0).getDecisionInstanceKey());
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByDecisionInstanceKey() {
-    // when
-    final long decisionInstanceKey = EVALUATED_DECISIONS.get(0).getDecisionInstanceKey();
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(f -> f.decisionInstanceKey(decisionInstanceKey))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().get(0).getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByStateAndType() {
-    // when
-    final DecisionInstanceState state = DecisionInstanceState.EVALUATED;
-    final DecisionDefinitionType type = DecisionDefinitionType.DECISION_TABLE;
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(f -> f.state(state).decisionDefinitionType(type))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(3);
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByEvaluationDate() {
-    // given
-    final var allResult =
-        zeebeClient.newDecisionInstanceQuery().page(p -> p.limit(1)).send().join();
-    final var di = allResult.items().getFirst();
-
-    // when
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(f -> f.evaluationDate(OffsetDateTime.parse(di.getEvaluationDate())))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items()).hasSize(1);
-    assertThat(result.items().getFirst().getDecisionInstanceKey())
-        .isEqualTo(di.getDecisionInstanceKey());
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGt() {
-    // given
-    final var allResult =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .sort(s -> s.evaluationDate().asc())
-            .page(p -> p.limit(1))
-            .send()
-            .join();
-    final var di = allResult.items().getFirst();
-    final DateTimeFilterProperty filter = new DateTimeFilterProperty();
-    filter.set$Gt(di.getEvaluationDate());
-
-    // when
-    final var result =
-        zeebeClient.newDecisionInstanceQuery().filter(f -> f.evaluationDate(filter)).send().join();
-
-    // then
-    assertThat(result.items()).hasSize(2);
-    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
-    assertThat(result.items())
-        .extracting("evaluationDate", String.class)
-        .allMatch(date -> requestDate.isBefore(OffsetDateTime.parse(date)));
-    assertThat(result.items())
-        .extracting("decisionInstanceKey", Long.class)
-        .noneMatch(key -> di.getDecisionInstanceKey() == key);
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByEvaluationDateFilterGte() {
-    // given
-    final var allResult =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .sort(s -> s.evaluationDate().asc())
-            .page(p -> p.limit(1))
-            .send()
-            .join();
-    final var di = allResult.items().getFirst();
-    final DateTimeFilterProperty filter = new DateTimeFilterProperty();
-    filter.set$Gte(di.getEvaluationDate());
-
-    // when
-    final var result =
-        zeebeClient.newDecisionInstanceQuery().filter(f -> f.evaluationDate(filter)).send().join();
-
-    // then
-    assertThat(result.items()).hasSize(3);
-    final var requestDate = OffsetDateTime.parse(di.getEvaluationDate());
-    assertThat(result.items())
-        .extracting("evaluationDate", String.class)
-        .allMatch(date -> !OffsetDateTime.parse(date).isBefore(requestDate));
-    assertThat(result.items())
-        .extracting("decisionInstanceKey", Long.class)
-        .anyMatch(key -> di.getDecisionInstanceKey() == key);
-  }
-
-  @Test
-  public void shouldRetrieveDecisionInstanceByDmnDecisionIdAndDecisionVersion() {
-    // when
-    final String dmnDecisionId = DEPLOYED_DECISIONS.get(1).getDmnDecisionId();
-    final int decisionVersion = DEPLOYED_DECISIONS.get(1).getVersion();
-    final var result =
-        zeebeClient
-            .newDecisionInstanceQuery()
-            .filter(
-                f ->
-                    f.decisionDefinitionId(dmnDecisionId)
-                        .decisionDefinitionVersion(decisionVersion))
-            .send()
-            .join();
-
-    // then
-    assertThat(result.items().size()).isEqualTo(1);
-    assertThat(result.items().get(0).getDecisionInstanceKey())
-        .isEqualTo(EVALUATED_DECISIONS.get(1).getDecisionInstanceKey());
-  }
-
   private static void waitForDecisionsBeingExported() {
     Awaitility.await("should receive data from ES")
         .atMost(Duration.ofMinutes(1))
@@ -703,30 +496,10 @@ class DecisionQueryTest {
             });
   }
 
-  private static void waitForDecisionInstancesBeingExported() {
-    Awaitility.await("should receive data from ES")
-        .atMost(Duration.ofMinutes(1))
-        .ignoreExceptions() // Ignore exceptions and continue retrying
-        .untilAsserted(
-            () -> {
-              assertThat(zeebeClient.newDecisionInstanceQuery().send().join().items().size())
-                  .isEqualTo(EVALUATED_DECISIONS.size());
-            });
-  }
-
   private static DeploymentEvent deployResource(final String resourceName) {
     return zeebeClient
         .newDeployResourceCommand()
         .addResourceFromClasspath(resourceName)
-        .send()
-        .join();
-  }
-
-  private static EvaluateDecisionResponse evaluateDecision(final long decisionKey) {
-    return zeebeClient
-        .newEvaluateDecisionCommand()
-        .decisionKey(decisionKey)
-        .variables("{\"input1\": \"A\"}")
         .send()
         .join();
   }
@@ -771,29 +544,5 @@ class DecisionQueryTest {
     assertThat(problemException.details().getDetail())
         .isEqualTo(
             "Decision requirements with key %d not found".formatted(decisionRequirementsKey));
-  }
-
-  @Test
-  void shouldGetDecisionInstance() {
-    // when
-    final long decisionInstanceKey = EVALUATED_DECISIONS.get(0).getDecisionInstanceKey();
-    final var result = zeebeClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join();
-
-    // then
-    assertThat(result.getDecisionInstanceKey()).isEqualTo(decisionInstanceKey);
-  }
-
-  @Test
-  void shouldReturn404ForNotFoundDecisionInstance() {
-    // when
-    final long decisionInstanceKey = new Random().nextLong();
-    final var problemException =
-        assertThrows(
-            ProblemException.class,
-            () -> zeebeClient.newDecisionInstanceGetRequest(decisionInstanceKey).send().join());
-    // then
-    assertThat(problemException.code()).isEqualTo(404);
-    assertThat(problemException.details().getDetail())
-        .isEqualTo("Decision instance with key %d not found".formatted(decisionInstanceKey));
   }
 }

--- a/qa/integration-tests/src/test/resources/decisions/invoiceBusinessDecisions_v_1.dmn
+++ b/qa/integration-tests/src/test/resources/decisions/invoiceBusinessDecisions_v_1.dmn
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="invoiceBusinessDecisions" name="Invoice Business Decisions" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+  <decision id="invoiceClassification" name="Invoice Classification">
+    <decisionTable id="decisionTable">
+      <input id="clause1" label="Invoice Amount" camunda:inputVariable="">
+        <inputExpression id="inputExpression1" typeRef="double">
+          <text>amount</text>
+        </inputExpression>
+      </input>
+      <input id="InputClause_15qmk0v" label="Invoice Category" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1oi86cw" typeRef="string">
+          <text>invoiceCategory</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0kisa67">
+          <text>"Travel Expenses","Misc","Software License Costs"</text>
+        </inputValues>
+      </input>
+      <output id="clause3" label="Classification" name="invoiceClassification" typeRef="string">
+        <outputValues id="UnaryTests_08dl8wf">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1of5a87">
+        <inputEntry id="LiteralExpression_0yrqmtg">
+          <text>&lt; 250</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_06edsin">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_046antl">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_1ak4z14">
+        <inputEntry id="LiteralExpression_0qmsef6">
+          <text>[250..1000]</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_09b743h">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_05xxvip">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-4">
+        <inputEntry id="UnaryTests_0le0gl8">
+          <text>&gt; 1000</text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0pukamj">
+          <text>"Misc"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1e76ugx">
+          <text>"exceptional"</text>
+        </outputEntry>
+      </rule>
+      <rule id="DecisionRule_0cuxolz">
+        <inputEntry id="LiteralExpression_05lyjk7">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_0ve4z34">
+          <text>"Travel Expenses"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1bq8m03">
+          <text>"day-to-day expense"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-2">
+        <inputEntry id="UnaryTests_1nssdlk">
+          <text></text>
+        </inputEntry>
+        <inputEntry id="UnaryTests_01ppb4l">
+          <text>"Software License Costs"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0y00iih">
+          <text>"budget"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <decision id="invoiceAssignApprover" name="Assign Approver Group">
+    <informationRequirement id="InformationRequirement_1kkeocv">
+      <requiredDecision href="#invoiceClassification" />
+    </informationRequirement>
+    <decisionTable id="DecisionTable_16o85h8" hitPolicy="COLLECT">
+      <input id="InputClause_0og2hn3" label="Invoice Classification" camunda:inputVariable="">
+        <inputExpression id="LiteralExpression_1vywt5q" typeRef="string">
+          <text>invoiceClassification</text>
+        </inputExpression>
+        <inputValues id="UnaryTests_0by7qiy">
+          <text>"day-to-day expense","budget","exceptional"</text>
+        </inputValues>
+      </input>
+      <output id="OutputClause_1cthd0w" label="Approver Group" name="result" typeRef="string">
+        <outputValues id="UnaryTests_1ulmk9p">
+          <text>"management","accounting","sales"</text>
+        </outputValues>
+      </output>
+      <rule id="row-49839158-1">
+        <inputEntry id="UnaryTests_18ifczd">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0sgxulk">
+          <text>"accounting"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-6">
+        <inputEntry id="UnaryTests_0kfae8g">
+          <text>"day-to-day expense"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1iksrro">
+          <text>"sales"</text>
+        </outputEntry>
+      </rule>
+      <rule id="row-49839158-5">
+        <inputEntry id="UnaryTests_08cevwi">
+          <text>"budget", "exceptional"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0c7hz8g">
+          <text>"management"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram id="DMNDiagram_1cuuevk">
+      <dmndi:DMNShape id="DMNShape_1abvt5s" dmnElementRef="invoiceClassification">
+        <dc:Bounds height="55" width="100" x="153" y="215" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_1ay7af5" dmnElementRef="invoiceAssignApprover">
+        <dc:Bounds height="55" width="100" x="224" y="84" />
+      </dmndi:DMNShape>
+      <dmndi:DMNEdge id="DMNEdge_1wn1950" dmnElementRef="InformationRequirement_1kkeocv">
+        <di:waypoint x="218" y="215" />
+        <di:waypoint x="258" y="139" />
+      </dmndi:DMNEdge>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -31,6 +31,7 @@ public final class DecisionInstanceFilterTransformer
   public SearchQuery toSearchQuery(final DecisionInstanceFilter filter) {
     final var queries = new ArrayList<SearchQuery>();
     ofNullable(getKeysQuery(filter.decisionInstanceKeys())).ifPresent(queries::add);
+    ofNullable(getIdsQuery(filter.decisionInstanceIds())).ifPresent(queries::add);
     ofNullable(getStatesQuery(filter.states())).ifPresent(queries::add);
     ofNullable(getEvaluationDateQuery(filter.evaluationDateOperations()))
         .ifPresent(queries::addAll);
@@ -58,6 +59,10 @@ public final class DecisionInstanceFilterTransformer
 
   private SearchQuery getKeysQuery(final List<Long> keys) {
     return longTerms("key", keys);
+  }
+
+  private SearchQuery getIdsQuery(final List<String> ids) {
+    return stringTerms("id", ids);
   }
 
   private SearchQuery getStatesQuery(final List<DecisionInstanceState> states) {

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/DecisionInstanceQueryTransformerTest.java
@@ -125,6 +125,28 @@ class DecisionInstanceQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
+  void shouldQueryByDecisionInstanceId() {
+    // given
+    final var decisionInstanceFilter =
+        FilterBuilders.decisionInstance(f -> f.decisionInstanceIds("12345-1"));
+    final var searchQuery =
+        SearchQueryBuilders.decisionInstanceSearchQuery(q -> q.filter(decisionInstanceFilter));
+
+    // when
+    final var searchRequest = transformQuery(decisionInstanceFilter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            t -> {
+              assertThat(t.field()).isEqualTo("id");
+              assertThat(t.value().stringValue()).isEqualTo("12345-1");
+            });
+  }
+
+  @Test
   void shouldQueryByDmnDecisionName() {
     // given
     final var decisionInstanceFilter =

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -25,6 +25,7 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
   private static Stream<Arguments> provideSortParameters() {
     return Stream.of(
         new TestArguments("key", SortOrder.ASC, s -> s.decisionInstanceKey().asc()),
+        new TestArguments("id", SortOrder.ASC, s -> s.decisionInstanceId().asc()),
         new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionKey().asc()),
         new TestArguments(
             "decisionDefinitionId", SortOrder.DESC, s -> s.decisionDefinitionId().desc()),

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -12,6 +12,7 @@ import java.util.List;
 
 public record DecisionInstanceEntity(
     long key,
+    String id,
     DecisionInstanceState state,
     OffsetDateTime evaluationDate,
     String evaluationFailure,

--- a/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/DecisionInstanceFilter.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 
 public record DecisionInstanceFilter(
     List<Long> decisionInstanceKeys,
+    List<String> decisionInstanceIds,
     List<DecisionInstanceState> states,
     List<Operation<OffsetDateTime>> evaluationDateOperations,
     List<String> evaluationFailures,
@@ -38,6 +39,7 @@ public record DecisionInstanceFilter(
   public static final class Builder implements ObjectBuilder<DecisionInstanceFilter> {
 
     private List<Long> decisionInstanceKeys;
+    private List<String> decisionInstanceIds;
     private List<DecisionInstanceState> states;
     private List<Operation<OffsetDateTime>> evaluationDateOperations;
     private List<String> evaluationFailures;
@@ -57,6 +59,15 @@ public record DecisionInstanceFilter(
 
     public Builder decisionInstanceKeys(final Long... values) {
       return decisionInstanceKeys(collectValuesAsList(values));
+    }
+
+    public Builder decisionInstanceIds(final List<String> values) {
+      decisionInstanceIds = addValuesToList(decisionInstanceIds, values);
+      return this;
+    }
+
+    public Builder decisionInstanceIds(final String... values) {
+      return decisionInstanceIds(collectValuesAsList(values));
     }
 
     public Builder states(final List<DecisionInstanceState> values) {
@@ -171,6 +182,7 @@ public record DecisionInstanceFilter(
     public DecisionInstanceFilter build() {
       return new DecisionInstanceFilter(
           Objects.requireNonNullElse(decisionInstanceKeys, Collections.emptyList()),
+          Objects.requireNonNullElse(decisionInstanceIds, Collections.emptyList()),
           Objects.requireNonNullElse(states, Collections.emptyList()),
           Objects.requireNonNullElse(evaluationDateOperations, Collections.emptyList()),
           Objects.requireNonNullElse(evaluationFailures, Collections.emptyList()),

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
@@ -31,6 +31,11 @@ public record DecisionInstanceSort(List<FieldSorting> orderings) implements Sort
       return this;
     }
 
+    public Builder decisionInstanceId() {
+      currentOrdering = new FieldSorting("id", null);
+      return this;
+    }
+
     public Builder state() {
       currentOrdering = new FieldSorting("state", null);
       return this;

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -69,23 +69,22 @@ public final class DecisionInstanceServices
   }
 
   /**
-   * Get a Decision Instance by its key.
+   * Get a Decision Instance by its id.
    *
-   * @param decisionInstanceKey the key of the Decision Instance
+   * @param decisionInstanceId the id of the Decision Instance
    * @return the Decision Instance
-   * @throws NotFoundException if the Decision Instance with the given key does not exist
-   * @throws CamundaSearchException if the Decision Instance with the given key exists more than
-   *     once
+   * @throws NotFoundException if the Decision Instance with the given id does not exist
+   * @throws CamundaSearchException if the Decision Instance with the given id exists more than once
    */
-  public DecisionInstanceEntity getByKey(final long decisionInstanceKey) {
+  public DecisionInstanceEntity getById(final String decisionInstanceId) {
     final var result =
         decisionInstanceSearchClient
             .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
             .searchDecisionInstances(
                 decisionInstanceSearchQuery(
-                    q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey))));
+                    q -> q.filter(f -> f.decisionInstanceIds(decisionInstanceId))));
     final var decisionInstanceEntity =
-        getSingleResultOrThrow(result, decisionInstanceKey, "Decision instance");
+        getSingleResultOrThrow(result, decisionInstanceId, "Decision instance");
     final var authorization = Authorization.of(a -> a.decisionDefinition().readInstance());
     if (!securityContextProvider.isAuthorized(
         decisionInstanceEntity.decisionId(), authentication, authorization)) {

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -69,12 +69,12 @@ public final class DecisionInstanceServices
   }
 
   /**
-   * Get a Decision Instance by its id.
+   * Get a Decision Instance by its ID.
    *
-   * @param decisionInstanceId the id of the Decision Instance
+   * @param decisionInstanceId the ID of the decision instance
    * @return the Decision Instance
-   * @throws NotFoundException if the Decision Instance with the given id does not exist
-   * @throws CamundaSearchException if the Decision Instance with the given id exists more than once
+   * @throws NotFoundException if the decision instance with the given ID does not exist
+   * @throws CamundaSearchException if the decision instance with the given ID exists more than once
    */
   public DecisionInstanceEntity getById(final String decisionInstanceId) {
     final var result =

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -29,12 +29,14 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
   public abstract SearchQueryResult<D> search(final Q query);
 
   protected <E> E getSingleResultOrThrow(
-      final SearchQueryResult<E> searchQueryResult, final long key, final String entityTypeLabel) {
+      final SearchQueryResult<E> searchQueryResult,
+      final Object key,
+      final String entityTypeLabel) {
     if (searchQueryResult.total() < 1) {
-      throw new NotFoundException(String.format("%s with key %d not found", entityTypeLabel, key));
+      throw new NotFoundException(String.format("%s with key %s not found", entityTypeLabel, key));
     } else if (searchQueryResult.total() > 1) {
       throw new CamundaSearchException(
-          String.format("Found %s with key %d more than once", entityTypeLabel, key));
+          String.format("Found %s with key %s more than once", entityTypeLabel, key));
     } else {
       return searchQueryResult.items().stream().findFirst().orElseThrow();
     }

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -65,9 +65,9 @@ class DecisionInstanceServiceTest {
   }
 
   @Test
-  void shouldGetDecisionInstanceByKey() {
+  void shouldGetDecisionInstanceById() {
     // given
-    final Long decisionInstanceKey = 1L;
+    final var decisionInstanceId = "1-1";
     final var decisionDefinitionKey = "dd1";
     final var result = mock(SearchQueryResult.class);
     when(result.total()).thenReturn(1L);
@@ -82,13 +82,13 @@ class DecisionInstanceServiceTest {
         .thenReturn(true);
 
     // when
-    services.getByKey(decisionInstanceKey);
+    services.getById(decisionInstanceId);
 
     // then
     verify(client)
         .searchDecisionInstances(
             SearchQueryBuilders.decisionInstanceSearchQuery(
-                q -> q.filter(f -> f.decisionInstanceKeys(decisionInstanceKey))));
+                q -> q.filter(f -> f.decisionInstanceIds(decisionInstanceId))));
   }
 
   @Test
@@ -117,9 +117,9 @@ class DecisionInstanceServiceTest {
   }
 
   @Test
-  void getByKeyShouldReturnForbiddenForUnauthorizedDecisionDefinition() {
+  void getByIdShouldReturnForbiddenForUnauthorizedDecisionDefinition() {
     // given
-    final Long decisionInstanceKey = 1L;
+    final var decisionInstanceId = "1-1";
     final var decisionDefinitionKey = "dd1";
     final var result = mock(SearchQueryResult.class);
     when(result.total()).thenReturn(1L);
@@ -134,7 +134,7 @@ class DecisionInstanceServiceTest {
         .thenReturn(false);
 
     // when
-    final Executable executable = () -> services.getByKey(decisionInstanceKey);
+    final Executable executable = () -> services.getById(decisionInstanceId);
 
     // then
     final var exception = assertThrows(ForbiddenException.class, executable);

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4842,7 +4842,8 @@ components:
         decisionInstanceKey:
           type: integer
           format: int64
-          description: The key of the decision instance.
+          description: |
+            The key of the decision instance. Note that this is not the unique identifier of the entity itself; the `decisionInstanceId` serves as the primary identifier.
         decisionInstanceId:
           type: string
           description: The ID of the decision instance.
@@ -4898,7 +4899,7 @@ components:
         decisionInstanceKey:
           type: integer
           format: int64
-          description: The key of the decision instance.
+          description: The key of the decision instance. Note that this is not the unique identifier of the entity itself; the `decisionInstanceId` serves as the primary identifier.
         decisionInstanceId:
           type: string
           description: The ID of the decision instance.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1702,7 +1702,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /decision-instances/{decisionInstanceKey}:
+  /decision-instances/{decisionInstanceId}:
     get:
       tags:
         - Decision instance
@@ -1717,13 +1717,12 @@ paths:
         This endpoint is an alpha feature and may be subject to change
         in future releases.
       parameters:
-        - name: decisionInstanceKey
+        - name: decisionInstanceId
           in: path
           required: true
-          description: The assigned key of the decision instance, which acts as a unique identifier for this decision instance.
+          description: The assigned id of the decision instance, which acts as a unique identifier for this decision instance.
           schema:
-            type: integer
-            format: int64
+            type: string
       responses:
         "200":
           description: >
@@ -1742,7 +1741,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "404":
           description: >
-            The decision instance with the given key was not found.
+            The decision instance with the given id was not found.
             More details are provided in the response body.
           content:
             application/problem+json:
@@ -4844,6 +4843,9 @@ components:
           type: integer
           format: int64
           description: The key of the decision instance.
+        decisionInstanceId:
+          type: string
+          description: The ID of the decision instance.
         state:
           $ref: "#/components/schemas/DecisionInstanceStateEnum"
         evaluationFailure:
@@ -4897,6 +4899,9 @@ components:
           type: integer
           format: int64
           description: The key of the decision instance.
+        decisionInstanceId:
+          type: string
+          description: The ID of the decision instance.
         state:
           $ref: "#/components/schemas/DecisionInstanceStateEnum"
         evaluationDate:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1720,7 +1720,7 @@ paths:
         - name: decisionInstanceId
           in: path
           required: true
-          description: The assigned id of the decision instance, which acts as a unique identifier for this decision instance.
+          description: The assigned ID of the decision instance, which acts as a unique identifier for this decision instance.
           schema:
             type: string
       responses:
@@ -1741,7 +1741,7 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "404":
           description: >
-            The decision instance with the given id was not found.
+            The decision instance with the given ID was not found.
             More details are provided in the response body.
           content:
             application/problem+json:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -193,6 +193,7 @@ public final class SearchQueryRequestMapper {
 
     if (filter != null) {
       ofNullable(filter.getDecisionInstanceKey()).ifPresent(builder::decisionInstanceKeys);
+      ofNullable(filter.getDecisionInstanceId()).ifPresent(builder::decisionInstanceIds);
       ofNullable(filter.getState())
           .map(s -> convertEnum(s, DecisionInstanceState.class))
           .ifPresent(builder::states);
@@ -224,6 +225,7 @@ public final class SearchQueryRequestMapper {
     } else {
       switch (field) {
         case "decisionInstanceKey" -> builder.decisionInstanceKey();
+        case "decisionInstanceId" -> builder.decisionInstanceId();
         case "state" -> builder.state();
         case "evaluationDate" -> builder.evaluationDate();
         case "processDefinitionKey" -> builder.processDefinitionKey();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -374,6 +374,7 @@ public final class SearchQueryResponseMapper {
   public static DecisionInstanceItem toDecisionInstance(final DecisionInstanceEntity entity) {
     return new DecisionInstanceItem()
         .decisionInstanceKey(entity.key())
+        .decisionInstanceId(entity.id())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())
@@ -391,6 +392,7 @@ public final class SearchQueryResponseMapper {
       final DecisionInstanceEntity entity) {
     return new DecisionInstanceGetQueryResponse()
         .decisionInstanceKey(entity.key())
+        .decisionInstanceId(entity.id())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryController.java
@@ -44,14 +44,14 @@ public class DecisionInstanceQueryController {
   @GetMapping(
       path = "/{decisionInstanceKey}",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
-  public ResponseEntity<DecisionInstanceGetQueryResponse> getDecisionInstanceByKey(
-      @PathVariable("decisionInstanceKey") final long decisionInstanceKey) {
+  public ResponseEntity<DecisionInstanceGetQueryResponse> getDecisionInstanceById(
+      @PathVariable("decisionInstanceKey") final String decisionInstanceId) {
     try {
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toDecisionInstanceGetQueryResponse(
               decisionInstanceServices
                   .withAuthentication(RequestMapper.getAuthentication())
-                  .getByKey(decisionInstanceKey)));
+                  .getById(decisionInstanceId)));
     } catch (final Exception e) {
       return RestErrorMapper.mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -56,6 +56,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                "items": [
                    {
                        "decisionInstanceKey": 123,
+                       "decisionInstanceId": "123-1",
                        "state": "EVALUATED",
                        "evaluationDate": "2024-06-05T08:29:15.027Z",
                        "processDefinitionKey": 2251799813688736,
@@ -84,6 +85,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
               List.of(
                   new DecisionInstanceEntity(
                       123L,
+                      "123-1",
                       DecisionInstanceState.EVALUATED,
                       OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
                       null,
@@ -196,10 +198,11 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldReturnDecisionInstanceByKey() {
     // given
-    final var decisionInstanceKey = 123L;
+    final var decisionInstanceId = "123-1";
     final var decisionInstanceInDB =
         new DecisionInstanceEntity(
             123L,
+            "123-1",
             DecisionInstanceState.EVALUATED,
             OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
             null,
@@ -217,11 +220,11 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                 new DecisionInstanceOutputEntity("1", "name1", "value1", "ruleId1", 1),
                 new DecisionInstanceOutputEntity("2", "name2", "value2", "ruleId1", 1),
                 new DecisionInstanceOutputEntity("3", "name3", "value3", "ruleId2", 2)));
-    when(decisionInstanceServices.getByKey(decisionInstanceKey)).thenReturn(decisionInstanceInDB);
+    when(decisionInstanceServices.getById(decisionInstanceId)).thenReturn(decisionInstanceInDB);
     // when
     webClient
         .get()
-        .uri("/v2/decision-instances/{decisionInstanceKey}", decisionInstanceKey)
+        .uri("/v2/decision-instances/{decisionInstanceId}", decisionInstanceId)
         .exchange()
         .expectStatus()
         .isOk()
@@ -282,13 +285,13 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   @Test
   void shouldReturn404WhenDecisionInstanceNotFound() {
     // given
-    final var decisionInstanceKey = 123L;
-    when(decisionInstanceServices.getByKey(decisionInstanceKey))
-        .thenThrow(new NotFoundException("Decision Instance with key 1 was not found."));
+    final var decisionInstanceId = "123-1";
+    when(decisionInstanceServices.getById(decisionInstanceId))
+        .thenThrow(new NotFoundException("Decision Instance with key 123-1 was not found."));
     // when
     webClient
         .get()
-        .uri("/v2/decision-instances/{decisionInstanceKey}", decisionInstanceKey)
+        .uri("/v2/decision-instances/{decisionInstanceId}", decisionInstanceId)
         .exchange()
         .expectStatus()
         .isNotFound()
@@ -301,21 +304,21 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                           "type": "about:blank",
                           "title": "NOT_FOUND",
                           "status": 404,
-                          "detail": "Decision Instance with key 1 was not found.",
-                          "instance": "/v2/decision-instances/123"
+                          "detail": "Decision Instance with key 123-1 was not found.",
+                          "instance": "/v2/decision-instances/123-1"
                         }""");
   }
 
   @Test
   void shouldReturn500ForInternalErrorGetDecisionDefinitionByKey() {
     // given
-    final var decisionInstanceKey = 123L;
-    when(decisionInstanceServices.getByKey(decisionInstanceKey))
+    final var decisionInstanceId = "123-1";
+    when(decisionInstanceServices.getById(decisionInstanceId))
         .thenThrow(new RuntimeException("Something bad happened."));
     // when
     webClient
         .get()
-        .uri("/v2/decision-instances/{decisionInstanceKey}", decisionInstanceKey)
+        .uri("/v2/decision-instances/{decisionInstanceId}", decisionInstanceId)
         .exchange()
         .expectStatus()
         .is5xxServerError()
@@ -329,21 +332,21 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                   "title": "java.lang.RuntimeException",
                   "status": 500,
                   "detail": "Unexpected error occurred during the request processing: Something bad happened.",
-                  "instance": "/v2/decision-instances/123"
+                  "instance": "/v2/decision-instances/123-1"
                 }""");
   }
 
   @Test
   void shouldReturn403ForUnauthorizedGetDecisionDefinitionByKey() {
     // given
-    final var decisionInstanceKey = 123L;
-    when(decisionInstanceServices.getByKey(decisionInstanceKey))
+    final var decisionInstanceId = "123-1";
+    when(decisionInstanceServices.getById(decisionInstanceId))
         .thenThrow(
             new ForbiddenException(Authorization.of(a -> a.decisionDefinition().readInstance())));
     // when
     webClient
         .get()
-        .uri("/v2/decision-instances/{decisionInstanceKey}", decisionInstanceKey)
+        .uri("/v2/decision-instances/{decisionInstanceId}", decisionInstanceId)
         .exchange()
         .expectStatus()
         .isForbidden()
@@ -357,7 +360,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                   "title": "io.camunda.service.exception.ForbiddenException",
                   "status": 403,
                   "detail": "Unauthorized to perform operation 'READ_PROCESS_INSTANCE' on resource 'DECISION_DEFINITION'",
-                  "instance": "/v2/decision-instances/123"
+                  "instance": "/v2/decision-instances/123-1"
                 }""");
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -287,7 +287,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
     // given
     final var decisionInstanceId = "123-1";
     when(decisionInstanceServices.getById(decisionInstanceId))
-        .thenThrow(new NotFoundException("Decision Instance with key 123-1 was not found."));
+        .thenThrow(new NotFoundException("Decision instance with key 123-1 was not found."));
     // when
     webClient
         .get()
@@ -304,7 +304,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                           "type": "about:blank",
                           "title": "NOT_FOUND",
                           "status": 404,
-                          "detail": "Decision Instance with key 123-1 was not found.",
+                          "detail": "Decision instance with key 123-1 was not found.",
                           "instance": "/v2/decision-instances/123-1"
                         }""");
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- replaces `GET /v2/decision-instances/{decisionInstanceKey}` by `GET /v2/decision-instances/{decisionInstanceId}`
- adds `decisionInstanceId` search filter to `POST /v2/decision-instances/search`
- adds  `decisionInstanceId` attribute to DecisionInstance items
- Zeebe client is accordingly updated
- DecisionInstance query integration tests are moved to the new IT style (based on `BrokerWithCamundaExporterITInvocationProvider` test extension)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24664
