### PR TITLE
refactor: remove default implementation of Scheduler#schedule 

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/cluster/impl/RaftClusterContextTest.java
@@ -25,6 +25,7 @@ import io.atomix.utils.concurrent.ThreadContext;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -488,6 +489,12 @@ final class RaftClusterContextTest {
   private RaftContext raftWithStoredConfiguration(final Configuration configuration) {
     final var threadContext =
         new ThreadContext() {
+          @Override
+          public Scheduled schedule(
+              final long delay, final TimeUnit timeUnit, final Runnable callback) {
+            throw new UnsupportedOperationException();
+          }
+
           @Override
           public Scheduled schedule(
               final Duration initialDelay, final Duration interval, final Runnable callback) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/storage/log/DelayedFlusherTest.java
@@ -17,6 +17,7 @@ import java.io.UncheckedIOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -44,9 +45,7 @@ final class DelayedFlusherTest {
     assertThat(scheduler.operations).hasSize(1);
 
     final var scheduled = scheduler.operations.get(0);
-    assertThat(scheduled)
-        .extracting(t -> t.initialDelay, t -> t.interval)
-        .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
+    assertThat(scheduled.delay).isEqualTo(Duration.ofSeconds(5));
     Mockito.verify(journal, Mockito.never()).flush();
   }
 
@@ -79,9 +78,7 @@ final class DelayedFlusherTest {
     // then
     assertThat(scheduler.operations).hasSize(1);
     final var scheduled = scheduler.operations.get(0);
-    assertThat(scheduled)
-        .extracting(t -> t.initialDelay, t -> t.interval)
-        .containsExactly(Duration.ZERO, Duration.ofSeconds(5));
+    assertThat(scheduled.delay).isEqualTo(Duration.ofSeconds(5));
   }
 
   @Test
@@ -148,16 +145,13 @@ final class DelayedFlusherTest {
   }
 
   private static final class TestScheduled implements Scheduled {
-    private final Duration initialDelay;
-    private final Duration interval;
+    private final Duration delay;
     private final Runnable operation;
 
     private boolean cancelled;
 
-    private TestScheduled(
-        final Duration initialDelay, final Duration interval, final Runnable operation) {
-      this.initialDelay = initialDelay;
-      this.interval = interval;
+    private TestScheduled(final Duration delay, final Runnable operation) {
+      this.delay = delay;
       this.operation = operation;
     }
 
@@ -176,11 +170,17 @@ final class DelayedFlusherTest {
     private final List<TestScheduled> operations = new ArrayList<>();
 
     @Override
-    public Scheduled schedule(
-        final Duration initialDelay, final Duration interval, final Runnable callback) {
-      final var scheduled = new TestScheduled(initialDelay, interval, callback);
+    public Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable callback) {
+      final var scheduled =
+          new TestScheduled(Duration.of(delay, timeUnit.toChronoUnit()), callback);
       operations.add(scheduled);
       return scheduled;
+    }
+
+    @Override
+    public Scheduled schedule(
+        final Duration initialDelay, final Duration interval, final Runnable callback) {
+      throw new UnsupportedOperationException("fixed rate scheduling unsupported");
     }
 
     private void runNext() {

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/concurrent/Scheduler.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /** Scheduler. */
-@FunctionalInterface
 public interface Scheduler extends CloseableSilently {
 
   /**
@@ -32,9 +31,7 @@ public interface Scheduler extends CloseableSilently {
    * @param callback the callback to run
    * @return the scheduled callback
    */
-  default Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable callback) {
-    return schedule(Duration.ofMillis(timeUnit.toMillis(delay)), callback);
-  }
+  Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable callback);
 
   /**
    * Schedules a runnable after a delay.
@@ -44,7 +41,7 @@ public interface Scheduler extends CloseableSilently {
    * @return the scheduled callback
    */
   default Scheduled schedule(final Duration delay, final Runnable callback) {
-    return schedule(Duration.ZERO, delay, callback);
+    return schedule(delay.toMillis(), TimeUnit.MILLISECONDS, callback);
   }
 
   /**

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -134,10 +134,15 @@ public class SingleThreadContext implements ThreadContext {
   }
 
   @Override
-  public Scheduled schedule(final Duration delay, final Runnable runnable) {
+  public Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable runnable) {
     final ScheduledFuture<?> future =
-        executor.schedule(new WrappedRunnable(runnable), delay.toMillis(), TimeUnit.MILLISECONDS);
+        executor.schedule(new WrappedRunnable(runnable), delay, timeUnit);
     return new ScheduledFutureImpl<>(future);
+  }
+
+  @Override
+  public Scheduled schedule(final Duration delay, final Runnable runnable) {
+    return schedule(delay.toMillis(), TimeUnit.MILLISECONDS, runnable);
   }
 
   @Override

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/utils/InlineThreadContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/utils/InlineThreadContext.java
@@ -10,11 +10,17 @@ package io.camunda.zeebe.broker.utils;
 import io.atomix.utils.concurrent.Scheduled;
 import io.atomix.utils.concurrent.ThreadContext;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 public class InlineThreadContext implements ThreadContext {
 
   @Override
   public void checkThread() {}
+
+  @Override
+  public Scheduled schedule(final long delay, final TimeUnit timeUnit, final Runnable callback) {
+    throw new UnsupportedOperationException("schedule");
+  }
 
   @Override
   public Scheduled schedule(


### PR DESCRIPTION
## Description
Default implementation of `schedule(Duration, Runnable)` (which schedule a runnable once) would call `schedule(Duration, Duration, Runnable)` (which schedules a runnable at a fixed rate).
In production files the only implementation of the interface is `SingleThreadContext` which overrides the default implementation of the interface, so there is no real behaviour change, but it still is a small cleanup in case this interface is implemented by other classes.
