### PR TITLE
fix: fetching authorization is cached

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderSelfManagedTest.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/CredentialsProviderSelfManagedTest.java
@@ -15,11 +15,8 @@
  */
 package io.camunda.zeebe.spring.client.config;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.ok;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.auth0.jwt.JWT;
@@ -97,21 +94,17 @@ public class CredentialsProviderSelfManagedTest {
     final CredentialsProvider credentialsProvider = configuration.getCredentialsProvider();
     final Map<String, String> headers = new HashMap<>();
 
-    final String accessToken = ACCESS_TOKEN;
     wm.stubFor(
         post("/auth-server")
             .willReturn(
                 ok().withJsonBody(
                         JsonNodeFactory.instance
                             .objectNode()
-                            .put("access_token", accessToken)
+                            .put("access_token", ACCESS_TOKEN)
                             .put("token_type", "bearer")
                             .put("expires_in", 300))));
 
     credentialsProvider.applyCredentials(headers::put);
-    assertThat(headers).isEqualTo(Map.of("Authorization", "Bearer " + accessToken));
-    wm.verify(
-        postRequestedFor(urlEqualTo("/auth-server"))
-            .withHeader("Content-Type", equalTo("application/x-www-form-urlencoded")));
+    assertThat(headers).isEqualTo(Map.of("Authorization", "Bearer " + ACCESS_TOKEN));
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Due to #24519 the client-id is saved in the cache, instead of retrieving the information from the auth-server. For this reason the endpoint is not called everytime. There is no need to verify if the endpoint is called for this test

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
