### PR TITLE
Process distributed commands idempotently

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandRedistributor.java
@@ -84,6 +84,7 @@ public final class CommandRedistributor implements StreamProcessorLifecycleAware
           final var retriable = new RetriableDistribution(distributionKey, record.getPartitionId());
           retriableDistributions.add(retriable);
           retryDistribution(retriable, record);
+          return true;
         });
 
     // Remove retry cycle tracking for completed distributions, i.e. those not visited in this cycle

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationAddPermissionProcessor.java
@@ -60,8 +60,15 @@ public final class AuthorizationAddPermissionProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), AuthorizationIntent.PERMISSION_ADDED, command.getValue());
+    permissionsBehavior
+        .permissionAlreadyExists(command.getValue())
+        .ifRightOrLeft(
+            ignored ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), AuthorizationIntent.PERMISSION_ADDED, command.getValue()),
+            rejection ->
+                rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
+
     distributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationRemovePermissionProcessor.java
@@ -60,8 +60,15 @@ public final class AuthorizationRemovePermissionProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<AuthorizationRecord> command) {
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), AuthorizationIntent.PERMISSION_REMOVED, command.getValue());
+    permissionsBehavior
+        .permissionDoesNotExist(command.getValue())
+        .ifRightOrLeft(
+            ignored ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), AuthorizationIntent.PERMISSION_REMOVED, command.getValue()),
+            rejection ->
+                rejectionWriter.appendRejection(command, rejection.type(), rejection.reason()));
+
     distributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/GroupRemoveEntityProcessor.java
@@ -30,7 +30,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcessor<GroupRecord> {
-
+  private static final String ENTITY_NOT_ASSIGNED_ERROR_MESSAGE =
+      "Expected to remove entity with key '%s' from group with key '%s', but the entity is not assigned to this group.";
   private final GroupState groupState;
   private final UserState userState;
   private final MappingState mappingState;
@@ -111,8 +112,21 @@ public class GroupRemoveEntityProcessor implements DistributedTypedRecordProcess
 
   @Override
   public void processDistributedCommand(final TypedRecord<GroupRecord> command) {
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue());
+    final var record = command.getValue();
+
+    groupState
+        .getEntityType(record.getGroupKey(), record.getEntityKey())
+        .ifPresentOrElse(
+            entityType ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), GroupIntent.ENTITY_REMOVED, command.getValue()),
+            () -> {
+              final var errorMessage =
+                  ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(
+                      record.getEntityKey(), record.getGroupKey());
+              rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+            });
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingCreateProcessor.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class MappingCreateProcessor implements DistributedTypedRecordProcessor<MappingRecord> {
 
+  private static final String MAPPING_ALREADY_EXISTS_ERROR_MESSAGE =
+      "Expected to create mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists.";
   private final MappingState mappingState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -69,8 +71,8 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
     final var persistedMapping = mappingState.get(record.getClaimName(), record.getClaimValue());
     if (persistedMapping.isPresent()) {
       final var errorMessage =
-          "Expected to create mapping with claimName '%s' and claimValue '%s', but a mapping with this claim already exists."
-              .formatted(record.getClaimName(), record.getClaimValue());
+          MAPPING_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
+              record.getClaimName(), record.getClaimValue());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
@@ -90,7 +92,18 @@ public class MappingCreateProcessor implements DistributedTypedRecordProcessor<M
 
   @Override
   public void processDistributedCommand(final TypedRecord<MappingRecord> command) {
-    stateWriter.appendFollowUpEvent(command.getKey(), MappingIntent.CREATED, command.getValue());
+    final var record = command.getValue();
+    mappingState
+        .get(record.getMappingKey())
+        .ifPresentOrElse(
+            existingMapping -> {
+              final var errorMessage =
+                  MAPPING_ALREADY_EXISTS_ERROR_MESSAGE.formatted(
+                      existingMapping.getClaimName(), existingMapping.getClaimValue());
+              rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
+            },
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), MappingIntent.CREATED, record));
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleAddEntityProcessor.java
@@ -121,7 +121,7 @@ public class RoleAddEntityProcessor implements DistributedTypedRecordProcessor<R
               final var errorMessage =
                   ENTITY_ALREADY_ASSIGNED_ERROR_MESSAGE.formatted(
                       record.getEntityKey(), record.getRoleKey());
-              rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, errorMessage);
+              rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
             },
             () ->
                 stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.ENTITY_ADDED, record));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleCreateProcessor.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class RoleCreateProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
+  private static final String ROLE_ALREADY_EXISTS_ERROR_MESSAGE =
+      "Expected to create role with name '%s', but a role with this name already exists";
   private final RoleState roleState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -67,9 +69,7 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
     final var record = command.getValue();
     final var roleKey = roleState.getRoleKeyByName(record.getName());
     if (roleKey.isPresent()) {
-      final var errorMessage =
-          "Expected to create role with name '%s', but a role with this name already exists"
-              .formatted(record.getName());
+      final var errorMessage = ROLE_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getName());
       rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.ALREADY_EXISTS, errorMessage);
       return;
