### PR TITLE
feat: added listener type filter to internal listener API

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -186,6 +186,55 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     assertEquals("11", resultListeners3.get(2).getListenerKey());
   }
 
+  @Test
+  public void testListenerReaderWithTypeFilters() throws Exception {
+    Mockito.when(userService.getCurrentUser()).thenReturn(new UserDto().setUserId(DEFAULT_USER));
+
+    // request only Execution Listeners
+    final ListenerRequestDto elRequest =
+        new ListenerRequestDto()
+            .setPageSize(20)
+            .setFlowNodeId("test_task")
+            .setListenerTypeFilter(ListenerType.EXECUTION_LISTENER);
+    final ListenerResponseDto elResponse = postListenerRequest("111", elRequest);
+    final List<ListenerDto> elResultListeners = elResponse.getListeners();
+
+    assertEquals(2L, elResponse.getTotalCount());
+    assertEquals(2, elResultListeners.size());
+
+    final ListenerDto actual0 = elResultListeners.get(0);
+    assertEquals("12", actual0.getListenerKey());
+    assertEquals(ListenerType.EXECUTION_LISTENER, actual0.getListenerType());
+
+    final ListenerDto actual1 = elResultListeners.get(1);
+    assertEquals("11", actual1.getListenerKey());
+    assertEquals(ListenerType.EXECUTION_LISTENER, actual1.getListenerType());
+
+    // Request only Task Listeners
+    final ListenerRequestDto tlRequest =
+        new ListenerRequestDto()
+            .setPageSize(20)
+            .setFlowNodeId("test_task")
+            .setListenerTypeFilter(ListenerType.TASK_LISTENER);
+    final ListenerResponseDto tlResponse = postListenerRequest("111", tlRequest);
+    final List<ListenerDto> tlResultListeners = tlResponse.getListeners();
+
+    assertEquals(3L, tlResponse.getTotalCount());
+    assertEquals(3, tlResultListeners.size());
+
+    final ListenerDto actual4 = tlResultListeners.get(0);
+    assertEquals("22", actual4.getListenerKey());
+    assertEquals(ListenerType.TASK_LISTENER, actual4.getListenerType());
+
+    final ListenerDto actual3 = tlResultListeners.get(1);
+    assertEquals("21", actual3.getListenerKey());
+    assertEquals(ListenerType.TASK_LISTENER, actual3.getListenerType());
+
+    final ListenerDto actual2 = tlResultListeners.get(2);
+    assertEquals("31", actual2.getListenerKey());
+    assertEquals(ListenerType.TASK_LISTENER, actual2.getListenerType());
+  }
+
   private void createData() throws IOException {
 
     final JobEntity e1 =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/ProcessInstanceRestServiceIT.java
@@ -16,6 +16,7 @@ import io.camunda.operate.util.TestApplication;
 import io.camunda.operate.util.j5templates.MockMvcManager;
 import io.camunda.operate.webapp.rest.ProcessInstanceRestService;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
+import io.camunda.webapps.schema.entities.operate.ListenerType;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -106,5 +107,24 @@ public class ProcessInstanceRestServiceIT {
     final MvcResult mvcResult = mockMvcManager.postRequest(url, request, 400);
     assertThat(mvcResult.getResolvedException().getMessage())
         .contains("Only one of 'flowNodeId' or 'flowNodeInstanceId'");
+  }
+
+  @Test
+  public void testListenersRequestWithListenerFilterInvalid() throws Exception {
+    final String url = ProcessInstanceRestService.PROCESS_INSTANCE_URL + "/1/listeners";
+    final ListenerRequestDto request =
+        new ListenerRequestDto()
+            .setPageSize(20)
+            .setFlowNodeId("testid")
+            .setListenerTypeFilter(ListenerType.UNKNOWN);
+    final MvcResult mvcResult = mockMvcManager.postRequest(url, request, 400);
+    assertThat(mvcResult.getResolvedException().getMessage())
+        .contains(
+            "'listenerTypeFilter' only allows for values: ["
+                + "null, "
+                + ListenerType.EXECUTION_LISTENER
+                + ", "
+                + ListenerType.TASK_LISTENER
+                + "]");
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ElasticsearchListenerReader.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
@@ -47,10 +48,15 @@ public class ElasticsearchListenerReader extends AbstractReader implements Liste
   private final JobTemplate jobTemplate;
   private final RestHighLevelClient esClient;
 
+  private final TermQueryBuilder executionListenersQ;
+  private final TermQueryBuilder taskListenersQ;
+
   public ElasticsearchListenerReader(
       final JobTemplate jobTemplate, final RestHighLevelClient esClient) {
     this.jobTemplate = jobTemplate;
     this.esClient = esClient;
+    executionListenersQ = termQuery(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER);
+    taskListenersQ = termQuery(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER);
   }
 
   @Override
@@ -58,17 +64,12 @@ public class ElasticsearchListenerReader extends AbstractReader implements Liste
       final String processInstanceId, final ListenerRequestDto request) {
     final TermQueryBuilder processInstanceQ =
         termQuery(JobTemplate.PROCESS_INSTANCE_KEY, processInstanceId);
-    final TermQueryBuilder flowNodeQ = getFlowNodeQuery(request);
-    final TermQueryBuilder executionListenersQ =
-        termQuery(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER);
-    final TermQueryBuilder taskListenersQ =
-        termQuery(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER);
 
     final SearchSourceBuilder sourceBuilder =
         new SearchSourceBuilder()
             .query(
                 joinWithAnd(
-                    processInstanceQ, flowNodeQ, joinWithOr(executionListenersQ, taskListenersQ)))
+                    processInstanceQ, getFlowNodeQuery(request), getListenerTypeQuery(request)))
             .size(request.getPageSize());
 
     applySorting(sourceBuilder, request);
