### PR TITLE
feat: start deployment reconstruction on startup if needed

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.clock.ClockProcessors;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
+import io.camunda.zeebe.engine.processing.deployment.DeploymentReconstructProcessor;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentReconstructionStarter;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
@@ -396,6 +397,11 @@ public final class EngineProcessors {
         ValueType.DEPLOYMENT_DISTRIBUTION,
         DeploymentDistributionIntent.COMPLETE,
         completeDeploymentDistributionProcessor);
+
+    typedRecordProcessors.onCommand(
+        ValueType.DEPLOYMENT,
+        DeploymentIntent.RECONSTRUCT,
+        new DeploymentReconstructProcessor(keyGenerator, writers));
 
     typedRecordProcessors.withListener(
         new DeploymentReconstructionStarter(processingState.getDeploymentState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavio
 import io.camunda.zeebe.engine.processing.clock.ClockProcessors;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
+import io.camunda.zeebe.engine.processing.deployment.DeploymentReconstructionStarter;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCommandSender;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCompleteProcessor;
@@ -395,6 +396,9 @@ public final class EngineProcessors {
         ValueType.DEPLOYMENT_DISTRIBUTION,
         DeploymentDistributionIntent.COMPLETE,
         completeDeploymentDistributionProcessor);
+
+    typedRecordProcessors.withListener(
+        new DeploymentReconstructionStarter(processingState.getDeploymentState()));
   }
 
   private static void addIncidentProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.deployment;
 
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -15,6 +16,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
+@ExcludeAuthorizationCheck
 public class DeploymentReconstructProcessor implements TypedRecordProcessor<DeploymentRecord> {
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -29,6 +29,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
   @Override
   public void processRecord(final TypedRecord<DeploymentRecord> record) {
     final var key = keyGenerator.nextKey();
-    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED, record.getValue());
+    // TODO: Only append the event when there are no more deployments to reconstruct
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED_ALL, record.getValue());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class DeploymentReconstructProcessor implements TypedRecordProcessor<DeploymentRecord> {
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+
+  public DeploymentReconstructProcessor(final KeyGenerator keyGenerator, final Writers writers) {
+    this.keyGenerator = keyGenerator;
+    stateWriter = writers.state();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<DeploymentRecord> record) {
+    final var key = keyGenerator.nextKey();
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED, record.getValue());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
@@ -41,6 +41,11 @@ public final class DeploymentReconstructionStarter implements StreamProcessorLif
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     LOG.debug("Not all deployments are stored, starting reconstruction");
+    // There's a chance that this command is written more than once, for example when the broker is
+    // restarted before the first command is processed.
+    // This is fine as long as the command is idempotent and does not contain any state. Do not
+    // start to add more state to the command or make the command non-idempotent unless you also
+    // find a way to prevent that this initial command is written more than once.
     taskResultBuilder.appendCommandRecord(DeploymentIntent.RECONSTRUCT, new DeploymentRecord());
     return taskResultBuilder.build();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class DeploymentReconstructionStarter implements StreamProcessorLifecycleAware, Task {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DeploymentReconstructionStarter.class);
+  private final DeploymentState deploymentState;
+
+  public DeploymentReconstructionStarter(final DeploymentState deploymentState) {
+    this.deploymentState = deploymentState;
+  }
+
+  @Override
+  public void onRecovered(final ReadonlyStreamProcessorContext context) {
+    if (deploymentState.hasStoredAllDeployments()) {
+      LOG.trace("All deployments are already stored, skipping reconstruction");
+      return;
+    }
+
+    context.getScheduleService().runDelayed(Duration.ZERO, this);
+  }
+
+  @Override
+  public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    LOG.debug("Not all deployments are stored, starting reconstruction");
+    return taskResultBuilder.build();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructionStarter.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.processing.deployment;
 
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -39,6 +41,7 @@ public final class DeploymentReconstructionStarter implements StreamProcessorLif
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     LOG.debug("Not all deployments are stored, starting reconstruction");
+    taskResultBuilder.appendCommandRecord(DeploymentIntent.RECONSTRUCT, new DeploymentRecord());
     return taskResultBuilder.build();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedAllApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedAllApplier.java
@@ -22,6 +22,6 @@ public class DeploymentReconstructedAllApplier
 
   @Override
   public void applyState(final long key, final DeploymentRecord value) {
-    deploymentState.markALlDeploymentsAsStored();
+    deploymentState.markAllDeploymentsAsStored();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedAllApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedAllApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+
+public class DeploymentReconstructedAllApplier
+    implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentReconstructedAllApplier(final MutableDeploymentState deploymentState) {
+    this.deploymentState = deploymentState;
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentRecord value) {
+    deploymentState.markALlDeploymentsAsStored();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -163,6 +163,9 @@ public final class EventAppliers implements EventApplier {
         DeploymentIntent.FULLY_DISTRIBUTED,
         new DeploymentFullyDistributedApplier(state.getDeploymentState()));
     register(DeploymentIntent.RECONSTRUCTED, NOOP_EVENT_APPLIER);
+    register(
+        DeploymentIntent.RECONSTRUCTED_ALL,
+        new DeploymentReconstructedAllApplier(state.getDeploymentState()));
   }
 
   private void registerVariableEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -162,6 +162,7 @@ public final class EventAppliers implements EventApplier {
     register(
         DeploymentIntent.FULLY_DISTRIBUTED,
         new DeploymentFullyDistributedApplier(state.getDeploymentState()));
+    register(DeploymentIntent.RECONSTRUCTED, NOOP_EVENT_APPLIER);
   }
 
   private void registerVariableEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDeploymentState.java
@@ -94,7 +94,7 @@ public final class DbDeploymentState implements MutableDeploymentState {
   }
 
   @Override
-  public void markALlDeploymentsAsStored() {
+  public void markAllDeploymentsAsStored() {
     deploymentsRecreatedKey.wrapString(DEPLOYMENTS_RECREATED_KEY);
     deploymentsRecreatedColumnFamily.insert(deploymentsRecreatedKey, DbNil.INSTANCE);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDeploymentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDeploymentState.java
@@ -24,5 +24,5 @@ public interface MutableDeploymentState extends DeploymentState {
    * Marks all deployments as stored. After this has been called, {@link
    * DeploymentState#hasStoredAllDeployments()} returns true.
    */
-  void markALlDeploymentsAsStored();
+  void markAllDeploymentsAsStored();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiPartitionDeploymentLifecycleTest.java
@@ -97,7 +97,8 @@ public class MultiPartitionDeploymentLifecycleTest {
                 .limit(r -> r.getIntent().equals(DeploymentIntent.CREATED))
                 .collect(Collectors.toList()))
         .extracting(Record::getIntent)
-        .containsExactly(DeploymentIntent.CREATE, ProcessIntent.CREATED, DeploymentIntent.CREATED);
+        .containsSubsequence(
+            DeploymentIntent.CREATE, ProcessIntent.CREATED, DeploymentIntent.CREATED);
 
     assertThat(
             RecordingExporter.records()
@@ -105,7 +106,8 @@ public class MultiPartitionDeploymentLifecycleTest {
                 .limit(r -> r.getIntent().equals(DeploymentIntent.CREATED))
                 .collect(Collectors.toList()))
         .extracting(Record::getIntent)
-        .containsExactly(DeploymentIntent.CREATE, ProcessIntent.CREATED, DeploymentIntent.CREATED);
+        .containsSubsequence(
+            DeploymentIntent.CREATE, ProcessIntent.CREATED, DeploymentIntent.CREATED);
   }
 
   @Test
@@ -137,7 +139,7 @@ public class MultiPartitionDeploymentLifecycleTest {
                 .limit(r -> r.getIntent().equals(DeploymentIntent.CREATED)))
         .describedAs("Has created DMN resources on partition 2")
         .extracting(Record::getIntent)
-        .containsExactly(
+        .containsSubsequence(
             DeploymentIntent.CREATE,
             DecisionRequirementsIntent.CREATED,
             DecisionIntent.CREATED,
@@ -149,7 +151,7 @@ public class MultiPartitionDeploymentLifecycleTest {
                 .limit(r -> r.getIntent().equals(DeploymentIntent.CREATED)))
         .describedAs("Has created DMN resources on partition 3")
         .extracting(Record::getIntent)
-        .containsExactly(
+        .containsSubsequence(
             DeploymentIntent.CREATE,
             DecisionRequirementsIntent.CREATED,
             DecisionIntent.CREATED,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
@@ -291,6 +292,7 @@ public class MultiResourceDeploymentTest {
       final long recordsCountBefore =
           RecordingExporter.records()
               .onlyEvents()
+              .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
               .limit(record -> record.getPosition() >= firstDeploymentRecord.getPosition())
               .count();
       assertThat(recordsCountBefore)
@@ -349,6 +351,7 @@ public class MultiResourceDeploymentTest {
       final long recordsCountAfter =
           RecordingExporter.records()
               .onlyEvents()
+              .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
               .limit(record -> record.getPosition() >= secondDeploymentRecord.getPosition())
               .count();
       assertThat(recordsCountAfter - recordsCountBefore)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -210,6 +210,7 @@ public class ResourceDeletionTest {
     assertThat(
             RecordingExporter.records()
                 .onlyEvents()
+                .filter(r -> r.getIntent() != DeploymentIntent.RECONSTRUCTED_ALL)
                 .limit(r -> r.getIntent().equals(ResourceDeletionIntent.DELETED)))
         .describedAs("Should write events in correct order")
         .extracting(Record::getIntent)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/CreateTenantMultiPartitionTest.java
@@ -74,7 +74,7 @@ public class CreateTenantMultiPartitionTest {
                   .limit(record -> record.getIntent().equals(TenantIntent.CREATED))
                   .collect(Collectors.toList()))
           .extracting(Record::getIntent)
-          .containsExactly(TenantIntent.CREATE, TenantIntent.CREATED);
+          .containsSubsequence(TenantIntent.CREATE, TenantIntent.CREATED);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DeploymentStateTest.java
@@ -316,7 +316,7 @@ public class DeploymentStateTest {
   @Test
   public void shouldReturnTrueWhenCheckingIfAllDeploymentsAreStored() {
     // given
-    deploymentState.markALlDeploymentsAsStored();
+    deploymentState.markAllDeploymentsAsStored();
 
     // when
     final var hasStoredAllDeployments = deploymentState.hasStoredAllDeployments();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRuleTest.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import java.time.Instant;
@@ -36,9 +35,10 @@ public class EngineRuleTest {
     engineRule.awaitProcessingOf(message);
 
     // then
-    final var records = RecordingExporter.getRecords();
+    final var records = RecordingExporter.messageRecords();
     assertThat(records)
-        .extracting(Record::getTimestamp)
-        .containsExactly(expectedTimestamp.toEpochMilli(), expectedTimestamp.toEpochMilli());
+        .allSatisfy(
+            record ->
+                assertThat(record.getTimestamp()).isEqualTo(expectedTimestamp.toEpochMilli()));
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -29,7 +29,10 @@ public enum DeploymentIntent implements Intent {
   @Deprecated
   DISTRIBUTED((short) 3),
   @Deprecated
-  FULLY_DISTRIBUTED((short) 4);
+  FULLY_DISTRIBUTED((short) 4),
+
+  RECONSTRUCT((short) 5),
+  RECONSTRUCTED((short) 6);
 
   private final short value;
 
@@ -53,6 +56,10 @@ public enum DeploymentIntent implements Intent {
         return DISTRIBUTED;
       case 4:
         return FULLY_DISTRIBUTED;
+      case 5:
+        return RECONSTRUCT;
+      case 6:
+        return RECONSTRUCTED;
       default:
         return UNKNOWN;
     }
@@ -69,6 +76,7 @@ public enum DeploymentIntent implements Intent {
       case CREATED:
       case DISTRIBUTED:
       case FULLY_DISTRIBUTED:
+      case RECONSTRUCTED:
         return true;
       default:
         return false;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -32,7 +32,8 @@ public enum DeploymentIntent implements Intent {
   FULLY_DISTRIBUTED((short) 4),
 
   RECONSTRUCT((short) 5),
-  RECONSTRUCTED((short) 6);
+  RECONSTRUCTED((short) 6),
+  RECONSTRUCTED_ALL((short) 7);
 
   private final short value;
 
@@ -60,6 +61,8 @@ public enum DeploymentIntent implements Intent {
         return RECONSTRUCT;
       case 6:
         return RECONSTRUCTED;
+      case 7:
+        return RECONSTRUCTED_ALL;
       default:
         return UNKNOWN;
     }
@@ -77,6 +80,7 @@ public enum DeploymentIntent implements Intent {
       case DISTRIBUTED:
       case FULLY_DISTRIBUTED:
       case RECONSTRUCTED:
+      case RECONSTRUCTED_ALL:
         return true;
       default:
         return false;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/FailOverReplicationTest.java
@@ -122,12 +122,17 @@ public class FailOverReplicationTest {
 
     clusteringRule.fillSegments(followers, segmentCount);
     final var snapshotMetadata = awaitSnapshot(newLeader);
+    // previous leader might have taken a snapshot already because of internal processing activity
+    final var firstSnapshotOnPreviousLeader =
+        clusteringRule.getSnapshot(previousLeader).orElse(null);
 
     // when
     clusteringRule.connect(previousLeader);
 
-    // then
-    final var receivedSnapshot = clusteringRule.waitForSnapshotAtBroker(previousLeader);
+    // then -- reconnected member is forced to receive a snapshot because leader has compacted the
+    // log after taking the snapshot.
+    final var receivedSnapshot =
+        clusteringRule.waitForNewSnapshotAtBroker(previousLeader, firstSnapshotOnPreviousLeader);
     assertThat(receivedSnapshot).isEqualTo(snapshotMetadata);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -31,7 +31,7 @@ public class BrokerAdminServiceEndpointTest {
   static RequestSpecification brokerServerSpec;
 
   @TestZeebe
-  private static final TestStandaloneBroker broker =
+  private static final TestStandaloneBroker BROKER =
       new TestStandaloneBroker().withProperty("management.server.base-path", "/foo");
 
   private static final String EXPECTED_PARTITIONS_JSON =
@@ -166,7 +166,7 @@ public class BrokerAdminServiceEndpointTest {
         new RequestSpecBuilder()
             .setContentType(ContentType.JSON)
             // set URL explicitly since we want to ensure the mapping is correct
-            .setBaseUri("http://localhost:" + broker.mappedPort(TestZeebePort.MONITORING) + "/foo")
+            .setBaseUri("http://localhost:" + BROKER.mappedPort(TestZeebePort.MONITORING) + "/foo")
             .addFilter(new ResponseLoggingFilter())
             .addFilter(new RequestLoggingFilter())
             .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -31,7 +31,7 @@ public class BrokerAdminServiceEndpointTest {
   static RequestSpecification brokerServerSpec;
 
   @TestZeebe
-  private static TestStandaloneBroker broker =
+  private static final TestStandaloneBroker broker =
       new TestStandaloneBroker().withProperty("management.server.base-path", "/foo");
 
   private static final String EXPECTED_PARTITIONS_JSON =
@@ -40,7 +40,7 @@ public class BrokerAdminServiceEndpointTest {
       {
         "1": {
           "role": "LEADER",
-          "processedPosition": -1,
+          "processedPosition": 1,
           "snapshotId": null,
           "processedPositionInSnapshot": null,
           "streamProcessorPhase": "PROCESSING",
@@ -97,7 +97,7 @@ public class BrokerAdminServiceEndpointTest {
       """
       {
         "role": "LEADER",
-        "processedPosition": -1,
+        "processedPosition": 1,
         "snapshotId": null,
         "processedPositionInSnapshot": null,
         "streamProcessorPhase": "PROCESSING",

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -73,14 +73,14 @@ public class BrokerAdminServiceClusterTest {
     followerStatus.forEach(
         partitionStatus -> {
           assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.processedPosition()).isEqualTo(-1L);
+          assertThat(partitionStatus.processedPosition()).isEqualTo(1L);
           assertThat(partitionStatus.snapshotId()).isNull();
           assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
           assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
     assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(leaderStatus.processedPosition()).isEqualTo(-1);
+    assertThat(leaderStatus.processedPosition()).isEqualTo(1L);
     assertThat(leaderStatus.snapshotId()).isNull();
     assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
     assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -35,7 +35,7 @@ public class BrokerAdminServiceWithOutExporterTest {
     // then
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
     assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(partitionStatus.processedPosition()).isEqualTo(-1);
+    assertThat(partitionStatus.processedPosition()).isEqualTo(1L);
     assertThat(partitionStatus.snapshotId()).isNull();
     assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);


### PR DESCRIPTION
Adds a new startup task that checks whether all deployments are stored in the state and writes a new `Deployment/Reconstruct` command if not.

The new `Deployment/Reconstruct` command has a placeholder processor that writes the  `Deployment/ReconstructedAll` event to confirm the command. The applier updates the deployment state to mark all deployments as reconstructed now. This is fake as long as we don't actually reconstruct the deployments.

closes #24715