### PR TITLE
fix: handle RawApiEntityConsumer buffer size correctly

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumer.java
@@ -72,7 +72,7 @@ final class ApiEntityConsumer<T> extends AbstractBinAsyncEntityConsumer<ApiEntit
       final boolean isResponse =
           String.class.equals(type)
               && SUPPORTED_TEXT_CONTENT_TYPES.stream().anyMatch(t -> t.isSameMimeType(contentType));
-      entityConsumer = new RawApiEntityConsumer<>(isResponse);
+      entityConsumer = new RawApiEntityConsumer<>(isResponse, maxCapacity);
     }
   }
 


### PR DESCRIPTION
## Description

Handle the buffer size of the RawApiEntityConsumer correctly - grow the buffer according to the number of bytes received, but only up to the max message size.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24779 
