### PR TITLE
feat: move Zeebe's backup actuator endpoint from /backups to /backup-runtime

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpoint.java
@@ -40,7 +40,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Component
-@WebEndpoint(id = "backups")
+@WebEndpoint(id = "backup-runtime")
 public final class BackupEndpoint {
   private final BackupApi api;
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -60,7 +60,7 @@ public interface BackupActuator {
    * @return a new instance of {@link BackupActuator}
    */
   static BackupActuator ofAddress(final String address) {
-    final var endpoint = String.format("http://%s/actuator/backups", address);
+    final var endpoint = String.format("http://%s/actuator/backup-runtime", address);
     return of(endpoint);
   }
 
@@ -71,7 +71,7 @@ public interface BackupActuator {
    * @return a new instance of {@link BackupActuator}
    */
   static BackupActuator of(final TestApplication<?> node) {
-    return of(node.actuatorUri("backups").toString());
+    return of(node.actuatorUri("backup-runtime").toString());
   }
 
   /**


### PR DESCRIPTION
## Description
No real changes, just moved path from `/backups `to `/backup-runtime` 
## Related issues

closes #24462
