### PR TITLE
Add support for group entity add event exporting

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -29,6 +29,7 @@ import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GroupCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.GroupDeletedHandler;
+import io.camunda.exporter.handlers.GroupEntityAddedHandler;
 import io.camunda.exporter.handlers.IncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
@@ -179,6 +180,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new TenantCreateUpdateHandler(
                 indexDescriptorsMap.get(TenantIndex.class).getFullQualifiedName()),
             new GroupCreatedUpdatedHandler(
+                indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),
+            new GroupEntityAddedHandler(
                 indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),
             new GroupDeletedHandler(
                 indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
+
+  public static final String SCRIPT_ADD_ENTITY =
+      """
+      if (ctx._source.assignedMemberKeys == null) {
+        ctx._source.assignedMemberKeys = params.addKeys;
+      }
+      for (newKey in params.addKeys) {
+        if (!ctx._source.assignedMemberKeys.contains(newKey)) {
+          ctx._source.assignedMemberKeys.add(newKey);
+        }
+      }""";
+
+  private final String indexName;
+
+  public GroupEntityAddedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.GROUP;
+  }
+
+  @Override
+  public Class<GroupEntity> getEntityType() {
+    return GroupEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<GroupRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && GroupIntent.ENTITY_ADDED.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<GroupRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public GroupEntity createNewEntity(final String id) {
+    return new GroupEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
+    final GroupRecordValue value = record.getValue();
+    final var entityKey = value.getEntityKey();
+
+    var memberKeys = entity.getAssignedMemberKeys();
+    memberKeys = memberKeys == null ? new HashSet<>() : memberKeys;
+    memberKeys.add(entityKey);
+
+    entity.setAssignedMemberKeys(memberKeys);
+  }
+
+  @Override
+  public void flush(final GroupEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+
+    batchRequest.updateWithScript(
+        indexName,
+        entity.getId(),
+        SCRIPT_ADD_ENTITY,
+        Map.of("addKeys", entity.getAssignedMemberKeys()));
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+public class GroupEntityAddedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-group";
+  private final GroupEntityAddedHandler underTest = new GroupEntityAddedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.GROUP);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(GroupEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final io.camunda.zeebe.protocol.record.Record<GroupRecordValue> groupDeletedRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_ADDED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(groupDeletedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<GroupRecordValue> groupRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_ADDED);
+
+    // when
+    final var idList = underTest.generateIds(groupRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(groupRecord.getKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
+    // given
+    final GroupEntity inputEntity =
+        new GroupEntity().setId("111").setAssignedMemberKeys(Set.of(222L));
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .updateWithScript(
+            indexName,
+            inputEntity.getId(),
+            GroupEntityAddedHandler.SCRIPT_ADD_ENTITY,
+            Map.of("addKeys", inputEntity.getAssignedMemberKeys()));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add support for group entity add event exporting

⚠️ PR is blocked until we reach a decision on the ES/OS Identity data restructuring. A PoC is provided with #24782.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24580
