### PR TITLE
Add group create service

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.DecisionInstanceSearchClient;
 import io.camunda.search.clients.DecisionRequirementSearchClient;
 import io.camunda.search.clients.FlowNodeInstanceSearchClient;
 import io.camunda.search.clients.FormSearchClient;
+import io.camunda.search.clients.GroupSearchClient;
 import io.camunda.search.clients.IncidentSearchClient;
 import io.camunda.search.clients.MappingSearchClient;
 import io.camunda.search.clients.ProcessDefinitionSearchClient;
@@ -33,6 +34,7 @@ import io.camunda.service.DocumentServices;
 import io.camunda.service.ElementInstanceServices;
 import io.camunda.service.FlowNodeInstanceServices;
 import io.camunda.service.FormServices;
+import io.camunda.service.GroupServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.MappingServices;
@@ -147,6 +149,14 @@ public class CamundaServicesConfiguration {
       final SecurityContextProvider securityContextProvider,
       final TenantSearchClient tenantSearchClient) {
     return new TenantServices(brokerClient, securityContextProvider, tenantSearchClient, null);
+  }
+
+  @Bean
+  public GroupServices groupServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final GroupSearchClient groupSearchClient) {
+    return new GroupServices(brokerClient, securityContextProvider, groupSearchClient, null);
   }
 
   @Bean

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -15,6 +15,7 @@ import io.camunda.search.entities.DecisionInstanceEntity;
 import io.camunda.search.entities.DecisionRequirementsEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity;
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.GroupEntity;
 import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.MappingEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
@@ -30,6 +31,7 @@ import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
 import io.camunda.search.query.FlowNodeInstanceQuery;
 import io.camunda.search.query.FormQuery;
+import io.camunda.search.query.GroupQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.MappingQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
@@ -58,7 +60,8 @@ public class SearchClients
         UserTaskSearchClient,
         UserSearchClient,
         VariableSearchClient,
