### PR TITLE
Register `OrderedCommandDistributionMigration` migration task

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -35,11 +35,8 @@ import org.slf4j.LoggerFactory;
 
 public class DbMigratorImpl implements DbMigrator {
 
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
-
   // add new migration tasks here, migrations are executed in the order they appear in the list
-  private static final List<MigrationTask> MIGRATION_TASKS =
+  public static final List<MigrationTask> MIGRATION_TASKS =
       List.of(
           new ProcessMessageSubscriptionSentTimeMigration(),
           new MessageSubscriptionSentTimeMigration(),
@@ -61,9 +58,10 @@ public class DbMigratorImpl implements DbMigrator {
           new JobBackoffRestoreMigration(),
           new RoutingInfoMigration(),
           new OrderedCommandDistributionMigration());
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DbMigratorImpl.class.getPackageName());
   // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
-
   private final MutableMigrationTaskContext migrationTaskContext;
   private final List<MigrationTask> migrationTasks;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyProcessStateMi
 import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_5.ColumnFamilyPrefixCorrectionMigration;
+import io.camunda.zeebe.engine.state.migration.to_8_6.OrderedCommandDistributionMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.ClusterContext;
 import io.camunda.zeebe.util.VersionUtil;
@@ -58,7 +59,8 @@ public class DbMigratorImpl implements DbMigrator {
           new ColumnFamilyPrefixCorrectionMigration(),
           new MultiTenancySignalSubscriptionStateMigration(),
           new JobBackoffRestoreMigration(),
-          new RoutingInfoMigration());
+          new RoutingInfoMigration(),
+          new OrderedCommandDistributionMigration());
   // Be mindful of https://github.com/camunda/camunda/issues/7248. In particular, that issue
   // should be solved first, before adding any migration that can take a long time
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/MigrationTaskRegistrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/MigrationTaskRegistrationTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(
+    packages = "io.camunda.zeebe.engine.state.migration",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+public class MigrationTaskRegistrationTest {
+
+  @ArchTest()
+  public static final ArchRule MIGRATION_TASKS_MUST_BE_REGISTERED =
+      classes()
+          .that()
+          .implement(MigrationTask.class)
+          .should()
+          .beAssignableFrom(anyOfTheRegisteredMigrationTasks());
+
+  private static DescribedPredicate<JavaClass> anyOfTheRegisteredMigrationTasks() {
+    return new DescribedPredicate<>("any of the migration tasks registered in the DbMigratorImpl") {
+      @Override
+      public boolean test(final JavaClass javaClass) {
+        return DbMigratorImpl.MIGRATION_TASKS.stream()
+            .map(MigrationTask::getClass)
+            .anyMatch(javaClass::isAssignableFrom);
+      }
+    };
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This migration was part of the 8.6 release, but was never registered. As a result it never ran. This PR adds registers the task and adds a test to make sure we don't encounter this problem in the future.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24836 
