### PR TITLE
fix: revert retries on truncating log on transition as it may lead to deadlock

### DIFF
--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/SingleThreadContextTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/concurrent/SingleThreadContextTest.java
@@ -16,9 +16,7 @@
 package io.atomix.utils.concurrent;
 
 import static io.atomix.utils.concurrent.Threads.namedThreads;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.util.CheckedRunnable;
 import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
@@ -31,119 +29,127 @@ import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SingleThreadContextTest {
 
-  private static final int NUM_RETRIES = 10;
-  private static final Duration MAX_DELAY = Duration.ofMillis(10);
-  private CheckedRunnable taskToRetry;
-  private RetryDelayStrategy delayStrategy;
   private final Logger log = LoggerFactory.getLogger("thread");
   private Consumer<Throwable> exceptionHandler;
-  private CountDownLatch latch;
-  private SingleThreadContext threadContext;
-
-  private AtomicInteger retryCount;
-
-  @BeforeEach
-  public void setup() {
-    retryCount = new AtomicInteger(0);
-    latch = new CountDownLatch(1);
-    delayStrategy = new ExponentialBackoffRetryDelay(MAX_DELAY, Duration.ofMillis(1));
-    threadContext =
-        new SingleThreadContext(namedThreads("test", log), e -> exceptionHandler.accept(e));
-    taskToRetry =
-        () -> {
-          // retry until NUM_RETRIES is reached, then wait for the latch
-          if (retryCount.incrementAndGet() < NUM_RETRIES) {
-            throw new IllegalArgumentException("Expected");
-          } else {
-            try {
-              latch.await();
-            } catch (final InterruptedException e) {
-              throw new RuntimeException(e);
-            }
-          }
-        };
-  }
-
-  @AfterEach
-  public void cleanUp() {
-    threadContext.close();
-  }
 
   @Test
   public void shouldInvokeHandlerOnException() throws InterruptedException {
     // given
-    final CountDownLatch latch = new CountDownLatch(1);
-    exceptionHandler = e -> latch.countDown();
+    try (final var threadContext =
+        new SingleThreadContext(namedThreads("test", log), e -> exceptionHandler.accept(e))) {
+      final CountDownLatch latch = new CountDownLatch(1);
+      exceptionHandler = e -> latch.countDown();
 
-    // when
-    threadContext.execute(
-        () -> {
-          throw new RuntimeException();
-        });
+      // when
+      threadContext.execute(
+          () -> {
+            throw new RuntimeException();
+          });
 
-    assertTrue(latch.await(2, TimeUnit.SECONDS));
+      assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
 
-    // then
-    assertEquals(0, latch.getCount());
+      // then
+      assertThat(0).isEqualTo(latch.getCount());
+    }
   }
 
-  @Test
-  public void shouldRetryCallableUntilSuccessful() {
-    // when
-    final var result =
-        threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> true);
+  @Nested
+  public class Schedule {
+    private static final int NUM_RETRIES = 10;
+    private static final Duration MAX_DELAY = Duration.ofMillis(10);
+    private CheckedRunnable taskToRetry;
+    private RetryDelayStrategy delayStrategy;
+    private AtomicInteger retryCount;
+    private CountDownLatch latch;
+    private SingleThreadContext threadContext;
 
-    // then
-    assertFalse(result.isDone());
-    Awaitility.await("Await 10 retries").until(() -> retryCount.get() >= NUM_RETRIES);
+    @BeforeEach
+    public void setup() {
+      threadContext =
+          new SingleThreadContext(
+              namedThreads("test", log), e -> exceptionHandler.accept(e)); // given
+      delayStrategy = new ExponentialBackoffRetryDelay(MAX_DELAY, Duration.ofMillis(1));
+      retryCount = new AtomicInteger(0);
+      latch = new CountDownLatch(1);
+      taskToRetry =
+          () -> {
+            // retry until NUM_RETRIES is reached, then wait for the latch
+            if (retryCount.incrementAndGet() < NUM_RETRIES) {
+              throw new IllegalArgumentException("Expected");
+            } else {
+              try {
+                latch.await();
+              } catch (final InterruptedException e) {
+                throw new RuntimeException(e);
+              }
+            }
+          };
+    }
 
-    // when
-    latch.countDown();
+    @AfterEach
+    public void tearDown() {
+      threadContext.close();
+    }
 
-    // then
-    Awaitility.await("the futures succeeds").until(result::isDone);
-  }
+    @Test
+    public void shouldRetryCallableUntilSuccessful() {
+      // when
+      final var result =
+          threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> true);
 
-  @Test
-  public void shouldNotRetryWhenPredicateIsFalse() {
-    // when
-    final var result =
-        threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> false);
+      // then
+      assertThat(result.isDone()).isFalse();
+      Awaitility.await("Await 10 retries").until(() -> retryCount.get() >= NUM_RETRIES);
 
-    // then
-    Awaitility.await("Await 1 retry ").until(() -> retryCount.get() == 1);
-    assertTrue(result.isCompletedExceptionally());
-  }
+      // when
+      latch.countDown();
 
