### PR TITLE
Verify schema creation eagerly

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.schema.MappingSource;
 import io.camunda.exporter.schema.SchemaTestUtil;
 import io.camunda.exporter.utils.CamundaExporterITInvocationProvider;
 import io.camunda.exporter.utils.SearchClientAdapter;
@@ -252,6 +254,70 @@ final class CamundaExporterIT {
                 retrievedIndexTemplate.at("/index_template/template/mappings"),
                 "/mappings-added-property.json"))
         .isTrue();
+  }
+
+  @TestTemplate
+  void shouldCreateHarmonizedSchemaEagerlyOnOpen(
+      final ExporterConfiguration config, final SearchClientAdapter ignored) {
+    // given
+    final CamundaExporter camundaExporter = new CamundaExporter();
+    camundaExporter.configure(getContextFromConfig(config));
+
+    final var adapter = ClientAdapter.of(config);
+    final var mappingsBeforeOpen =
+        adapter.getSearchEngineClient().getMappings(CONFIG_PREFIX + "*", MappingSource.INDEX);
+    assertThat(mappingsBeforeOpen.keySet()).isEmpty();
+    final String[] expectedIndices = getExpectedIndices(config);
+
+    // when
+    camundaExporter.open(new ExporterTestController());
+
+    // then
+    final var mappingsAfterOpen =
+        adapter.getSearchEngineClient().getMappings(CONFIG_PREFIX + "*", MappingSource.INDEX);
+    assertThat(mappingsAfterOpen.keySet())
+        .isNotEmpty()
+        .hasSize(expectedIndices.length)
+        // we verify the names hard coded on purpose
+        // to make sure no index will be accidentally dropped, names are changed or added
+        .containsExactlyInAnyOrder(
+            "custom-prefix-identity-authorizations-8.7.0_",
+            "custom-prefix-identity-groups-8.7.0_",
+            "custom-prefix-identity-mappings-8.7.0_",
+            "custom-prefix-identity-role-8.7.0_",
+            "custom-prefix-identity-tenants-8.7.0_",
+            "custom-prefix-identity-users-8.7.0_",
+            "custom-prefix-operate-batch-operation-1.0.0_",
+            "custom-prefix-operate-decision-8.3.0_",
+            "custom-prefix-operate-decision-instance-8.3.0_",
+            "custom-prefix-operate-decision-requirements-8.3.0_",
+            "custom-prefix-operate-event-8.3.0_",
+            "custom-prefix-operate-flownode-instance-8.3.1_",
+            "custom-prefix-operate-incident-8.3.1_",
+            "custom-prefix-operate-list-view-8.3.0_",
+            "custom-prefix-operate-metric-8.3.0_",
+            "custom-prefix-operate-operation-8.4.1_",
+            "custom-prefix-operate-post-importer-queue-8.3.0_",
+            "custom-prefix-operate-process-8.3.0_",
+            "custom-prefix-operate-sequence-flow-8.3.0_",
+            "custom-prefix-operate-variable-8.3.0_",
+            "custom-prefix-tasklist-form-8.4.0_",
+            "custom-prefix-tasklist-metric-8.3.0_",
+            "custom-prefix-tasklist-task-8.5.0_");
+  }
+
+  private static String[] getExpectedIndices(final ExporterConfiguration config) {
+    final DefaultExporterResourceProvider defaultExporterResourceProvider =
+        new DefaultExporterResourceProvider();
+    defaultExporterResourceProvider.init(
+        config, mock(ExporterEntityCacheProvider.class), new SimpleMeterRegistry());
+
+    return Stream.concat(
+            defaultExporterResourceProvider.getIndexTemplateDescriptors().stream()
+                .map(IndexDescriptor::getFullQualifiedName),
+            defaultExporterResourceProvider.getIndexDescriptors().stream()
+                .map(IndexDescriptor::getFullQualifiedName))
+        .toArray(String[]::new);
   }
 
   private static Stream<Arguments> containerProvider() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -267,7 +267,6 @@ final class CamundaExporterIT {
     final var mappingsBeforeOpen =
         adapter.getSearchEngineClient().getMappings(CONFIG_PREFIX + "*", MappingSource.INDEX);
     assertThat(mappingsBeforeOpen.keySet()).isEmpty();
-    final String[] expectedIndices = getExpectedIndices(config);
 
     // when
     camundaExporter.open(new ExporterTestController());
@@ -276,8 +275,6 @@ final class CamundaExporterIT {
     final var mappingsAfterOpen =
         adapter.getSearchEngineClient().getMappings(CONFIG_PREFIX + "*", MappingSource.INDEX);
     assertThat(mappingsAfterOpen.keySet())
-        .isNotEmpty()
-        .hasSize(expectedIndices.length)
         // we verify the names hard coded on purpose
         // to make sure no index will be accidentally dropped, names are changed or added
         .containsExactlyInAnyOrder(
@@ -304,20 +301,6 @@ final class CamundaExporterIT {
             "custom-prefix-tasklist-form-8.4.0_",
             "custom-prefix-tasklist-metric-8.3.0_",
             "custom-prefix-tasklist-task-8.5.0_");
-  }
-
-  private static String[] getExpectedIndices(final ExporterConfiguration config) {
-    final DefaultExporterResourceProvider defaultExporterResourceProvider =
-        new DefaultExporterResourceProvider();
-    defaultExporterResourceProvider.init(
-        config, mock(ExporterEntityCacheProvider.class), new SimpleMeterRegistry());
-
-    return Stream.concat(
-            defaultExporterResourceProvider.getIndexTemplateDescriptors().stream()
-                .map(IndexDescriptor::getFullQualifiedName),
-            defaultExporterResourceProvider.getIndexDescriptors().stream()
-                .map(IndexDescriptor::getFullQualifiedName))
-        .toArray(String[]::new);
   }
 
   private static Stream<Arguments> containerProvider() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -41,7 +41,7 @@ public class CamundaExporterITInvocationProvider
         BeforeAllCallback,
         AfterEachCallback {
 
-  public static final String CONFIG_PREFIX = "camunda-record";
+  public static final String CONFIG_PREFIX = "custom-prefix";
   protected SearchClientAdapter elsClientAdapter;
   protected SearchClientAdapter osClientAdapter;
   private final ElasticsearchContainer elsContainer =

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/utils/CamundaExporterITInvocationProvider.java
@@ -59,9 +59,11 @@ public class CamundaExporterITInvocationProvider
     config.getBulk().setSize(1); // force flushing on the first record
     if (connectionType == ELASTICSEARCH) {
       config.getConnect().setUrl(elsContainer.getHttpHostAddress());
+
     } else if (connectionType == OPENSEARCH) {
       config.getConnect().setUrl(osContainer.getHttpHostAddress());
     }
+    config.getConnect().setClusterName(connectionType.name());
     config.getConnect().setType(connectionType.getType());
     return config;
   }


### PR DESCRIPTION
## Description

Verifies that the camunda exporter creates the schema eagerly, and not lazy.
Furthermore, verifies the explicit names of the indices, to make sure no index is mistakenly changed, dropped or added. If so it must be done on purpose with adjusting the explicit test.


## Related issues

closes https://github.com/camunda/camunda/issues/24412
