### PR TITLE
feat: added socket buffers size parameters to config

### DIFF
--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -82,9 +82,12 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
-      # ZEEBE_BROKER_NETWORK_SOCKETRECEIVEBUFFER
+      # Sets the size of the socket receive buffer (SO_RCVBUF).
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETRECEIVEBUFFER.
       # socketReceiveBuffer: 1MB
-      # ZEEBE_BROKER_NETWORK_SOCKETSENDBUFFER
+
+      # Sets the size of the socket send buffer (SO_SNDBUF).
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SOCKETSENDBUFFER.
       # socketSendBuffer: 1MB
 
       # security:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -82,10 +82,10 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
-      # ZEEBE_BROKER_NETWORK_SORCVBUF
-      # soRcvbuf: 1MB
-      # ZEEBE_BROKER_NETWORK_SOSNDBUF
-      # soSndbuf: 1MB
+      # ZEEBE_BROKER_NETWORK_SOCKETRECEIVEBUFFER
+      # socketReceiveBuffer: 1MB
+      # ZEEBE_BROKER_NETWORK_SOCKETSENDBUFFER
+      # socketSendBuffer: 1MB
 
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -82,6 +82,11 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # ZEEBE_BROKER_NETWORK_SORCVBUF
+      # soRcvbuf: 1MB
+      # ZEEBE_BROKER_NETWORK_SOSNDBUF
+      # soSndbuf: 1MB
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # If this setting is enabled then the certificate and private key must either be provided separately

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -60,12 +60,12 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
-      # Sets the size of the socket receive buffer (SO_RCVBUF)
-      # ZEEBE_GATEWAY_NETWORK_SOCKET_RECEIVE_BUFFER
+      # Sets the size of the socket receive buffer (SO_RCVBUF).
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_SOCKETRECEIVEBUFFER.
       # socketReceiveBuffer: 1MB
 
-      # Sets the size of the socket send buffer (SO_SNDBUF)
-      # ZEEBE_GATEWAY_NETWORK_SOCKET_SEND_BUFFER
+      # Sets the size of the socket send buffer (SO_SNDBUF).
+      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_SOCKETSENDBUFFER.
       # socketSendBuffer: 1MB
 
     # cluster:

--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -60,6 +60,14 @@
       # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Sets the size of the socket receive buffer (SO_RCVBUF)
+      # ZEEBE_GATEWAY_NETWORK_SOCKET_RECEIVE_BUFFER
+      # socketReceiveBuffer: 1MB
+
+      # Sets the size of the socket send buffer (SO_SNDBUF)
+      # ZEEBE_GATEWAY_NETWORK_SOCKET_SEND_BUFFER
+      # socketSendBuffer: 1MB
+
     # cluster:
       # Sets initial contact points (brokers), which the gateway should contact to
       # The contact points of the internal network configuration must be specified.

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -272,12 +272,6 @@
       <artifactId>netty-resolver</artifactId>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>6.1.14</version>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -272,6 +272,12 @@
       <artifactId>netty-resolver</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.14</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -35,6 +35,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
