### PR TITLE
test: use always CamundaExporter

### DIFF
--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -105,7 +105,7 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
         .withAdditionalInitializer(new WebappsConfigurationInitializer());
 
     // default exporters
-    withRecordingExporter(true).withElasticsearchExporter(true);
+    withRecordingExporter(true).withCamundaExporter();
   }
 
   @Override


### PR DESCRIPTION
## Description

In integration tests, we should make sure to always use the CamundaExporter to get early feedback.

<!-- Describe the goal and purpose of this PR. -->


### Current state:

 * With creating and writing the treePath in the engine #25501 
 * And exporting the tree path https://github.com/camunda/camunda/pull/25531

We should be able to run all IT with the CamundaExporter



### Old

Most API tests were running already \cc @tmetzke 


![2024-11-18_15-08](https://github.com/user-attachments/assets/cba208a6-02ac-4ccd-b39d-4a7c3e928f2a)

#### User tasks

@panagiotisgts @romansmirnov Regarding the user task tests I see the following errors:


```
5:15:40.465 [Broker-0] [Exporter-1] [zb-fs-workers-1] WARN  io.camunda.exporter.store.ElasticsearchBatchRequest - Bulk request execution failed. BulkResponseItem: {"index":{"_id":"2251799813685261","_index":"tasklist-task-8.5.0_","status":400,"error":{"type":"strict_dynamic_mapping_exception","reason":"[1:72] mapping set to strict, dynamic introduction of [join] within [_doc] is not allowed"}}}. Cause: [1:72] mapping set to strict, dynamic introduction of [join] within [_doc] is not allowed.
15:15:40.466 [Broker-0] [Exporter-1] [zb-fs-workers-1] WARN  io.camunda.zeebe.broker.exporter.camundaExporter - Error on exporting record with key 2251799813685261
io.camunda.zeebe.exporter.api.ExporterException: Operation failed: [1:72] mapping set to strict, dynamic introduction of [join] within [_doc] is not allowed
	at io.camunda.exporter.CamundaExporter.flush(CamundaExporter.java:196) ~[classes/:?]
	at io.camunda.exporter.CamundaExporter.export(CamundaExporter.java:152) ~[classes/:?]
	at io.camunda.zeebe.broker.exporter.stream.ExporterContainer.lambda$export$5(ExporterContainer.java:245) ~[classes/:?]
	at io.camunda.zeebe.util.jar.ThreadContextUtil.runCheckedWithClassLoader(ThreadContextUtil.java:59) ~[classes/:?]
	at io.camunda.zeebe.util.jar.ThreadContextUtil.runWithClassLoader(ThreadContextUtil.java:35) ~[classes/:?]
	at io.camunda.zeebe.broker.exporter.stream.ExporterContainer.export(ExporterContainer.java:244) ~[classes/:?]
	at io.camunda.zeebe.broker.exporter.stream.ExporterContainer.exportRecord(ExporterContainer.java:222) ~[classes/:?]
	at io.camunda.zeebe.broker.exporter.stream.RecordExporter.export(RecordExporter.java:78) ~[classes/:?]
	at io.camunda.zeebe.scheduler.retry.BackOffRetryStrategy.run(BackOffRetryStrategy.java:51) ~[classes/:?]
	at io.camunda.zeebe.scheduler.ActorJob.invoke(ActorJob.java:85) [classes/:?]
	at io.camunda.zeebe.scheduler.ActorJob.execute(ActorJob.java:42) [classes/:?]
	at io.camunda.zeebe.scheduler.ActorTask.execute(ActorTask.java:122) [classes/:?]
	at io.camunda.zeebe.scheduler.ActorThread.executeCurrentTask(ActorThread.java:130) [classes/:?]
	at io.camunda.zeebe.scheduler.ActorThread.doWork(ActorThread.java:108) [classes/:?]
	at io.camunda.zeebe.scheduler.ActorThread.run(ActorThread.java:227) [classes/:?]
Caused by: io.camunda.exporter.exceptions.PersistenceException: Operation failed: [1:72] mapping set to strict, dynamic introduction of [join] within [_doc] is not allowed
	at io.camunda.exporter.store.ElasticsearchBatchRequest.execute(ElasticsearchBatchRequest.java:239) ~[classes/:?]
	at io.camunda.exporter.store.ElasticsearchBatchRequest.execute(ElasticsearchBatchRequest.java:217) ~[classes/:?]
	at io.camunda.exporter.store.ExporterBatchWriter.flush(ExporterBatchWriter.java:76) ~[classes/:?]
	at io.camunda.exporter.CamundaExporter.flush(CamundaExporter.java:193) ~[classes/:?]
	... 14 more
```

Looks like the the schema creation failed? Is it because there some old schemas in tasklist?! 

#### TreePath

Is failing because treePaths are null

```
 @Test
  void shouldQueryFlowNodeInstanceByTreePath() {
    // given
    final var treePath = flowNodeInstance.getTreePath();
    // when
    final var result =
        zeebeClient.newFlownodeInstanceQuery().filter(f -> f.treePath(treePath)).send().join();

    // then
    assertThat(result.items().size()).isEqualTo(1);
    assertThat(result.items().getFirst().getTreePath()).isEqualTo(treePath);
  }

```

Query returns 20 elements. @tmetzke @sdorokhova  I guess makes sense as we don't have yet the changes for the scope key?


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
