### PR TITLE
fix: Fix typo in AbstractProcessVariableQueryFilterOS.createNumericQuery and QueryDSL #24754

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/AbstractProcessVariableQueryFilterOS.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/os/report/filter/AbstractProcessVariableQueryFilterOS.java
@@ -129,7 +129,7 @@ public abstract class AbstractProcessVariableQueryFilterOS extends AbstractVaria
       final String variableName, final String valueToContain) {
     final String lowerCaseValue = valueToContain.toLowerCase(Locale.ENGLISH);
     final Query filter =
-        (lowerCaseValue.length() > MAX_GRAM)
+        lowerCaseValue.length() > MAX_GRAM
             /*
               using the slow wildcard query for uncommonly large filter strings (> 10 chars)
             */
@@ -208,7 +208,7 @@ public abstract class AbstractProcessVariableQueryFilterOS extends AbstractVaria
         new ArrayList<>(
             List.of(
                 term(getNestedVariableNameField(), dto.getName()),
-                term(getNestedVariableNameField(), dto.getType().getId())));
+                term(getNestedVariableTypeField(), dto.getType().getId())));
 
     Object value = OperatorMultipleValuesVariableFilterDataDtoUtil.retrieveValue(dto);
     switch (data.getOperator()) {

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/externalcode/client/dsl/QueryDSL.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/os/externalcode/client/dsl/QueryDSL.java
@@ -168,7 +168,7 @@ public interface QueryDSL {
   }
 
   static <A> Query lt(final String field, final A lt) {
-    return RangeQuery.of(q -> q.field(field).lte(json(lt))).toQuery();
+    return RangeQuery.of(q -> q.field(field).lt(json(lt))).toQuery();
   }
 
   static <A> Query lte(final String field, final A lte) {


### PR DESCRIPTION

## Description

Fix typo in AbstractProcessVariableQueryFilterOS.createNumericQuery and QueryDSL

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24754
