### PR TITLE
docs: update path spec in the REST API documentation

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2289,7 +2289,7 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
-  /document/{documentId}/links:
+  /documents/{documentId}/links:
     post:
       tags:
         - Document


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This PR addresses an issue in the REST API documentation for the Document API where the path for the "Create Document Link" REST endpoint is incorrectly specified. The current documentation shows an invalid endpoint in the API path.

**Changes:**

- Corrected the path specification in the OpenAPI definition for the Create Document Link API to reflect the accurate endpoint `/v2/documents/:documentId/links`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24540 
