### PR TITLE
Extend BackgroundTaskManager to run non rescheduled tasks.

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -124,7 +124,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
         createProcessInstanceTask(
             metrics, logger, resourceProvider, repository, executor, config.getArchiver()));
     if (partitionId == START_PARTITION_ID) {
-      threadCount++;
+      threadCount = 2;
       tasks.add(
           createBatchOperationTask(
               metrics, logger, resourceProvider, repository, executor, config.getArchiver()));

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -179,8 +179,6 @@ public final class BackgroundTaskManager implements CloseableSilently {
     executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
     executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
     executor.setRemoveOnCancelPolicy(true);
-    executor.allowCoreThreadTimeOut(true);
-    executor.setKeepAliveTime(1, TimeUnit.MINUTES);
 
     return executor;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ApplyRolloverPeriodJob.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.archiver;
+
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import org.slf4j.Logger;
+
+public class ApplyRolloverPeriodJob implements Runnable {
+
+  private final ArchiverRepository repository;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+
+  public ApplyRolloverPeriodJob(
+      final ArchiverRepository repository,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    this.repository = repository;
+    this.metrics = metrics;
+    this.logger = logger;
+  }
+
+  @Override
+  public void run() {
+    repository.setLifeCycleToAllIndexes();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverRepository.java
@@ -19,6 +19,8 @@ public interface ArchiverRepository extends AutoCloseable {
 
   CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName);
 
+  CompletableFuture<Void> setLifeCycleToAllIndexes();
+
   CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final String idFieldName,
@@ -55,6 +57,11 @@ public interface ArchiverRepository extends AutoCloseable {
 
     @Override
     public CompletableFuture<Void> setIndexLifeCycle(final String destinationIndexName) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Void> setLifeCycleToAllIndexes() {
       return CompletableFuture.completedFuture(null);
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchRepository.java
@@ -134,6 +134,11 @@ public final class ElasticsearchRepository implements ArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<Void> setLifeCycleToAllIndexes() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final String idFieldName,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/OpenSearchRepository.java
@@ -144,6 +144,11 @@ public final class OpenSearchRepository implements ArchiverRepository {
   }
 
   @Override
+  public CompletableFuture<Void> setLifeCycleToAllIndexes() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
   public CompletableFuture<Void> deleteDocuments(
       final String sourceIndexName,
       final String idFieldName,


### PR DESCRIPTION
## Description

This PR extends BackgroundTaskManager so that later can be used to apply ILM policy on all indices.
This also adds the skeleton for ApplyRolloverPeriodTask wich will be implemented in the following PRs.

relates: https://github.com/camunda/camunda/issues/24382
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