@@ -88,7 +88,17 @@ public class RoleCreateProcessor implements DistributedTypedRecordProcessor<Role
 
   @Override
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
-    stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.CREATED, command.getValue());
+    final var record = command.getValue();
+    roleState
+        .getRole(record.getRoleKey())
+        .ifPresentOrElse(
+            persistedRole -> {
+              final var errorMessage =
+                  ROLE_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getName());
+              rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
+            },
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.CREATED, record));
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -99,7 +99,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
             role -> {
               removeMembers(command.getValue());
               stateWriter.appendFollowUpEvent(
-                    command.getKey(), RoleIntent.DELETED, command.getValue());
+                  command.getKey(), RoleIntent.DELETED, command.getValue());
             },
             () -> {
               final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleDeleteProcessor.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
 
+  private static final String ROLE_NOT_FOUND_ERROR_MESSAGE =
+      "Expected to delete role with key '%s', but a role with this key doesn't exist.";
   private final RoleState roleState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -57,9 +59,7 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
     final var roleKey = record.getRoleKey();
     final var persistedRecord = roleState.getRole(roleKey);
     if (persistedRecord.isEmpty()) {
-      final var errorMessage =
-          "Expected to delete role with key '%s', but a role with this key doesn't exist."
-              .formatted(roleKey);
+      final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(roleKey);
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
       responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, errorMessage);
       return;
@@ -92,8 +92,20 @@ public class RoleDeleteProcessor implements DistributedTypedRecordProcessor<Role
 
   @Override
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
-    removeMembers(command.getValue());
-    stateWriter.appendFollowUpEvent(command.getKey(), RoleIntent.DELETED, command.getValue());
+    final var record = command.getValue();
+    roleState
+        .getRole(record.getRoleKey())
+        .ifPresentOrElse(
+            role -> {
+              removeMembers(command.getValue());
+              stateWriter.appendFollowUpEvent(
+                    command.getKey(), RoleIntent.DELETED, command.getValue());
+            },
+            () -> {
+              final var errorMessage = ROLE_NOT_FOUND_ERROR_MESSAGE.formatted(record.getRoleKey());
+              rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+            });
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/RoleRemoveEntityProcessor.java
@@ -30,7 +30,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcessor<RoleRecord> {
-
+  private static final String ENTITY_NOT_ASSIGNED_ERROR_MESSAGE =
+      "Expected to remove entity with key '%s' from role with key '%s', but the entity is not assigned to this role.";
   private final RoleState roleState;
   private final UserState userState;
   private final MappingState mappingState;
@@ -111,8 +112,20 @@ public class RoleRemoveEntityProcessor implements DistributedTypedRecordProcesso
 
   @Override
   public void processDistributedCommand(final TypedRecord<RoleRecord> command) {
-    stateWriter.appendFollowUpEvent(
-        command.getKey(), RoleIntent.ENTITY_REMOVED, command.getValue());
+    final var record = command.getValue();
+    roleState
+        .getEntityType(record.getRoleKey(), record.getEntityKey())
+        .ifPresentOrElse(
+            entityType ->
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), RoleIntent.ENTITY_REMOVED, command.getValue()),
+            () -> {
+              final var errorMessage =
+                  ENTITY_NOT_ASSIGNED_ERROR_MESSAGE.formatted(
+                      record.getEntityKey(), record.getRoleKey());
+              rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, errorMessage);
+            });
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -142,6 +142,15 @@ public class ResourceDeletionDeleteProcessor
       rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, exception.getMessage());
       responseWriter.writeRejectionOnCommand(
           command, RejectionType.NOT_FOUND, exception.getMessage());
+
+      // TODO verify this fix. There is a risk attached to it as deployment creation and resource
+      //  deletion were not distributed in guaranteed order before.
+      if (command.isCommandDistributed()) {
+        // If the command is distributed, and it cannot be found upon processing, we can acknowledge
+        // the distribution.
+        commandDistributionBehavior.acknowledgeCommand(command);
+      }
+
       return ProcessingError.EXPECTED_ERROR;
     } else if (error instanceof final ActiveProcessInstancesException exception) {
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, exception.getMessage());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -143,8 +143,6 @@ public class ResourceDeletionDeleteProcessor
       responseWriter.writeRejectionOnCommand(
           command, RejectionType.NOT_FOUND, exception.getMessage());
 
-      // TODO verify this fix. There is a risk attached to it as deployment creation and resource
-      //  deletion were not distributed in guaranteed order before.
       if (command.isCommandDistributed()) {
         // If the command is distributed, and it cannot be found upon processing, we can acknowledge
         // the distribution.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantCreateProcessor.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class TenantCreateProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
+  private static final String TENANT_ALREADY_EXISTS_ERROR_MESSAGE =
+      "Expected to create tenant with ID '%s', but a tenant with this ID already exists";
   private final TenantState tenantState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -61,8 +63,7 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
       rejectCommand(
           command,
           RejectionType.ALREADY_EXISTS,
-          "Expected to create tenant with ID '%s', but a tenant with this ID already exists"
-              .formatted(record.getTenantId()));
+          TENANT_ALREADY_EXISTS_ERROR_MESSAGE.formatted(record.getTenantId()));
     } else {
       createTenant(command, record);
       distributeCommand(command, record);
@@ -71,7 +72,17 @@ public class TenantCreateProcessor implements DistributedTypedRecordProcessor<Te
 
   @Override
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
-    stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.CREATED, command.getValue());
+    final var record = command.getValue();
+    tenantState
+        .getTenantByKey(record.getTenantKey())
+        .ifPresentOrElse(
+            tenant -> {
+              final var errorMessage =
+                  TENANT_ALREADY_EXISTS_ERROR_MESSAGE.formatted(tenant.getTenantId());
+              rejectionWriter.appendRejection(command, RejectionType.ALREADY_EXISTS, errorMessage);
+            },
+            () -> stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.CREATED, record));
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -91,8 +91,8 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
         .ifPresentOrElse(
             tenant -> {
               removeAssignedEntities(command.getValue());
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), TenantIntent.DELETED, command.getValue());
+              stateWriter.appendFollowUpEvent(
+                  command.getKey(), TenantIntent.DELETED, command.getValue());
             },
             () ->
                 rejectCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantDeleteProcessor.java
@@ -27,6 +27,8 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<TenantRecord> {
 
+  private static final String TENANT_NOT_FOUND_ERROR_MESSAGE =
+      "Expected to delete tenant with key '%s', but no tenant with this key exists.";
   private final TenantState tenantState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
@@ -58,10 +60,7 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
     if (persistedTenantRecord.isEmpty()) {
       rejectCommand(
-          command,
-          RejectionType.NOT_FOUND,
-          "Expected to delete tenant with key '%s', but no tenant with this key exists."
-              .formatted(tenantKey));
+          command, RejectionType.NOT_FOUND, TENANT_NOT_FOUND_ERROR_MESSAGE.formatted(tenantKey));
       return;
     }
 
@@ -86,8 +85,21 @@ public class TenantDeleteProcessor implements DistributedTypedRecordProcessor<Te
 
   @Override
   public void processDistributedCommand(final TypedRecord<TenantRecord> command) {
-    removeAssignedEntities(command.getValue());
-    stateWriter.appendFollowUpEvent(command.getKey(), TenantIntent.DELETED, command.getValue());
+    final var record = command.getValue();
+    tenantState
+        .getTenantByKey(record.getTenantKey())
+        .ifPresentOrElse(
+            tenant -> {
+              removeAssignedEntities(command.getValue());
+                stateWriter.appendFollowUpEvent(
+                    command.getKey(), TenantIntent.DELETED, command.getValue());
+            },
+            () ->
+                rejectCommand(
+                    command,
+                    RejectionType.NOT_FOUND,
+                    TENANT_NOT_FOUND_ERROR_MESSAGE.formatted(record.getTenantKey())));
+
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/DbDistributionState.java
@@ -311,7 +311,8 @@ public class DbDistributionState implements MutableDistributionState {
           }
 
           final var commandDistributionRecord = new CommandDistributionRecord();
-          commandDistributionRecord.wrap(lastCommandDistribution.get()).setPartitionId(partitionId);
+          commandDistributionRecord.copyFrom(lastCommandDistribution.get());
+          commandDistributionRecord.setPartitionId(partitionId);
           return visitor.visit(distributionKey, commandDistributionRecord);
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -63,6 +63,11 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
     return value.isEmpty() ? Optional.empty() : Optional.of(value);
   }
 
