### PR TITLE
Use multi-line string in `denied` description

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4335,9 +4335,10 @@ components:
       properties:
         denied:
           type: boolean
-          description: Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. >
-            For example, a Task Listener can deny the completion of a task by setting this flag to true. >
-            In this example, the completion of a task is represented by a job that the worker can complete as denied. >
+          description: >
+            Indicates whether the worker denies the work, i.e. explicitly doesn't approve it.
+            For example, a Task Listener can deny the completion of a task by setting this flag to true.
+            In this example, the completion of a task is represented by a job that the worker can complete as denied.
             As a result, the completion request is rejected and the task remains active.
             Defaults to false.
           nullable: true


### PR DESCRIPTION
## Description

There are many ways to create multi-line strings in yaml files, but generally either `>` and `|` are used to specify the block style.

However, if `>` is just placed inside the string, then it becomes part of the string. That was not intentional, and is what this commit fixes.

## Related issues

Relates to https://github.com/camunda/camunda/pull/24637