### PR TITLE
ci: use correct registry for operate

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -76,6 +76,7 @@ jobs:
       operate-tag: ${{ needs.benchmark-data.outputs.operate }}
       benchmark-load: >
         -f https://raw.githubusercontent.com/zeebe-io/benchmark-helm/refs/heads/main/charts/zeebe-benchmark/values-realistic-benchmark.yaml
+        --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
         --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}
   setup-latency-benchmark:
     name: Latency Benchmark


### PR DESCRIPTION
## Description

Use the correct registry to set up benchmarks with operate, otherwise deployment will not be able to resolve the docker image

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

[Slack thread](https://camunda.slack.com/archives/C05DH1F5TAR/p1731928114390969)
