### PR TITLE
Add job result corrections to protocol

### DIFF
--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
@@ -200,7 +200,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   }
 
   @Override
-  public JobResultValueImpl getResult() {
+  public JobResultValue getResult() {
     // Not used by importer, dummy implementation for compiler
     return null;
   }
@@ -314,13 +314,5 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + ", changedAttributes="
         + changedAttributes
         + '}';
-  }
-
-  public static class JobResultValueImpl implements JobResultValue {
-    @Override
-    public boolean isDenied() {
-      // Not used by importer, dummy implementation for compiler
-      return false;
-    }
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/JobRecordValueImpl.java
@@ -200,7 +200,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   }
 
   @Override
-  public JobResultValueImpl getResult() {
+  public JobResultValue getResult() {
     // Not used by importer, dummy implementation for compiler
     return null;
   }
@@ -314,13 +314,5 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + ", changedAttributes="
         + changedAttributes
         + '}';
-  }
-
-  public static class JobResultValueImpl implements JobResultValue {
-    @Override
-    public boolean isDenied() {
-      // Not used by importer, dummy implementation for compiler
-      return false;
-    }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -105,6 +105,31 @@
                   "properties": {
                     "denied": {
                       "type": "boolean"
+                    },
+                    "correctedAttributes": {
+                      "type": "text"
+                    },
+                    "corrections": {
+                      "properties": {
+                        "assignee": {
+                          "type": "keyword"
+                        },
+                        "dueDate": {
+                          "type": "keyword"
+                        },
+                        "followUpDate": {
+                          "type": "keyword"
+                        },
+                        "candidateGroups": {
+                          "type": "text"
+                        },
+                        "candidateUsers": {
+                          "type": "text"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -86,6 +86,31 @@
               "properties": {
                 "denied": {
                   "type": "boolean"
+                },
+                "correctedAttributes": {
+                  "type": "text"
+                },
+                "corrections": {
+                  "properties": {
+                    "assignee": {
+                      "type": "keyword"
+                    },
+                    "dueDate": {
+                      "type": "keyword"
+                    },
+                    "followUpDate": {
+                      "type": "keyword"
+                    },
+                    "candidateGroups": {
+                      "type": "text"
+                    },
+                    "candidateUsers": {
+                      "type": "text"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -105,6 +105,31 @@
                   "properties": {
                     "denied": {
                       "type": "boolean"
+                    },
+                    "correctedAttributes": {
+                      "type": "text"
+                    },
+                    "corrections": {
+                      "properties": {
+                        "assignee": {
+                          "type": "keyword"
+                        },
+                        "dueDate": {
+                          "type": "keyword"
+                        },
+                        "followUpDate": {
+                          "type": "keyword"
+                        },
+                        "candidateGroups": {
+                          "type": "text"
+                        },
+                        "candidateUsers": {
+                          "type": "text"
+                        },
+                        "priority": {
+                          "type": "integer"
+                        }
+                      }
                     }
                   }
                 }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -86,6 +86,31 @@
               "properties": {
                 "denied": {
                   "type": "boolean"
+                },
+                "correctedAttributes": {
+                  "type": "text"
+                },
+                "corrections": {
+                  "properties": {
+                    "assignee": {
+                      "type": "keyword"
+                    },
+                    "dueDate": {
+                      "type": "keyword"
+                    },
+                    "followUpDate": {
+                      "type": "keyword"
+                    },
+                    "candidateGroups": {
+                      "type": "text"
+                    },
+                    "candidateUsers": {
+                      "type": "text"
+                    },
+                    "priority": {
+                      "type": "integer"
+                    }
+                  }
                 }
               }
             }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobCorrections.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.job;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
@@ -18,6 +20,12 @@ import java.util.List;
 import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
 
+@JsonIgnoreProperties({
+    /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+    "empty",
+    "encodedLength",
+    "length"
+})
 public final class JobCorrections extends UnpackedObject implements JobCorrectionsValue {
 
   private final StringProperty assigneeProp = new StringProperty("assignee", "");
@@ -48,6 +56,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     setPriority(other.getPriority());
   }
 
+  @JsonIgnore
   public DirectBuffer getAssigneeBuffer() {
     return assigneeProp.getValue();
   }
@@ -125,10 +134,12 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     return this;
   }
 
+  @JsonIgnore
   public DirectBuffer getDueDateBuffer() {
     return dueDateProp.getValue();
   }
 
+  @JsonIgnore
   public DirectBuffer getFollowUpDateBuffer() {
     return followUpDateProp.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobCorrections.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.job;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobCorrectionsValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.agrona.DirectBuffer;
+
+public final class JobCorrections extends UnpackedObject implements JobCorrectionsValue {
+
+  private final StringProperty assigneeProp = new StringProperty("assignee", "");
+  private final StringProperty dueDateProp = new StringProperty("dueDate", "");
+  private final StringProperty followUpDateProp = new StringProperty("followUpDate", "");
+  private final ArrayProperty<StringValue> candidateUsersProp =
+      new ArrayProperty<>("candidateUsers", StringValue::new);
+  private final ArrayProperty<StringValue> candidateGroupsProp =
+      new ArrayProperty<>("candidateGroups", StringValue::new);
+  private final IntegerProperty priorityProp = new IntegerProperty("priority", -1);
+
+  public JobCorrections() {
+    super(6);
+    declareProperty(assigneeProp)
+        .declareProperty(dueDateProp)
+        .declareProperty(followUpDateProp)
+        .declareProperty(candidateUsersProp)
+        .declareProperty(candidateGroupsProp)
+        .declareProperty(priorityProp);
+  }
+
+  public void wrap(final JobCorrections other) {
+    setAssignee(other.getAssignee());
+    setDueDate(other.getDueDate());
+    setFollowUpDate(other.getFollowUpDate());
+    setCandidateUsers(other.getCandidateUsers());
+    setCandidateGroups(other.getCandidateGroups());
+    setPriority(other.getPriority());
+  }
+
+  public DirectBuffer getAssigneeBuffer() {
+    return assigneeProp.getValue();
+  }
+
+  @Override
+  public String getAssignee() {
+    final var buffer = getAssigneeBuffer();
+    return BufferUtil.bufferAsString(buffer);
+  }
+
+  public JobCorrections setAssignee(final String assignee) {
+    assigneeProp.setValue(assignee);
+    return this;
+  }
+
+  @Override
+  public String getDueDate() {
+    final var buffer = getDueDateBuffer();
+    return BufferUtil.bufferAsString(buffer);
+  }
+
+  public JobCorrections setDueDate(final String dueDate) {
+    dueDateProp.setValue(dueDate);
+    return this;
+  }
+
+  @Override
+  public String getFollowUpDate() {
+    final var buffer = getFollowUpDateBuffer();
+    return BufferUtil.bufferAsString(buffer);
+  }
+
+  public JobCorrections setFollowUpDate(final String followUpDate) {
+    followUpDateProp.setValue(followUpDate);
+    return this;
+  }
+
+  @Override
+  public List<String> getCandidateGroups() {
+    return StreamSupport.stream(candidateGroupsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .toList();
+  }
+
+  public JobCorrections setCandidateGroups(final List<String> candidateGroups) {
+    candidateGroupsProp.reset();
+    candidateGroups.forEach(
+        candidateGroup -> candidateGroupsProp.add().wrap(BufferUtil.wrapString(candidateGroup)));
+    return this;
+  }
+
+  @Override
+  public List<String> getCandidateUsers() {
+    return StreamSupport.stream(candidateUsersProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .toList();
+  }
+
+  public JobCorrections setCandidateUsers(final List<String> candidateUsers) {
+    candidateUsersProp.reset();
+    candidateUsers.forEach(
+        candidateUser -> candidateUsersProp.add().wrap(BufferUtil.wrapString(candidateUser)));
+    return this;
+  }
+
+  @Override
+  public int getPriority() {
+    return priorityProp.getValue();
+  }
+
+  public JobCorrections setPriority(final int priority) {
+    priorityProp.setValue(priority);
+    return this;
+  }
+
+  public DirectBuffer getDueDateBuffer() {
+    return dueDateProp.getValue();
+  }
+
+  public DirectBuffer getFollowUpDateBuffer() {
+    return followUpDateProp.getValue();
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -29,8 +29,8 @@ public class JobResult extends UnpackedObject implements JobResultValue {
   private final BooleanProperty deniedProp = new BooleanProperty("denied", false);
   private final ArrayProperty<StringValue> correctedAttributesProp =
       new ArrayProperty<>("correctedAttributes", StringValue::new);
-  private final ObjectProperty<JobCorrections> correctionsProp =
-      new ObjectProperty<>("corrections", new JobCorrections());
+  private final ObjectProperty<JobResultCorrections> correctionsProp =
+      new ObjectProperty<>("corrections", new JobResultCorrections());
 
   public JobResult() {
     super(3);
@@ -72,11 +72,11 @@ public class JobResult extends UnpackedObject implements JobResultValue {
   }
 
   @Override
-  public JobCorrections getCorrections() {
+  public JobResultCorrections getCorrections() {
     return correctionsProp.getValue();
   }
 
-  public JobResult setCorrections(final JobCorrections corrections) {
+  public JobResult setCorrections(final JobResultCorrections corrections) {
     correctionsProp.getValue().wrap(corrections);
     return this;
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResult.java
@@ -9,8 +9,14 @@ package io.camunda.zeebe.protocol.impl.record.value.job;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultValue;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.StreamSupport;
 
 @JsonIgnoreProperties({
   /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
@@ -21,15 +27,23 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultValue;
 public class JobResult extends UnpackedObject implements JobResultValue {
 
   private final BooleanProperty deniedProp = new BooleanProperty("denied", false);
+  private final ArrayProperty<StringValue> correctedAttributesProp =
+      new ArrayProperty<>("correctedAttributes", StringValue::new);
+  private final ObjectProperty<JobCorrections> correctionsProp =
+      new ObjectProperty<>("corrections", new JobCorrections());
 
   public JobResult() {
-    super(1);
-    declareProperty(deniedProp);
+    super(3);
+    declareProperty(deniedProp)
+        .declareProperty(correctionsProp)
+        .declareProperty(correctedAttributesProp);
   }
 
   /** Sets all properties to current instance from provided user task job data */
   public void wrap(final JobResult result) {
     deniedProp.setValue(result.isDenied());
+    setCorrectedAttributes(result.getCorrectedAttributes());
+    setCorrections(result.getCorrections());
   }
 
   @Override
@@ -39,6 +53,31 @@ public class JobResult extends UnpackedObject implements JobResultValue {
 
   public JobResult setDenied(final boolean denied) {
     deniedProp.setValue(denied);
+    return this;
+  }
+
+  @Override
+  public List<String> getCorrectedAttributes() {
+    return StreamSupport.stream(correctedAttributesProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
+        .toList();
+  }
+
+  public JobResult setCorrectedAttributes(final List<String> correctedAttributes) {
+    correctedAttributesProp.reset();
+    correctedAttributes.forEach(
+        attribute -> correctedAttributesProp.add().wrap(BufferUtil.wrapString(attribute)));
+    return this;
+  }
+
+  @Override
+  public JobCorrections getCorrections() {
+    return correctionsProp.getValue();
+  }
+
+  public JobResult setCorrections(final JobCorrections corrections) {
+    correctionsProp.getValue().wrap(corrections);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
@@ -14,19 +14,20 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
-import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobCorrectionsValue;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue.JobResultCorrectionsValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
 
 @JsonIgnoreProperties({
-    /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
-    "empty",
-    "encodedLength",
-    "length"
+  /* These fields are inherited from ObjectValue; there have no purpose in exported JSON records*/
+  "empty",
+  "encodedLength",
+  "length"
 })
-public final class JobCorrections extends UnpackedObject implements JobCorrectionsValue {
+public final class JobResultCorrections extends UnpackedObject
+    implements JobResultCorrectionsValue {
 
   private final StringProperty assigneeProp = new StringProperty("assignee", "");
   private final StringProperty dueDateProp = new StringProperty("dueDate", "");
@@ -37,7 +38,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
       new ArrayProperty<>("candidateGroups", StringValue::new);
   private final IntegerProperty priorityProp = new IntegerProperty("priority", -1);
 
-  public JobCorrections() {
+  public JobResultCorrections() {
     super(6);
     declareProperty(assigneeProp)
         .declareProperty(dueDateProp)
@@ -47,7 +48,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
         .declareProperty(priorityProp);
   }
 
-  public void wrap(final JobCorrections other) {
+  public void wrap(final JobResultCorrections other) {
     setAssignee(other.getAssignee());
     setDueDate(other.getDueDate());
     setFollowUpDate(other.getFollowUpDate());
@@ -67,7 +68,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     return BufferUtil.bufferAsString(buffer);
   }
 
-  public JobCorrections setAssignee(final String assignee) {
+  public JobResultCorrections setAssignee(final String assignee) {
     assigneeProp.setValue(assignee);
     return this;
   }
@@ -78,7 +79,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     return BufferUtil.bufferAsString(buffer);
   }
 
-  public JobCorrections setDueDate(final String dueDate) {
+  public JobResultCorrections setDueDate(final String dueDate) {
     dueDateProp.setValue(dueDate);
     return this;
   }
@@ -89,7 +90,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     return BufferUtil.bufferAsString(buffer);
   }
 
-  public JobCorrections setFollowUpDate(final String followUpDate) {
+  public JobResultCorrections setFollowUpDate(final String followUpDate) {
     followUpDateProp.setValue(followUpDate);
     return this;
   }
@@ -102,7 +103,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
         .toList();
   }
 
-  public JobCorrections setCandidateGroups(final List<String> candidateGroups) {
+  public JobResultCorrections setCandidateGroups(final List<String> candidateGroups) {
     candidateGroupsProp.reset();
     candidateGroups.forEach(
         candidateGroup -> candidateGroupsProp.add().wrap(BufferUtil.wrapString(candidateGroup)));
@@ -117,7 +118,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
         .toList();
   }
 
-  public JobCorrections setCandidateUsers(final List<String> candidateUsers) {
+  public JobResultCorrections setCandidateUsers(final List<String> candidateUsers) {
     candidateUsersProp.reset();
     candidateUsers.forEach(
         candidateUser -> candidateUsersProp.add().wrap(BufferUtil.wrapString(candidateUser)));
@@ -129,7 +130,7 @@ public final class JobCorrections extends UnpackedObject implements JobCorrectio
     return priorityProp.getValue();
   }
 
-  public JobCorrections setPriority(final int priority) {
+  public JobResultCorrections setPriority(final int priority) {
     priorityProp.setValue(priority);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
@@ -690,7 +691,25 @@ final class JsonSerializableToJsonTest {
               final String activityId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
-              final JobResult result = new JobResult().setDenied(true);
+              final JobResult result =
+                  new JobResult()
+                      .setDenied(true)
+                      .setCorrections(
+                          new JobCorrections()
+                              .setAssignee("frodo")
+                              .setDueDate("today")
+                              .setFollowUpDate("tomorrow")
+                              .setCandidateGroups(List.of("fellowship", "eagles"))
+                              .setCandidateUsers(List.of("frodo", "sam", "gollum"))
+                              .setPriority(1))
+                      .setCorrectedAttributes(
+                          List.of(
+                              "assignee",
+                              "dueDate",
+                              "followUpDate",
+                              "candidateGroups",
+                              "candidateUsers",
+                              "priority"));
 
               jobRecord
                   .setWorker(wrapString(worker))
@@ -748,7 +767,23 @@ final class JsonSerializableToJsonTest {
               "tenantId": "<default>",
               "changedAttributes": ["bar", "foo"],
               "result": {
-                "denied": true
+                "denied": true,
+                "correctedAttributes": [
+                  "assignee",
+                  "dueDate",
+                  "followUpDate",
+                  "candidateGroups",
+                  "candidateUsers",
+                  "priority"
+                ],
+                "corrections": {
+                  "assignee": "frodo",
+                  "dueDate": "today",
+                  "followUpDate": "tomorrow",
+                  "candidateGroups": ["fellowship", "eagles"],
+                  "candidateUsers": ["frodo", "sam", "gollum"],
+                  "priority": 1
+                }
               }
             }
           ],
@@ -800,7 +835,25 @@ final class JsonSerializableToJsonTest {
               final String elementId = "activity";
               final int activityInstanceKey = 123;
               final Set<String> changedAttributes = Set.of("bar", "foo");
-              final JobResult result = new JobResult().setDenied(true);
+              final JobResult result =
+                  new JobResult()
+                      .setDenied(true)
+                      .setCorrections(
+                          new JobCorrections()
+                              .setAssignee("frodo")
+                              .setDueDate("today")
+                              .setFollowUpDate("tomorrow")
+                              .setCandidateGroups(List.of("fellowship", "eagles"))
+                              .setCandidateUsers(List.of("frodo", "sam", "gollum"))
+                              .setPriority(1))
+                      .setCorrectedAttributes(
+                          List.of(
+                              "assignee",
+                              "dueDate",
+                              "followUpDate",
+                              "candidateGroups",
+                              "candidateUsers",
+                              "priority"));
 
               final Map<String, String> customHeaders =
                   Collections.singletonMap("workerVersion", "42");
@@ -857,8 +910,24 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": ["bar", "foo"],
           "result": {
-            "denied": true
-           }
+            "denied": true,
+            "correctedAttributes": [
+              "assignee",
+              "dueDate",
+              "followUpDate",
+              "candidateGroups",
+              "candidateUsers",
+              "priority"
+            ],
+            "corrections": {
+              "assignee": "frodo",
+              "dueDate": "today",
+              "followUpDate": "tomorrow",
+              "candidateGroups": ["fellowship", "eagles"],
+              "candidateUsers": ["frodo", "sam", "gollum"],
+              "priority": 1
+            }
+          }
         }
         """
       },
@@ -893,7 +962,16 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": [],
           "result": {
-            "denied": false
+            "denied": false,
+            "correctedAttributes": [],
+            "corrections": {
+              "assignee": "",
+              "dueDate": "",
+              "followUpDate": "",
+              "candidateGroups": [],
+              "candidateUsers": [],
+              "priority": -1
+            }
           }
         }
         """
@@ -934,7 +1012,16 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "changedAttributes": [],
           "result": {
-            "denied": false
+            "denied": false,
+            "correctedAttributes": [],
+            "corrections": {
+              "assignee": "",
+              "dueDate": "",
+              "followUpDate": "",
+              "candidateGroups": [],
+              "candidateUsers": [],
+              "priority": -1
+            }
           }
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -37,9 +37,9 @@ import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
-import io.camunda.zeebe.protocol.impl.record.value.job.JobCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobResultCorrections;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
@@ -695,7 +695,7 @@ final class JsonSerializableToJsonTest {
                   new JobResult()
                       .setDenied(true)
                       .setCorrections(
-                          new JobCorrections()
+                          new JobResultCorrections()
                               .setAssignee("frodo")
                               .setDueDate("today")
                               .setFollowUpDate("tomorrow")
@@ -839,7 +839,7 @@ final class JsonSerializableToJsonTest {
                   new JobResult()
                       .setDenied(true)
                       .setCorrections(
-                          new JobCorrections()
+                          new JobResultCorrections()
                               .setAssignee("frodo")
                               .setDueDate("today")
                               .setFollowUpDate("tomorrow")

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -141,13 +141,13 @@ public interface JobRecordValue
     boolean isDenied();
 
     /**
-     * May only contain the attribute names of {@link JobCorrectionsValue} as entries. Those
+     * May only contain the attribute names of {@link JobResultCorrectionsValue} as entries. Those
      * attributes that are contained in this list are the ones that were corrected by the worker.
      * Others are considered not corrected.
      *
      * @return the list of attributes that the worker corrected when handling the job
      * @apiNote only attributes in this list should be considered when accessing {@link
-     *     JobCorrectionsValue} as unset fields receive default values
+     *     JobResultCorrectionsValue} as unset fields receive default values
      */
     List<String> getCorrectedAttributes();
 
@@ -156,7 +156,7 @@ public interface JobRecordValue
      * @apiNote contains defaults for fields that were not set, use {@link
      *     JobResultValue#getCorrectedAttributes()} to determine which fields are set
      */
-    JobCorrectionsValue getCorrections();
+    JobResultCorrectionsValue getCorrections();
   }
 
   /**
@@ -166,8 +166,8 @@ public interface JobRecordValue
    *     JobResultValue#getCorrectedAttributes()} to determine which fields are set.
    */
   @Value.Immutable
-  @ImmutableProtocol(builder = ImmutableJobCorrectionsValue.Builder.class)
-  interface JobCorrectionsValue {
+  @ImmutableProtocol(builder = ImmutableJobResultCorrectionsValue.Builder.class)
+  interface JobResultCorrectionsValue {
 
     /**
      * @return the corrected assignee value

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -139,6 +139,24 @@ public interface JobRecordValue
      * @return true if the operation was rejected by Task Listener
      */
     boolean isDenied();
+
+    /**
+     * May only contain the attribute names of {@link JobCorrectionsValue} as entries. Those
+     * attributes that are contained in this list are the ones that were corrected by the worker.
+     * Others are considered not corrected.
+     *
+     * @return the list of attributes that the worker corrected when handling the job
+     * @apiNote only attributes in this list should be considered when accessing {@link
+     *     JobCorrectionsValue} as unset fields receive default values
+     */
+    List<String> getCorrectedAttributes();
+
+    /**
+     * @return the corrections the worker made as a result of completing the job
+     * @apiNote contains defaults for fields that were not set, use {@link
+     *     JobResultValue#getCorrectedAttributes()} to determine which fields are set
+     */
+    JobCorrectionsValue getCorrections();
   }
 
   /**

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.immutables.value.Value;
@@ -138,5 +139,46 @@ public interface JobRecordValue
      * @return true if the operation was rejected by Task Listener
      */
     boolean isDenied();
+  }
+
+  /**
+   * Represents the corrections that can be part of a {@link JobResultValue}.
+   *
+   * @apiNote the fields are all optional, but receive a default value if not set. Use {@link
+   *     JobResultValue#getCorrectedAttributes()} to determine which fields are set.
+   */
+  @Value.Immutable
+  @ImmutableProtocol(builder = ImmutableJobCorrectionsValue.Builder.class)
+  interface JobCorrectionsValue {
+
+    /**
+     * @return the corrected assignee value
+     */
+    String getAssignee();
+
+    /**
+     * @return the corrected due date value
+     */
+    String getDueDate();
+
+    /**
+     * @return the corrected follow-up date value
+     */
+    String getFollowUpDate();
+
+    /**
+     * @return the corrected candidate users
+     */
+    List<String> getCandidateGroups();
+
+    /**
+     * @return the corrected candidate groups
+     */
+    List<String> getCandidateUsers();
+
+    /**
+     * @return the corrected priority
+     */
+    int getPriority();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduces two new properties to `JobResult`:
- `correctedAttributes`: a list of strings referencing those properties of `corrections` that actually changed
- `corrections`: an object that can contains corrections, but may contain defaults. You should always refer to the `correctedAttributes` to know what was actually corrected.

This split was needed because we don't support writing `null` into values in our msgpack implementation.

Tests have been expanded to cover all cases.

An example of the new job result is:
```json
"result": {
  "denied": false,
  "correctedAttributes": [
    "assignee",
    "dueDate",
    "followUpDate",
    "candidateGroups",
    "candidateUsers",
    "priority"
  ],
  "corrections": {
    "assignee": "frodo",
    "dueDate": "today",
    "followUpDate": "tomorrow",
    "candidateGroups": ["fellowship", "eagles"],
    "candidateUsers": ["frodo", "sam", "gollum"],
    "priority": 1
  }
}
```

## Related issues

closes #24712 
