### PR TITLE
ci: re-enable flaky auth IT tests

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -36,10 +36,6 @@
             <include>**/*Tests.java</include>
             <include>**/*TestCase.java</include>
           </includes>
-          <excludes>
-            <exclude>**/io/camunda/it/auth/*.java</exclude>
-            <!-- FIXME - temporarily ignoring flaky tests -->
-          </excludes>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Re-enable some of the flaky tests that were disabled in https://github.com/camunda/camunda/pull/24694
Increasing the timeout to allow more time for the default user creation. 
I have run the CI multiple times, and these tests no longer appear to be flaky.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
