### PR TITLE
feature: add keyset pagination to flowNodeInstance search in RDBMS

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/FlowNodeInstanceDbQuery.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/domain/FlowNodeInstanceDbQuery.java
@@ -7,48 +7,43 @@
  */
 package io.camunda.db.rdbms.read.domain;
 
+import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
-import io.camunda.search.page.SearchQueryPage;
-import io.camunda.search.query.SearchQueryBase;
-import io.camunda.search.sort.FlowNodeInstanceSort;
-import io.camunda.search.sort.SortOptionBuilders;
 import io.camunda.util.ObjectBuilder;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Function;
 
 public record FlowNodeInstanceDbQuery(
-    FlowNodeInstanceFilter filter, FlowNodeInstanceSort sort, SearchQueryPage page) {
-
-  public FlowNodeInstanceDbQuery {
-    // There should be a default in the SearchQueryPage, so this should never happen
-    Objects.requireNonNull(page);
-  }
+    FlowNodeInstanceFilter filter, DbQuerySorting<FlowNodeInstanceEntity> sort, DbQueryPage page) {
 
   public static FlowNodeInstanceDbQuery of(
       final Function<FlowNodeInstanceDbQuery.Builder, ObjectBuilder<FlowNodeInstanceDbQuery>> fn) {
     return fn.apply(new FlowNodeInstanceDbQuery.Builder()).build();
   }
 
-  public static final class Builder
-      extends SearchQueryBase.AbstractQueryBuilder<FlowNodeInstanceDbQuery.Builder>
-      implements ObjectBuilder<FlowNodeInstanceDbQuery> {
+  public static final class Builder implements ObjectBuilder<FlowNodeInstanceDbQuery> {
 
     private static final FlowNodeInstanceFilter EMPTY_FILTER =
         FilterBuilders.flowNodeInstance().build();
-    private static final FlowNodeInstanceSort EMPTY_SORT =
-        SortOptionBuilders.flowNodeInstance().build();
 
     private FlowNodeInstanceFilter filter;
-    private FlowNodeInstanceSort sort;
+    private DbQuerySorting<FlowNodeInstanceEntity> sort;
+    private DbQueryPage page;
 
     public Builder filter(final FlowNodeInstanceFilter value) {
       filter = value;
       return this;
     }
 
-    public Builder sort(final FlowNodeInstanceSort value) {
+    public Builder sort(final DbQuerySorting<FlowNodeInstanceEntity> value) {
       sort = value;
+      return this;
+    }
+
+    public Builder page(final DbQueryPage value) {
+      page = value;
       return this;
     }
 
@@ -58,20 +53,18 @@ public record FlowNodeInstanceDbQuery(
     }
 
     public Builder sort(
-        final Function<FlowNodeInstanceSort.Builder, ObjectBuilder<FlowNodeInstanceSort>> fn) {
-      return sort(SortOptionBuilders.flowNodeInstance(fn));
-    }
-
-    @Override
-    protected Builder self() {
-      return this;
+        final Function<
+                DbQuerySorting.Builder<FlowNodeInstanceEntity>,
+                ObjectBuilder<DbQuerySorting<FlowNodeInstanceEntity>>>
+            fn) {
+      return sort(DbQuerySorting.of(fn));
     }
 
     @Override
     public FlowNodeInstanceDbQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
-      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
-      return new FlowNodeInstanceDbQuery(filter, sort, page().sanitize());
+      sort = Objects.requireNonNullElse(sort, new DbQuerySorting<>(List.of()));
+      return new FlowNodeInstanceDbQuery(filter, sort, page);
     }
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
@@ -9,47 +9,41 @@ package io.camunda.db.rdbms.read.service;
 
 import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
+import io.camunda.db.rdbms.sql.columns.FlowNodeInstanceSearchColumn;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
-import io.camunda.search.filter.FlowNodeInstanceFilter;
-import java.util.List;
+import io.camunda.search.query.FlowNodeInstanceQuery;
+import io.camunda.search.query.SearchQueryResult;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class FlowNodeInstanceReader {
+public class FlowNodeInstanceReader extends AbstractEntityReader<FlowNodeInstanceEntity> {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlowNodeInstanceReader.class);
 
   private final FlowNodeInstanceMapper flowNodeInstanceMapper;
 
   public FlowNodeInstanceReader(final FlowNodeInstanceMapper flowNodeInstanceMapper) {
+    super(FlowNodeInstanceSearchColumn::findByProperty);
     this.flowNodeInstanceMapper = flowNodeInstanceMapper;
   }
 
-  public Optional<FlowNodeInstanceEntity> findOne(final long processInstanceKey) {
-    LOG.trace(
-        "[RDBMS DB] Search for process instance with flowNodeInstanceKey {}", processInstanceKey);
-
-    final var searchResult =
-        search(
-            FlowNodeInstanceDbQuery.of(
-                b ->
-                    b.filter(
-                        FlowNodeInstanceFilter.of(
-                            f -> f.flowNodeInstanceKeys(processInstanceKey)))));
-    if (searchResult.hits == null || searchResult.hits.isEmpty()) {
-      return Optional.empty();
-    } else {
-      return Optional.of(searchResult.hits.getFirst());
-    }
+  public Optional<FlowNodeInstanceEntity> findOne(final long key) {
+    final var result =
+        search(FlowNodeInstanceQuery.of(b -> b.filter(f -> f.flowNodeInstanceKeys(key))));
+    return Optional.ofNullable(result.items()).flatMap(it -> it.stream().findFirst());
   }
 
-  public SearchResult search(final FlowNodeInstanceDbQuery filter) {
-    LOG.trace("[RDBMS DB] Search for process instance with filter {}", filter);
-    final var totalHits = flowNodeInstanceMapper.count(filter);
-    final var hits = flowNodeInstanceMapper.search(filter);
-    return new SearchResult(hits, totalHits);
-  }
+  public SearchQueryResult<FlowNodeInstanceEntity> search(final FlowNodeInstanceQuery query) {
+    final var dbSort =
+        convertSort(query.sort(), FlowNodeInstanceSearchColumn.FLOW_NODE_INSTANCE_KEY);
+    final var dbQuery =
+        FlowNodeInstanceDbQuery.of(
+            b -> b.filter(query.filter()).sort(dbSort).page(convertPaging(dbSort, query.page())));
 
-  public record SearchResult(List<FlowNodeInstanceEntity> hits, Long total) {}
+    LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
+    final var totalHits = flowNodeInstanceMapper.count(dbQuery);
+    final var hits = flowNodeInstanceMapper.search(dbQuery);
+    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+  }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/FlowNodeInstanceSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/FlowNodeInstanceSearchColumn.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.sql.columns;
+
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.zeebe.util.DateUtil;
+import java.util.function.Function;
+
+public enum FlowNodeInstanceSearchColumn implements SearchColumn<FlowNodeInstanceEntity> {
+  FLOW_NODE_INSTANCE_KEY("key", FlowNodeInstanceEntity::key),
+  FLOW_NODE_ID("flowNodeId", FlowNodeInstanceEntity::flowNodeId),
+  PROCESS_INSTANCE_KEY("processInstanceKey", FlowNodeInstanceEntity::processInstanceKey),
+  PROCESS_DEFINITION_KEY("processDefinitionKey", FlowNodeInstanceEntity::processDefinitionKey),
+  PROCESS_DEFINITION_ID("bpmnProcessId", FlowNodeInstanceEntity::bpmnProcessId),
+  START_DATE("startDate", FlowNodeInstanceEntity::startDate, DateUtil::fuzzyToOffsetDateTime),
+  END_DATE("endDate", FlowNodeInstanceEntity::endDate, DateUtil::fuzzyToOffsetDateTime),
+  STATE("state", FlowNodeInstanceEntity::state),
+  TYPE("type", FlowNodeInstanceEntity::type),
+  TENANT_ID("tenantId", FlowNodeInstanceEntity::tenantId),
+  TREE_PATH("treePath", FlowNodeInstanceEntity::treePath),
+  INCIDENT_KEY("incidentKey", FlowNodeInstanceEntity::incidentKey),
+  INCIDENT("incident", FlowNodeInstanceEntity::incident);
+
+  private final String property;
+  private final Function<FlowNodeInstanceEntity, Object> propertyReader;
+  private final Function<Object, Object> sortOptionConverter;
+
+  FlowNodeInstanceSearchColumn(
+      final String property, final Function<FlowNodeInstanceEntity, Object> propertyReader) {
+    this(property, propertyReader, Function.identity());
+  }
+
+  FlowNodeInstanceSearchColumn(
+      final String property,
+      final Function<FlowNodeInstanceEntity, Object> propertyReader,
+      final Function<Object, Object> sortOptionConverter) {
+    this.property = property;
+    this.propertyReader = propertyReader;
+    this.sortOptionConverter = sortOptionConverter;
+  }
+
+  @Override
+  public Object getPropertyValue(final FlowNodeInstanceEntity entity) {
+    return propertyReader.apply(entity);
+  }
+
+  @Override
+  public Object convertSortOption(final Object object) {
+    if (object == null) {
+      return null;
+    }
+
+    return sortOptionConverter.apply(object);
+  }
+
+  public static FlowNodeInstanceSearchColumn findByProperty(final String property) {
+    for (final FlowNodeInstanceSearchColumn column : FlowNodeInstanceSearchColumn.values()) {
+      if (column.property.equals(property)) {
+        return column;
+      }
+    }
+
+    return null;
+  }
+}

--- a/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/FlowNodeInstanceMapper.xml
@@ -19,6 +19,7 @@
   <!-- default search statement for databases supporting LIMIT/OFFSET-->
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery"
     resultMap="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.searchResultMap">
+    SELECT * FROM (
     SELECT
     FLOW_NODE_INSTANCE_KEY,
     FLOW_NODE_ID,
@@ -36,13 +37,10 @@
     SCOPE_KEY
     FROM FLOW_NODE_INSTANCE
     <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.searchFilter"/>
-    <if test="sort != null and sort.orderings != null and !sort.orderings.isEmpty()">
-      <foreach collection="sort.orderings" open="ORDER BY " separator=", " item="item">
-        <include refid="io.camunda.db.rdbms.sql.FlowNodeInstanceMapper.flowNodeInstanceSortMapper"/>
-        ${item.order}
-      </foreach>
-    </if>
-    ${paging.after}
+    ) t
+    <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
+    <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
   </select>
 
   <sql id="searchFilter">
@@ -94,47 +92,6 @@
       AND TENANT_ID IN
       <foreach collection="filter.tenantIds" item="value" open="(" separator=", " close=")">#{value}</foreach>
     </if>
-  </sql>
-
-  <sql id="flowNodeInstanceSortMapper">
-    <choose>
-      <when test='item.field == "key"'>
-        FLOW_NODE_INSTANCE_KEY
-      </when>
-      <when test='item.field == "bpmnProcessId"'>
-        PROCESS_DEFINITION_ID
-      </when>
-      <when test='item.field == "processDefinitionKey"'>
-        PROCESS_DEFINITION_KEY
-      </when>
-      <when test='item.field == "processInstanceKey"'>
-        PROCESS_INSTANCE_KEY
-      </when>
-      <when test='item.field == "flowNodeId"'>
-        FLOW_NODE_ID
-      </when>
-      <when test='item.field == "type"'>
-        TYPE
-      </when>
-      <when test='item.field == "state"'>
-        STATE
-      </when>
-      <when test='item.field == "startDate"'>
-        START_DATE
-      </when>
-      <when test='item.field == "endDate"'>
-        END_DATE
-      </when>
-      <when test='item.field == "tenantId"'>
-        TENANT_ID
-      </when>
-      <when test='item.field == "incidentKey"'>
-        INCIDENT_KEY
-      </when>
-      <when test='item.field == "incidentKey"'>
-        INCIDENT_KEY
-      </when>
-    </choose>
   </sql>
 
   <resultMap id="searchResultMap" type="io.camunda.search.entities.FlowNodeInstanceEntity">

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSortIT.java
@@ -12,7 +12,6 @@ import static io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures.createAnd
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.util.CamundaRdbmsInvocationContextProviderExtension;
@@ -20,6 +19,7 @@ import io.camunda.it.rdbms.db.util.CamundaRdbmsTestApplication;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import io.camunda.search.sort.FlowNodeInstanceSort.Builder;
 import io.camunda.util.ObjectBuilder;
@@ -170,13 +170,13 @@ public class FlowNodeInstanceSortIT {
     final var searchResult =
         reader
             .search(
-                new FlowNodeInstanceDbQuery(
+                new FlowNodeInstanceQuery(
                     new FlowNodeInstanceFilter.Builder()
                         .processDefinitionKeys(processDefinitionKey)
                         .build(),
                     FlowNodeInstanceSort.of(sortBuilder),
                     SearchQueryPage.of(b -> b)))
-            .hits();
+            .items();
 
     assertThat(searchResult).hasSize(20);
     assertThat(searchResult).isSortedAccordingTo(comparator);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/flownodeinstance/FlowNodeInstanceSpecificFilterIT.java
@@ -13,7 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.service.FlowNodeInstanceReader;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.it.rdbms.db.fixtures.FlowNodeInstanceFixtures;
@@ -22,6 +21,7 @@ import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.sort.FlowNodeInstanceSort;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -78,14 +78,14 @@ public class FlowNodeInstanceSpecificFilterIT {
 
     final var searchResult =
         flowNodeInstanceReader.search(
-            new FlowNodeInstanceDbQuery(
+            new FlowNodeInstanceQuery(
                 filter,
                 FlowNodeInstanceSort.of(b -> b),
                 SearchQueryPage.of(b -> b.from(0).size(5))));
 
     assertThat(searchResult.total()).isEqualTo(1);
-    assertThat(searchResult.hits()).hasSize(1);
-    assertThat(searchResult.hits().getFirst().key()).isEqualTo(42L);
+    assertThat(searchResult.items()).hasSize(1);
+    assertThat(searchResult.items().getFirst().key()).isEqualTo(42L);
   }
 
   static List<FlowNodeInstanceFilter> shouldFindFlowNodeInstanceWithSpecificFilterParameters() {

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -8,7 +8,6 @@
 package io.camunda.search.rdbms;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.db.rdbms.read.domain.FlowNodeInstanceDbQuery;
 import io.camunda.db.rdbms.read.domain.UserTaskDbQuery;
 import io.camunda.search.clients.AuthorizationSearchClient;
 import io.camunda.search.clients.DecisionDefinitionSearchClient;
@@ -129,14 +128,7 @@ public class RdbmsSearchClient
   @Override
   public SearchQueryResult<FlowNodeInstanceEntity> searchFlowNodeInstances(
       final FlowNodeInstanceQuery query) {
-    final var searchResult =
-        rdbmsService
-            .getFlowNodeInstanceReader()
-            .search(
-                FlowNodeInstanceDbQuery.of(
-                    b -> b.filter(query.filter()).sort(query.sort()).page(query.page())));
-
-    return new SearchQueryResult<>(searchResult.total(), searchResult.hits(), null);
+    return rdbmsService.getFlowNodeInstanceReader().search(query);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/query/FlowNodeInstanceQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/FlowNodeInstanceQuery.java
@@ -20,6 +20,11 @@ public record FlowNodeInstanceQuery(
     FlowNodeInstanceFilter filter, FlowNodeInstanceSort sort, SearchQueryPage page)
     implements TypedSearchQuery<FlowNodeInstanceFilter, FlowNodeInstanceSort> {
 
+  public static FlowNodeInstanceQuery of(
+      final Function<FlowNodeInstanceQuery.Builder, ObjectBuilder<FlowNodeInstanceQuery>> fn) {
+    return fn.apply(new FlowNodeInstanceQuery.Builder()).build();
+  }
+
   public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
       implements TypedSearchQueryBuilder<
           FlowNodeInstanceQuery, Builder, FlowNodeInstanceFilter, FlowNodeInstanceSort> {


### PR DESCRIPTION
## Description

Adds keyset pagination to FlowNodeInstance in RDBMS exporter and searchClient to align the searchable entities.

## Related issues

Takes part in #24002 