@@ -110,6 +111,18 @@ public class ElasticsearchListenerReader extends AbstractReader implements Liste
       return termQuery(JobTemplate.FLOW_NODE_INSTANCE_ID, request.getFlowNodeInstanceId());
     }
     return termQuery(JobTemplate.FLOW_NODE_ID, request.getFlowNodeId());
+  }
+
+  private QueryBuilder getListenerTypeQuery(final ListenerRequestDto request) {
+    final ListenerType listenerFilter = request.getListenerTypeFilter();
+    if (listenerFilter == null) {
+      return joinWithOr(executionListenersQ, taskListenersQ);
+    } else if (listenerFilter.equals(ListenerType.EXECUTION_LISTENER)) {
+      return executionListenersQ;
+    } else if (listenerFilter.equals(ListenerType.TASK_LISTENER)) {
+      return taskListenersQ;
+    }
+    throw new IllegalArgumentException("'listenerFilter' is set to an unsupported value.");
   }
 
   private void applySorting(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchListenerReader.java
@@ -39,8 +39,10 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
 
   private final JobTemplate jobTemplate;
   private final RichOpenSearchClient richOpenSearchClient;
-
   private final ObjectMapper objectMapper;
+
+  private final Query executionListenersQ;
+  private final Query taskListenersQ;
 
   public OpensearchListenerReader(
       final JobTemplate jobTemplate,
@@ -49,6 +51,8 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
     this.jobTemplate = jobTemplate;
     this.richOpenSearchClient = richOpenSearchClient;
     this.objectMapper = objectMapper;
+    executionListenersQ = term(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER.name());
+    taskListenersQ = term(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER.name());
   }
 
   @Override
@@ -58,9 +62,7 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
         and(
             term(JobTemplate.PROCESS_INSTANCE_KEY, processInstanceId),
             getFlowNodeQuery(request),
-            or(
-                term(JobTemplate.JOB_KIND, ListenerType.EXECUTION_LISTENER.name()),
-                term(JobTemplate.JOB_KIND, ListenerType.TASK_LISTENER.name())));
+            getListenerTypeQuery(request));
 
     final var searchRequestBuilder = searchRequestBuilder(jobTemplate.getAlias()).query(query);
     applySorting(searchRequestBuilder, request);
