### PR TITLE
feat: deployment state tracks whether all deployments are available or not

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -94,6 +94,12 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
+  public void markALlDeploymentsAsStored() {
+    deploymentsRecreatedKey.wrapString(DEPLOYMENTS_RECREATED_KEY);
+    deploymentsRecreatedColumnFamily.insert(deploymentsRecreatedKey, DbNil.INSTANCE);
+  }
+
+  @Override
   public boolean hasPendingDeploymentDistribution(final long deploymentKey) {
     this.deploymentKey.wrapLong(deploymentKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.db.impl.DbCompositeKey;
 import io.camunda.zeebe.db.impl.DbInt;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -28,6 +29,7 @@ import org.slf4j.Logger;
 
 public final class DbDeploymentState implements MutableDeploymentState {
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
+  private static final String DEPLOYMENTS_RECREATED_KEY = "DEPLOYMENTS_RECREATED";
 
   private final DbLong deploymentKey;
   private final DbInt partitionKey;
@@ -36,6 +38,9 @@ public final class DbDeploymentState implements MutableDeploymentState {
 
   private final DeploymentRaw deploymentRaw;
   private final ColumnFamily<DbLong, DeploymentRaw> deploymentRawColumnFamily;
+
+  private final DbString deploymentsRecreatedKey;
+  private final ColumnFamily<DbString, DbNil> deploymentsRecreatedColumnFamily;
 
   public DbDeploymentState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -54,6 +59,11 @@ public final class DbDeploymentState implements MutableDeploymentState {
     deploymentRawColumnFamily =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.DEPLOYMENT_RAW, transactionContext, deploymentKey, deploymentRaw);
+
+    deploymentsRecreatedKey = new DbString();
+    deploymentsRecreatedColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DEFAULT, transactionContext, deploymentsRecreatedKey, DbNil.INSTANCE);
   }
 
   @Override
@@ -103,6 +113,12 @@ public final class DbDeploymentState implements MutableDeploymentState {
     this.deploymentKey.wrapLong(deploymentKey);
     partitionKey.wrapInt(partitionId);
     return pendingDeploymentColumnFamily.exists(deploymentPartitionKey);
+  }
+
+  @Override
+  public boolean hasStoredAllDeployments() {
+    deploymentsRecreatedKey.wrapString(DEPLOYMENTS_RECREATED_KEY);
+    return deploymentsRecreatedColumnFamily.exists(deploymentsRecreatedKey);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DeploymentState.java
@@ -31,6 +31,14 @@ public interface DeploymentState {
   boolean hasPendingDeploymentDistribution(long deploymentKey, int partitionId);
 
   /**
+   * Returns true if all deployments are available to be read via {@link
+   * #getStoredDeploymentRecord(long)}. Since we used to not store deployments, there may be brief
+   * periods where we have not reconstructed all deployments yet. This method can be used to check
+   * if all deployments are available.
+   */
+  boolean hasStoredAllDeployments();
+
+  /**
    * Returns true when there is a deployment record stored for the given deployment key. Similar to
    * {@link #getStoredDeploymentRecord(long)} but doesn't return the record.
    */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDeploymentState.java
@@ -19,4 +19,10 @@ public interface MutableDeploymentState extends DeploymentState {
   void storeDeploymentRecord(long key, DeploymentRecord value);
 
   void removeDeploymentRecord(long key);
+
+  /**
+   * Marks all deployments as stored. After this has been called, {@link
+   * DeploymentState#hasStoredAllDeployments()} returns true.
+   */
+  void markALlDeploymentsAsStored();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -313,6 +313,18 @@ public class DeploymentStateTest {
     assertThat(hasStoredAllDeployments).isFalse();
   }
 
+  @Test
+  public void shouldReturnTrueWhenCheckingIfAllDeploymentsAreStored() {
+    // given
+    deploymentState.markALlDeploymentsAsStored();
+
+    // when
+    final var hasStoredAllDeployments = deploymentState.hasStoredAllDeployments();
+
+    // then
+    assertThat(hasStoredAllDeployments).isTrue();
+  }
+
   private DeploymentRecord createDeployment() {
     final var modelInstance =
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -302,6 +302,17 @@ public class DeploymentStateTest {
     assertThat(nextDeployment).isNull();
   }
 
+  @Test
+  public void shouldInitiallyReturnFalseWhenCheckingIfAllDeploymentsAreStored() {
+    // given
+
+    // when
+    final var hasStoredAllDeployments = deploymentState.hasStoredAllDeployments();
+
+    // then
+    assertThat(hasStoredAllDeployments).isFalse();
+  }
+
   private DeploymentRecord createDeployment() {
     final var modelInstance =
         Bpmn.createExecutableProcess("process").startEvent().endEvent().done();


### PR DESCRIPTION
Uses the `DEFAULT` column family to track whether all deployments have been stored or not. Defaults to `false` because that's the current state. Only allows flipping to `true`, not back to `false` again because that's not an anticipated usecase.

Depends on https://github.com/camunda/camunda/pull/24692
Closes #24708