+  public PersistedCommandDistribution setQueueId(final String queueId) {
+    queueIdProperty.setValue(queueId);
+    return this;
+  }
+
   public ValueType getValueType() {
     return valueTypeProperty.getValue();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -70,6 +70,17 @@ public interface DistributionState {
   void foreachRetriableDistribution(PendingDistributionVisitor visitor);
 
   /**
+   * Visits each persisted pending distribution, providing both the key of that distribution and the
+   * {@link CommandDistributionRecord}.
+   *
+   * <p>Note that a new instance of the record is provided for each visit, so the visitor does not
+   * have to make a copy when long term access is needed.
+   *
+   * @param visitor Each pending distribution is visited by this visitor
+   */
+  void foreachPendingDistribution(PendingDistributionVisitor visitor);
+
+  /**
    * Returns the distribution key at the head of the queue for the given partition.
    *
    * @param queue the queue to look up
@@ -111,7 +122,7 @@ public interface DistributionState {
      * @param distributionKey The key of the pending distribution
      * @param pendingDistribution The pending distribution itself as command distribution record
      */
-    void visit(final long distributionKey, final CommandDistributionRecord pendingDistribution);
+    boolean visit(final long distributionKey, final CommandDistributionRecord pendingDistribution);
   }
 
   @FunctionalInterface

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DistributionState.java
@@ -121,6 +121,7 @@ public interface DistributionState {
      *
      * @param distributionKey The key of the pending distribution
      * @param pendingDistribution The pending distribution itself as command distribution record
+     * @return true if the visitor should continue visiting, false if it should stop
      */
     boolean visit(final long distributionKey, final CommandDistributionRecord pendingDistribution);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.DbProcessMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_4.DbSignalSubscriptionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_5.DbColumnFamilyCorrectionMigrationState;
 import io.camunda.zeebe.engine.state.migration.to_8_6.DbDistributionMigrationState;
+import io.camunda.zeebe.engine.state.migration.to_8_7.DbDistributionMigrationState8dot7;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableEventScopeInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
@@ -129,6 +130,7 @@ public class DbMigrationState implements MutableMigrationState {
 
   private final DbColumnFamilyCorrectionMigrationState columnFamilyCorrectionMigrationState;
   private final DbDistributionMigrationState distributionState;
+  private final DbDistributionMigrationState8dot7 distributionState8dot7;
 
   public DbMigrationState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
@@ -288,6 +290,7 @@ public class DbMigrationState implements MutableMigrationState {
         new DbColumnFamilyCorrectionMigrationState(zeebeDb, transactionContext);
 
     distributionState = new DbDistributionMigrationState(zeebeDb, transactionContext);
+    distributionState8dot7 = new DbDistributionMigrationState8dot7(zeebeDb, transactionContext);
   }
 
   @Override
@@ -509,5 +512,10 @@ public class DbMigrationState implements MutableMigrationState {
   @Override
   public void migrateOrderedCommandDistribution() {
     distributionState.migratePendingDistributionsToRetriableDistributions();
+  }
+
+  @Override
+  public void migrateIdempotentCommandDistribution() {
+    distributionState8dot7.migrateIdempotentCommandDistributions();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDe
 import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_7.IdempotentCommandDistributionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
@@ -57,7 +58,8 @@ public class DbMigratorImpl implements DbMigrator {
           new MultiTenancySignalSubscriptionStateMigration(),
           new JobBackoffRestoreMigration(),
           new RoutingInfoMigration(),
-          new OrderedCommandDistributionMigration());
+          new OrderedCommandDistributionMigration(),
+          new IdempotentCommandDistributionMigration());
   private static final Logger LOGGER =
       LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
   // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/DbDistributionMigrationState8dot7.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbForeignKey;
+import io.camunda.zeebe.db.impl.DbInt;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.Loggers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.distribution.PersistedCommandDistribution;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+
+public class DbDistributionMigrationState8dot7 {
+  private static final Logger LOG = Loggers.STREAM_PROCESSING;
+
+  private final DbLong distributionKey;
+  private final DbInt partitionKey;
+  private final DbCompositeKey<DbForeignKey<DbLong>, DbInt> distributionPartitionKey;
+
+  /** [distribution key | partition id] => [DbNil] */
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
+      pendingDistributionColumnFamily;
+
+  /** [distribution key | partition id] => [DbNil] */
+  private final ColumnFamily<DbCompositeKey<DbForeignKey<DbLong>, DbInt>, DbNil>
+      retriableDistributionColumnFamily;
+
+  /** [distribution key] => [persisted command distribution] */
+  private final ColumnFamily<DbLong, PersistedCommandDistribution>
+      commandDistributionRecordColumnFamily;
+
+  /** [queue id | partition id | distribution key ] => [] */
+  private final ColumnFamily<
+          DbCompositeKey<DbString, DbCompositeKey<DbInt, DbForeignKey<DbLong>>>, DbNil>
+      queuedCommandDistributionColumnFamily;
+
+  private final DbString queueId;
+  private final DbCompositeKey<DbString, DbInt> queuePerPartitionKey;
+  private final DbCompositeKey<DbString, DbCompositeKey<DbInt, DbForeignKey<DbLong>>>
+      queuedDistributionKey;
+
+  /** [queue id | continuation key] => persisted continuation command */
+  private final ColumnFamily<DbCompositeKey<DbString, DbLong>, PersistedCommandDistribution>
+      continuationCommandColumnFamily;
+
+  private final DbLong continuationKey;
+  private final DbCompositeKey<DbString, DbLong> continuationByQueueKey;
+
+  public DbDistributionMigrationState8dot7(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    distributionKey = new DbLong();
+    final DbForeignKey<DbLong> fkDistribution =
+        new DbForeignKey<>(distributionKey, ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD);
+    commandDistributionRecordColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.COMMAND_DISTRIBUTION_RECORD,
+            transactionContext,
+            distributionKey,
+            new PersistedCommandDistribution());
+
+    partitionKey = new DbInt();
+    distributionPartitionKey = new DbCompositeKey<>(fkDistribution, partitionKey);
+    pendingDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.PENDING_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
+
+    retriableDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.RETRIABLE_DISTRIBUTION,
+            transactionContext,
+            distributionPartitionKey,
+            DbNil.INSTANCE);
+
+    queueId = new DbString();
+    queuePerPartitionKey = new DbCompositeKey<>(queueId, partitionKey);
+    queuedDistributionKey =
+        new DbCompositeKey<>(queueId, new DbCompositeKey<>(partitionKey, fkDistribution));
+    queuedCommandDistributionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.QUEUED_DISTRIBUTION,
+            transactionContext,
+            queuedDistributionKey,
+            DbNil.INSTANCE);
+
+    continuationKey = new DbLong();
+    continuationByQueueKey = new DbCompositeKey<>(queueId, continuationKey);
+    continuationCommandColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.DISTRIBUTION_CONTINUATION,
+            transactionContext,
+            continuationByQueueKey,
+            new PersistedCommandDistribution());
+  }
+
+  public void migrateIdempotentCommandDistributions() {
+    queueId.wrapString(DistributionQueue.DEPLOYMENT.getQueueId());
+    final var isFirstInQueue = new AtomicBoolean(true);
+
+    pendingDistributionColumnFamily.forEach(
+        (compositeKey, nil) -> {
+          final var distributionKey = compositeKey.first().inner().getValue();
+          final var partitionId = compositeKey.second().getValue();
+          this.distributionKey.wrapLong(distributionKey);
+          partitionKey.wrapInt(partitionId);
+
+          final var persistedDistribution =
+              commandDistributionRecordColumnFamily.get(this.distributionKey);
+
+          final var valueType = persistedDistribution.getValueType();
+          final var isDeploymentOrDeletion =
+              valueType == ValueType.DEPLOYMENT || valueType == ValueType.RESOURCE_DELETION;
+
+          if (isDeploymentOrDeletion && persistedDistribution.getQueueId().isEmpty()) {
+            persistedDistribution.setQueueId(DistributionQueue.DEPLOYMENT.getQueueId());
+            commandDistributionRecordColumnFamily.update(
+                this.distributionKey, persistedDistribution);
+            queuedCommandDistributionColumnFamily.insert(queuedDistributionKey, DbNil.INSTANCE);
+
+            if (isFirstInQueue.get()) {
+              isFirstInQueue.set(false);
+            } else {
+              retriableDistributionColumnFamily.deleteExisting(distributionPartitionKey);
+            }
+          }
+        });
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/IdempotentCommandDistributionMigration.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_7/IdempotentCommandDistributionMigration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import io.camunda.zeebe.engine.state.migration.MigrationTask;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContext;
+import io.camunda.zeebe.engine.state.migration.MutableMigrationTaskContext;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class IdempotentCommandDistributionMigration implements MigrationTask {
+
+  @Override
+  public String getIdentifier() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public boolean needsToRun(final MigrationTaskContext context) {
+    final var distributionState = context.processingState().getDistributionState();
+
+    final var shouldRun = new AtomicBoolean(false);
+
+    distributionState.foreachPendingDistribution(
+        (distributionKey, distributionRecord) -> {
+          final var valueType = distributionRecord.getValueType();
+          final var isDeploymentOrDeletion =
+              valueType == ValueType.DEPLOYMENT || valueType == ValueType.RESOURCE_DELETION;
+          final var hasQueueId = distributionRecord.getQueueId();
+
+          if (isDeploymentOrDeletion && hasQueueId == null) {
+            shouldRun.set(true);
+            return false;
+          }
+
+          return true;
+        });
+
+    return shouldRun.get();
+  }
+
+  @Override
+  public void runMigration(final MutableMigrationTaskContext context) {
+    context.processingState().getMigrationState().migrateIdempotentCommandDistribution();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -52,4 +52,6 @@ public interface MutableMigrationState extends MigrationState {
   void correctColumnFamilyPrefix();
 
   void migrateOrderedCommandDistribution();
+
+  void migrateIdempotentCommandDistribution();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddEntityRoleMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -57,7 +56,7 @@ public class AddEntityRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.ROLE
@@ -118,7 +117,7 @@ public class AddEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -151,11 +150,10 @@ public class AddEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationMultiPartitionTest.java
@@ -62,7 +62,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.AUTHORIZATION
@@ -98,7 +98,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
       assertThat(
               RecordingExporter.records()
                   .withPartitionId(partitionId)
-                  .limit(r -> r.getIntent().equals(AuthorizationIntent.PERMISSION_ADDED))
+                  .limitByCount(r -> r.getIntent().equals(AuthorizationIntent.PERMISSION_ADDED), 2)
                   .collect(Collectors.toList()))
           .extracting(Record::getIntent)
           .endsWith(AuthorizationIntent.ADD_PERMISSION, AuthorizationIntent.PERMISSION_ADDED);
@@ -128,7 +128,7 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -166,11 +166,10 @@ public class AddPermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(2))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/CreateRoleMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -122,12 +121,10 @@ public class CreateRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(2))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
-            tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
-            tuple(ValueType.ROLE, RoleIntent.CREATE));
+            tuple(ValueType.USER, UserIntent.CREATE), tuple(ValueType.ROLE, RoleIntent.CREATE));
   }
 
   private void interceptUserCreateForPartition(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemoveEntityRoleMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -63,7 +62,7 @@ public class RemoveEntityRoleMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.ROLE
@@ -130,7 +129,7 @@ public class RemoveEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -169,11 +168,10 @@ public class RemoveEntityRoleMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(5))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.ROLE, RoleIntent.CREATE),
             tuple(ValueType.ROLE, RoleIntent.ADD_ENTITY),
             tuple(ValueType.ROLE, RoleIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationMultiPartitionTest.java
@@ -58,7 +58,7 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.AUTHORIZATION
@@ -121,7 +121,7 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -154,11 +154,10 @@ public class RemovePermissionAuthorizationMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.AUTHORIZATION, AuthorizationIntent.REMOVE_PERMISSION));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -1,0 +1,621 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.zeebe.engine.processing.clock.ClockProcessor;
+import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationAddPermissionProcessor;
+import io.camunda.zeebe.engine.processing.identity.AuthorizationRemovePermissionProcessor;
+import io.camunda.zeebe.engine.processing.identity.GroupAddEntityProcessor;
+import io.camunda.zeebe.engine.processing.identity.GroupCreateProcessor;
+import io.camunda.zeebe.engine.processing.identity.GroupDeleteProcessor;
+import io.camunda.zeebe.engine.processing.identity.GroupRemoveEntityProcessor;
+import io.camunda.zeebe.engine.processing.identity.GroupUpdateProcessor;
+import io.camunda.zeebe.engine.processing.identity.MappingCreateProcessor;
+import io.camunda.zeebe.engine.processing.identity.MappingDeleteProcessor;
+import io.camunda.zeebe.engine.processing.identity.RoleAddEntityProcessor;
+import io.camunda.zeebe.engine.processing.identity.RoleCreateProcessor;
+import io.camunda.zeebe.engine.processing.identity.RoleDeleteProcessor;
+import io.camunda.zeebe.engine.processing.identity.RoleRemoveEntityProcessor;
+import io.camunda.zeebe.engine.processing.identity.RoleUpdateProcessor;
+import io.camunda.zeebe.engine.processing.message.MessageSubscriptionMigrateProcessor;
+import io.camunda.zeebe.engine.processing.resource.ResourceDeletionDeleteProcessor;
+import io.camunda.zeebe.engine.processing.signal.SignalBroadcastProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.tenant.TenantAddEntityProcessor;
+import io.camunda.zeebe.engine.processing.tenant.TenantCreateProcessor;
+import io.camunda.zeebe.engine.processing.tenant.TenantDeleteProcessor;
+import io.camunda.zeebe.engine.processing.tenant.TenantRemoveEntityProcessor;
+import io.camunda.zeebe.engine.processing.tenant.TenantUpdateProcessor;
+import io.camunda.zeebe.engine.processing.user.UserCreateProcessor;
+import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
+import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.MappingIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.awaitility.Awaitility;
+import org.junit.AfterClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.platform.commons.support.ReflectionSupport;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class CommandDistributionIdempotencyTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(2);
+
+  private static final Set<Class<?>> DISTRIBUTING_PROCESSORS =
+      new HashSet<>(
+          ReflectionSupport.findAllClassesInPackage(
+              "io.camunda.zeebe.engine.processing",
+              c -> {
+                final var interfaces = c.getInterfaces();
+                return Arrays.asList(interfaces).contains(DistributedTypedRecordProcessor.class);
+              },
+              ignored -> true));
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final Scenario scenario;
+  private final Class<?> processor;
+
+  public CommandDistributionIdempotencyTest(
+      final String testName, final Scenario scenario, final Class<?> processor) {
+    this.scenario = scenario;
+    this.processor = processor;
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    // TODO we need to add a scenario for this processor. I wasn't sure how to trigger it :)
+    DISTRIBUTING_PROCESSORS.remove(MessageSubscriptionMigrateProcessor.class);
+    if (!DISTRIBUTING_PROCESSORS.isEmpty()) {
+      fail("No test scenario found for processors: '%s'".formatted(DISTRIBUTING_PROCESSORS));
+    }
+  }
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> scenarios() {
+    return Arrays.asList(
+        new Object[][] {
+          {
+            "Authorization.ADD_PERMISSION is idempotent",
+            new Scenario(
+                ValueType.AUTHORIZATION,
+                AuthorizationIntent.ADD_PERMISSION,
+                () -> {
+                  final var user = createUser();
+                  ENGINE
+                      .authorization()
+                      .permission()
+                      .withOwnerKey(user.getKey())
+                      .withResourceType(AuthorizationResourceType.USER)
+                      .withPermission(PermissionType.READ, "*")
+                      .add();
+                },
+                2),
+            AuthorizationAddPermissionProcessor.class
+          },
+          {
+            "Authorization.REMOVE_PERMISSION is idempotent",
+            new Scenario(
+                ValueType.AUTHORIZATION,
+                AuthorizationIntent.REMOVE_PERMISSION,
+                () -> {
+                  final var user = createUser();
+                  ENGINE
+                      .authorization()
+                      .permission()
+                      .withOwnerKey(user.getKey())
+                      .withResourceType(AuthorizationResourceType.USER)
+                      .withPermission(PermissionType.READ, user.getValue().getUsername())
+                      .remove();
+                },
+                2),
+            AuthorizationRemovePermissionProcessor.class
+          },
+          {
+            "Clock.RESET is idempotent",
+            new Scenario(ValueType.CLOCK, ClockIntent.RESET, () -> ENGINE.clock().reset(), 1),
+            ClockProcessor.class
+          },
+          {
+            "Deployment.CREATE is idempotent",
+            new Scenario(
+                ValueType.DEPLOYMENT,
+                DeploymentIntent.CREATE,
+                CommandDistributionIdempotencyTest::deployProcess,
+                1),
+            DeploymentCreateProcessor.class
+          },
+          {
+            "Group.CREATE is idempotent",
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.CREATE,
+                CommandDistributionIdempotencyTest::createGroup,
+                1),
+            GroupCreateProcessor.class
+          },
+          {
+            "Group.DELETE is idempotent",
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.DELETE,
+                () -> {
+                  final var group = createGroup();
+                  ENGINE.group().deleteGroup(group.getKey()).delete();
+                },
+                2),
+            GroupDeleteProcessor.class
+          },
+          {
+            "Group.UPDATE is idempotent",
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.UPDATE,
+                () -> {
+                  final var group = createGroup();
+                  ENGINE
+                      .group()
+                      .updateGroup(group.getKey())
+                      .withName(UUID.randomUUID().toString())
+                      .update();
+                },
+                2),
+            GroupUpdateProcessor.class
+          },
+          {
+            "Group.ADD_ENTITY is idempotent",
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.ADD_ENTITY,
+                () -> {
+                  final var group = createGroup();
+                  final var user = createUser();
+                  ENGINE
+                      .group()
+                      .addEntity(group.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                },
+                3),
+            GroupAddEntityProcessor.class
+          },
+          {
+            "Group.REMOVE_ENTITY is idempotent",
+            new Scenario(
+                ValueType.GROUP,
+                GroupIntent.REMOVE_ENTITY,
+                () -> {
+                  final var group = createGroup();
+                  final var user = createUser();
+                  ENGINE
+                      .group()
+                      .addEntity(group.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                  ENGINE
+                      .group()
+                      .removeEntity(group.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .remove();
+                },
+                4),
+            GroupRemoveEntityProcessor.class
+          },
+          {
+            "Mapping.CREATE is idempotent",
+            new Scenario(
+                ValueType.MAPPING,
+                MappingIntent.CREATE,
+                CommandDistributionIdempotencyTest::createMapping,
+                1),
+            MappingCreateProcessor.class
+          },
+          {
+            "Mapping.DELETE is idempotent",
+            new Scenario(
+                ValueType.MAPPING,
+                MappingIntent.DELETE,
+                () -> {
+                  final var mapping = createMapping();
+                  ENGINE.mapping().deleteMapping(mapping.getKey()).delete();
+                },
+                2),
+            MappingDeleteProcessor.class
+          },
+          {
+            "ResourceDeletion.DELETE is idempotent",
+            new Scenario(
+                ValueType.RESOURCE_DELETION,
+                ResourceDeletionIntent.DELETE,
+                () -> {
+                  final var process = deployProcess();
+                  ENGINE
+                      .resourceDeletion()
+                      .withResourceKey(
+                          process
+                              .getValue()
+                              .getProcessesMetadata()
+                              .getFirst()
+                              .getProcessDefinitionKey())
+                      .delete();
+                },
+                2),
+            ResourceDeletionDeleteProcessor.class
+          },
+          {
+            "Role.CREATE is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.CREATE,
+                CommandDistributionIdempotencyTest::createRole,
+                1),
+            RoleCreateProcessor.class
+          },
+          {
+            "Role.DELETE is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.DELETE,
+                () -> {
+                  final var group = createRole();
+                  ENGINE.role().deleteRole(group.getKey()).delete();
+                },
+                2),
+            RoleDeleteProcessor.class
+          },
+          {
+            "Role.UPDATE is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.UPDATE,
+                () -> {
+                  final var role = createRole();
+                  ENGINE
+                      .role()
+                      .updateRole(role.getKey())
+                      .withName(UUID.randomUUID().toString())
+                      .update();
+                },
+                2),
+            RoleUpdateProcessor.class
+          },
+          {
+            "Role.ADD_ENTITY is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.ADD_ENTITY,
+                () -> {
+                  final var role = createRole();
+                  final var user = createUser();
+                  ENGINE
+                      .role()
+                      .addEntity(role.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                },
+                3),
+            RoleAddEntityProcessor.class
+          },
+          {
+            "Role.REMOVE_ENTITY is idempotent",
+            new Scenario(
+                ValueType.ROLE,
+                RoleIntent.REMOVE_ENTITY,
+                () -> {
+                  final var role = createRole();
+                  final var user = createUser();
+                  ENGINE
+                      .role()
+                      .addEntity(role.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                  ENGINE
+                      .role()
+                      .removeEntity(role.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .remove();
+                },
+                4),
+            RoleRemoveEntityProcessor.class
+          },
+          {
+            "Signal.BROADCAST is idempotent",
+            new Scenario(
+                ValueType.SIGNAL,
+                SignalIntent.BROADCAST,
+                () -> ENGINE.signal().withSignalName(UUID.randomUUID().toString()).broadcast(),
+                1),
+            SignalBroadcastProcessor.class
+          },
+          {
+            "Tenant.CREATE is idempotent",
+            new Scenario(
+                ValueType.TENANT,
+                TenantIntent.CREATE,
+                CommandDistributionIdempotencyTest::createTenant,
+                1),
+            TenantCreateProcessor.class
+          },
+          {
+            "Tenant.DELETE is idempotent",
+            new Scenario(
+                ValueType.TENANT,
+                TenantIntent.DELETE,
+                () -> {
+                  final var tenant = createTenant();
+                  ENGINE.tenant().deleteTenant(tenant.getKey()).delete();
+                },
+                2),
+            TenantDeleteProcessor.class
+          },
+          {
+            "Tenant.UPDATE is idempotent",
+            new Scenario(
+                ValueType.TENANT,
+                TenantIntent.UPDATE,
+                () -> {
+                  final var tenant = createTenant();
+                  ENGINE
+                      .tenant()
+                      .updateTenant(tenant.getKey())
+                      .withName(UUID.randomUUID().toString())
+                      .update();
+                },
+                2),
+            TenantUpdateProcessor.class
+          },
+          {
+            "Tenant.ADD_ENTITY is idempotent",
+            new Scenario(
+                ValueType.TENANT,
+                TenantIntent.ADD_ENTITY,
+                () -> {
+                  final var tenant = createTenant();
+                  final var user = createUser();
+                  ENGINE
+                      .tenant()
+                      .addEntity(tenant.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                },
+                3),
+            TenantAddEntityProcessor.class
+          },
+          {
+            "Tenant.REMOVE_ENTITY is idempotent",
+            new Scenario(
+                ValueType.TENANT,
+                TenantIntent.REMOVE_ENTITY,
+                () -> {
+                  final var tenant = createTenant();
+                  final var user = createUser();
+                  ENGINE
+                      .tenant()
+                      .addEntity(tenant.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .add();
+                  ENGINE
+                      .tenant()
+                      .removeEntity(tenant.getKey())
+                      .withEntityKey(user.getKey())
+                      .withEntityType(EntityType.USER)
+                      .remove();
+                },
+                4),
+            TenantRemoveEntityProcessor.class
+          },
+          {
+            "User.CREATE is idempotent",
+            new Scenario(
+                ValueType.USER,
+                UserIntent.CREATE,
+                CommandDistributionIdempotencyTest::createUser,
+                1),
+            UserCreateProcessor.class
+          },
+          {
+            "User.DELETE is idempotent",
+            new Scenario(
+                ValueType.USER,
+                UserIntent.DELETE,
+                () -> {
+                  final var user = createUser();
+                  ENGINE
+                      .user()
+                      .deleteUser(user.getKey())
+                      .withUsername(UUID.randomUUID().toString())
+                      .delete();
+                },
+                2),
+            UserDeleteProcessor.class,
+          },
+          {
+            "User.UPDATE is idempotent",
+            new Scenario(
+                ValueType.USER,
+                UserIntent.UPDATE,
+                () -> {
+                  final var user = createUser();
+                  ENGINE
+                      .user()
+                      .updateUser(user.getKey())
+                      .withUsername(user.getValue().getUsername())
+                      .withName(UUID.randomUUID().toString())
+                      .update();
+                },
+                2),
+            UserUpdateProcessor.class
+          }
+        });
+  }
+
+  @Test
+  public void test() {
+    DISTRIBUTING_PROCESSORS.remove(processor);
+    // given we intercept the first acknowledgement
+    interceptAcknowledgement(scenario);
+
+    // when distribution is started
+    scenario.commandSender.sendCommand();
+    RecordingExporter.commandDistributionRecords(CommandDistributionIntent.STARTED)
+        .withDistributionIntent(scenario.intent())
+        .withDistributionValueType(scenario.valueType())
+        .await();
+
+    // wait until the 2nd partition received the command twice
+    RecordingExporter.setMaximumWaitTime(100);
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              ENGINE.getClock().addTime(CommandRedistributor.COMMAND_REDISTRIBUTION_INTERVAL);
+              assertThat(
+                      RecordingExporter.records()
+                          .withPartitionId(2)
+                          .withValueType(scenario.valueType())
+                          .withIntent(scenario.intent())
+                          .limit(2))
+                  .hasSize(2);
+            });
+    RecordingExporter.setMaximumWaitTime(5000);
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .withPartitionId(1)
+                .withDistributionValueType(scenario.valueType())
+                .withDistributionIntent(scenario.intent())
+                .exists())
+        .isTrue();
+  }
+
+  private static void interceptAcknowledgement(final Scenario scenario) {
+    final var hasInterceptedAlready = new AtomicBoolean(false);
+    final var acknowledgementCounter = new AtomicInteger(0);
+    ENGINE.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (intent != CommandDistributionIntent.ACKNOWLEDGE) {
+            return true;
+          }
+
+          final var currentAcknowledgementCount = acknowledgementCounter.incrementAndGet();
+
+          if (hasInterceptedAlready.get()
+              || currentAcknowledgementCount < scenario.expectedAmountOfDistributions) {
+            return true;
+          }
+
+          hasInterceptedAlready.set(true);
+          return false;
+        });
+  }
+
+  private static Record<UserRecordValue> createUser() {
+    return ENGINE
+        .user()
+        .newUser(UUID.randomUUID().toString())
+        .withName("name")
+        .withEmail("email")
+        .withPassword("password")
+        .create();
+  }
+
+  private static Record<GroupRecordValue> createGroup() {
+    return ENGINE.group().newGroup(UUID.randomUUID().toString()).create();
+  }
+
+  private static Record<RoleRecordValue> createRole() {
+    return ENGINE.role().newRole(UUID.randomUUID().toString()).create();
+  }
+
+  private static Record<TenantRecordValue> createTenant() {
+    return ENGINE
+        .tenant()
+        .newTenant()
+        .withName(UUID.randomUUID().toString())
+        .withTenantId(UUID.randomUUID().toString())
+        .create();
+  }
+
+  private static Record<MappingRecordValue> createMapping() {
+    return ENGINE
+        .mapping()
+        .newMapping(UUID.randomUUID().toString())
+        .withClaimValue(UUID.randomUUID().toString())
+        .create();
+  }
+
+  private static Record<DeploymentRecordValue> deployProcess() {
+    return ENGINE
+        .deployment()
+        .withXmlResource(
+            "process.bpmn", Bpmn.createExecutableProcess().startEvent().endEvent().done())
+        .expectCreated()
+        .deploy();
+  }
+
+  public record Scenario(
+      ValueType valueType,
+      Intent intent,
+      CommandSender commandSender,
+      int expectedAmountOfDistributions) {}
+
+  @FunctionalInterface
+  interface CommandSender {
+    void sendCommand();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.processing.identity.GroupCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.GroupDeleteProcessor;
 import io.camunda.zeebe.engine.processing.identity.GroupRemoveEntityProcessor;
 import io.camunda.zeebe.engine.processing.identity.GroupUpdateProcessor;
+import io.camunda.zeebe.engine.processing.identity.IdentitySetupInitializeProcessor;
 import io.camunda.zeebe.engine.processing.identity.MappingCreateProcessor;
 import io.camunda.zeebe.engine.processing.identity.MappingDeleteProcessor;
 import io.camunda.zeebe.engine.processing.identity.RoleAddEntityProcessor;
@@ -41,6 +42,8 @@ import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
 import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
@@ -48,6 +51,7 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -511,6 +515,27 @@ public class CommandDistributionIdempotencyTest {
                 CommandDistributionIdempotencyTest::migrateMessageSubscription,
                 2),
             MessageSubscriptionMigrateProcessor.class
+          },
+          {
+            "IdentitySetup.INITIALIZE is idempotent",
+            new Scenario(
+                ValueType.IDENTITY_SETUP,
+                IdentitySetupIntent.INITIALIZE,
+                () ->
+                    ENGINE
+                        .identitySetup()
+                        .initialize()
+                        .withRole(new RoleRecord().setRoleKey(1L).setName("role"))
+                        .withUser(
+                            new UserRecord()
+                                .setUserKey(2L)
+                                .setUsername("user")
+                                .setEmail("email")
+                                .setPassword("password")
+                                .setName("name"))
+                        .initialize(),
+                1),
+            IdentitySetupInitializeProcessor.class
           }
         });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/AddEntityGroupMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -58,7 +57,7 @@ public class AddEntityGroupMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.GROUP