@@ -90,6 +92,18 @@ public class OpensearchListenerReader extends OpensearchAbstractReader implement
       return term(JobTemplate.FLOW_NODE_INSTANCE_ID, request.getFlowNodeInstanceId());
     }
     return term(JobTemplate.FLOW_NODE_ID, request.getFlowNodeId());
+  }
+
+  private Query getListenerTypeQuery(final ListenerRequestDto request) {
+    final ListenerType listenerFilter = request.getListenerTypeFilter();
+    if (listenerFilter == null) {
+      return or(executionListenersQ, taskListenersQ);
+    } else if (listenerFilter.equals(ListenerType.EXECUTION_LISTENER)) {
+      return executionListenersQ;
+    } else if (listenerFilter.equals(ListenerType.TASK_LISTENER)) {
+      return taskListenersQ;
+    }
+    throw new IllegalArgumentException("'listenerFilter' is set to an unsupported value.");
   }
 
   private void applySorting(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerRequestDto.java
@@ -10,12 +10,15 @@ package io.camunda.operate.webapp.rest.dto;
 import io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
 import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
+import io.camunda.webapps.schema.entities.operate.ListenerType;
 import java.util.Objects;
 import java.util.Set;
 
 public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
   private String flowNodeId;
   private Long flowNodeInstanceId;
+
+  private ListenerType listenerTypeFilter;
 
   public ListenerRequestDto() {}
 
@@ -34,6 +37,15 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
 
   public ListenerRequestDto setFlowNodeInstanceId(final Long flowNodeInstanceId) {
     this.flowNodeInstanceId = flowNodeInstanceId;
+    return this;
+  }
+
+  public ListenerType getListenerTypeFilter() {
+    return listenerTypeFilter;
+  }
+
+  public ListenerRequestDto setListenerTypeFilter(final ListenerType listenerTypeFilter) {
+    this.listenerTypeFilter = listenerTypeFilter;
     return this;
   }
 
@@ -60,7 +72,7 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), flowNodeId, flowNodeInstanceId);
+    return Objects.hash(super.hashCode(), flowNodeId, flowNodeInstanceId, listenerTypeFilter);
   }
 
   @Override
@@ -76,7 +88,8 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
     }
     final ListenerRequestDto that = (ListenerRequestDto) o;
     return Objects.equals(flowNodeId, that.flowNodeId)
-        && Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId);
+        && Objects.equals(flowNodeInstanceId, that.flowNodeInstanceId)
+        && listenerTypeFilter == that.listenerTypeFilter;
   }
 
   @Override
@@ -87,6 +100,8 @@ public class ListenerRequestDto extends PaginatedQuery<ListenerRequestDto> {
         + '\''
         + ", flowNodeInstanceId="
         + flowNodeInstanceId
+        + ", listenerTypeFilter="
+        + listenerTypeFilter
         + '}';
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/validation/ProcessInstanceRequestValidator.java
@@ -15,6 +15,7 @@ import io.camunda.operate.webapp.rest.dto.metadata.FlowNodeMetadataRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateBatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.webapps.schema.entities.operate.ListenerType;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -70,6 +71,18 @@ public class ProcessInstanceRequestValidator {
     if (request.getFlowNodeId() != null && request.getFlowNodeInstanceId() != null) {
       throw new InvalidRequestException(
           "Only one of 'flowNodeId' or 'flowNodeInstanceId' must be specified in the request.");
+    }
+    final ListenerType listenerTypeFilter = request.getListenerTypeFilter();
+    if (listenerTypeFilter != null
+        && listenerTypeFilter != ListenerType.EXECUTION_LISTENER
+        && listenerTypeFilter != ListenerType.TASK_LISTENER) {
+      throw new InvalidRequestException(
+          "'listenerTypeFilter' only allows for values: ["
+              + "null, "
+              + ListenerType.EXECUTION_LISTENER
+              + ", "
+              + ListenerType.TASK_LISTENER
+              + "]");
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Added optional field `listenerTypeFilter` to listener requests to allow for filtering by listener type in the frontend and the necessary logic for the ES/OS requests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/23944
