### PR TITLE
fix: group and role name should be unique

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupUpdateProcessor.java
@@ -80,7 +80,7 @@ public class GroupUpdateProcessor implements DistributedTypedRecordProcessor<Gro
       return;
     }
 
-    if (updatedGroupName.equals(persistedRecord.get().getName())) {
+    if (groupState.getGroupKeyByName(updatedGroupName).isPresent()) {
       final var errorMessage =
           "Expected to update group with name '%s', but a group with this name already exists."
               .formatted(updatedGroupName);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleUpdateProcessor.java
@@ -79,7 +79,7 @@ public class RoleUpdateProcessor implements DistributedTypedRecordProcessor<Role
       return;
     }
 
-    if (updatedName.equals(persistedRecord.get().getName())) {
+    if (roleState.getRoleKeyByName(updatedName).isPresent()) {
       final var errorMessage =
           "Expected to update role with name '%s', but a role with this name already exists."
               .formatted(updatedName);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RoleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RoleTest.java
@@ -97,16 +97,18 @@ public class RoleTest {
     // given
     final var name = UUID.randomUUID().toString();
     final var roleKey = engine.role().newRole(name).create().getKey();
+    final var anotherName = UUID.randomUUID().toString();
+    engine.role().newRole(anotherName).create();
 
     // when
     final var notPresentUpdateRecord =
-        engine.role().updateRole(roleKey).withName(name).expectRejection().update();
+        engine.role().updateRole(roleKey).withName(anotherName).expectRejection().update();
 
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             "Expected to update role with name '%s', but a role with this name already exists."
-                .formatted(name));
+                .formatted(anotherName));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/GroupTest.java
@@ -86,22 +86,23 @@ public class GroupTest {
   }
 
   @Test
-  public void shouldRejectUpdatedIfSameGroupExists() {
+  public void shouldRejectUpdatedIfSameNameGroupExists() {
     // given
     final var groupName = "yolo";
     final var groupKey = engine.group().newGroup(groupName).create().getKey();
+    final var anotherGroupName = "yolo2";
+    engine.group().newGroup(anotherGroupName).create();
 
     // when
-    final var updatedName = "yolo";
     final var updatedGroupRecord =
-        engine.group().updateGroup(groupKey).withName(updatedName).expectRejection().update();
+        engine.group().updateGroup(groupKey).withName(anotherGroupName).expectRejection().update();
 
     // then
     assertThat(updatedGroupRecord)
         .hasRejectionType(RejectionType.ALREADY_EXISTS)
         .hasRejectionReason(
             "Expected to update group with name '%s', but a group with this name already exists."
-                .formatted(updatedName));
+                .formatted(anotherGroupName));
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When trying to update a group/role we should verify that the provided updated name is unique in the state, if there is another group/role with the same name a rejection is thrown

## Related issues

related to https://github.com/camunda/camunda/issues/23546