@@ -119,7 +118,7 @@ public class AddEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -152,11 +151,10 @@ public class AddEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.GROUP, GroupIntent.CREATE),
             tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/group/RemoveEntityGroupMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -62,7 +61,7 @@ public class RemoveEntityGroupMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.GROUP
@@ -129,7 +128,7 @@ public class RemoveEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -168,11 +167,10 @@ public class RemoveEntityGroupMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(5))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.GROUP, GroupIntent.CREATE),
             tuple(ValueType.GROUP, GroupIntent.ADD_ENTITY),
             tuple(ValueType.GROUP, GroupIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrationTestUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrationTestUtil.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 
 public class MigrationTestUtil {
 
-  protected static long extractProcessDefinitionKeyByProcessId(
+  public static long extractProcessDefinitionKeyByProcessId(
       final Record<DeploymentRecordValue> deployment, final String processId) {
     return deployment.getValue().getProcessesMetadata().stream()
         .filter(p -> p.getBpmnProcessId().equals(processId))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -64,7 +63,7 @@ public class AddEntityTenantMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.TENANT
@@ -128,7 +127,7 @@ public class AddEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -168,11 +167,10 @@ public class AddEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(4))
+                .limit(3))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.ADD_ENTITY));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/RemoveEntityTenantMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -71,7 +70,7 @@ public class RemoveEntityTenantMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.TENANT
@@ -118,7 +117,7 @@ public class RemoveEntityTenantMultiPartitionTest {
     setupTenantWithUserAndRemoveEntity();
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 5)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 4)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -137,11 +136,10 @@ public class RemoveEntityTenantMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(5))
+                .limit(4))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             tuple(ValueType.USER, UserIntent.CREATE),
-            tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             tuple(ValueType.TENANT, TenantIntent.CREATE),
             tuple(ValueType.TENANT, TenantIntent.ADD_ENTITY),
             tuple(ValueType.TENANT, TenantIntent.REMOVE_ENTITY));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/CreateUserMultiPartitionTest.java
