### PR TITLE
refactor: adjust decision instance search domain classes

### DIFF
--- a/search/search-client-query-transformer/pom.xml
+++ b/search/search-client-query-transformer/pom.xml
@@ -31,6 +31,10 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapps-schema</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -127,7 +127,8 @@ public class SearchClients
             transformers,
             new DocumentAuthorizationQueryStrategy(this),
             securityContext);
-    return executor.search(filter, DecisionInstanceEntity.class);
+    return executor.search(
+        filter, io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformer.java
@@ -10,4 +10,8 @@ package io.camunda.search.clients.transformers;
 public interface ServiceTransformer<T, R> {
 
   R apply(final T value);
+
+  static <T> ServiceTransformer<T, T> identity() {
+    return t -> t;
+  }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -9,6 +9,7 @@ package io.camunda.search.clients.transformers;
 
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.transformers.entity.DecisionInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ComparableValueFilterTransformer;
 import io.camunda.search.clients.transformers.filter.DateValueFilterTransformer;
@@ -25,12 +26,11 @@ import io.camunda.search.clients.transformers.filter.UserFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserTaskFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableValueFilterTransformer;
-import io.camunda.search.clients.transformers.query.SearchQueryResultTransformer;
 import io.camunda.search.clients.transformers.query.TypedSearchQueryTransformer;
 import io.camunda.search.clients.transformers.result.DecisionInstanceResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.DecisionRequirementsResultConfigTransformer;
 import io.camunda.search.clients.transformers.result.ProcessInstanceResultConfigTransformer;
-import io.camunda.search.clients.transformers.sort.FieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.DecisionInstanceFieldSortingTransformer;
 import io.camunda.search.filter.AuthorizationFilter;
 import io.camunda.search.filter.ComparableValueFilter;
 import io.camunda.search.filter.DateValueFilter;
@@ -56,7 +56,6 @@ import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
-import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
@@ -64,8 +63,10 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.search.result.DecisionInstanceQueryResultConfig;
 import io.camunda.search.result.DecisionRequirementsQueryResultConfig;
 import io.camunda.search.result.ProcessInstanceQueryResultConfig;
+import io.camunda.search.sort.DecisionInstanceSort;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.SortOption;
+import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -118,11 +119,12 @@ public final class ServiceTransformers {
         FlowNodeInstanceQuery.class,
         new TypedSearchQueryTransformer<FlowNodeInstanceFilter, FlowNodeInstanceSort>(mappers));
     mappers.put(ProcessDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    // search query response -> search query result
-    mappers.put(SearchQueryResult.class, new SearchQueryResultTransformer());
 
-    // sorting -> search sort options
-    mappers.put(FieldSortingTransformer.class, new FieldSortingTransformer());
+    // document entity -> domain entity
+    mappers.put(DecisionInstanceEntity.class, new DecisionInstanceEntityTransformer());
+
+    // domain field sorting -> database field sorting
+    mappers.put(DecisionInstanceSort.class, new DecisionInstanceFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(ProcessInstanceFilter.class, new ProcessInstanceFilterTransformer());

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
@@ -27,8 +27,8 @@ public class DecisionInstanceEntityTransformer
   public DecisionInstanceEntity apply(
       final io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity source) {
     return new DecisionInstanceEntity(
-        source.getKey(),
         source.getId(),
+        source.getKey(),
         toDecisionInstanceState(source.getState()),
         source.getEvaluationDate(),
         source.getEvaluationFailure(),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/DecisionInstanceEntityTransformer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import static java.util.Optional.ofNullable;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceInputEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceOutputEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.webapps.schema.entities.operate.dmn.DecisionType;
+import java.util.List;
+
+public class DecisionInstanceEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity,
+        DecisionInstanceEntity> {
+
+  @Override
+  public DecisionInstanceEntity apply(
+      final io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity source) {
+    return new DecisionInstanceEntity(
+        source.getKey(),
+        source.getId(),
+        toDecisionInstanceState(source.getState()),
+        source.getEvaluationDate(),
+        source.getEvaluationFailure(),
+        source.getProcessDefinitionKey(),
+        source.getProcessInstanceKey(),
+        source.getTenantId(),
+        source.getDecisionId(),
+        ofNullable(source.getDecisionDefinitionId()).map(Long::valueOf).orElse(null),
+        source.getDecisionName(),
+        source.getDecisionVersion(),
+        toDecisionType(source.getDecisionType()),
+        source.getResult(),
+        toEvaluatedInputs(source.getEvaluatedInputs()),
+        toEvaluatedOutputs(source.getEvaluatedOutputs()));
+  }
+
+  private List<DecisionInstanceOutputEntity> toEvaluatedOutputs(
+      final List<io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceOutputEntity>
+          source) {
+    if (source == null) {
+      return null;
+    }
+    return source.stream()
+        .map(
+            s ->
+                new DecisionInstanceOutputEntity(
+                    s.getId(), s.getName(), s.getValue(), s.getRuleId(), s.getRuleIndex()))
+        .toList();
+  }
+
+  private List<DecisionInstanceInputEntity> toEvaluatedInputs(
+      final List<io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceInputEntity>
+          source) {
+    if (source == null) {
+      return null;
+    }
+    return source.stream()
+        .map(s -> new DecisionInstanceInputEntity(s.getId(), s.getName(), s.getValue()))
+        .toList();
+  }
+
+  private DecisionDefinitionType toDecisionType(final DecisionType source) {
+    if (source == null) {
+      return null;
+    }
+    return switch (source) {
+      case DECISION_TABLE -> DecisionDefinitionType.DECISION_TABLE;
+      case LITERAL_EXPRESSION -> DecisionDefinitionType.LITERAL_EXPRESSION;
+      case UNSPECIFIED -> DecisionDefinitionType.UNSPECIFIED;
+      default -> DecisionDefinitionType.UNKNOWN;
+    };
+  }
+
+  private DecisionInstanceState toDecisionInstanceState(
+      final io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceState source) {
+    if (source == null) {
+      return null;
+    }
+    return switch (source) {
+      case EVALUATED -> DecisionInstanceState.EVALUATED;
+      case FAILED -> DecisionInstanceState.FAILED;
+      default -> DecisionInstanceState.UNKNOWN;
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/DecisionInstanceFilterTransformer.java
@@ -13,6 +13,18 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.intTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringOperations;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_NAME;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_TYPE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_VERSION;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.EVALUATION_DATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.EVALUATION_FAILURE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.TENANT_ID;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.clients.query.SearchQuery;
@@ -58,11 +70,11 @@ public final class DecisionInstanceFilterTransformer
   }
 
   private SearchQuery getKeysQuery(final List<Long> keys) {
-    return longTerms("key", keys);
+    return longTerms(KEY, keys);
   }
 
   private SearchQuery getIdsQuery(final List<String> ids) {
-    return stringTerms("id", ids);
+    return stringTerms(ID, ids);
   }
 
   private SearchQuery getStatesQuery(final List<DecisionInstanceState> states) {
@@ -71,19 +83,19 @@ public final class DecisionInstanceFilterTransformer
 
   private List<SearchQuery> getEvaluationDateQuery(
       final List<Operation<OffsetDateTime>> evaluationDateOperations) {
-    return dateTimeOperations("evaluationDate", evaluationDateOperations);
+    return dateTimeOperations(EVALUATION_DATE, evaluationDateOperations);
   }
 
   private SearchQuery getEvaluationFailuresQuery(final List<String> evaluationFailures) {
-    return stringTerms("evaluationFailure", evaluationFailures);
+    return stringTerms(EVALUATION_FAILURE, evaluationFailures);
   }
 
   private SearchQuery getProcessDefinitionKeysQuery(final List<Long> processDefinitionKeys) {
-    return longTerms("processDefinitionKey", processDefinitionKeys);
+    return longTerms(PROCESS_DEFINITION_KEY, processDefinitionKeys);
   }
 
   private SearchQuery getProcessInstanceKeysQuery(final List<Long> processInstanceKeys) {
-    return longTerms("processInstanceKey", processInstanceKeys);
+    return longTerms(PROCESS_INSTANCE_KEY, processInstanceKeys);
   }
 
   private List<SearchQuery> getDecisionDefinitionKeysQuery(
@@ -96,30 +108,30 @@ public final class DecisionInstanceFilterTransformer
                   return new Operation<>(op.operator(), values);
                 })
             .toList();
-    return stringOperations("decisionDefinitionId", stringOperations);
+    return stringOperations(DECISION_DEFINITION_ID, stringOperations);
   }
 
   private SearchQuery getDecisionDefinitionIdsQuery(final List<String> decisionDefinitionIds) {
-    return stringTerms("decisionId", decisionDefinitionIds);
+    return stringTerms(DECISION_ID, decisionDefinitionIds);
   }
 
   private SearchQuery getDecisionDefinitionNamesQuery(final List<String> decisionDefinitionNames) {
-    return stringTerms("decisionName", decisionDefinitionNames);
+    return stringTerms(DECISION_NAME, decisionDefinitionNames);
   }
 
   private SearchQuery getDecisionDefinitionVersionsQuery(
       final List<Integer> decisionDefinitionVersions) {
-    return intTerms("decisionVersion", decisionDefinitionVersions);
+    return intTerms(DECISION_VERSION, decisionDefinitionVersions);
   }
 
   private SearchQuery getDecisionDefinitionTypesQuery(
       final List<DecisionDefinitionType> decisionTypes) {
     return stringTerms(
-        "decisionType",
+        DECISION_TYPE,
         decisionTypes != null ? decisionTypes.stream().map(Enum::name).toList() : null);
   }
 
   private SearchQuery getTenantIdsQuery(final List<String> tenantIds) {
-    return stringTerms("tenantId", tenantIds);
+    return stringTerms(TENANT_ID, tenantIds);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/TypedSearchQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/TypedSearchQueryTransformer.java
@@ -18,14 +18,15 @@ import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.clients.transformers.filter.FilterTransformer;
 import io.camunda.search.clients.transformers.result.ResultConfigTransformer;
 import io.camunda.search.clients.transformers.sort.FieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.SortingTransformer;
 import io.camunda.search.filter.FilterBase;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.result.QueryResultConfig;
 import io.camunda.search.sort.SearchSortOptions;
 import io.camunda.search.sort.SortOption;
-import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
+import java.util.Objects;
 
 public final class TypedSearchQueryTransformer<F extends FilterBase, S extends SortOption>
     implements SearchRequestTransformer<F, S> {
@@ -91,7 +92,7 @@ public final class TypedSearchQueryTransformer<F extends FilterBase, S extends S
 
   private List<SearchSortOptions> toSearchSortOptions(final S sort, final boolean reverse) {
     final var orderings = sort.getFieldSortings();
-    final var sortingTransformer = getFieldSortingTransformer();
+    final var sortingTransformer = getSortingTransformer(sort.getClass());
     return sortingTransformer.apply(Tuple.of(orderings, reverse));
   }
 
@@ -99,10 +100,12 @@ public final class TypedSearchQueryTransformer<F extends FilterBase, S extends S
     return transformers.getFilterTransformer(cls);
   }
 
-  private FieldSortingTransformer getFieldSortingTransformer() {
-    final ServiceTransformer<Tuple<List<FieldSorting>, Boolean>, List<SearchSortOptions>>
-        transformer = transformers.getTransformer(FieldSortingTransformer.class);
-    return (FieldSortingTransformer) transformer;
+  private SortingTransformer getSortingTransformer(final Class<? extends SortOption> cls) {
+    // TODO remove the fallback to identity once all FieldSortingTransformer are implemented
+    final ServiceTransformer<String, String> fieldSortingTransformer =
+        Objects.requireNonNullElseGet(
+            transformers.getTransformer(cls), () -> FieldSortingTransformer.identity());
+    return new SortingTransformer((FieldSortingTransformer) fieldSortingTransformer);
   }
 
   private <T extends QueryResultConfig>

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
@@ -7,24 +7,44 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_DEFINITION_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_NAME;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_TYPE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.DECISION_VERSION;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.EVALUATION_DATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.EVALUATION_FAILURE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.PROCESS_DEFINITION_KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.PROCESS_INSTANCE_KEY;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.STATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate.TENANT_ID;
+
 public class DecisionInstanceFieldSortingTransformer implements FieldSortingTransformer {
 
   @Override
   public String apply(final String domainField) {
     return switch (domainField) {
-      case "decisionInstanceKey" -> "key";
-      case "decisionInstanceId" -> "id";
-      case "decisionDefinitionId" -> "decisionId";
-      case "decisionDefinitionKey" -> "decisionDefinitionId"; // yes, this is correct
-      case "decisionDefinitionName" -> "decisionName";
-      case "decisionDefinitionVersion" -> "decisionVersion";
-      case "decisionDefinitionType" -> "decisionType";
-      default -> domainField;
+      case "decisionInstanceKey" -> KEY;
+      case "decisionInstanceId" -> ID;
+      case "state" -> STATE;
+      case "evaluationDate" -> EVALUATION_DATE;
+      case "evaluationFailure" -> EVALUATION_FAILURE;
+      case "processDefinitionKey" -> PROCESS_DEFINITION_KEY;
+      case "processInstanceKey" -> PROCESS_INSTANCE_KEY;
+      case "decisionDefinitionKey" -> DECISION_DEFINITION_ID; // yes, this is correct
+      case "decisionDefinitionId" -> DECISION_ID;
+      case "decisionDefinitionName" -> DECISION_NAME;
+      case "decisionDefinitionVersion" -> DECISION_VERSION;
+      case "decisionDefinitionType" -> DECISION_TYPE;
+      case "tenantId" -> TENANT_ID;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
     };
   }
 
   @Override
   public String defaultSortField() {
-    return "id"; // PK of DecisionInstanceEntity
+    return ID; // PK of DecisionInstanceEntity
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/DecisionInstanceFieldSortingTransformer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+public class DecisionInstanceFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "decisionInstanceKey" -> "key";
+      case "decisionInstanceId" -> "id";
+      case "decisionDefinitionId" -> "decisionId";
+      case "decisionDefinitionKey" -> "decisionDefinitionId"; // yes, this is correct
+      case "decisionDefinitionName" -> "decisionName";
+      case "decisionDefinitionVersion" -> "decisionVersion";
+      case "decisionDefinitionType" -> "decisionType";
+      default -> domainField;
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
+    return "id"; // PK of DecisionInstanceEntity
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/FieldSortingTransformer.java
@@ -7,64 +7,18 @@
  */
 package io.camunda.search.clients.transformers.sort;
 
-import static io.camunda.search.sort.SortOptionsBuilders.reverseOrder;
-import static io.camunda.search.sort.SortOptionsBuilders.sortOptions;
-
 import io.camunda.search.clients.transformers.ServiceTransformer;
-import io.camunda.search.sort.SearchSortOptions;
-import io.camunda.search.sort.SortOption.FieldSorting;
-import io.camunda.search.sort.SortOrder;
-import io.camunda.zeebe.util.collection.Tuple;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 
-public final class FieldSortingTransformer
-    implements ServiceTransformer<Tuple<List<FieldSorting>, Boolean>, List<SearchSortOptions>> {
-
-  private static final SearchSortOptions DEFAULT_SORT_BY_KEY_ASC =
-      sortOptions("key", SortOrder.ASC);
-  private static final SearchSortOptions DEFAULT_SORT_BY_KEY_DESC =
-      sortOptions("key", SortOrder.DESC);
+public interface FieldSortingTransformer extends ServiceTransformer<String, String> {
 
   @Override
-  public List<SearchSortOptions> apply(final Tuple<List<FieldSorting>, Boolean> value) {
-    final var orderings = value.getLeft();
-    final var reverse = value.getRight();
-    final var sorting = map(orderings, reverse);
-    final var defaultSorting = getDefaultSearchSortOption(reverse);
-    sorting.add(defaultSorting);
-    return sorting;
+  String apply(final String domainField);
+
+  default String defaultSortField() {
+    return "key";
   }
 
-  private List<SearchSortOptions> map(final List<FieldSorting> orderings, final boolean reverse) {
-    final List<SearchSortOptions> sorting;
-    if (orderings != null && !orderings.isEmpty()) {
-      sorting =
-          orderings.stream()
-              .map((f) -> toSearchSortOption(f, reverse))
-              .collect(Collectors.toList());
-    } else {
-      sorting = new ArrayList<>();
-    }
-    return sorting;
-  }
-
-  private SearchSortOptions toSearchSortOption(final FieldSorting value, final boolean reverse) {
-    final var field = value.field();
-    final var order = value.order();
-    if (!reverse) {
-      return sortOptions(field, order, "_last");
-    } else {
-      return sortOptions(field, reverseOrder(order), "_first");
-    }
-  }
-
-  private SearchSortOptions getDefaultSearchSortOption(final boolean reverse) {
-    if (!reverse) {
-      return DEFAULT_SORT_BY_KEY_ASC;
-    } else {
-      return DEFAULT_SORT_BY_KEY_DESC;
-    }
+  static FieldSortingTransformer identity() {
+    return t -> t;
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/SortingTransformer.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.search.sort.SortOptionsBuilders.reverseOrder;
+import static io.camunda.search.sort.SortOptionsBuilders.sortOptions;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOption.FieldSorting;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class SortingTransformer
+    implements ServiceTransformer<Tuple<List<FieldSorting>, Boolean>, List<SearchSortOptions>> {
+
+  private final FieldSortingTransformer fieldSortingTransformer;
+
+  public SortingTransformer(final FieldSortingTransformer fieldSortingTransformer) {
+    this.fieldSortingTransformer = fieldSortingTransformer;
+  }
+
+  @Override
+  public List<SearchSortOptions> apply(final Tuple<List<FieldSorting>, Boolean> value) {
+    final var orderings = value.getLeft();
+    final var reverse = value.getRight();
+    final var sorting = map(orderings, reverse);
+    final var defaultSorting = getDefaultSearchSortOption(reverse);
+    sorting.add(defaultSorting);
+    return sorting;
+  }
+
+  private List<SearchSortOptions> map(final List<FieldSorting> orderings, final boolean reverse) {
+    final List<SearchSortOptions> sorting;
+    if (orderings != null && !orderings.isEmpty()) {
+      sorting =
+          orderings.stream()
+              .map((f) -> toSearchSortOption(f, reverse))
+              .collect(Collectors.toList());
+    } else {
+      sorting = new ArrayList<>();
+    }
+    return sorting;
+  }
+
+  private SearchSortOptions toSearchSortOption(final FieldSorting value, final boolean reverse) {
+    final var field = fieldSortingTransformer.apply(value.field());
+    final var order = value.order();
+    if (!reverse) {
+      return sortOptions(field, order, "_last");
+    } else {
+      return sortOptions(field, reverseOrder(order), "_first");
+    }
+  }
+
+  private SearchSortOptions getDefaultSearchSortOption(final boolean reverse) {
+    return sortOptions(
+        fieldSortingTransformer.defaultSortField(), reverse ? SortOrder.DESC : SortOrder.ASC);
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.auth.AuthorizationQueryStrategy;
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.core.SearchQueryResponse;
+import io.camunda.search.clients.transformers.ServiceTransformers;
+import io.camunda.search.entities.DecisionInstanceEntity;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
+import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
+import io.camunda.search.query.DecisionInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DecisionInstanceSearchClientBasedQueryExecutorTest {
+
+  private final DecisionInstanceEntity domainEntity =
+      new DecisionInstanceEntity(
+          123L,
+          "123-1",
+          DecisionInstanceState.EVALUATED,
+          OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
+          "failure",
+          2251799813688736L,
+          6755399441058457L,
+          "tenantId",
+          "ddi",
+          123456L,
+          "ddn",
+          0,
+          DecisionDefinitionType.DECISION_TABLE,
+          "result",
+          null,
+          null);
+
+  private final io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity
+      documentEntity =
+          new io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity()
+              .setKey(123L)
+              .setId("123-1")
+              .setState(
+                  io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceState.EVALUATED)
+              .setEvaluationDate(OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"))
+              .setEvaluationFailure("failure")
+              .setProcessDefinitionKey(2251799813688736L)
+              .setProcessInstanceKey(6755399441058457L)
+              .setTenantId("tenantId")
+              .setDecisionId("ddi")
+              .setDecisionDefinitionId("123456")
+              .setDecisionName("ddn")
+              .setDecisionVersion(0)
+              .setDecisionType(
+                  io.camunda.webapps.schema.entities.operate.dmn.DecisionType.DECISION_TABLE)
+              .setResult("result")
+              .setEvaluatedOutputs(null)
+              .setEvaluatedInputs(null);
+
+  @Mock private DocumentBasedSearchClient searchClient;
+  @Mock private AuthorizationQueryStrategy authorizationQueryStrategy;
+  private final ServiceTransformers serviceTransformers = ServiceTransformers.newInstance(false);
+
+  private SearchClientBasedQueryExecutor queryExecutor;
+
+  @BeforeEach
+  void setUp() {
+    queryExecutor =
+        new SearchClientBasedQueryExecutor(
+            searchClient,
+            serviceTransformers,
+            authorizationQueryStrategy,
+            SecurityContext.withoutAuthentication());
+  }
+
+  @Test
+  void shouldSearchUsingTransformers() {
+    // Given our search Query
+    final var searchAllQuery = new DecisionInstanceQuery.Builder().build();
+
+    // And our search client returns stuff
+    final var decisionInstanceEntityResponse = createDecisionInstanceEntityResponse(documentEntity);
+
+    when(searchClient.search(
+            any(SearchQueryRequest.class),
+            eq(io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity.class)))
+        .thenReturn(decisionInstanceEntityResponse);
+    when(authorizationQueryStrategy.applyAuthorizationToQuery(
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+        .thenAnswer(i -> i.getArgument(0));
+
+    // When we search
+    final SearchQueryResult<DecisionInstanceEntity> searchResult =
+        queryExecutor.search(
+            searchAllQuery,
+            io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity.class);
+
+    assertThat(searchResult.total()).isEqualTo(1);
+    final List<DecisionInstanceEntity> items = searchResult.items();
+    assertThat(items).hasSize(1);
+    assertThat(items.getFirst()).isEqualTo(domainEntity);
+  }
+
+  @Test
+  void shouldFindAllUsingTransformers() {
+    // Given our search Query
+    final var searchAllQuery = new DecisionInstanceQuery.Builder().build();
+
+    // And our search client returns stuff
+    final var decisionInstanceEntityResponse = List.of(documentEntity);
+
+    when(searchClient.findAll(
+            any(SearchQueryRequest.class),
+            eq(io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity.class)))
+        .thenReturn(decisionInstanceEntityResponse);
+    when(authorizationQueryStrategy.applyAuthorizationToQuery(
+            any(SearchQueryRequest.class), any(SecurityContext.class), any()))
+        .thenAnswer(i -> i.getArgument(0));
+
+    // When we search
+    final List<DecisionInstanceEntity> searchResult =
+        queryExecutor.findAll(
+            searchAllQuery,
+            io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity.class);
+
+    assertThat(searchResult).hasSize(1);
+    assertThat(searchResult.getFirst()).isEqualTo(domainEntity);
+  }
+
+  private SearchQueryResponse<io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity>
+      createDecisionInstanceEntityResponse(
+          final io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity
+              documentEntity) {
+    final var hit =
+        new SearchQueryHit.Builder<
+                io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity>()
+            .id("1000")
+            .source(documentEntity)
+            .build();
+
+    return SearchQueryResponse.of(
+        (f) -> {
+          f.totalHits(1).hits(List.of(hit));
+          return f;
+        });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/DecisionInstanceSearchClientBasedQueryExecutorTest.java
@@ -36,8 +36,8 @@ class DecisionInstanceSearchClientBasedQueryExecutorTest {
 
   private final DecisionInstanceEntity domainEntity =
       new DecisionInstanceEntity(
-          123L,
           "123-1",
+          123L,
           DecisionInstanceState.EVALUATED,
           OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
           "failure",

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/SearchClientBasedQueryExecutorTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.clients.transformers.ServiceTransformers;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.SecurityContext;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -81,7 +82,8 @@ class SearchClientBasedQueryExecutorTest {
         .thenAnswer(i -> i.getArgument(0));
 
     // When we search
-    final var searchResult = queryExecutor.search(searchAllQuery, ProcessInstanceEntity.class);
+    final SearchQueryResult<ProcessInstanceEntity> searchResult =
+        queryExecutor.search(searchAllQuery, ProcessInstanceEntity.class);
 
     assertThat(searchResult.total()).isEqualTo(1);
     final List<ProcessInstanceEntity> items = searchResult.items();
@@ -104,7 +106,8 @@ class SearchClientBasedQueryExecutorTest {
         .thenAnswer(i -> i.getArgument(0));
 
     // When we search
-    final var searchResult = queryExecutor.findAll(searchAllQuery, ProcessInstanceEntity.class);
+    final List<ProcessInstanceEntity> searchResult =
+        queryExecutor.findAll(searchAllQuery, ProcessInstanceEntity.class);
 
     assertThat(searchResult).hasSize(1);
     assertThat(searchResult.getFirst().key()).isEqualTo(demoProcessInstance.key());

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/DecisionInstanceSortTest.java
@@ -26,9 +26,9 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
     return Stream.of(
         new TestArguments("key", SortOrder.ASC, s -> s.decisionInstanceKey().asc()),
         new TestArguments("id", SortOrder.ASC, s -> s.decisionInstanceId().asc()),
-        new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionKey().asc()),
+        new TestArguments("decisionId", SortOrder.ASC, s -> s.decisionDefinitionId().asc()),
         new TestArguments(
-            "decisionDefinitionId", SortOrder.DESC, s -> s.decisionDefinitionId().desc()),
+            "decisionDefinitionId", SortOrder.DESC, s -> s.decisionDefinitionKey().desc()),
         new TestArguments("decisionName", SortOrder.DESC, s -> s.decisionDefinitionName().desc()),
         new TestArguments("decisionType", SortOrder.DESC, s -> s.decisionDefinitionType().desc()),
         new TestArguments(
@@ -37,7 +37,7 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
         new TestArguments("tenantId", SortOrder.ASC, s -> s.tenantId().asc()),
         new TestArguments(
             "processDefinitionKey", SortOrder.ASC, s -> s.processDefinitionKey().asc()),
-        new TestArguments("processInstanceId", SortOrder.ASC, s -> s.processInstanceId().asc()));
+        new TestArguments("processInstanceKey", SortOrder.ASC, s -> s.processInstanceKey().asc()));
   }
 
   @ParameterizedTest
@@ -63,7 +63,7 @@ class DecisionInstanceSortTest extends AbstractSortTransformerTest {
         .isInstanceOfSatisfying(
             SearchSortOptions.class,
             t -> {
-              assertThat(t.field().field()).isEqualTo("key");
+              assertThat(t.field().field()).isEqualTo("id");
               assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
             });
   }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -11,8 +11,8 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public record DecisionInstanceEntity(
+    String decisionInstanceId, // this is the unique identifier of the decision instance
     Long decisionInstanceKey,
-    String decisionInstanceId,
     DecisionInstanceState state,
     OffsetDateTime evaluationDate,
     String evaluationFailure,

--- a/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/DecisionInstanceEntity.java
@@ -11,27 +11,27 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public record DecisionInstanceEntity(
-    long key,
-    String id,
+    Long decisionInstanceKey,
+    String decisionInstanceId,
     DecisionInstanceState state,
     OffsetDateTime evaluationDate,
     String evaluationFailure,
-    long processDefinitionKey,
-    long processInstanceKey,
-    String bpmnProcessId,
-    String decisionId,
+    Long processDefinitionKey,
+    Long processInstanceKey,
+    String tenantId,
     String decisionDefinitionId,
-    String decisionName,
-    int decisionVersion,
-    DecisionDefinitionType decisionType,
+    Long decisionDefinitionKey,
+    String decisionDefinitionName,
+    Integer decisionDefinitionVersion,
+    DecisionDefinitionType decisionDefinitionType,
     String result,
     List<DecisionInstanceInputEntity> evaluatedInputs,
     List<DecisionInstanceOutputEntity> evaluatedOutputs) {
 
-  public record DecisionInstanceInputEntity(String id, String name, String value) {}
+  public record DecisionInstanceInputEntity(String inputId, String inputName, String inputValue) {}
 
   public record DecisionInstanceOutputEntity(
-      String id, String name, String value, String ruleId, int ruleIndex) {}
+      String outputId, String outputName, String outputValue, String ruleId, int ruleIndex) {}
 
   public enum DecisionDefinitionType {
     DECISION_TABLE,

--- a/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/DecisionInstanceSort.java
@@ -27,12 +27,12 @@ public record DecisionInstanceSort(List<FieldSorting> orderings) implements Sort
       implements ObjectBuilder<DecisionInstanceSort> {
 
     public Builder decisionInstanceKey() {
-      currentOrdering = new FieldSorting("key", null);
+      currentOrdering = new FieldSorting("decisionInstanceKey", null);
       return this;
     }
 
     public Builder decisionInstanceId() {
-      currentOrdering = new FieldSorting("id", null);
+      currentOrdering = new FieldSorting("decisionInstanceId", null);
       return this;
     }
 
@@ -56,13 +56,13 @@ public record DecisionInstanceSort(List<FieldSorting> orderings) implements Sort
       return this;
     }
 
-    public Builder processInstanceId() {
-      currentOrdering = new FieldSorting("processInstanceId", null);
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
       return this;
     }
 
     public Builder decisionDefinitionKey() {
-      currentOrdering = new FieldSorting("decisionId", null);
+      currentOrdering = new FieldSorting("decisionDefinitionKey", null);
       return this;
     }
 
@@ -72,17 +72,17 @@ public record DecisionInstanceSort(List<FieldSorting> orderings) implements Sort
     }
 
     public Builder decisionDefinitionName() {
-      currentOrdering = new FieldSorting("decisionName", null);
+      currentOrdering = new FieldSorting("decisionDefinitionName", null);
       return this;
     }
 
     public Builder decisionDefinitionVersion() {
-      currentOrdering = new FieldSorting("decisionVersion", null);
+      currentOrdering = new FieldSorting("decisionDefinitionVersion", null);
       return this;
     }
 
     public Builder decisionDefinitionType() {
-      currentOrdering = new FieldSorting("decisionType", null);
+      currentOrdering = new FieldSorting("decisionDefinitionType", null);
       return this;
     }
 

--- a/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionInstanceServices.java
@@ -87,7 +87,7 @@ public final class DecisionInstanceServices
         getSingleResultOrThrow(result, decisionInstanceId, "Decision instance");
     final var authorization = Authorization.of(a -> a.decisionDefinition().readInstance());
     if (!securityContextProvider.isAuthorized(
-        decisionInstanceEntity.decisionId(), authentication, authorization)) {
+        decisionInstanceEntity.decisionDefinitionId(), authentication, authorization)) {
       throw new ForbiddenException(authorization);
     }
     return decisionInstanceEntity;

--- a/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionInstanceServiceTest.java
@@ -72,7 +72,7 @@ class DecisionInstanceServiceTest {
     final var result = mock(SearchQueryResult.class);
     when(result.total()).thenReturn(1L);
     final var decisionInstanceEntity = mock(DecisionInstanceEntity.class);
-    when(decisionInstanceEntity.decisionId()).thenReturn(decisionDefinitionKey);
+    when(decisionInstanceEntity.decisionDefinitionId()).thenReturn(decisionDefinitionKey);
     when(result.items()).thenReturn(List.of(decisionInstanceEntity));
     when(client.searchDecisionInstances(any())).thenReturn(result);
     when(securityContextProvider.isAuthorized(
@@ -124,7 +124,7 @@ class DecisionInstanceServiceTest {
     final var result = mock(SearchQueryResult.class);
     when(result.total()).thenReturn(1L);
     final var decisionInstanceEntity = mock(DecisionInstanceEntity.class);
-    when(decisionInstanceEntity.decisionId()).thenReturn(decisionDefinitionKey);
+    when(decisionInstanceEntity.decisionDefinitionId()).thenReturn(decisionDefinitionKey);
     when(result.items()).thenReturn(List.of(decisionInstanceEntity));
     when(client.searchDecisionInstances(any())).thenReturn(result);
     when(securityContextProvider.isAuthorized(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -228,7 +228,9 @@ public final class SearchQueryRequestMapper {
         case "decisionInstanceId" -> builder.decisionInstanceId();
         case "state" -> builder.state();
         case "evaluationDate" -> builder.evaluationDate();
+        case "evaluationFailure" -> builder.evaluationFailure();
         case "processDefinitionKey" -> builder.processDefinitionKey();
+        case "processInstanceKey" -> builder.processInstanceKey();
         case "decisionDefinitionKey" -> builder.decisionDefinitionKey();
         case "decisionDefinitionId" -> builder.decisionDefinitionId();
         case "decisionDefinitionName" -> builder.decisionDefinitionName();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -373,36 +373,36 @@ public final class SearchQueryResponseMapper {
 
   public static DecisionInstanceItem toDecisionInstance(final DecisionInstanceEntity entity) {
     return new DecisionInstanceItem()
-        .decisionInstanceKey(entity.key())
-        .decisionInstanceId(entity.id())
+        .decisionInstanceKey(entity.decisionInstanceKey())
+        .decisionInstanceId(entity.decisionInstanceId())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())
         .processDefinitionKey(entity.processDefinitionKey())
         .processInstanceKey(entity.processInstanceKey())
-        .decisionDefinitionKey(Long.valueOf(entity.decisionDefinitionId()))
-        .decisionDefinitionId(entity.decisionId())
-        .decisionDefinitionName(entity.decisionName())
-        .decisionDefinitionVersion(entity.decisionVersion())
-        .decisionDefinitionType(toDecisionDefinitionTypeEnum(entity.decisionType()))
+        .decisionDefinitionKey(entity.decisionDefinitionKey())
+        .decisionDefinitionId(entity.decisionDefinitionId())
+        .decisionDefinitionName(entity.decisionDefinitionName())
+        .decisionDefinitionVersion(entity.decisionDefinitionVersion())
+        .decisionDefinitionType(toDecisionDefinitionTypeEnum(entity.decisionDefinitionType()))
         .result(entity.result());
   }
 
   public static DecisionInstanceGetQueryResponse toDecisionInstanceGetQueryResponse(
       final DecisionInstanceEntity entity) {
     return new DecisionInstanceGetQueryResponse()
-        .decisionInstanceKey(entity.key())
-        .decisionInstanceId(entity.id())
+        .decisionInstanceKey(entity.decisionInstanceKey())
+        .decisionInstanceId(entity.decisionInstanceId())
         .state(toDecisionInstanceStateEnum(entity.state()))
         .evaluationDate(formatDate(entity.evaluationDate()))
         .evaluationFailure(entity.evaluationFailure())
         .processDefinitionKey(entity.processDefinitionKey())
         .processInstanceKey(entity.processInstanceKey())
-        .decisionDefinitionKey(Long.valueOf(entity.decisionDefinitionId()))
-        .decisionDefinitionId(entity.decisionId())
-        .decisionDefinitionName(entity.decisionName())
-        .decisionDefinitionVersion(entity.decisionVersion())
-        .decisionDefinitionType(toDecisionDefinitionTypeEnum(entity.decisionType()))
+        .decisionDefinitionKey(entity.decisionDefinitionKey())
+        .decisionDefinitionId(entity.decisionDefinitionId())
+        .decisionDefinitionName(entity.decisionDefinitionName())
+        .decisionDefinitionVersion(entity.decisionDefinitionVersion())
+        .decisionDefinitionType(toDecisionDefinitionTypeEnum(entity.decisionDefinitionType()))
         .result(entity.result())
         .evaluatedInputs(toEvaluatedInputs(entity.evaluatedInputs()))
         .matchedRules(toMatchedRules(entity.evaluatedOutputs()));
@@ -417,9 +417,9 @@ public final class SearchQueryResponseMapper {
         .map(
             input ->
                 new EvaluatedDecisionInputItem()
-                    .inputId(input.id())
-                    .inputName(input.name())
-                    .inputValue(input.value()))
+                    .inputId(input.inputId())
+                    .inputName(input.inputName())
+                    .inputValue(input.inputValue()))
         .toList();
   }
 
@@ -444,9 +444,9 @@ public final class SearchQueryResponseMapper {
                           .map(
                               output ->
                                   new EvaluatedDecisionOutputItem()
-                                      .outputId(output.id())
-                                      .outputName(output.name())
-                                      .outputValue(output.value()))
+                                      .outputId(output.outputId())
+                                      .outputName(output.outputName())
+                                      .outputValue(output.outputValue()))
                           .toList());
             })
         .toList();

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -84,8 +84,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
           .items(
               List.of(
                   new DecisionInstanceEntity(
-                      123L,
                       "123-1",
+                      123L,
                       DecisionInstanceState.EVALUATED,
                       OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
                       null,
@@ -201,8 +201,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
     final var decisionInstanceId = "123-1";
     final var decisionInstanceInDB =
         new DecisionInstanceEntity(
-            123L,
             "123-1",
+            123L,
             DecisionInstanceState.EVALUATED,
             OffsetDateTime.parse("2024-06-05T08:29:15.027+00:00"),
             null,

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -62,7 +62,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                        "processDefinitionKey": 2251799813688736,
                        "processInstanceKey": 6755399441058457,
                        "decisionDefinitionKey": 123456,
-                       "decisionDefinitionId": "di",
+                       "decisionDefinitionId": "ddi",
                        "decisionDefinitionName": "ddn",
                        "decisionDefinitionVersion": 0,
                        "decisionDefinitionType": "DECISION_TABLE",
@@ -91,9 +91,9 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                       null,
                       2251799813688736L,
                       6755399441058457L,
-                      "bpi",
-                      "di",
-                      "123456",
+                      "tenantId",
+                      "ddi",
+                      123456L,
                       "ddn",
                       0,
                       DecisionDefinitionType.DECISION_TABLE,
@@ -196,7 +196,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldReturnDecisionInstanceByKey() {
+  void shouldReturnDecisionInstanceById() {
     // given
     final var decisionInstanceId = "123-1";
     final var decisionInstanceInDB =
@@ -208,9 +208,9 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
             null,
             2251799813688736L,
             6755399441058457L,
-            "bpi",
-            "di",
-            "123456",
+            "tenantId",
+            "ddi",
+            123456L,
             "ddn",
             0,
             DecisionDefinitionType.DECISION_TABLE,
@@ -238,7 +238,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                      "processDefinitionKey": 2251799813688736,
                      "processInstanceKey": 6755399441058457,
                      "decisionDefinitionKey": 123456,
-                     "decisionDefinitionId": "di",
+                     "decisionDefinitionId": "ddi",
                      "decisionDefinitionName": "ddn",
                      "decisionDefinitionVersion": 0,
                      "decisionDefinitionType": "DECISION_TABLE",


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
As discussed in [Slack](https://camunda.slack.com/archives/C06UKS51QV9/p1731598147347449?thread_ts=1731062628.410319&cid=C06UKS51QV9)
In this pull request, I separate search domain model from database model
- `io.camunda.search.entities.*` entities are reserved for the search domain model and use the business terminology.
- `io.camunda.webapps.schema.entities.*` entities to deserialize the results from ES/OS
- transform data entity to business entity in the searchClients
- for sorting, create ES/OS transformers per entity

I applied the change only for `DecisionInstance` to have a "small" PR to review. This will be rolled out for other entities in other PRs

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/24911