+  private Integer brokerSoSndbuf = 1024;
+  private Integer brokerSoRcvbuf = 1024;
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -248,6 +250,24 @@ public class MessagingConfig implements Config {
 
   public String getKeyStorePassword() {
     return keyStorePassword;
+  }
+
+  public Integer getBrokerSoSndbuf() {
+    return brokerSoSndbuf;
+  }
+
+  public MessagingConfig setBrokerSoSndbuf(final Integer brokerSoSndbuf) {
+    this.brokerSoSndbuf = brokerSoSndbuf;
+    return this;
+  }
+
+  public Integer getBrokerSoRcvbuf() {
+    return brokerSoRcvbuf;
+  }
+
+  public MessagingConfig setBrokerSoRcvbuf(final Integer brokerSoRcvbuf) {
+    this.brokerSoRcvbuf = brokerSoRcvbuf;
+    return this;
   }
 
   public enum CompressionAlgorithm {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -21,7 +21,6 @@ import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import org.springframework.util.unit.DataSize;
 
 /** Messaging configuration. */
 public class MessagingConfig implements Config {
@@ -36,8 +35,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
-  private DataSize brokerSoSndbuf = DataSize.ofMegabytes(1);
-  private DataSize brokerSoRcvbuf = DataSize.ofMegabytes(1);
+  private int soSndbuf = 1024 * 1024;
+  private int soRcvbuf = 1024 * 1024;
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -253,21 +252,39 @@ public class MessagingConfig implements Config {
     return keyStorePassword;
   }
 
-  public DataSize getBrokerSoSndbuf() {
-    return brokerSoSndbuf;
+  /**
+   * @return the configured size in bytes for SO_SNDBUF
+   */
+  public int getSoSndbuf() {
+    return soSndbuf;
   }
 
-  public MessagingConfig setBrokerSoSndbuf(final DataSize brokerSoSndbuf) {
-    this.brokerSoSndbuf = brokerSoSndbuf;
+  /**
+   * Sets the size of SO_SNDBUF.
+   *
+   * @param soSndbuf the data size in bytes to use for SO_SNDBUF
+   * @return this config for chaining
+   */
+  public MessagingConfig setSoSndbuf(final int soSndbuf) {
+    this.soSndbuf = soSndbuf;
     return this;
   }
 
-  public DataSize getBrokerSoRcvbuf() {
-    return brokerSoRcvbuf;
+  /**
+   * @return the configured size in bytes for SO_RCVBUF
+   */
+  public int getSoRcvbuf() {
+    return soRcvbuf;
   }
 
-  public MessagingConfig setBrokerSoRcvbuf(final DataSize brokerSoRcvbuf) {
-    this.brokerSoRcvbuf = brokerSoRcvbuf;
+  /**
+   * Sets the size of SO_RCVBUF.
+   *
+   * @param soRcvbuf the data size in bytes to use for SO_RCVBUF
+   * @return this config for chaining
+   */
+  public MessagingConfig setSoRcvbuf(final int soRcvbuf) {
+    this.soRcvbuf = soRcvbuf;
     return this;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -21,6 +21,7 @@ import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import org.springframework.util.unit.DataSize;
 
 /** Messaging configuration. */
 public class MessagingConfig implements Config {
@@ -35,8 +36,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
-  private Integer brokerSoSndbuf = 1024;
-  private Integer brokerSoRcvbuf = 1024;
+  private DataSize brokerSoSndbuf = DataSize.ofMegabytes(1);
+  private DataSize brokerSoRcvbuf = DataSize.ofMegabytes(1);
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -252,20 +253,20 @@ public class MessagingConfig implements Config {
     return keyStorePassword;
   }
 
-  public Integer getBrokerSoSndbuf() {
+  public DataSize getBrokerSoSndbuf() {
     return brokerSoSndbuf;
   }
 
-  public MessagingConfig setBrokerSoSndbuf(final Integer brokerSoSndbuf) {
+  public MessagingConfig setBrokerSoSndbuf(final DataSize brokerSoSndbuf) {
     this.brokerSoSndbuf = brokerSoSndbuf;
     return this;
   }
 
-  public Integer getBrokerSoRcvbuf() {
+  public DataSize getBrokerSoRcvbuf() {
     return brokerSoRcvbuf;
   }
 
-  public MessagingConfig setBrokerSoRcvbuf(final Integer brokerSoRcvbuf) {
+  public MessagingConfig setBrokerSoRcvbuf(final DataSize brokerSoRcvbuf) {
     this.brokerSoRcvbuf = brokerSoRcvbuf;
     return this;
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -35,8 +35,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
-  private int soSndbuf = 1024 * 1024;
-  private int soRcvbuf = 1024 * 1024;
+  private int socketSendBuffer = 1024 * 1024;
+  private int socketReceiveBuffer = 1024 * 1024;
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -255,36 +255,36 @@ public class MessagingConfig implements Config {
   /**
    * @return the configured size in bytes for SO_SNDBUF
    */
-  public int getSoSndbuf() {
-    return soSndbuf;
+  public int getSocketSendBuffer() {
+    return socketSendBuffer;
   }
 
   /**
-   * Sets the size of SO_SNDBUF.
+   * Sets the size of SO_SNDBUF.GatewayCfgT
    *
-   * @param soSndbuf the data size in bytes to use for SO_SNDBUF
+   * @param socketSendBuffer the data size in bytes to use for SO_SNDBUF
    * @return this config for chaining
    */
-  public MessagingConfig setSoSndbuf(final int soSndbuf) {
-    this.soSndbuf = soSndbuf;
+  public MessagingConfig setSocketSendBuffer(final int socketSendBuffer) {
+    this.socketSendBuffer = socketSendBuffer;
     return this;
   }
 
   /**
    * @return the configured size in bytes for SO_RCVBUF
    */
-  public int getSoRcvbuf() {
-    return soRcvbuf;
+  public int getSocketReceiveBuffer() {
+    return socketReceiveBuffer;
   }
 
   /**
    * Sets the size of SO_RCVBUF.
    *
-   * @param soRcvbuf the data size in bytes to use for SO_RCVBUF
+   * @param socketReceiveBuffer the data size in bytes to use for SO_RCVBUF
    * @return this config for chaining
    */
-  public MessagingConfig setSoRcvbuf(final int soRcvbuf) {
-    this.soRcvbuf = soRcvbuf;
+  public MessagingConfig setSocketReceiveBuffer(final int socketReceiveBuffer) {
+    this.socketReceiveBuffer = socketReceiveBuffer;
     return this;
   }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -813,8 +813,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    bootstrap.option(ChannelOption.SO_RCVBUF, 1024 * 1024);
-    bootstrap.option(ChannelOption.SO_SNDBUF, 1024 * 1024);
+    bootstrap.option(ChannelOption.SO_RCVBUF, config.getBrokerSoRcvbuf() * 1024);
+    bootstrap.option(ChannelOption.SO_SNDBUF, config.getBrokerSoSndbuf() * 1024);
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
@@ -871,8 +871,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
-    b.childOption(ChannelOption.SO_RCVBUF, 1024 * 1024);
-    b.childOption(ChannelOption.SO_SNDBUF, 1024 * 1024);
+    b.childOption(ChannelOption.SO_RCVBUF, config.getBrokerSoRcvbuf() * 1024);
+    b.childOption(ChannelOption.SO_SNDBUF, config.getBrokerSoSndbuf() * 1024);
     b.childOption(ChannelOption.SO_KEEPALIVE, true);
     b.childOption(ChannelOption.TCP_NODELAY, true);
     b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -813,8 +813,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    bootstrap.option(ChannelOption.SO_RCVBUF, (int) config.getBrokerSoRcvbuf().toBytes());
-    bootstrap.option(ChannelOption.SO_SNDBUF, (int) config.getBrokerSoSndbuf().toBytes());
+    bootstrap.option(ChannelOption.SO_RCVBUF, config.getSoRcvbuf());
+    bootstrap.option(ChannelOption.SO_SNDBUF, config.getSoSndbuf());
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
@@ -871,8 +871,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
-    b.childOption(ChannelOption.SO_RCVBUF, (int) config.getBrokerSoRcvbuf().toBytes());
-    b.childOption(ChannelOption.SO_SNDBUF, (int) config.getBrokerSoSndbuf().toBytes());
+    b.childOption(ChannelOption.SO_RCVBUF, config.getSoRcvbuf());
+    b.childOption(ChannelOption.SO_SNDBUF, config.getSoSndbuf());
     b.childOption(ChannelOption.SO_KEEPALIVE, true);
     b.childOption(ChannelOption.TCP_NODELAY, true);
     b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -813,8 +813,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    bootstrap.option(ChannelOption.SO_RCVBUF, config.getBrokerSoRcvbuf() * 1024);
-    bootstrap.option(ChannelOption.SO_SNDBUF, config.getBrokerSoSndbuf() * 1024);
+    bootstrap.option(ChannelOption.SO_RCVBUF, (int) config.getBrokerSoRcvbuf().toBytes());
+    bootstrap.option(ChannelOption.SO_SNDBUF, (int) config.getBrokerSoSndbuf().toBytes());
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
@@ -871,8 +871,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
-    b.childOption(ChannelOption.SO_RCVBUF, config.getBrokerSoRcvbuf() * 1024);
-    b.childOption(ChannelOption.SO_SNDBUF, config.getBrokerSoSndbuf() * 1024);
+    b.childOption(ChannelOption.SO_RCVBUF, (int) config.getBrokerSoRcvbuf().toBytes());
+    b.childOption(ChannelOption.SO_SNDBUF, (int) config.getBrokerSoSndbuf().toBytes());
     b.childOption(ChannelOption.SO_KEEPALIVE, true);
     b.childOption(ChannelOption.TCP_NODELAY, true);
     b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -813,8 +813,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     bootstrap.option(
         ChannelOption.WRITE_BUFFER_WATER_MARK,
         new WriteBufferWaterMark(10 * 32 * 1024, 10 * 64 * 1024));
-    bootstrap.option(ChannelOption.SO_RCVBUF, config.getSoRcvbuf());
-    bootstrap.option(ChannelOption.SO_SNDBUF, config.getSoSndbuf());
+    bootstrap.option(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
+    bootstrap.option(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
     bootstrap.option(ChannelOption.SO_KEEPALIVE, true);
     bootstrap.option(ChannelOption.TCP_NODELAY, true);
     bootstrap.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000);
@@ -871,8 +871,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
     b.option(ChannelOption.SO_BACKLOG, 128);
     b.childOption(
         ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(8 * 1024, 32 * 1024));
-    b.childOption(ChannelOption.SO_RCVBUF, config.getSoRcvbuf());
-    b.childOption(ChannelOption.SO_SNDBUF, config.getSoSndbuf());
+    b.childOption(ChannelOption.SO_RCVBUF, config.getSocketReceiveBuffer());
+    b.childOption(ChannelOption.SO_SNDBUF, config.getSocketSendBuffer());
     b.childOption(ChannelOption.SO_KEEPALIVE, true);
     b.childOption(ChannelOption.TCP_NODELAY, true);
     b.childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -79,7 +79,9 @@ public final class ClusterConfigFactory {
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
-            .setPort(network.getInternalApi().getPort());
+            .setPort(network.getInternalApi().getPort())
+            .setBrokerSoRcvbuf(network.getSoRcvbuf())
+            .setBrokerSoSndbuf(network.getSoSndbuf());
 
     if (network.getSecurity().isEnabled()) {
       final var security = network.getSecurity();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -80,8 +80,8 @@ public final class ClusterConfigFactory {
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
             .setPort(network.getInternalApi().getPort())
-            .setBrokerSoRcvbuf(network.getSoRcvbuf())
-            .setBrokerSoSndbuf(network.getSoSndbuf());
+            .setSoRcvbuf((int) network.getSoRcvbuf().toBytes())
+            .setSoSndbuf((int) network.getSoSndbuf().toBytes());
 
     if (network.getSecurity().isEnabled()) {
       final var security = network.getSecurity();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -80,8 +80,8 @@ public final class ClusterConfigFactory {
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
             .setPort(network.getInternalApi().getPort())
-            .setSoRcvbuf((int) network.getSoRcvbuf().toBytes())
-            .setSoSndbuf((int) network.getSoSndbuf().toBytes());
+            .setSocketReceiveBuffer((int) network.getSocketReceiveBuffer().toBytes())
+            .setSocketSendBuffer((int) network.getSocketSendBuffer().toBytes());
 
     if (network.getSecurity().isEnabled()) {
       final var security = network.getSecurity();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -20,16 +20,16 @@ public final class NetworkCfg implements ConfigurationEntry {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DEFAULT_ADVERTISED_HOST =
       Address.defaultAdvertisedHost().getHostAddress();
-  private static final int DEFAULT_BROKER_SO_SNDBUF = 1024;
-  private static final int DEFAULT_BROKER_SO_RCVBUF = 1024;
+  private static final DataSize DEFAULT_BROKER_SOSNDBUF = DataSize.ofMegabytes(1);
+  private static final DataSize DEFAULT_BROKER_SORCVBUF = DataSize.ofMegabytes(1);
 
   // leave host and advertised host to null, so we can distinguish if they are set explicitly or not
   private String host = null;
   private String advertisedHost = null;
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
-  private int soSndbuf = DEFAULT_BROKER_SO_SNDBUF;
-  private int soRcvbuf = DEFAULT_BROKER_SO_RCVBUF;
+  private DataSize soSndbuf = DEFAULT_BROKER_SOSNDBUF;
+  private DataSize soRcvbuf = DEFAULT_BROKER_SORCVBUF;
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -90,19 +90,19 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public int getSoSndbuf() {
+  public DataSize getSoSndbuf() {
     return soSndbuf;
   }
 
-  public void setSoSndbuf(final int soSndbuf) {
+  public void setSoSndbuf(final DataSize soSndbuf) {
     this.soSndbuf = soSndbuf;
   }
 
-  public int getSoRcvbuf() {
+  public DataSize getSoRcvbuf() {
     return soRcvbuf;
   }
 
-  public void setSoRcvbuf(final int soRcvbuf) {
+  public void setSoRcvbuf(final DataSize soRcvbuf) {
     this.soRcvbuf = soRcvbuf;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -20,16 +20,16 @@ public final class NetworkCfg implements ConfigurationEntry {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DEFAULT_ADVERTISED_HOST =
       Address.defaultAdvertisedHost().getHostAddress();
-  private static final DataSize DEFAULT_BROKER_SOSNDBUF = DataSize.ofMegabytes(1);
-  private static final DataSize DEFAULT_BROKER_SORCVBUF = DataSize.ofMegabytes(1);
+  private static final DataSize DEFAULT_BROKER_SOCKET_SEND_BUFFER = DataSize.ofMegabytes(1);
+  private static final DataSize DEFAULT_BROKER_SOCKET_RECEIVE_BUFFER = DataSize.ofMegabytes(1);
 
   // leave host and advertised host to null, so we can distinguish if they are set explicitly or not
   private String host = null;
   private String advertisedHost = null;
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
-  private DataSize soSndbuf = DEFAULT_BROKER_SOSNDBUF;
-  private DataSize soRcvbuf = DEFAULT_BROKER_SORCVBUF;
+  private DataSize socketSendBuffer = DEFAULT_BROKER_SOCKET_SEND_BUFFER;
+  private DataSize socketReceiveBuffer = DEFAULT_BROKER_SOCKET_RECEIVE_BUFFER;
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -90,20 +90,20 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
-  public DataSize getSoSndbuf() {
-    return soSndbuf;
+  public DataSize getSocketSendBuffer() {
+    return socketSendBuffer;
   }
 
-  public void setSoSndbuf(final DataSize soSndbuf) {
-    this.soSndbuf = soSndbuf;
+  public void setSocketSendBuffer(final DataSize socketSendBuffer) {
+    this.socketSendBuffer = socketSendBuffer;
   }
 
-  public DataSize getSoRcvbuf() {
-    return soRcvbuf;
+  public DataSize getSocketReceiveBuffer() {
+    return socketReceiveBuffer;
   }
 
-  public void setSoRcvbuf(final DataSize soRcvbuf) {
-    this.soRcvbuf = soRcvbuf;
+  public void setSocketReceiveBuffer(final DataSize socketReceiveBuffer) {
+    this.socketReceiveBuffer = socketReceiveBuffer;
   }
 
   public CommandApiCfg getCommandApi() {
@@ -137,10 +137,10 @@ public final class NetworkCfg implements ConfigurationEntry {
         + '\''
         + ", maxMessageSize="
         + maxMessageSize
-        + ", so_sndbuf="
-        + soSndbuf
-        + ", so_rcvbuf="
-        + soRcvbuf
+        + ", socketReceiveBuffer="
+        + socketReceiveBuffer
+        + ", socketSendBuffer="
+        + socketSendBuffer
         + ", commandApi="
         + commandApi
         + ", internalApi="

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -20,12 +20,16 @@ public final class NetworkCfg implements ConfigurationEntry {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DEFAULT_ADVERTISED_HOST =
       Address.defaultAdvertisedHost().getHostAddress();
+  private static final int DEFAULT_BROKER_SO_SNDBUF = 1024;
+  private static final int DEFAULT_BROKER_SO_RCVBUF = 1024;
 
   // leave host and advertised host to null, so we can distinguish if they are set explicitly or not
   private String host = null;
   private String advertisedHost = null;
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+  private int soSndbuf = DEFAULT_BROKER_SO_SNDBUF;
+  private int soRcvbuf = DEFAULT_BROKER_SO_RCVBUF;
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -86,6 +90,22 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
+  public int getSoSndbuf() {
+    return soSndbuf;
+  }
+
+  public void setSoSndbuf(final int soSndbuf) {
+    this.soSndbuf = soSndbuf;
+  }
+
+  public int getSoRcvbuf() {
+    return soRcvbuf;
+  }
+
+  public void setSoRcvbuf(final int soRcvbuf) {
+    this.soRcvbuf = soRcvbuf;
+  }
+
   public CommandApiCfg getCommandApi() {
     return commandApi;
   }
@@ -117,6 +137,10 @@ public final class NetworkCfg implements ConfigurationEntry {
         + '\''
         + ", maxMessageSize="
         + maxMessageSize
+        + ", so_sndbuf="
+        + soSndbuf
+        + ", so_rcvbuf="
+        + soRcvbuf
         + ", commandApi="
         + commandApi
         + ", internalApi="

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -52,8 +52,8 @@ public final class BrokerCfgTest {
   private static final String ZEEBE_BROKER_NETWORK_ADVERTISED_HOST =
       "zeebe.broker.network.advertisedHost";
   private static final String ZEEBE_BROKER_NETWORK_PORT_OFFSET = "zeebe.broker.network.portOffset";
-  private static final String ZEEBE_BROKER_NETWORK_SO_SNDBUF = "zeebe.broker.network.so_sndbuf";
-  private static final String ZEEBE_BROKER_NETWORK_SO_RCVBUF = "zeebe.broker.network.so_rcvbuf";
+  private static final String ZEEBE_BROKER_NETWORK_SOSNDBUF = "zeebe.broker.network.soSndbuf";
+  private static final String ZEEBE_BROKER_NETWORK_SORCVBUF = "zeebe.broker.network.soRcvbuf";
   private static final String ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED =
       "zeebe.broker.executionMetricsExporterEnabled";
 
@@ -528,6 +528,47 @@ public final class BrokerCfgTest {
     assertThat(membershipCfg.getSuspectProbes()).isEqualTo(5);
     assertThat(membershipCfg.getFailureTimeout()).isEqualTo(Duration.ofSeconds(20));
     assertThat(membershipCfg.getSyncInterval()).isEqualTo(Duration.ofSeconds(25));
+  }
+
+  @Test
+  public void shouldUseSoSndbufFromEnvironment() {
+    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
+  }
+
+  private void assertSocketBufferParameter(
+      final String socketBufferParameter, final String number) {
+    assertThat(environment.get(socketBufferParameter)).isEqualTo(number);
+  }
+
+  @Test
+  public void shouldOverrideSpecifiedSoSndbufFromEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // then
+    assertThat(cfg.getNetwork().getSoSndbuf()).isEqualTo(2048);
+  }
+
+  @Test
+  public void shouldUseSoRcvbufFromEnvironment() {
+    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
+  }
+
+  @Test
+  public void shouldOverrideSpecifiedSoRcvbufFromEnvironment() {
+    // given
+    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // then
+    assertThat(cfg.getNetwork().getSoRcvbuf()).isEqualTo(2048);
   }
 
   private void assertDefaultPorts(final int command, final int internal) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -52,8 +52,10 @@ public final class BrokerCfgTest {
   private static final String ZEEBE_BROKER_NETWORK_ADVERTISED_HOST =
       "zeebe.broker.network.advertisedHost";
   private static final String ZEEBE_BROKER_NETWORK_PORT_OFFSET = "zeebe.broker.network.portOffset";
-  private static final String ZEEBE_BROKER_NETWORK_SOSNDBUF = "zeebe.broker.network.soSndbuf";
-  private static final String ZEEBE_BROKER_NETWORK_SORCVBUF = "zeebe.broker.network.soRcvbuf";
+  private static final String ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER =
+      "zeebe.broker.network.socketSendBuffer";
+  private static final String ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER =
+      "zeebe.broker.network.socketReceiveBuffer";
   private static final String ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED =
       "zeebe.broker.executionMetricsExporterEnabled";
 
@@ -532,8 +534,8 @@ public final class BrokerCfgTest {
 
   @Test
   public void shouldUseSoSndbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2MB");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2MB");
+    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2MB");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2MB");
   }
 
   private void assertSocketBufferParameter(
@@ -544,31 +546,31 @@ public final class BrokerCfgTest {
   @Test
   public void shouldOverrideSpecifiedSoSndbufFromEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048KB");
+    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2048KB");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSoSndbuf().toBytes()).isEqualTo(2097152);
+    assertThat(cfg.getNetwork().getSocketSendBuffer().toBytes()).isEqualTo(2097152);
   }
 
   @Test
   public void shouldUseSoRcvbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "3MB");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SORCVBUF, "3MB");
+    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "3MB");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "3MB");
   }
 
   @Test
   public void shouldOverrideSpecifiedSoRcvbufFromEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2MB");
+    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "2MB");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSoRcvbuf().toKilobytes()).isEqualTo(2048);
+    assertThat(cfg.getNetwork().getSocketReceiveBuffer().toKilobytes()).isEqualTo(2048);
   }
 
   private void assertDefaultPorts(final int command, final int internal) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -533,18 +533,18 @@ public final class BrokerCfgTest {
   }
 
   @Test
-  public void shouldUseSoSndbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2MB");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2MB");
-  }
+  public void shouldUseSocketSendBufferFromEnvironment() {
+    // given no value is defined
 
-  private void assertSocketBufferParameter(
-      final String socketBufferParameter, final String number) {
-    assertThat(environment.get(socketBufferParameter)).isEqualTo(number);
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // then
+    assertThat(cfg.getNetwork().getSocketSendBuffer().toKilobytes()).isEqualTo(1024);
   }
 
   @Test
-  public void shouldOverrideSpecifiedSoSndbufFromEnvironment() {
+  public void shouldOverrideSpecifiedSocketSendBufferFromEnvironment() {
     // given
     environment.put(ZEEBE_BROKER_NETWORK_SOCKET_SEND_BUFFER, "2048KB");
 
@@ -556,13 +556,18 @@ public final class BrokerCfgTest {
   }
 
   @Test
-  public void shouldUseSoRcvbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "3MB");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "3MB");
+  public void shouldUseDefaultSocketReceiveBufferFromEnvironment() {
+    // given no value is defined
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
+
+    // then
+    assertThat(cfg.getNetwork().getSocketReceiveBuffer().toKilobytes()).isEqualTo(1024);
   }
 
   @Test
-  public void shouldOverrideSpecifiedSoRcvbufFromEnvironment() {
+  public void shouldOverrideSpecifiedSocketReceiveBufferFromEnvironment() {
     // given
     environment.put(ZEEBE_BROKER_NETWORK_SOCKET_RECEIVE_BUFFER, "2MB");
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -532,8 +532,8 @@ public final class BrokerCfgTest {
 
   @Test
   public void shouldUseSoSndbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
+    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2MB");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2MB");
   }
 
   private void assertSocketBufferParameter(
@@ -544,31 +544,31 @@ public final class BrokerCfgTest {
   @Test
   public void shouldOverrideSpecifiedSoSndbufFromEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048");
+    environment.put(ZEEBE_BROKER_NETWORK_SOSNDBUF, "2048KB");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSoSndbuf()).isEqualTo(2048);
+    assertThat(cfg.getNetwork().getSoSndbuf().toBytes()).isEqualTo(2097152);
   }
 
   @Test
   public void shouldUseSoRcvbufFromEnvironment() {
-    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
-    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
+    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "3MB");
+    assertSocketBufferParameter(ZEEBE_BROKER_NETWORK_SORCVBUF, "3MB");
   }
 
   @Test
   public void shouldOverrideSpecifiedSoRcvbufFromEnvironment() {
     // given
-    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2048");
+    environment.put(ZEEBE_BROKER_NETWORK_SORCVBUF, "2MB");
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("cluster-cfg", environment);
 
     // then
-    assertThat(cfg.getNetwork().getSoRcvbuf()).isEqualTo(2048);
+    assertThat(cfg.getNetwork().getSoRcvbuf().toKilobytes()).isEqualTo(2048);
   }
 
   private void assertDefaultPorts(final int command, final int internal) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/BrokerCfgTest.java
@@ -52,6 +52,8 @@ public final class BrokerCfgTest {
   private static final String ZEEBE_BROKER_NETWORK_ADVERTISED_HOST =
       "zeebe.broker.network.advertisedHost";
   private static final String ZEEBE_BROKER_NETWORK_PORT_OFFSET = "zeebe.broker.network.portOffset";
+  private static final String ZEEBE_BROKER_NETWORK_SO_SNDBUF = "zeebe.broker.network.so_sndbuf";
+  private static final String ZEEBE_BROKER_NETWORK_SO_RCVBUF = "zeebe.broker.network.so_rcvbuf";
   private static final String ZEEBE_BROKER_EXECUTION_METRICS_EXPORTER_ENABLED =
       "zeebe.broker.executionMetricsExporterEnabled";
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -260,8 +260,8 @@ public final class Gateway implements CloseableSilently {
         .maxInboundMessageSize(maxMessageSize)
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
         .permitKeepAliveWithoutCalls(false)
-        .withOption(ChannelOption.SO_RCVBUF, cfg.getSoRcvbuf())
-        .withOption(ChannelOption.SO_SNDBUF, cfg.getSoSndbuf());
+        .withOption(ChannelOption.SO_RCVBUF, (int) cfg.getSoRcvbuf().toBytes())
+        .withOption(ChannelOption.SO_SNDBUF, (int) cfg.getSoSndbuf().toBytes());
   }
 
   private void setSecurityConfig(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -260,8 +260,8 @@ public final class Gateway implements CloseableSilently {
         .maxInboundMessageSize(maxMessageSize)
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
         .permitKeepAliveWithoutCalls(false)
-        .withOption(ChannelOption.SO_RCVBUF, (int) cfg.getSoRcvbuf().toBytes())
-        .withOption(ChannelOption.SO_SNDBUF, (int) cfg.getSoSndbuf().toBytes());
+        .withOption(ChannelOption.SO_RCVBUF, (int) cfg.getSocketReceiveBuffer().toBytes())
+        .withOption(ChannelOption.SO_SNDBUF, (int) cfg.getSocketSendBuffer().toBytes());
   }
 
   private void setSecurityConfig(

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -50,6 +50,7 @@ import io.grpc.StatusException;
 import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NettyServerBuilder;
 import io.grpc.protobuf.StatusProto;
+import io.netty.channel.ChannelOption;
 import io.netty.handler.ssl.SslContextBuilder;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -258,7 +259,9 @@ public final class Gateway implements CloseableSilently {
     return NettyServerBuilder.forAddress(new InetSocketAddress(cfg.getHost(), cfg.getPort()))
         .maxInboundMessageSize(maxMessageSize)
         .permitKeepAliveTime(minKeepAliveInterval.toMillis(), TimeUnit.MILLISECONDS)
-        .permitKeepAliveWithoutCalls(false);
+        .permitKeepAliveWithoutCalls(false)
+        .withOption(ChannelOption.SO_RCVBUF, cfg.getSoRcvbuf())
+        .withOption(ChannelOption.SO_SNDBUF, cfg.getSoSndbuf());
   }
 
   private void setSecurityConfig(

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.configuration;
 
 import java.time.Duration;
+import org.springframework.util.unit.DataSize;
 
 public final class ConfigurationDefaults {
 
@@ -17,12 +18,8 @@ public final class ConfigurationDefaults {
   public static final String DEFAULT_CONTACT_POINT_HOST = "127.0.0.1";
   public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
 
-  public static final int DEFAULT_SO_SNDBUF = 1024;
-  public static final int DEFAULT_SO_RCVBUF = 1024;
-  public static final int DEFAULT_BROKER_SO_SNDBUF = 1024;
-  public static final int DEFAULT_BROKER_SO_RCVBUF = 1024;
-  public static final int DEFAULT_GATEWAY_SO_SNDBUF = 1024;
-  public static final int DEFAULT_GATEWAY_SO_RCVBUF = 1024;
+  public static final DataSize DEFAULT_GATEWAY_SO_SNDBUF = DataSize.ofMegabytes(1);
+  public static final DataSize DEFAULT_GATEWAY_SO_RCVBUF = DataSize.ofMegabytes(1);
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
   public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -17,6 +17,12 @@ public final class ConfigurationDefaults {
   public static final String DEFAULT_CONTACT_POINT_HOST = "127.0.0.1";
   public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
 
+  public static final int DEFAULT_SO_SNDBUF = 1024;
+  public static final int DEFAULT_SO_RCVBUF = 1024;
+  public static final int DEFAULT_BROKER_SO_SNDBUF = 1024;
+  public static final int DEFAULT_BROKER_SO_RCVBUF = 1024;
+  public static final int DEFAULT_GATEWAY_SO_SNDBUF = 1024;
+  public static final int DEFAULT_GATEWAY_SO_RCVBUF = 1024;
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
   public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/ConfigurationDefaults.java
@@ -18,8 +18,8 @@ public final class ConfigurationDefaults {
   public static final String DEFAULT_CONTACT_POINT_HOST = "127.0.0.1";
   public static final int DEFAULT_CONTACT_POINT_PORT = 26502;
 
-  public static final DataSize DEFAULT_GATEWAY_SO_SNDBUF = DataSize.ofMegabytes(1);
-  public static final DataSize DEFAULT_GATEWAY_SO_RCVBUF = DataSize.ofMegabytes(1);
+  public static final DataSize DEFAULT_GATEWAY_SOCKET_SEND_BUFFER = DataSize.ofMegabytes(1);
+  public static final DataSize DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER = DataSize.ofMegabytes(1);
   public static final String DEFAULT_MAX_MESSAGE_SIZE = "4M";
   public static final int DEFAULT_MAX_MESSAGE_COUNT = 16;
   public static final Duration DEFAULT_REQUEST_TIMEOUT = Duration.ofSeconds(15);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -22,8 +22,8 @@ public final class NetworkCfg {
   private int port = DEFAULT_PORT;
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
   private DataSize maxMessageSize = DataSize.ofMegabytes(4);
-  private int so_sndbuf = DEFAULT_GATEWAY_SO_SNDBUF;
-  private int so_rcvbuf = DEFAULT_GATEWAY_SO_RCVBUF;
+  private DataSize soSndbuf = DEFAULT_GATEWAY_SO_SNDBUF;
+  private DataSize soRcvbuf = DEFAULT_GATEWAY_SO_RCVBUF;
 
   public void init(final String defaultHost) {
     if (host == null) {
@@ -67,21 +67,21 @@ public final class NetworkCfg {
     return this;
   }
 
-  public int getSoSndbuf() {
-    return so_sndbuf;
+  public DataSize getSoSndbuf() {
+    return soSndbuf;
   }
 
-  public NetworkCfg setSoSndbuf(final int soSndbuf) {
-    so_sndbuf = soSndbuf;
+  public NetworkCfg setSoSndbuf(final DataSize soSndbuf) {
+    this.soSndbuf = soSndbuf;
     return this;
   }
 
-  public int getSoRcvbuf() {
-    return so_rcvbuf;
+  public DataSize getSoRcvbuf() {
+    return soRcvbuf;
   }
 
-  public NetworkCfg setSoRcvbuf(final int soRcvbuf) {
-    so_rcvbuf = soRcvbuf;
+  public NetworkCfg setSoRcvbuf(final DataSize soRcvbuf) {
+    this.soRcvbuf = soRcvbuf;
     return this;
   }
 
@@ -91,7 +91,7 @@ public final class NetworkCfg {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port);
+    return Objects.hash(host, port, soSndbuf, soRcvbuf);
   }
 
   @Override
@@ -103,7 +103,10 @@ public final class NetworkCfg {
       return false;
     }
     final NetworkCfg that = (NetworkCfg) o;
-    return port == that.port && Objects.equals(host, that.host);
+    return port == that.port
+        && Objects.equals(host, that.host)
+        && Objects.equals(soRcvbuf, that.soRcvbuf)
+        && Objects.equals(soSndbuf, that.soSndbuf);
   }
 
   @Override
@@ -117,9 +120,9 @@ public final class NetworkCfg {
         + ", minKeepAliveInterval="
         + minKeepAliveInterval
         + ", so_sndbuf="
-        + so_sndbuf
+        + soSndbuf
         + ", so_rcvbuf="
-        + so_rcvbuf
+        + soRcvbuf
         + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.impl.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_RCVBUF;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_SNDBUF;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
 import java.net.InetSocketAddress;
@@ -20,6 +22,8 @@ public final class NetworkCfg {
   private int port = DEFAULT_PORT;
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
   private DataSize maxMessageSize = DataSize.ofMegabytes(4);
+  private int so_sndbuf = DEFAULT_GATEWAY_SO_SNDBUF;
+  private int so_rcvbuf = DEFAULT_GATEWAY_SO_RCVBUF;
 
   public void init(final String defaultHost) {
     if (host == null) {
@@ -63,6 +67,24 @@ public final class NetworkCfg {
     return this;
   }
 
+  public int getSoSndbuf() {
+    return so_sndbuf;
+  }
+
+  public NetworkCfg setSoSndbuf(final int soSndbuf) {
+    so_sndbuf = soSndbuf;
+    return this;
+  }
+
+  public int getSoRcvbuf() {
+    return so_rcvbuf;
+  }
+
+  public NetworkCfg setSoRcvbuf(final int soRcvbuf) {
+    so_rcvbuf = soRcvbuf;
+    return this;
+  }
+
   public InetSocketAddress toSocketAddress() {
     return new InetSocketAddress(host, port);
   }
@@ -94,6 +116,10 @@ public final class NetworkCfg {
         + port
         + ", minKeepAliveInterval="
         + minKeepAliveInterval
+        + ", so_sndbuf="
+        + so_sndbuf
+        + ", so_rcvbuf="
+        + so_rcvbuf
         + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/NetworkCfg.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.zeebe.gateway.impl.configuration;
 
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_RCVBUF;
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_SNDBUF;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
 import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_PORT;
 
 import java.net.InetSocketAddress;
@@ -22,8 +22,8 @@ public final class NetworkCfg {
   private int port = DEFAULT_PORT;
   private Duration minKeepAliveInterval = Duration.ofSeconds(30);
   private DataSize maxMessageSize = DataSize.ofMegabytes(4);
-  private DataSize soSndbuf = DEFAULT_GATEWAY_SO_SNDBUF;
-  private DataSize soRcvbuf = DEFAULT_GATEWAY_SO_RCVBUF;
+  private DataSize socketSendBuffer = DEFAULT_GATEWAY_SOCKET_SEND_BUFFER;
+  private DataSize socketReceiveBuffer = DEFAULT_GATEWAY_SOCKET_RECEIVE_BUFFER;
 
   public void init(final String defaultHost) {
     if (host == null) {
@@ -67,21 +67,21 @@ public final class NetworkCfg {
     return this;
   }
 
-  public DataSize getSoSndbuf() {
-    return soSndbuf;
+  public DataSize getSocketSendBuffer() {
+    return socketSendBuffer;
   }
 
-  public NetworkCfg setSoSndbuf(final DataSize soSndbuf) {
-    this.soSndbuf = soSndbuf;
+  public NetworkCfg setSocketSendBuffer(final DataSize socketSendBuffer) {
+    this.socketSendBuffer = socketSendBuffer;
     return this;
   }
 
-  public DataSize getSoRcvbuf() {
-    return soRcvbuf;
+  public DataSize getSocketReceiveBuffer() {
+    return socketReceiveBuffer;
   }
 
-  public NetworkCfg setSoRcvbuf(final DataSize soRcvbuf) {
-    this.soRcvbuf = soRcvbuf;
+  public NetworkCfg setSocketReceiveBuffer(final DataSize socketReceiveBuffer) {
+    this.socketReceiveBuffer = socketReceiveBuffer;
     return this;
   }
 
@@ -91,7 +91,7 @@ public final class NetworkCfg {
 
   @Override
   public int hashCode() {
-    return Objects.hash(host, port, soSndbuf, soRcvbuf);
+    return Objects.hash(host, port, socketSendBuffer, socketReceiveBuffer);
   }
 
   @Override
@@ -105,8 +105,8 @@ public final class NetworkCfg {
     final NetworkCfg that = (NetworkCfg) o;
     return port == that.port
         && Objects.equals(host, that.host)
-        && Objects.equals(soRcvbuf, that.soRcvbuf)
-        && Objects.equals(soSndbuf, that.soSndbuf);
+        && Objects.equals(socketReceiveBuffer, that.socketReceiveBuffer)
+        && Objects.equals(socketSendBuffer, that.socketSendBuffer);
   }
 
   @Override
@@ -119,10 +119,10 @@ public final class NetworkCfg {
         + port
         + ", minKeepAliveInterval="
         + minKeepAliveInterval
-        + ", so_sndbuf="
-        + soSndbuf
-        + ", so_rcvbuf="
-        + soRcvbuf
+        + ", socketReceiveBuffer="
+        + socketReceiveBuffer
+        + ", socketSendBuffer="
+        + socketSendBuffer
         + '}';
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -175,8 +175,8 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
     setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
     setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
-    setEnv("zeebe.gateway.network.soSndbuf", "3MB");
-    setEnv("zeebe.gateway.network.soRcvbuf", "3MB");
+    setEnv("zeebe.gateway.network.socketSendBuffer", "3MB");
+    setEnv("zeebe.gateway.network.socketReceiveBuffer", "3MB");
 
     final GatewayCfg expected = new GatewayCfg();
     expected
@@ -184,8 +184,8 @@ public final class GatewayCfgTest {
         .setHost("zeebe")
         .setPort(5432)
         .setMinKeepAliveInterval(Duration.ofSeconds(30))
-        .setSoRcvbuf(DataSize.ofMegabytes(3))
-        .setSoSndbuf(DataSize.ofMegabytes(3));
+        .setSocketReceiveBuffer(DataSize.ofMegabytes(3))
+        .setSocketSendBuffer(DataSize.ofMegabytes(3));
     expected
         .getCluster()
         .setInitialContactPoints(List.of("broker:432", "anotherBroker:789"))

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -176,8 +176,8 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
     setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
     setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
-    setEnv("zeebe.gateway.network.so_sndbuf", String.valueOf(DEFAULT_GATEWAY_SO_SNDBUF));
-    setEnv("zeebe.gateway.network.so_rcvbuf", String.valueOf(DEFAULT_GATEWAY_SO_RCVBUF));
+    setEnv("zeebe.gateway.network.soSndbuf", DEFAULT_GATEWAY_SO_SNDBUF.toString());
+    setEnv("zeebe.gateway.network.soRcvbuf", DEFAULT_GATEWAY_SO_RCVBUF.toString());
 
     final GatewayCfg expected = new GatewayCfg();
     expected

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.gateway.impl.configuration;
 
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_RCVBUF;
-import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_SNDBUF;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.net.Address;
@@ -23,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.Test;
+import org.springframework.util.unit.DataSize;
 
 public final class GatewayCfgTest {
 
@@ -176,8 +175,8 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
     setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
     setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
-    setEnv("zeebe.gateway.network.soSndbuf", DEFAULT_GATEWAY_SO_SNDBUF.toString());
-    setEnv("zeebe.gateway.network.soRcvbuf", DEFAULT_GATEWAY_SO_RCVBUF.toString());
+    setEnv("zeebe.gateway.network.soSndbuf", "3MB");
+    setEnv("zeebe.gateway.network.soRcvbuf", "3MB");
 
     final GatewayCfg expected = new GatewayCfg();
     expected
@@ -185,8 +184,8 @@ public final class GatewayCfgTest {
         .setHost("zeebe")
         .setPort(5432)
         .setMinKeepAliveInterval(Duration.ofSeconds(30))
-        .setSoRcvbuf(DEFAULT_GATEWAY_SO_RCVBUF)
-        .setSoSndbuf(DEFAULT_GATEWAY_SO_SNDBUF);
+        .setSoRcvbuf(DataSize.ofMegabytes(3))
+        .setSoSndbuf(DataSize.ofMegabytes(3));
     expected
         .getCluster()
         .setInitialContactPoints(List.of("broker:432", "anotherBroker:789"))

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.gateway.impl.configuration;
 
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_RCVBUF;
+import static io.camunda.zeebe.gateway.impl.configuration.ConfigurationDefaults.DEFAULT_GATEWAY_SO_SNDBUF;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.utils.net.Address;
@@ -174,13 +176,17 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
     setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
     setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
+    setEnv("zeebe.gateway.network.so_sndbuf", String.valueOf(DEFAULT_GATEWAY_SO_SNDBUF));
+    setEnv("zeebe.gateway.network.so_rcvbuf", String.valueOf(DEFAULT_GATEWAY_SO_RCVBUF));
 
     final GatewayCfg expected = new GatewayCfg();
     expected
         .getNetwork()
         .setHost("zeebe")
         .setPort(5432)
-        .setMinKeepAliveInterval(Duration.ofSeconds(30));
+        .setMinKeepAliveInterval(Duration.ofSeconds(30))
+        .setSoRcvbuf(DEFAULT_GATEWAY_SO_RCVBUF)
+        .setSoSndbuf(DEFAULT_GATEWAY_SO_SNDBUF);
     expected
         .getCluster()
         .setInitialContactPoints(List.of("broker:432", "anotherBroker:789"))

--- a/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -47,6 +47,11 @@
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MINKEEPALIVEINTERVAL.
 # minKeepAliveInterval: 30s
 
+# ZEEBE_GATEWAY_NETWORK_SORCVBUF
+# soRcvbuf: 1MB
+# ZEEBE_GATEWAY_NETWORK_SOSNDBUF
+# soSndbuf: 1MB
+
 # cluster:
 # Sets initial contact points of brokers
 # The contact points of the internal network configuration must be specified.

--- a/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -47,10 +47,13 @@
 # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_NETWORK_MINKEEPALIVEINTERVAL.
 # minKeepAliveInterval: 30s
 
-# ZEEBE_GATEWAY_NETWORK_SORCVBUF
-# soRcvbuf: 1MB
-# ZEEBE_GATEWAY_NETWORK_SOSNDBUF
-# soSndbuf: 1MB
+# Sets the size of the socket receive buffer (SO_RCVBUF)
+# ZEEBE_GATEWAY_NETWORK_SOCKET_RECEIVE_BUFFER
+# socketReceiveBuffer: 1MB
+
+# Sets the size of the socket send buffer (SO_SNDBUF)
+# ZEEBE_GATEWAY_NETWORK_SOCKET_SEND_BUFFER
+# socketSendBuffer: 1MB
 
 # cluster:
 # Sets initial contact points of brokers


### PR DESCRIPTION
## Description

This PR adds new configuration parameters to set the size of SO_SNDBUF and SO_RCVBUF.

## Checklist

Benchmarks
- [x] baseline (1MB)
- [x] 2MB
- [x] 3MB
- [x] 4MB
- [x] 6+4MB

Modified config unit tests
- [x] Broker
- [x] Gateway


## Related issues

closes #24104