@@ -49,8 +49,7 @@ public class CreateUserMultiPartitionTest {
     assertThat(
             RecordingExporter.records()
                 .withPartitionId(1)
-                .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
+                .limit(record -> record.getIntent().equals(CommandDistributionIntent.FINISHED))
                 .filter(
                     record ->
                         record.getValueType() == ValueType.USER

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserMultiPartitionTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
@@ -67,7 +66,7 @@ public class DeleteUserMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.USER
@@ -134,7 +133,7 @@ public class DeleteUserMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());
@@ -171,11 +170,10 @@ public class DeleteUserMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
-                .limit(3))
+                .limit(2))
         .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
         .containsExactly(
             Assertions.tuple(ValueType.USER, UserIntent.CREATE),
-            Assertions.tuple(ValueType.AUTHORIZATION, AuthorizationIntent.ADD_PERMISSION),
             Assertions.tuple(ValueType.USER, UserIntent.DELETE));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/UpdateUserMultiPartitionTest.java
@@ -64,7 +64,7 @@ public class UpdateUserMultiPartitionTest {
             RecordingExporter.records()
                 .withPartitionId(1)
                 .limitByCount(
-                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                    record -> record.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .filter(
                     record ->
                         record.getValueType() == ValueType.USER
@@ -131,7 +131,7 @@ public class UpdateUserMultiPartitionTest {
     // then
     assertThat(
             RecordingExporter.commandDistributionRecords()
-                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 2)
                 .withIntent(CommandDistributionIntent.ENQUEUED))
         .extracting(r -> r.getValue().getQueueId())
         .containsOnly(DistributionQueue.IDENTITY.getQueueId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_7/IdempotentCommandDistributionMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_7/IdempotentCommandDistributionMigrationTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration.to_8_7;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.state.distribution.DbDistributionState;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.migration.MigrationTaskContextImpl;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
+import io.camunda.zeebe.stream.impl.ClusterContextImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class IdempotentCommandDistributionMigrationTest {
+
+  final IdempotentCommandDistributionMigration sut = new IdempotentCommandDistributionMigration();
+
+  private ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private MutableProcessingState processingState;
+  private TransactionContext transactionContext;
+
+  private DbDistributionState state;
+  private DbDistributionMigrationState8dot7 migrationState;
+
+  @BeforeEach
+  void setup() {
+    state = new DbDistributionState(zeebeDb, transactionContext);
+    migrationState = new DbDistributionMigrationState8dot7(zeebeDb, transactionContext);
+  }
+
+  @Test
+  void shouldMigratePendingDistributionsToQueue() {
+    // given
+    final var createDistributionKey = 1L;
+    final var deleteDistributionKey = 2L;
+    final var partitionId = 1;
+    final var createRecord = createDeploymentCreateRecord();
+    final var deleteRecord = createResourceDeletionDeleteRecord();
+
+    state.addCommandDistribution(createDistributionKey, createRecord);
+    state.addCommandDistribution(deleteDistributionKey, deleteRecord);
+    state.addPendingDistribution(createDistributionKey, partitionId);
+    state.addPendingDistribution(deleteDistributionKey, partitionId);
+    state.addRetriableDistribution(createDistributionKey, partitionId);
+    state.addRetriableDistribution(deleteDistributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    assertThat(sut.needsToRun(context)).isTrue();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasPendingDistribution(createDistributionKey)).isTrue();
+    assertThat(state.hasPendingDistribution(deleteDistributionKey)).isTrue();
+    assertThat(state.hasRetriableDistribution(createDistributionKey)).isTrue();
+    assertThat(state.hasRetriableDistribution(deleteDistributionKey)).isFalse();
+
+    final var queueId = DistributionQueue.DEPLOYMENT.getQueueId();
+    assertThat(state.getQueueIdForDistribution(createDistributionKey))
+        .isPresent()
+        .get()
+        .isEqualTo(queueId);
+    assertThat(state.getQueueIdForDistribution(deleteDistributionKey))
+        .isPresent()
+        .get()
+        .isEqualTo(queueId);
+
+    assertThat(state.getNextQueuedDistributionKey(queueId, partitionId))
+        .isPresent()
+        .get()
+        .isEqualTo(createDistributionKey);
+    state.removeQueuedDistribution(queueId, partitionId, createDistributionKey);
+    assertThat(state.getNextQueuedDistributionKey(queueId, partitionId))
+        .isPresent()
+        .get()
+        .isEqualTo(deleteDistributionKey);
+  }
+
+  @Test
+  void shouldNotMigrateNonDeploymentOrResourceDeletionDistributions() {
+    // given
+    final var distributionKey = 1L;
+    final var partitionId = 1;
+    final var clockRecord = createClockRecord();
+
+    state.addCommandDistribution(distributionKey, clockRecord);
+    state.addPendingDistribution(distributionKey, partitionId);
+    state.addRetriableDistribution(distributionKey, partitionId);
+
+    // when
+    final var context = new MigrationTaskContextImpl(new ClusterContextImpl(1), processingState);
+    assertThat(sut.needsToRun(context)).isFalse();
+    sut.runMigration(context);
+
+    // then
+    assertThat(state.hasPendingDistribution(distributionKey)).isTrue();
+    assertThat(state.hasRetriableDistribution(distributionKey)).isTrue();
+    assertThat(state.getQueueIdForDistribution(distributionKey)).isEmpty();
+    assertThat(state.getNextQueuedDistributionKey(DistributionQueue.DEPLOYMENT.getQueueId(), 1))
+        .isEmpty();
+  }
+
+  private CommandDistributionRecord createDeploymentCreateRecord() {
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord
+        .resources()
+        .add()
+        .setResourceName("my_first_bpmn.bpmn")
+        .setResource(wrapString("This is the contents of the BPMN"));
+    deploymentRecord
+        .processesMetadata()
+        .add()
+        .setKey(123)
+        .setVersion(1)
+        .setBpmnProcessId("my_first_process")
+        .setResourceName("my_first_bpmn.bpmn")
+        .setChecksum(wrapString("sha1"));
+
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setValueType(ValueType.DEPLOYMENT)
+        .setIntent(DeploymentIntent.CREATE)
+        .setCommandValue(deploymentRecord);
+  }
+
+  private CommandDistributionRecord createResourceDeletionDeleteRecord() {
+    final var deletionRecord = new ResourceDeletionRecord().setResourceKey(1L);
+
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setValueType(ValueType.RESOURCE_DELETION)
+        .setIntent(ResourceDeletionIntent.DELETE)
+        .setCommandValue(deletionRecord);
+  }
+
+  private CommandDistributionRecord createClockRecord() {
+    final var clockRecord = new ClockRecord().pinAt(1000L);
+
+    return new CommandDistributionRecord()
+        .setPartitionId(1)
+        .setValueType(ValueType.CLOCK)
+        .setIntent(ClockIntent.PIN)
+        .setCommandValue(clockRecord);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CommandDistributionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CommandDistributionRecordStream.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.test.util.record;
 
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import java.util.stream.Stream;
@@ -32,5 +33,9 @@ public class CommandDistributionRecordStream
 
   public CommandDistributionRecordStream withDistributionIntent(final Intent intent) {
     return valueFilter(v -> v.getIntent() == intent);
+  }
+
+  public CommandDistributionRecordStream withDistributionValueType(final ValueType valueType) {
+    return valueFilter(v -> v.getValueType() == valueType);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

It turns out not all distributed commands were processed idempotently. This is an issue as it could result in an inifnite retry loop. This becomes a bigger issue when queues are involved, as the infinite retry causes the queue to never proceed.

This PR makes our processors that distribute idempotent. It also adds a test generic that verifies all processors which process distributed commands are idempotent.

When I was building I realized it required a migration. Any existing distributions are not queued. If we process those idempotently it could result in state differences between partitions. For this reason I added a migration task distributios of deployment creations and resource deletions. This ensures these existing distributions will now be ordered as well, meaning it is safe to make them idempotent.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24739
