### PR TITLE
fix: make role indexing and querying work

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/RoleFilterTransformer.java
@@ -20,7 +20,7 @@ public class RoleFilterTransformer implements FilterTransformer<RoleFilter> {
   public SearchQuery toSearchQuery(final RoleFilter filter) {
 
     return and(
-        filter.roleKey() == null ? null : term("roleKey", filter.roleKey()),
+        filter.roleKey() == null ? null : term("key", filter.roleKey()),
         filter.name() == null ? null : term("name", filter.name()));
   }
 

--- a/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/RoleEntity.java
@@ -11,4 +11,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record RoleEntity(Long roleKey, String name, Set<Long> assignedMemberKeys) {}
+public record RoleEntity(Long key, String name, Set<Long> assignedMemberKeys) {}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/RoleSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/RoleSort.java
@@ -26,7 +26,7 @@ public record RoleSort(List<FieldSorting> orderings) implements SortOption {
       implements ObjectBuilder<RoleSort> {
 
     public Builder roleKey() {
-      currentOrdering = new FieldSorting("roleKey", null);
+      currentOrdering = new FieldSorting("key", null);
       return this;
     }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
@@ -13,7 +13,7 @@ public class RoleIndex extends RoleIndexDescriptor {
   public static final String INDEX_NAME = "role";
   public static final String INDEX_VERSION = "8.7.0";
 
-  public static final String ROLEKEY = "roleKey";
+  public static final String KEY = "key";
   public static final String NAME = "name";
   public static final String ASSIGNEDMEMBERKEYS = "assignedMemberKeys";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/RoleEntity.java
@@ -16,12 +16,12 @@ public class RoleEntity extends AbstractExporterEntity<RoleEntity> {
   private String name;
   private Set<Long> assignedMemberKeys;
 
-  public Long getRoleKey() {
+  public Long getKey() {
     return roleKey;
   }
 
-  public RoleEntity setRoleKey(final Long roleKey) {
-    this.roleKey = roleKey;
+  public RoleEntity setKey(final Long key) {
+    roleKey = key;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-role.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-role.json
@@ -5,7 +5,7 @@
       "id": {
         "type": "keyword"
       },
-      "roleKey": {
+      "key": {
         "type": "long"
       },
       "name": {

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-role.json
@@ -5,7 +5,7 @@
       "id": {
         "type": "keyword"
       },
-      "roleKey": {
+      "key": {
         "type": "long"
       },
       "name": {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -16,6 +16,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.JOB;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
@@ -209,6 +210,7 @@ public class CamundaExporter implements Exporter {
             DECISION,
             DECISION_REQUIREMENTS,
             PROCESS_INSTANCE,
+            ROLE,
             VARIABLE,
             JOB,
             INCIDENT,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/RoleCreateUpdateHandler.java
@@ -53,7 +53,7 @@ public class RoleCreateUpdateHandler implements ExportHandler<RoleEntity, RoleRe
   @Override
   public void updateEntity(final Record<RoleRecordValue> record, final RoleEntity entity) {
     final RoleRecordValue value = record.getValue();
-    entity.setRoleKey(value.getRoleKey()).setName(value.getName());
+    entity.setKey(value.getRoleKey()).setName(value.getName());
   }
 
   @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3953,7 +3953,7 @@ components:
       description: Role search response item.
       type: object
       properties:
-        roleKey:
+        key:
           type: integer
           description: The role key.
           format: int64

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -234,9 +234,12 @@ public final class SearchQueryResponseMapper {
 
   private static RoleItem toRole(final RoleEntity roleEntity) {
     return new RoleItem()
-        .roleKey(roleEntity.roleKey())
+        .key(roleEntity.key())
         .name(roleEntity.name())
-        .assignedMemberKeys(roleEntity.assignedMemberKeys().stream().sorted().toList());
+        .assignedMemberKeys(
+            roleEntity.assignedMemberKeys() == null
+                ? null
+                : roleEntity.assignedMemberKeys().stream().sorted().toList());
   }
 
   private static List<DecisionDefinitionItem> toDecisionDefinitions(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -44,12 +44,12 @@ public class RoleQueryControllerTest extends RestControllerTest {
   void getRoleShouldReturnOk() {
     // given
     final var role = new RoleEntity(100L, "Role Name", Set.of());
-    when(roleServices.getRole(role.roleKey())).thenReturn(role);
+    when(roleServices.getRole(role.key())).thenReturn(role);
 
     // when
     webClient
         .get()
-        .uri("%s/%s".formatted(ROLE_BASE_URL, role.roleKey()))
+        .uri("%s/%s".formatted(ROLE_BASE_URL, role.key()))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -59,11 +59,11 @@ public class RoleQueryControllerTest extends RestControllerTest {
             """
             {
               "name": "Role Name",
-              "roleKey": 100
+              "key": 100
             }""");
 
     // then
-    verify(roleServices, times(1)).getRole(role.roleKey());
+    verify(roleServices, times(1)).getRole(role.key());
   }
 
   @Test
@@ -130,17 +130,17 @@ public class RoleQueryControllerTest extends RestControllerTest {
           {
              "items": [
                {
-                 "roleKey": 100,
+                 "key": 100,
                  "name": "Role 1",
                  "assignedMemberKeys": []
                },
                {
-                 "roleKey": 200,
+                 "key": 200,
                  "name": "Role 2",
                  "assignedMemberKeys": [1, 2]
                },
                {
-                 "roleKey": 300,
+                 "key": 300,
                  "name": "Role 12",
                  "assignedMemberKeys": [3]
                }


### PR DESCRIPTION
We must use the standard key property name in the role index mapping to make the default sorting in FieldSortingTransformer work.

Also, we shouldn't crash when assignedMemberKeys is null.
