### PR TITLE
feature: PrometheusMeterService will throw an exception when registering invalid metrics

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/metrics/MetricsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/metrics/MetricsConfiguration.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.commons.metrics;
+
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MetricsConfiguration implements BeanPostProcessor {
+
+  /** Configure PrometheusMeterRegistry if it's configured */
+  @Override
+  public Object postProcessAfterInitialization(final Object bean, final String beanName)
+      throws BeansException {
+    if (bean instanceof PrometheusMeterRegistry) {
+      // throw an exception if the user is trying to register invalid metrics, such as
+      // the same metric but with different number of labels.
+      ((PrometheusMeterRegistry) bean).throwExceptionOnRegistrationFailure();
+    }
+    return bean;
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -77,7 +77,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
 
   @Bean
   public ExporterRepository exporterRepository(
-      @Autowired(required = false) List<ExporterDescriptor> exporterDescriptors) {
+      @Autowired(required = false) final List<ExporterDescriptor> exporterDescriptors) {
     if (exporterDescriptors != null && !exporterDescriptors.isEmpty()) {
       LOGGER.info("Create ExporterRepository with predefined exporter descriptors.");
       return new ExporterRepository(exporterDescriptors);

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/RecordsReaderElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/RecordsReaderElasticSearch.java
@@ -66,7 +66,7 @@ public class RecordsReaderElasticSearch extends RecordsReaderAbstract {
     super(partitionId, importValueType, queueSize);
   }
 
-  private SearchHit[] withTimerSearchHits(final Callable<SearchHit[]> callable) throws Exception {
+  private <A> A withTimer(final Callable<A> callable) throws Exception {
     return metrics
         .getTimer(
             Metrics.TIMER_NAME_IMPORT_QUERY,
@@ -217,7 +217,7 @@ public class RecordsReaderElasticSearch extends RecordsReaderAbstract {
 
     try {
       final SearchHit[] hits =
-          withTimerSearchHits(() -> read(searchRequest, maxNumberOfHits >= QUERY_MAX_SIZE));
+          withTimer(() -> read(searchRequest, maxNumberOfHits >= QUERY_MAX_SIZE));
       if (hits.length == 0) {
         countEmptyRuns++;
       } else {
@@ -240,10 +240,6 @@ public class RecordsReaderElasticSearch extends RecordsReaderAbstract {
               "Exception occurred, while obtaining next Zeebe records batch: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
     }
-  }
-
-  private SearchResponse withTimer(final Callable<SearchResponse> callable) throws Exception {
-    return metrics.getTimer(Metrics.TIMER_NAME_IMPORT_QUERY).recordCallable(callable);
   }
 
   private SearchRequest createSearchQuery(

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
@@ -66,7 +66,7 @@ public class RecordsReaderOpenSearch extends RecordsReaderAbstract {
     super(partitionId, importValueType, queueSize);
   }
 
-  private Hit[] withTimerSearchHits(final Callable<Hit[]> callable) throws Exception {
+  private <A> A withTimer(final Callable<A> callable) throws Exception {
     return metrics
         .getTimer(
             Metrics.TIMER_NAME_IMPORT_QUERY,
@@ -220,8 +220,7 @@ public class RecordsReaderOpenSearch extends RecordsReaderAbstract {
             .index(aliasName);
 
     try {
-      final Hit[] hits =
-          withTimerSearchHits(() -> read(searchRequest, maxNumberOfHits >= QUERY_MAX_SIZE));
+      final Hit[] hits = withTimer(() -> read(searchRequest, maxNumberOfHits >= QUERY_MAX_SIZE));
       if (hits.length == 0) {
         countEmptyRuns++;
       } else {
@@ -244,10 +243,6 @@ public class RecordsReaderOpenSearch extends RecordsReaderAbstract {
               "Exception occurred, while obtaining next Zeebe records batch: %s", e.getMessage());
       throw new TasklistRuntimeException(message, e);
     }
-  }
-
-  private SearchResponse withTimer(final Callable<SearchResponse> callable) throws Exception {
-    return metrics.getTimer(Metrics.TIMER_NAME_IMPORT_QUERY).recordCallable(callable);
   }
 
   private SearchRequest createSearchQuery(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Configure prometheus to throw an exception if a metric is not being registered correctly.
This required a small fix in taskslist importer as one metric was registered with 0 labels first and then with 2 labels afterwards.