-        MappingSearchClient {
+        MappingSearchClient,
+        GroupSearchClient {
 
   private final DocumentBasedSearchClient searchClient;
   private final ServiceTransformers transformers;
@@ -240,6 +243,16 @@ public class SearchClients
             new DocumentAuthorizationQueryStrategy(this),
             securityContext)
         .search(filter, io.camunda.webapps.schema.entities.usermanagement.TenantEntity.class);
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> searchGroups(final GroupQuery filter) {
+    return new SearchClientBasedQueryExecutor(
+            searchClient,
+            transformers,
+            new DocumentAuthorizationQueryStrategy(this),
+            securityContext)
+        .search(filter, GroupEntity.class);
   }
 
   @Override

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.GroupFilter;
+import java.util.List;
+
+public class GroupFilterTransformer implements FilterTransformer<GroupFilter> {
+
+  @Override
+  public SearchQuery toSearchQuery(final GroupFilter filter) {
+
+    return and(
+        filter.groupKey() == null ? null : term("key", filter.groupKey()),
+        filter.name() == null ? null : term("name", filter.name()));
+  }
+
+  @Override
+  public List<String> toIndices(final GroupFilter filter) {
+    return List.of("identity-group-8.7.0_alias");
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/GroupSearchClient.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.SecurityContext;
+
+public interface GroupSearchClient {
+
+  SearchQueryResult<GroupEntity> searchGroups(final GroupQuery filter);
+
+  GroupSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/GroupEntity.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Set;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GroupEntity(Long key, String name, Set<Long> assignedMemberKeys) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -72,6 +72,10 @@ public final class FilterBuilders {
     return new TenantFilter.Builder();
   }
 
+  public static GroupFilter.Builder group() {
+    return new GroupFilter.Builder();
+  }
+
   public static AuthorizationFilter.Builder authorization() {
     return new AuthorizationFilter.Builder();
   }
@@ -126,6 +130,11 @@ public final class FilterBuilders {
   public static TenantFilter tenant(
       final Function<TenantFilter.Builder, ObjectBuilder<TenantFilter>> fn) {
     return fn.apply(new TenantFilter.Builder()).build();
+  }
+
+  public static GroupFilter group(
+      final Function<GroupFilter.Builder, ObjectBuilder<GroupFilter>> fn) {
+    return fn.apply(new GroupFilter.Builder()).build();
   }
 
   public static AuthorizationFilter authorization(

--- a/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/GroupFilter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+
+public record GroupFilter(Long groupKey, String name) implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<GroupFilter> {
+    private Long groupKey;
+    private String name;
+
+    public Builder groupKey(final Long value) {
+      groupKey = value;
+      return this;
+    }
+
+    public Builder name(final String value) {
+      name = value;
+      return this;
+    }
+
+    @Override
+    public GroupFilter build() {
+      return new GroupFilter(groupKey, name);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/GroupQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/GroupQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.GroupFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.GroupSort;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record GroupQuery(GroupFilter filter, GroupSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<GroupFilter, GroupSort> {
+
+  public static GroupQuery of(final Function<GroupQuery.Builder, ObjectBuilder<GroupQuery>> fn) {
+    return fn.apply(new GroupQuery.Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<GroupQuery.Builder>
+      implements TypedSearchQueryBuilder<GroupQuery, GroupQuery.Builder, GroupFilter, GroupSort> {
+    private static final GroupFilter EMPTY_FILTER = FilterBuilders.group().build();
+    private static final GroupSort EMPTY_SORT = SortOptionBuilders.group().build();
+
+    private GroupFilter filter;
+    private GroupSort sort;
+
+    @Override
+    public GroupQuery.Builder filter(final GroupFilter value) {
+      filter = value;
+      return this;
+    }
+
+    @Override
+    public GroupQuery.Builder sort(final GroupSort value) {
+      sort = value;
+      return this;
+    }
+
+    public GroupQuery.Builder filter(
+        final Function<GroupFilter.Builder, ObjectBuilder<GroupFilter>> fn) {
+      return filter(FilterBuilders.group(fn));
+    }
+
+    public GroupQuery.Builder sort(final Function<GroupSort.Builder, ObjectBuilder<GroupSort>> fn) {
+      return sort(SortOptionBuilders.group(fn));
+    }
+
+    @Override
+    protected GroupQuery.Builder self() {
+      return this;
+    }
+
+    @Override
+    public GroupQuery build() {
+      return new GroupQuery(
+          Objects.requireNonNullElse(filter, EMPTY_FILTER),
+          Objects.requireNonNullElse(sort, EMPTY_SORT),
+          page());
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -132,6 +132,15 @@ public final class SearchQueryBuilders {
     return fn.apply(tenantSearchQuery()).build();
   }
 
+  public static GroupQuery.Builder groupSearchQuery() {
+    return new GroupQuery.Builder();
+  }
+
+  public static GroupQuery groupSearchQuery(
+      final Function<GroupQuery.Builder, ObjectBuilder<GroupQuery>> fn) {
+    return fn.apply(groupSearchQuery()).build();
+  }
+
   public static AuthorizationQuery.Builder authorizationSearchQuery() {
     return new AuthorizationQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/GroupSort.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record GroupSort(List<FieldSorting> orderings) implements SortOption {
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static GroupSort of(final Function<Builder, ObjectBuilder<GroupSort>> fn) {
+    return SortOptionBuilders.group(fn);
+  }
+
+  public static final class Builder extends AbstractBuilder<Builder>
+      implements ObjectBuilder<GroupSort> {
+
+    public Builder groupKey() {
+      currentOrdering = new FieldSorting("key", null);
+      return this;
+    }
+
+    public Builder name() {
+      currentOrdering = new FieldSorting("name", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public Builder asc() {
+      return addOrdering(SortOrder.ASC);
+    }
+
+    @Override
+    public Builder desc() {
+      return addOrdering(SortOrder.DESC);
+    }
+
+    @Override
+    public GroupSort build() {
+      return new GroupSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -72,6 +72,10 @@ public final class SortOptionBuilders {
     return new TenantSort.Builder();
   }
 
+  public static GroupSort.Builder group() {
+    return new GroupSort.Builder();
+  }
+
   public static AuthorizationSort.Builder authorization() {
     return new AuthorizationSort.Builder();
   }
@@ -123,6 +127,10 @@ public final class SortOptionBuilders {
   public static TenantSort tenant(
       final Function<TenantSort.Builder, ObjectBuilder<TenantSort>> fn) {
     return fn.apply(tenant()).build();
+  }
+
+  public static GroupSort group(final Function<GroupSort.Builder, ObjectBuilder<GroupSort>> fn) {
+    return fn.apply(group()).build();
   }
 
   public static FormSort.Builder form() {

--- a/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
+++ b/security/security-core/src/main/java/io/camunda/security/auth/Authorization.java
@@ -10,6 +10,7 @@ package io.camunda.security.auth;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.AUTHORIZATION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.DECISION_REQUIREMENTS_DEFINITION;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.GROUP;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.MAPPING_RULE;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.ROLE;
@@ -64,6 +65,10 @@ public record Authorization(AuthorizationResourceType resourceType, PermissionTy
 
     public Builder role() {
       return resourceType(ROLE);
+    }
+
+    public Builder group() {
+      return resourceType(GROUP);
     }
 
     public Builder tenant() {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -91,6 +91,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-asserts</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/io/camunda/service/GroupServices.java
+++ b/service/src/main/java/io/camunda/service/GroupServices.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.GroupSearchClient;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.exception.NotFoundException;
+import io.camunda.search.query.GroupQuery;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.group.BrokerGroupCreateRequest;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+public class GroupServices extends SearchQueryService<GroupServices, GroupQuery, GroupEntity> {
+
+  private final GroupSearchClient groupSearchClient;
+
+  public GroupServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final GroupSearchClient groupSearchClient,
+      final Authentication authentication) {
+    super(brokerClient, securityContextProvider, authentication);
+    this.groupSearchClient = groupSearchClient;
+  }
+
+  @Override
+  public SearchQueryResult<GroupEntity> search(final GroupQuery query) {
+    return groupSearchClient
+        .withSecurityContext(
+            securityContextProvider.provideSecurityContext(
+                authentication, Authorization.of(a -> a.group().read())))
+        .searchGroups(query);
+  }
+
+  @Override
+  public GroupServices withAuthentication(final Authentication authentication) {
+    return new GroupServices(
+        brokerClient, securityContextProvider, groupSearchClient, authentication);
+  }
+
+  public CompletableFuture<GroupRecord> createGroup(final String name) {
+    return sendBrokerRequest(new BrokerGroupCreateRequest().setName(name));
+  }
+
+  public GroupEntity getGroup(final Long groupKey) {
+    return findGroup(groupKey)
+        .orElseThrow(
+            () -> new NotFoundException("Group with groupKey %d not found".formatted(groupKey)));
+  }
+
+  public Optional<GroupEntity> findGroup(final Long groupKey) {
+    return search(SearchQueryBuilders.groupSearchQuery().filter(f -> f.groupKey(groupKey)).build())
+        .items()
+        .stream()
+        .findFirst();
+  }
+}

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.GroupSearchClient;
+import io.camunda.search.entities.GroupEntity;
+import io.camunda.search.filter.GroupFilter;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.group.BrokerGroupCreateRequest;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import java.util.List;
+import org.assertj.core.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class GroupServiceTest {
+
+  private GroupServices services;
+  private GroupSearchClient client;
+  private Authentication authentication;
+  private StubbedBrokerClient stubbedBrokerClient;
+
+  @BeforeEach
+  public void before() {
+    authentication = Authentication.of(builder -> builder.user(1234L).token("auth_token"));
+    stubbedBrokerClient = new StubbedBrokerClient();
+    client = mock(GroupSearchClient.class);
+    when(client.withSecurityContext(any())).thenReturn(client);
+    services =
+        new GroupServices(
+            stubbedBrokerClient, mock(SecurityContextProvider.class), client, authentication);
+  }
+
+  @Test
+  public void shouldCreateGroup() {
+    // given
+    final var groupName = "testGroup";
+
+    // when
+    services.createGroup(groupName);
+
+    // then
+    final BrokerGroupCreateRequest request = stubbedBrokerClient.getSingleBrokerRequest();
+    final GroupRecord record = request.getRequestWriter();
+    assertThat(request.getValueType()).isEqualTo(ValueType.GROUP);
+    assertThat(request.getIntent()).isEqualTo(GroupIntent.CREATE);
+    assertThat(request.getKey()).isEqualTo(-1L);
+    assertThat(record).hasName(groupName);
+  }
+
+  @Test
+  public void shouldEmptyQueryReturnGroups() {
+    // given
+    final var result = mock(SearchQueryResult.class);
+    when(client.searchGroups(any())).thenReturn(result);
+
+    final GroupFilter filter = new GroupFilter.Builder().build();
+    final var searchQuery = SearchQueryBuilders.groupSearchQuery((b) -> b.filter(filter));
+
+    // when
+    final var searchQueryResult = services.search(searchQuery);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(result);
+  }
+
+  @Test
+  public void shouldReturnSingleGroup() {
+    // given
+    final var entity = mock(GroupEntity.class);
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    when(client.searchGroups(any())).thenReturn(result);
+  }
+
+  @Test
+  public void shouldReturnSingleGroupForGet() {
+    // given
+    final var entity = mock(GroupEntity.class);
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    when(client.searchGroups(any())).thenReturn(result);
+
+    // when
+    final var searchQueryResult = services.findGroup(1L);
+
+    // then
+    assertThat(searchQueryResult).contains(entity);
+  }
+
+  @Test
+  public void shouldThrowExceptionIfGroupNotFoundByKey() {
+    // given
+    final var key = 100L;
+    when(client.searchGroups(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+
+    // when / then
+    assertThat(services.findGroup(key)).isEmpty();
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupCreateRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupCreateRequest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request.group;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import org.agrona.DirectBuffer;
+
+public class BrokerGroupCreateRequest extends BrokerExecuteCommand<GroupRecord> {
+
+  private final GroupRecord requestDto = new GroupRecord();
+
+  public BrokerGroupCreateRequest() {
+    super(ValueType.GROUP, GroupIntent.CREATE);
+    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
+  }
+
+  public BrokerGroupCreateRequest setName(final String name) {
+    requestDto.setName(name);
+    return this;
+  }
+
+  @Override
+  public GroupRecord getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected GroupRecord toResponseDto(final DirectBuffer buffer) {
+    final var response = new GroupRecord();
+    response.wrap(buffer);
+    return response;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add a group service together with `create`, `find`, and `get` methods.

ℹ️ The PR also implements the `GroupSearchClient`, as it was required to implement the `GroupService` class fully. As a result, a `search` method is also provided. The `search` method is then used in the `get` and `find` methods. If necessary, I can split these changes into two PRs.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24815
closes #24882