-  @Test
-  public void shouldNotContinueIfFutureIsCancelled() throws InterruptedException {
-    // given
-    final var result =
-        threadContext.retryUntilSuccessful(
-            () -> {
-              throw new RuntimeException("expected");
-            },
-            delayStrategy,
-            (ignored) -> true);
+      // then
+      Awaitility.await("the futures succeeds").until(result::isDone);
+    }
 
-    // when
-    result.cancel(false);
+    @Test
+    public void shouldNotRetryWhenPredicateIsFalse() {
+      // when
+      final var result =
+          threadContext.retryUntilSuccessful(taskToRetry, delayStrategy, (ignored) -> false);
 
-    // submit a task after the cancellation with MAX_DELAY so that it will be executed after
-    // the first task checks for cancellation
-    final var scheduled = threadContext.schedule(MAX_DELAY, () -> {});
-    Awaitility.await("task is completed").until(scheduled::isDone);
+      // then
+      Awaitility.await("Await 1 retry ").until(() -> retryCount.get() == 1);
+      assertThat(result.isCompletedExceptionally()).isTrue();
+    }
 
-    // then - no tasks are scheduled
-    final var scheduledTasks = threadContext.executor.shutdownNow();
-    assertTrue(scheduledTasks.isEmpty());
-    // executor terminates gracefully if no task is scheduled
-    assertTrue(threadContext.executor.awaitTermination(1, TimeUnit.SECONDS));
+    @Test
+    public void shouldNotContinueIfFutureIsCancelled() throws InterruptedException {
+      // given
+      final var result =
+          threadContext.retryUntilSuccessful(
+              () -> {
+                throw new RuntimeException("expected");
+              },
+              delayStrategy,
+              (ignored) -> true);
+
+      // when
+      result.cancel(false);
+
+      // submit a task after the cancellation with MAX_DELAY so that it will be executed after
+      // the first task checks for cancellation
+      final var scheduled = threadContext.schedule(MAX_DELAY, () -> {});
+      Awaitility.await("task is completed").until(scheduled::isDone);
+
+      // then - no tasks are scheduled
+      final var scheduledTasks = threadContext.executor.shutdownNow();
+      assertThat(scheduledTasks.isEmpty()).isTrue();
+      // executor terminates gracefully if no task is scheduled
+      assertThat(threadContext.executor.awaitTermination(1, TimeUnit.SECONDS)).isTrue();
+    }
   }
 }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SubClassOfTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.util;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -17,10 +18,10 @@ class SubClassOfTest {
     final var subclass =
         SubClassOf.make(IllegalArgumentException.class, IllegalStateException.class);
 
-    assertTrue(subclass.test(new IllegalArgumentException("")));
-    assertTrue(subclass.test(new IllegalStateException("")));
-    assertTrue(subclass.test(new MyIllegalArgumentException()));
-    assertFalse(subclass.test(new RuntimeException("")));
+    assertThat(subclass.test(new IllegalArgumentException(""))).isTrue();
+    assertThat(subclass.test(new IllegalStateException(""))).isTrue();
+    assertThat(subclass.test(new MyIllegalArgumentException())).isTrue();
+    assertThat(subclass.test(new RuntimeException(""))).isFalse();
   }
 
   @Test
@@ -29,9 +30,9 @@ class SubClassOfTest {
     final var objects = new Object[] {"", 1, 1.0, new Object[] {}};
 
     for (final var obj : objects) {
-      assertFalse(subclass.test(obj));
+      assertThat(subclass.test(obj)).isFalse();
     }
   }
 
-  public static final class MyIllegalArgumentException extends IllegalArgumentException {}
+  private static final class MyIllegalArgumentException extends IllegalArgumentException {}
 }


### PR DESCRIPTION
## Description
Retrying asynchronously in the `start` method of a Role is not safe as during the transition the future will be waited by blocking on it. Because we are in the same thread as the scheduler the future may never complete.

See comments on the issue #24634 

Contains also some cosmetic refactorings that were not part of #24498 by mistake

## Related issues
relates #24634

