### PR TITLE
Add support for `assignment` task listeners after `CLAIM` command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -272,6 +272,15 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     final var userTaskIntent =
         switch (lifecycleState) {
+          /*
+           Note: After receiving either `ASSIGN` or `CLAIM` commands, the user task transitions
+           to the `ASSIGNING` lifecycle state, making it indistinguishable which command initially
+           led to this state.
+
+           Therefore, the `ASSIGNING` state is mapped to the `ASSIGN` intent, and `UserTaskAssignProcessor`
+           is selected to finalize the command after all task listeners are processed.
+           This approach is acceptable as long as both commands share identical finalization logic.
+          */
           case ASSIGNING -> UserTaskIntent.ASSIGN;
           case UPDATING -> UserTaskIntent.UPDATE;
           case COMPLETING -> UserTaskIntent.COMPLETE;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -272,15 +272,6 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
     final var userTaskIntent =
         switch (lifecycleState) {
-          /*
-           Note: After receiving either `ASSIGN` or `CLAIM` commands, the user task transitions
-           to the `ASSIGNING` lifecycle state, making it indistinguishable which command initially
-           led to this state.
-
-           Therefore, the `ASSIGNING` state is mapped to the `ASSIGN` intent, and `UserTaskAssignProcessor`
-           is selected to finalize the command after all task listeners are processed.
-           This approach is acceptable as long as both commands share identical finalization logic.
-          */
           case ASSIGNING -> UserTaskIntent.ASSIGN;
           case UPDATING -> UserTaskIntent.UPDATE;
           case COMPLETING -> UserTaskIntent.COMPLETE;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -61,6 +61,15 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 
+  /*
+   Note: This method finalizes the `ASSIGN` command by default but also handles finalization
+   for the `CLAIM` command when `assignment` listeners are defined for the user task.
+
+   This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
+   `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this state.
+   Therefore, `UserTaskAssignProcessor` is selected to finalize the command after all task listeners
+   are processed when the user task is in the `ASSIGNING` state.
+  */
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -61,15 +61,16 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 
-  /*
-   Note: This method finalizes the `ASSIGN` command by default but also handles finalization
-   for the `CLAIM` command when `assignment` listeners are defined for the user task.
-
-   This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
-   `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this state.
-   Therefore, `UserTaskAssignProcessor` is selected to finalize the command after all task listeners
-   are processed when the user task is in the `ASSIGNING` state.
-  */
+  /// {@inheritDoc}
+  ///
+  /// @apiNote This method finalizes the [UserTaskIntent#ASSIGN] command by default but also handles
+  /// finalization for the [UserTaskIntent#CLAIM] command when `assignment` listeners are defined
+  /// for the user task.
+  ///
+  /// This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
+  /// `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this
+  /// state. Therefore, the current processor is selected to finalize the command after all task
+  /// listeners are processed when the user task is in the [LifecycleState#ASSIGNING] state.
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -12,9 +12,11 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -30,6 +32,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
   private static final String INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE =
       "Expected to claim user task with key '%d', but provided assignee is empty";
 
+  private final UserTaskState userTaskState;
   private final StateWriter stateWriter;
   private final TypedResponseWriter responseWriter;
   private final UserTaskCommandPreconditionChecker preconditionChecker;
@@ -38,6 +41,7 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
       final ProcessingState state,
       final Writers writers,
       final AuthorizationCheckBehavior authCheckBehavior) {
+    userTaskState = state.getUserTaskState();
     stateWriter = writers.state();
     responseWriter = writers.response();
     preconditionChecker =
@@ -64,9 +68,47 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
-    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-    responseWriter.writeEventOnCommand(
-        userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
+  }
+
+  /*
+   Note: This method finalizes the `CLAIM` command only when there are no `assignment` listeners
+   for the user task. If `assignment` listeners are defined, the `onFinalizeCommand` method
+   from `UserTaskAssignProcessor` will handle this logic instead.
+
+   This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
+   `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this state.
+   Therefore, `UserTaskAssignProcessor` is selected to finalize the command after all task listeners
+   are processed when the user task is in the `ASSIGNING` state.
+
+   This approach is acceptable as long as `CLAIM` and `ASSIGN` share identical finalization logic.
+   Any need for distinct handling would require a further update to this behavior.
+  */
+  @Override
+  public void onFinalizeCommand(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = command.getKey();
+
+    userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
+
+    if (command.hasRequestMetadata()) {
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+      responseWriter.writeEventOnCommand(
+          userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
+    } else {
+      final var recordRequestMetadata = userTaskState.findRecordRequestMetadata(userTaskKey);
+      stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+
+      recordRequestMetadata.ifPresent(
+          metadata ->
+              responseWriter.writeResponse(
+                  userTaskKey,
+                  UserTaskIntent.ASSIGNED,
+                  userTaskRecord,
+                  ValueType.USER_TASK,
+                  metadata.getRequestId(),
+                  metadata.getRequestStreamId()));
+    }
   }
 
   private static Either<Tuple<RejectionType, String>, UserTaskRecord> checkClaim(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -70,19 +70,21 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 
-  /*
-   Note: This method finalizes the `CLAIM` command only when there are no `assignment` listeners
-   for the user task. If `assignment` listeners are defined, the `onFinalizeCommand` method
-   from `UserTaskAssignProcessor` will handle this logic instead.
-
-   This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
-   `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this state.
-   Therefore, `UserTaskAssignProcessor` is selected to finalize the command after all task listeners
-   are processed when the user task is in the `ASSIGNING` state.
-
-   This approach is acceptable as long as `CLAIM` and `ASSIGN` share identical finalization logic.
-   Any need for distinct handling would require a further update to this behavior.
-  */
+  /// {@inheritDoc}
+  ///
+  /// @apiNote This method finalizes the [UserTaskIntent#CLAIM] command only when there are no
+  /// `assignment` listeners for the user task. If `assignment` listeners are defined,
+  /// [UserTaskAssignProcessor#onFinalizeCommand(TypedRecord, UserTaskRecord)] method will handle
+  /// this logic instead.
+  ///
+  /// This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
+  /// `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this
+  /// state. Therefore, [UserTaskAssignProcessor] is selected to finalize the command after all task
+  /// listeners are processed when the user task is in the [LifecycleState#ASSIGNING] state.
+  ///
+  /// This approach is acceptable as long as `CLAIM` and `ASSIGN` commands share identical
+  /// finalization logic. Any need for distinct handling would require a further update to this
+  /// behavior.
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {


### PR DESCRIPTION
## Description
This PR is the second part of the work required to support `assignment` Task Listeners on the User Task element, it enables the execution of `assignment` listeners after receiving the `CLAIM` command.

> [!NOTE]
> Currently, the `UserTaskClaimProcessor#onFinalizeCommand` method finalizes the `CLAIM` command only if no `assignment` listeners are defined for the user task. When `assignment` listeners are present, finalization is handled by the `onFinalizeCommand` method from `UserTaskAssignProcessor`.
>
> This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this state. Therefore, inside `UserTaskProcessor#determineProcessorFromUserTaskLifecycleState` the `ASSIGNING` state is mapped to the `ASSIGN` intent and `UserTaskAssignProcessor` is selected to finalize the command after all `assignment` task listeners are processed.

> [!WARNING]
> This approach is acceptable as long as `CLAIM` and `ASSIGN` commands have identical finalization logic.
Any need for distinct handling would require a further update to this behavior.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to #24232 
