### PR TITLE
fix: replacing batchSourceEventPosition with lastReadRecordPosition

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -210,7 +210,7 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
           batch.forEachRemaining(this::replayEvent);
 
           if (batchSourceEventPosition > snapshotPosition) {
-            lastProcessedPositionState.markAsProcessed(batchSourceEventPosition);
+            lastProcessedPositionState.markAsProcessed(lastReadRecordPosition);
           }
         });
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorContinouslyReplayModeTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorContinouslyReplayModeTest.java
@@ -269,7 +269,7 @@ public final class StreamProcessorContinouslyReplayModeTest {
     // then
     Assertions.assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition())
         .describedAs("Last processed position in the state must be the last source position")
-        .isEqualTo(1);
+        .isEqualTo(2);
   }
 
   @Test
@@ -313,9 +313,9 @@ public final class StreamProcessorContinouslyReplayModeTest {
         .untilAsserted(
             () ->
                 Assertions.assertThat(streamProcessor.getLastProcessedPositionAsync().join())
-                    .isEqualTo(3L));
+                    .isEqualTo(4L));
 
-    Assertions.assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(3);
+    Assertions.assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(4);
     Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
         .isEqualTo(19L);
   }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -160,7 +160,7 @@ final class StreamProcessorReplayTest {
             () -> assertThat(streamProcessor.getLastWrittenPositionAsync().join()).isEqualTo(2L));
 
     // state has to be updated
-    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
+    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(2);
     assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(19L);
   }
 
@@ -195,13 +195,13 @@ final class StreamProcessorReplayTest {
 
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () -> assertThat(streamProcessor.getLastProcessedPositionAsync().join()).isEqualTo(1L));
+            () -> assertThat(streamProcessor.getLastProcessedPositionAsync().join()).isEqualTo(2L));
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
             () -> assertThat(streamProcessor.getLastWrittenPositionAsync().join()).isEqualTo(2L));
 
     // state has to be updated
-    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
+    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(2);
     assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(19L);
   }
 


### PR DESCRIPTION
## Description

From our analysis on #24819, we decided to replace `batchSourceEventPosition` with `lastReadRecordPosition` as the `ReplayStateMachine` seems to be counting on monotonically increasing `sourceRecordPosition` numbers on the records to be replayed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24819
