### PR TITLE
    refactor: throw CheckedJournalException from all methods in journal

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -744,7 +744,11 @@ public class PassiveRole extends InactiveRole {
       // Reset the log to the previous index plus one.
       if (request.prevLogTerm() == 0) {
         log.debug("Reset first index to {}", request.prevLogIndex() + 1);
-        raft.getLog().reset(request.prevLogIndex() + 1);
+        try {
+          raft.getLog().reset(request.prevLogIndex() + 1);
+        } catch (final CheckedJournalException e) {
+          failAppend(request.prevLogIndex(), future);
+        }
       }
 
       // Iterate through entries and append them.
@@ -828,7 +832,7 @@ public class PassiveRole extends InactiveRole {
         if (lastEntry.term() != entry.term()) {
           try {
             raft.getLog().deleteAfter(index - 1);
-          } catch (final FlushException e) {
+          } catch (final CheckedJournalException e) {
             return !failAppend(index - 1, future);
           }
 
@@ -887,7 +891,7 @@ public class PassiveRole extends InactiveRole {
       if (existingEntry.term() != entry.term()) {
         try {
           raft.getLog().deleteAfter(index - 1);
-        } catch (final FlushException e) {
+        } catch (final CheckedJournalException e) {
           return failAppend(index - 1, future);
         }
 
@@ -994,7 +998,8 @@ public class PassiveRole extends InactiveRole {
     return succeeded;
   }
 
-  private void resetLogOnReceivingSnapshot(final long snapshotIndex) {
+  private void resetLogOnReceivingSnapshot(final long snapshotIndex)
+      throws CheckedJournalException {
     final var raftLog = raft.getLog();
 
     log.info(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -39,6 +39,7 @@ import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import io.camunda.zeebe.snapshots.testing.TestFileBasedSnapshotStore;
+import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.io.File;
@@ -365,7 +366,10 @@ public final class ControllableRaftContexts {
           raftContext.getCommitIndex());
     }
 
-    raftContext.getThreadContext().execute(() -> raftContext.getLog().deleteUntil(snapshotIndex));
+    raftContext
+        .getThreadContext()
+        .execute(
+            CheckedRunnable.toUnchecked(() -> raftContext.getLog().deleteUntil(snapshotIndex)));
   }
 
   public void restart(final MemberId memberId) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
@@ -14,6 +14,7 @@ import io.atomix.raft.snapshot.InMemorySnapshot;
 import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.log.RaftLog;
 import io.atomix.utils.concurrent.ThreadContext;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -53,7 +54,7 @@ final class LogCompactorTest {
   }
 
   @Test
-  void shouldCompact() {
+  void shouldCompact() throws CheckedJournalException {
     // given
     compactor.setCompactableIndex(12);
 
@@ -69,7 +70,7 @@ final class LogCompactorTest {
   }
 
   @Test
-  void shouldCompactIgnoringThreshold() {
+  void shouldCompactIgnoringThreshold() throws CheckedJournalException {
     // given
     compactor.setCompactableIndex(12);
 
@@ -93,7 +94,7 @@ final class LogCompactorTest {
   }
 
   @Test
-  void shouldCompactBasedOnOldestSnapshot() {
+  void shouldCompactBasedOnOldestSnapshot() throws CheckedJournalException {
     // given
     final var store = new TestSnapshotStore(new AtomicReference<>());
     InMemorySnapshot.newPersistedSnapshot(0, 10L, 1, 30, store).reserve();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -43,6 +43,7 @@ import io.atomix.raft.zeebe.EntryValidator.ValidationResult;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.raft.zeebe.util.TestAppender;
 import io.atomix.utils.concurrent.SingleThreadContext;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import java.io.IOException;
@@ -65,7 +66,7 @@ public class LeaderRoleTest {
   private LogCompactor logCompactor;
 
   @Before
-  public void setup() {
+  public void setup() throws CheckedJournalException {
     context = Mockito.mock(RaftContext.class, RETURNS_DEEP_STUBS);
     logCompactor = mock(LogCompactor.class);
 
@@ -121,7 +122,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldRetryAppendEntryOnIOException() throws InterruptedException {
+  public void shouldRetryAppendEntryOnIOException()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class)))
         .thenThrow(new JournalException(new IOException()))
@@ -151,7 +153,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldStopRetryAppendEntryAfterMaxRetries() throws InterruptedException {
+  public void shouldStopRetryAppendEntryAfterMaxRetries()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class))).thenThrow(new JournalException(new IOException()));
 
@@ -178,7 +181,7 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldCompactOnOutOfDiskSpace() throws InterruptedException {
+  public void shouldCompactOnOutOfDiskSpace() throws InterruptedException, CheckedJournalException {
     // given - fail once with OOD then accept the next entry
     when(log.append(any(RaftLogEntry.class)))
         .thenThrow(new JournalException.OutOfDiskSpace("Boom file out"))
@@ -209,7 +212,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldStopAppendEntryOnOutOfDisk() throws InterruptedException {
+  public void shouldStopAppendEntryOnOutOfDisk()
+      throws InterruptedException, CheckedJournalException {
     // given - fail once with OOD then accept the next entry
     when(log.append(any(RaftLogEntry.class)))
         .thenThrow(new JournalException.OutOfDiskSpace("Boom file out"))
@@ -245,7 +249,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldTransitionToFollowerWhenAppendEntryException() throws InterruptedException {
+  public void shouldTransitionToFollowerWhenAppendEntryException()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class))).thenThrow(new RuntimeException("expected"));
 
@@ -273,7 +278,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldNotAppendFollowingEntryOnException() throws InterruptedException {
+  public void shouldNotAppendFollowingEntryOnException()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class))).thenThrow(new RuntimeException("expected"));
 
@@ -306,7 +312,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldRetryAppendEntriesInOrder() throws InterruptedException {
+  public void shouldRetryAppendEntriesInOrder()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class)))
         .thenThrow(new JournalException(new IOException()))
@@ -343,7 +350,8 @@ public class LeaderRoleTest {
   }
 
   @Test
-  public void shouldDetectInconsistencyWithLastEntry() throws InterruptedException {
+  public void shouldDetectInconsistencyWithLastEntry()
+      throws InterruptedException, CheckedJournalException {
     // given
     when(log.append(any(RaftLogEntry.class)))
         .then(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/roles/PassiveRoleTest.java
@@ -82,7 +82,7 @@ public class PassiveRoleTest {
   }
 
   @Test
-  public void shouldFailAppendWithIncorrectChecksum() {
+  public void shouldFailAppendWithIncorrectChecksum() throws CheckedJournalException {
     // given
     final var entries = List.of(new ReplicatableJournalRecord(1, 1, 12345, new byte[1]));
     final VersionedAppendRequest request =

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogCommittedReaderTest.java
@@ -19,7 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
+import io.camunda.zeebe.util.exception.Rethrow;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -149,7 +151,11 @@ class RaftLogCommittedReaderTest {
     for (int i = 0; i < count; i++) {
       final var applicationEntry = new SerializedApplicationEntry(i + 1, i + 1, data);
       final var entry = new RaftLogEntry(1, applicationEntry);
-      raftlog.append(entry);
+      try {
+        raftlog.append(entry);
+      } catch (final CheckedJournalException e) {
+        Rethrow.rethrowUnchecked(e);
+      }
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogTest.java
@@ -85,7 +85,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldAppendInitialEntry() {
+  void shouldAppendInitialEntry() throws CheckedJournalException {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, initialEntry);
     // when
@@ -100,7 +100,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldAppendConfigurationEntry() {
+  void shouldAppendConfigurationEntry() throws CheckedJournalException {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, configurationEntry);
     // when
@@ -118,7 +118,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldAppendApplicationEntry() {
+  void shouldAppendApplicationEntry() throws CheckedJournalException {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);
     // when
@@ -137,7 +137,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldUpdateLastAppendedEntry() {
+  void shouldUpdateLastAppendedEntry() throws CheckedJournalException {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);
     // when
@@ -148,7 +148,8 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldAppendReplicatableJournalRecord(@TempDir final File directory) {
+  void shouldAppendReplicatableJournalRecord(@TempDir final File directory)
+      throws CheckedJournalException {
     // given
     final RaftLogEntry entry = new RaftLogEntry(1, firstApplicationEntry);
     final var persistedRaftRecord = raftlog.append(entry).getReplicatableJournalRecord();
@@ -191,7 +192,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldNotDeleteCommittedEntries() {
+  void shouldNotDeleteCommittedEntries() throws CheckedJournalException {
     // given
     raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
     final ApplicationEntry secondApplicationEntry =
@@ -211,7 +212,7 @@ class RaftLogTest {
   }
 
   @Test
-  void shouldReset() {
+  void shouldReset() throws CheckedJournalException {
     // given
     raftlog.append(new RaftLogEntry(1, firstApplicationEntry));
     final IndexedRaftLogEntry secondEntry =

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/RaftLogUncommittedReaderTest.java
@@ -22,6 +22,7 @@ import io.atomix.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.raft.storage.log.entry.SerializedApplicationEntry;
 import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
+import io.camunda.zeebe.util.exception.Rethrow;
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -146,7 +147,11 @@ class RaftLogUncommittedReaderTest {
     for (int i = 0; i < count; i++) {
       final ApplicationEntry applicationEntry = new SerializedApplicationEntry(i + 1, i + 1, data);
       final RaftLogEntry entry = new RaftLogEntry(1, applicationEntry);
-      raftlog.append(entry);
+      try {
+        raftlog.append(entry);
+      } catch (final CheckedJournalException e) {
+        Rethrow.rethrowUnchecked(e);
+      }
     }
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/CheckedJournalException.java
@@ -19,5 +19,21 @@ public sealed class CheckedJournalException extends Exception {
     public FlushException(final IOException cause) {
       super("Error when flushing", cause);
     }
+
+    public FlushException(final String message, final IOException cause) {
+      super(message, cause);
+    }
+  }
+
+  public static final class CreationFileException extends CheckedJournalException {
+    public CreationFileException(final String message, final IOException cause) {
+      super(message, cause);
+    }
+  }
+
+  public static final class DeletionFileException extends CheckedJournalException {
+    public DeletionFileException(final String message, final IOException cause) {
+      super(message, cause);
+    }
   }
 }

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/Journal.java
@@ -32,7 +32,7 @@ public interface Journal extends AutoCloseable {
    * @param recordDataWriter a writer that outputs the data of the record
    * @return the journal record that was appended
    */
-  JournalRecord append(BufferWriter recordDataWriter);
+  JournalRecord append(BufferWriter recordDataWriter) throws CheckedJournalException;
 
   /**
    * Appends a new {@link JournalRecord} that contains the data to be written by the
@@ -44,20 +44,20 @@ public interface Journal extends AutoCloseable {
    * @param recordDataWriter a writer that outputs the data of the record
    * @return the journal record that was appended
    */
-  JournalRecord append(long asqn, BufferWriter recordDataWriter);
+  JournalRecord append(long asqn, BufferWriter recordDataWriter) throws CheckedJournalException;
 
   /**
    * Appends a {@link JournalRecord}. If the index of the record is not the next expected index, the
    * append will fail.
    *
    * @deprecated This method was used to append entries received via replication. {@link
-   *     Journal#append(long, long, byte[])} must be used instead.
+   *     Journal#append(long, byte[])} must be used instead.
    * @param record the record to be appended
    * @exception InvalidIndex if the index of record is not the next expected index
    * @exception InvalidChecksum if the checksum in record does not match the checksum of the data
    */
   @Deprecated(since = "8.4.0")
-  void append(JournalRecord record);
+  void append(JournalRecord record) throws CheckedJournalException;
 
   /**
    * Appends already serialized journal record. See {@link JournalRecord#serializedRecord()}
@@ -65,7 +65,7 @@ public interface Journal extends AutoCloseable {
    * @param checksum checksum of serializedRecord
    * @param serializedRecord serializedRecord
    */
-  JournalRecord append(long checksum, byte[] serializedRecord);
+  JournalRecord append(long checksum, byte[] serializedRecord) throws CheckedJournalException;
 
   /**
    * Delete all records after indexExclusive. After a call to this method, {@link
@@ -73,7 +73,7 @@ public interface Journal extends AutoCloseable {
    *
    * @param indexExclusive the index after which the records will be deleted.
    */
-  void deleteAfter(long indexExclusive);
+  void deleteAfter(long indexExclusive) throws CheckedJournalException;
 
   /**
    * Attempts to delete all records until indexExclusive. The records may be immediately deleted or
@@ -83,7 +83,7 @@ public interface Journal extends AutoCloseable {
    *     deleted.
    * @return true if anything was deleted, false otherwise
    */
-  boolean deleteUntil(long indexExclusive);
+  boolean deleteUntil(long indexExclusive) throws CheckedJournalException;
 
   /**
    * Delete all records in the journal and reset the next index to nextIndex. The following calls to
@@ -94,7 +94,7 @@ public interface Journal extends AutoCloseable {
    *
    * @param nextIndex the next index of the journal.
    */
-  void reset(long nextIndex);
+  void reset(long nextIndex) throws CheckedJournalException;
 
   /**
    * Returns the index of last record in the journal

--- a/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
+++ b/zeebe/journal/src/main/java/io/camunda/zeebe/journal/file/JournalMetrics.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.CheckedJournalException;
+import io.camunda.zeebe.util.CheckedRunnable;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Gauge.Timer;
@@ -138,8 +140,9 @@ final class JournalMetrics {
     seekLatency = SEEK_LATENCY.labels(partitionId);
   }
 
-  void observeSegmentCreation(final Runnable segmentCreation) {
-    segmentCreationTime.time(segmentCreation);
+  void observeSegmentCreation(final CheckedRunnable segmentCreation)
+      throws CheckedJournalException {
+    segmentCreationTime.time(CheckedRunnable.toUnchecked(segmentCreation));
   }
 
   Histogram.Timer observeSegmentFlush() {

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalAppendTest.java
@@ -71,7 +71,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendData() {
+  void shouldAppendData() throws CheckedJournalException {
     // when
     final var recordAppended = journal.append(1, recordDataWriter);
 
@@ -81,7 +81,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendJournalRecord() {
+  void shouldAppendJournalRecord() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -104,7 +104,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendMultipleData() {
+  void shouldAppendMultipleData() throws CheckedJournalException {
     // when
     final var firstRecord = journal.append(10, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -118,7 +118,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithAlreadyAppendedIndex() {
+  void shouldNotAppendRecordWithAlreadyAppendedIndex() throws CheckedJournalException {
     // given
     final var record = journal.append(recordDataWriter);
     journal.append(recordDataWriter);
@@ -133,7 +133,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithGapInIndex() {
+  void shouldNotAppendRecordWithGapInIndex() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -155,7 +155,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendLastRecord() {
+  void shouldNotAppendLastRecord() throws CheckedJournalException {
     // given
     final var record = journal.append(recordDataWriter);
 
@@ -169,7 +169,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendRecordWithASQNToIgnore() {
+  void shouldAppendRecordWithASQNToIgnore() throws CheckedJournalException {
     // given
     final var firstIndex = journal.append(1, recordDataWriter).index();
 
@@ -181,7 +181,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithInvalidChecksum() {
+  void shouldNotAppendRecordWithInvalidChecksum() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -203,7 +203,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithTooLowASQN() {
+  void shouldNotAppendRecordWithTooLowASQN() throws CheckedJournalException {
     // given
     journal.append(1, recordDataWriter);
 
@@ -213,7 +213,8 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendRecordWithTooLowASQNIfPreviousRecordIsIgnoreASQN() {
+  void shouldNotAppendRecordWithTooLowASQNIfPreviousRecordIsIgnoreASQN()
+      throws CheckedJournalException {
     // given
     journal.append(1, recordDataWriter);
 
@@ -226,7 +227,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendSerializedJournalRecord() {
+  void shouldAppendSerializedJournalRecord() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -249,7 +250,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldAppendSerializedJournalRecordReturnedByReader() {
+  void shouldAppendSerializedJournalRecordReturnedByReader() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -273,7 +274,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendSerializedRecordWithAlreadyAppendedIndex() {
+  void shouldNotAppendSerializedRecordWithAlreadyAppendedIndex() throws CheckedJournalException {
     // given
     final var record = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
@@ -288,7 +289,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendSerializedRecordWithGapInIndex() {
+  void shouldNotAppendSerializedRecordWithGapInIndex() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()
@@ -309,7 +310,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendDuplicateSerializedRecord() {
+  void shouldNotAppendDuplicateSerializedRecord() throws CheckedJournalException {
     // given
     final var record = journal.append(1, recordDataWriter);
 
@@ -322,7 +323,7 @@ final class JournalAppendTest {
   }
 
   @Test
-  void shouldNotAppendSerializedRecordWithInvalidChecksum() {
+  void shouldNotAppendSerializedRecordWithInvalidChecksum() throws CheckedJournalException {
     // given
     try (final var receiverJournal =
         SegmentedJournal.builder()

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalReaderTest.java
@@ -52,7 +52,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeek() {
+  void shouldSeek() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
@@ -72,7 +72,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToFirst() {
+  void shouldSeekToFirst() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
@@ -91,7 +91,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToLast() {
+  void shouldSeekToLast() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
@@ -109,7 +109,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldNotReadIfSeekIsHigherThanLast() {
+  void shouldNotReadIfSeekIsHigherThanLast() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
@@ -124,7 +124,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldReadAppendedDataAfterSeek() {
+  void shouldReadAppendedDataAfterSeek() throws CheckedJournalException {
     // given
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter).index();
@@ -141,7 +141,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToAsqn() {
+  void shouldSeekToAsqn() throws CheckedJournalException {
     // given that all records with index i will have an asqn of startAsqn + i
     final long startAsqn = 10;
     for (int i = 0; i < ENTRIES; i++) {
@@ -162,7 +162,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToHighestAsqnLowerThanProvidedAsqn() {
+  void shouldSeekToHighestAsqnLowerThanProvidedAsqn() throws CheckedJournalException {
     // given
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -177,7 +177,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToHighestAsqnWithinBoundIndex() {
+  void shouldSeekToHighestAsqnWithinBoundIndex() throws CheckedJournalException {
     // given
     final var firstIndex = journal.append(1, recordDataWriter).index();
     final var secondIndex = journal.append(4, recordDataWriter).index();
@@ -203,7 +203,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToLastAsqn() {
+  void shouldSeekToLastAsqn() throws CheckedJournalException {
     // given
     final var expectedRecord = journal.append(5, recordDataWriter);
     journal.append(recordDataWriter);
@@ -214,7 +214,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() {
+  void shouldSeekToHighestLowerAsqnSkippingRecordsWithNoAsqn() throws CheckedJournalException {
     // given
     final var expectedRecord = journal.append(1, recordDataWriter);
     journal.append(recordDataWriter);
@@ -230,7 +230,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToFirstWhenAllAsqnIsHigher() {
+  void shouldSeekToFirstWhenAllAsqnIsHigher() throws CheckedJournalException {
     // given
     final var expectedRecord = journal.append(recordDataWriter);
     journal.append(5, recordDataWriter);
@@ -246,7 +246,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToFirstIfLowerThanFirst() {
+  void shouldSeekToFirstIfLowerThanFirst() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES; i++) {
       journal.append(i, recordDataWriter).index();
@@ -265,7 +265,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekAfterTruncate() {
+  void shouldSeekAfterTruncate() throws CheckedJournalException {
     // given
     long lastIndex = -1;
     for (int i = 1; i <= ENTRIES; i++) {
@@ -284,7 +284,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekAfterCompact() {
+  void shouldSeekAfterCompact() throws CheckedJournalException {
     // given
     journal.append(1, recordDataWriter).index();
     journal.append(2, recordDataWriter).index();
@@ -303,7 +303,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToIndex() {
+  void shouldSeekToIndex() throws CheckedJournalException {
     // given
     long asqn = 1;
     JournalRecord lastRecordWritten = null;
@@ -343,7 +343,7 @@ final class JournalReaderTest {
   }
 
   @Test
-  void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() {
+  void shouldSeekToFirstWhenNoRecordsWithValidAsqnExists() throws CheckedJournalException {
     // given
     for (int i = 0; i < ENTRIES; i++) {
       journal.append(recordDataWriter);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/JournalTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.journal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
 import io.camunda.zeebe.journal.file.LogCorrupter;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
 import io.camunda.zeebe.journal.file.SegmentedJournalBuilder;
@@ -66,7 +65,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotBeEmpty() {
+  void shouldNotBeEmpty() throws CheckedJournalException {
     // given
     journal.append(1, recordDataWriter);
 
@@ -75,7 +74,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldReadRecord() {
+  void shouldReadRecord() throws CheckedJournalException {
     // given
     final var recordAppended = journal.append(1, recordDataWriter);
 
@@ -88,7 +87,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldAppendMultipleData() {
+  void shouldAppendMultipleData() throws CheckedJournalException {
     // when
     final var firstRecord = journal.append(10, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -102,7 +101,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldReadMultipleRecord() {
+  void shouldReadMultipleRecord() throws CheckedJournalException {
     // given
     final var firstRecord = journal.append(1, recordDataWriter);
     final var secondRecord = journal.append(20, otherRecordDataWriter);
@@ -118,7 +117,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldAppendAndReadMultipleRecordsInOrder() {
+  void shouldAppendAndReadMultipleRecordsInOrder() throws CheckedJournalException {
     // when
     for (int i = 0; i < 10; i++) {
       final var recordAppended = journal.append(i + 10, recordDataWriter);
@@ -139,7 +138,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldAppendAndReadMultipleRecords() {
+  void shouldAppendAndReadMultipleRecords() throws CheckedJournalException {
     final var reader = journal.openReader();
     for (int i = 0; i < 10; i++) {
       // given
@@ -162,7 +161,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldReset() {
+  void shouldReset() throws CheckedJournalException {
     // given
     long asqn = 1;
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -181,7 +180,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadAfterJournalResetWithoutReaderReset() {
+  void shouldNotReadAfterJournalResetWithoutReaderReset() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     long asqn = 1;
@@ -200,7 +199,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldWriteToTruncatedIndex() {
+  void shouldWriteToTruncatedIndex() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -225,7 +224,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldTruncate() {
+  void shouldTruncate() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -245,7 +244,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldCompact() {
+  void shouldCompact() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     final var firstIndex = journal.getFirstIndex();
@@ -267,7 +266,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadTruncatedEntries() {
+  void shouldNotReadTruncatedEntries() throws CheckedJournalException {
     // given
     final int totalWrites = 10;
     final int truncateIndex = 5;
@@ -308,7 +307,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() {
+  void shouldNotReadTruncatedEntriesWhenReaderPastTruncateIndex() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -328,7 +327,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() {
+  void shouldNotReadTruncatedEntriesWhenReaderAtTruncateIndex() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -348,7 +347,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() {
+  void shouldNotReadTruncatedEntriesWhenReaderBeforeTruncateIndex() throws CheckedJournalException {
     // given
     final var reader = journal.openReader();
     assertThat(journal.getLastIndex()).isEqualTo(0);
@@ -368,7 +367,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldReturnFirstIndex() {
+  void shouldReturnFirstIndex() throws CheckedJournalException {
     // when
     final long firstIndex = journal.append(recordDataWriter).index();
     journal.append(recordDataWriter);
@@ -378,7 +377,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldReturnLastIndex() {
+  void shouldReturnLastIndex() throws CheckedJournalException {
     // when
     journal.append(recordDataWriter);
     final long lastIndex = journal.append(recordDataWriter).index();
@@ -451,7 +450,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldNotReadDeletedEntries() {
+  void shouldNotReadDeletedEntries() throws CheckedJournalException {
     // given
     final var firstRecord = journal.append(recordDataWriter);
     journal.append(recordDataWriter);
@@ -541,7 +540,7 @@ final class JournalTest {
   }
 
   @Test
-  void shouldUpdateMetastoreAfterFlush() throws FlushException {
+  void shouldUpdateMetastoreAfterFlush() throws CheckedJournalException {
     journal = openJournal();
     journal.append(1, recordDataWriter);
     final var lastWrittenIndex = journal.append(2, recordDataWriter).index();

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentLoaderTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.journal.file;
 
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.util.PosixPathAssert;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,7 +22,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 final class SegmentLoaderTest {
   @Test
   void shouldPreallocateNewFileIfUnusedSegmentAlreadyExists(final @TempDir Path tmpDir)
-      throws IOException {
+      throws IOException, CheckedJournalException {
     // given
     final var segmentSize = 4 * 1024 * 1024;
     final var descriptor =

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalReaderTest.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.record.RecordData;
 import io.camunda.zeebe.journal.record.SBESerializer;
@@ -68,7 +69,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldReadAfterCompact() {
+  void shouldReadAfterCompact() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES_PER_SEGMENT * 5; i++) {
       assertThat(journal.append(i, recordDataWriter).index()).isEqualTo(i);
@@ -86,7 +87,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldSeekToAnyIndexInMultipleSegments() {
+  void shouldSeekToAnyIndexInMultipleSegments() throws CheckedJournalException {
     // given
     long asqn = 1;
 
@@ -105,7 +106,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldSeekToAnyAsqnInMultipleSegments() {
+  void shouldSeekToAnyAsqnInMultipleSegments() throws CheckedJournalException {
     // given
 
     for (int i = 1; i <= ENTRIES_PER_SEGMENT * 2; i++) {
@@ -123,7 +124,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldNotReadWhenAccessingDeletedSegment() {
+  void shouldNotReadWhenAccessingDeletedSegment() throws CheckedJournalException {
     // given
     journal.append(recordDataWriter);
     final var reader = journal.openReader();
@@ -136,7 +137,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldReadAfterReset() {
+  void shouldReadAfterReset() throws CheckedJournalException {
     // given
     journal.append(recordDataWriter);
     final var reader = journal.openReader();
@@ -152,7 +153,7 @@ class SegmentedJournalReaderTest {
   }
 
   @Test
-  void shouldBuiltIndexOnDemandWhileSeek() {
+  void shouldBuiltIndexOnDemandWhileSeek() throws CheckedJournalException {
     // given
     for (int i = 1; i <= ENTRIES_PER_SEGMENT; i++) {
       assertThat(journal.append(i, recordDataWriter).index()).isEqualTo(i);

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentedJournalWriterTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.journal.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.journal.CheckedJournalException.FlushException;
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.io.IOException;
 import java.nio.MappedByteBuffer;
@@ -41,7 +41,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @BeforeEach
-  void beforeEach(final @TempDir Path tempDir) {
+  void beforeEach(final @TempDir Path tempDir) throws CheckedJournalException {
     segments = journalFactory.segmentsManager(tempDir);
     segments.open();
     writer = new SegmentedJournalWriter(segments, flusher, journalFactory.metrics());
@@ -53,7 +53,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldResetLastFlushedIndexOnDeleteAfter() throws FlushException {
+  void shouldResetLastFlushedIndexOnDeleteAfter() throws CheckedJournalException {
     // given
     writer.append(1, journalFactory.entry());
     writer.append(2, journalFactory.entry());
@@ -70,7 +70,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldResetLastFlushedIndexOnReset() throws FlushException {
+  void shouldResetLastFlushedIndexOnReset() throws CheckedJournalException {
     // given
     writer.append(1, journalFactory.entry());
     writer.append(2, journalFactory.entry());
@@ -85,7 +85,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldUpdateDescriptor() {
+  void shouldUpdateDescriptor() throws CheckedJournalException {
     // given
     while (segments.getFirstSegment() == segments.getLastSegment()) {
       writer.append(-1, journalFactory.entry());
@@ -103,7 +103,8 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldResetToLastEntryEvenIfLastPositionInDescriptorIsIncorrect() throws IOException {
+  void shouldResetToLastEntryEvenIfLastPositionInDescriptorIsIncorrect()
+      throws IOException, CheckedJournalException {
     // given
     while (segments.getFirstSegment() == segments.getLastSegment()) {
       writer.append(-1, journalFactory.entry());
@@ -132,7 +133,7 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldInvalidateNextEntryAfterAppend() {
+  void shouldInvalidateNextEntryAfterAppend() throws CheckedJournalException {
     try (final SegmentedJournalReader reader =
         new SegmentedJournalReader(journalFactory.journal(segments), new JournalMetrics("1"))) {
       // when
@@ -146,7 +147,8 @@ final class SegmentedJournalWriterTest {
   }
 
   @Test
-  void shouldInvalidateNextEntryAfterAppendingSerializedRecord(@TempDir final Path tempDir) {
+  void shouldInvalidateNextEntryAfterAppendingSerializedRecord(@TempDir final Path tempDir)
+      throws CheckedJournalException {
     // given
     final var writtenRecord = writer.append(-1, journalFactory.entry());
 

--- a/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
+++ b/zeebe/journal/src/test/java/io/camunda/zeebe/journal/file/SegmentsManagerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.camunda.zeebe.journal.CheckedJournalException;
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import java.io.File;
@@ -40,7 +41,7 @@ class SegmentsManagerTest {
   }
 
   @Test
-  void shouldDeleteFilesMarkedForDeletionsOnLoad() {
+  void shouldDeleteFilesMarkedForDeletionsOnLoad() throws CheckedJournalException {
     // given
     segments = journalFactory.segmentsManager(directory);
     segments.open();
@@ -127,7 +128,7 @@ class SegmentsManagerTest {
   }
 
   @Test
-  void shouldDetectMissingEntryAsCorruption() {
+  void shouldDetectMissingEntryAsCorruption() throws CheckedJournalException {
     // given
     final var journal = openJournal();
     final var indexInFirstSegment = journal.append(1, journalFactory.entry()).index();
@@ -201,7 +202,8 @@ class SegmentsManagerTest {
   }
 
   @Test
-  void shouldHandleCrashOnResetAfterDeletionBeforeSegmentIsCreated() throws IOException {
+  void shouldHandleCrashOnResetAfterDeletionBeforeSegmentIsCreated()
+      throws IOException, CheckedJournalException {
     // given
     try (final var journal = openJournal()) {
       journal.append(1, journalFactory.entry()).index();
@@ -222,7 +224,8 @@ class SegmentsManagerTest {
   }
 
   @Test
-  void shouldHandleCrashOnTruncateAfterDeletionBeforeSegmentIsCreated() {
+  void shouldHandleCrashOnTruncateAfterDeletionBeforeSegmentIsCreated()
+      throws CheckedJournalException {
     // given
     try (final var journal = openJournal()) {
       journal.append(1, journalFactory.entry()).index();
@@ -258,7 +261,7 @@ class SegmentsManagerTest {
   }
 
   @RegressionTest("https://github.com/camunda/camunda/issues/12754")
-  void shouldDeleteSegmentsInReverseOrderOnReset() {
+  void shouldDeleteSegmentsInReverseOrderOnReset() throws CheckedJournalException {
     // given
     final var loader = Mockito.spy(journalFactory.segmentLoader());
     final var metaStore = Mockito.spy(journalFactory.metaStore());

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/exception/Rethrow.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/exception/Rethrow.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util.exception;
+
+public final class Rethrow {
+
+  private Rethrow() {}
+
+  /**
+   * Rethrow an {@link java.lang.Throwable} preserving the stack trace but making it unchecked.
+   *
+   * @param ex to be rethrown and unchecked.
+   */
+  public static <A> A rethrowUnchecked(final Throwable ex) {
+    return Rethrow.<A, RuntimeException>rethrow(ex);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <A, T extends Throwable> A rethrow(final Throwable t) throws T {
+    throw (T) t;
+  }
+}


### PR DESCRIPTION
# Description
Adding a checked exception to the flush of directory implies that all methods of Journal now will throw a checked exception.

- [X] add `throws CheckedJournalException` to all Journal methods
- [ ] add `StraceTest` where we inject faults in `fsync/msync` in followers & leaders

# Related issues
relates #14865 
