### PR TITLE
feat: Ensure endpoints are backward compatible when zeebe is deployed standalone

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -646,6 +646,16 @@
       <artifactId>testcontainers</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.boot.actuate.endpoint.annotation.Selector;
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
+import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
+import org.springframework.context.annotation.Profile;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+@WebEndpoint(id = "backups")
+@Profile("broker & standalone")
+public final class BackupEndpointStandalone {
+  private final BackupEndpoint backupEndpoint;
+
+  private BackupEndpointStandalone(final BackupEndpoint backupEndpoint) {
+    this.backupEndpoint = backupEndpoint;
+  }
+
+  @WriteOperation
+  public WebEndpointResponse<?> take(final long backupId) {
+    return backupEndpoint.take(backupId);
+  }
+
+  public WebEndpointResponse<?> status(@Selector @NonNull final long id) {
+    return backupEndpoint.status(id);
+  }
+
+  @ReadOperation
+  public WebEndpointResponse<?> list() {
+    return backupEndpoint.list();
+  }
+
+  @DeleteOperation
+  public WebEndpointResponse<?> delete(@Selector @NonNull final long id) {
+    return backupEndpoint.delete(id);
+  }
+}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneBrokerTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneBrokerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {BackupEndpointStandalone.class})
+@ActiveProfiles({"broker", "standalone"})
+public class BackupEndpointStandaloneBrokerTest {
+
+  @MockBean private BackupEndpoint backupEndpoint;
+  @Autowired private BackupEndpointStandalone backupEndpointStandalone;
+
+  @Test
+  public void shouldCallTakeWhenIsStandalone() {
+    backupEndpointStandalone.take(11L);
+    verify(backupEndpoint).take(11L);
+  }
+
+  @Test
+  public void shouldCallListWhenIsStandalone() {
+    backupEndpointStandalone.list();
+    verify(backupEndpoint).list();
+  }
+
+  @Test
+  public void shouldCallGetWhenIsStandalone() {
+    backupEndpointStandalone.status(11L);
+    verify(backupEndpoint).status(11L);
+  }
+
+  @Test
+  public void shouldCallDeleteWhenIsStandalone() {
+    backupEndpointStandalone.delete(11L);
+    verify(backupEndpoint).delete(11L);
+  }
+}


### PR DESCRIPTION
## Description
A new WebEndpoint controller (at `backups`) has been added that is enabled only when the profile is zeebe, but not operate or tasklist.
The new controller just delegate every call directly to the backup controller mounted at `/backup-runtime`

Operate & Tasklist controller have not yet been migrated to the new schema, so they are not part of this PR

## Related issues
closes #24850
