### PR TITLE
Support multi handler flush

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /** Caches exporter entities of different types and provide the method to flush them in a batch. */
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -43,20 +45,19 @@ public class ExporterBatchWriter {
       final Record<?> record, final ExportHandler handler, final String id) {
     final var cacheKey = new EntityIdAndEntityType(id, handler.getEntityType());
 
-    final ExporterEntity entity;
+    final EntityAndHandler entityAndHandler =
+        cachedEntities.computeIfAbsent(
+            cacheKey,
+            (k) -> {
+              final ExporterEntity entity = handler.createNewEntity(id);
+              return new EntityAndHandler(entity, new HashSet<>());
+            });
 
-    final boolean alreadyCached = cachedEntities.containsKey(cacheKey);
-    if (alreadyCached) {
-      entity = cachedEntities.get(cacheKey).entity();
-    } else {
-      entity = handler.createNewEntity(id);
-    }
-
+    final var entity = entityAndHandler.entity;
     handler.updateEntity(record, entity);
 
-    // always store the latest handler in the tuple, because that is the one
-    // taking care of flushing
-    cachedEntities.put(cacheKey, new EntityAndHandler(entity, handler));
+    // we store all handlers for an entity to make sure not to miss any flushes
+    entityAndHandler.handlers.add(handler);
   }
 
   public void flush(final BatchRequest batchRequest) throws PersistenceException {
@@ -70,8 +71,9 @@ public class ExporterBatchWriter {
 
     for (final var entityAndHandler : cachedEntities.values()) {
       final ExporterEntity entity = entityAndHandler.entity();
-      final ExportHandler handler = entityAndHandler.handler();
-      handler.flush(entity, batchRequest);
+      for (final var handler : entityAndHandler.handlers()) {
+        handler.flush(entity, batchRequest);
+      }
     }
     batchRequest.execute();
     reset();
@@ -111,5 +113,5 @@ public class ExporterBatchWriter {
 
   private record EntityIdAndEntityType(String entityId, Class<?> entityType) {}
 
-  private record EntityAndHandler(ExporterEntity entity, ExportHandler handler) {}
+  private record EntityAndHandler(ExporterEntity entity, Set<ExportHandler> handlers) {}
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ExporterBatchWriter.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,7 +50,7 @@ public class ExporterBatchWriter {
             cacheKey,
             (k) -> {
               final ExporterEntity entity = handler.createNewEntity(id);
-              return new EntityAndHandlers(entity, new HashSet<>());
+              return new EntityAndHandlers(entity, new LinkedHashSet<>());
             });
 
     final var entity = entityAndHandlers.entity;

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.store;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.handlers.ExportHandler;
+import io.camunda.exporter.store.ExporterBatchWriter.Builder;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Integration test with actual exporter handlers */
+public class ExporterBatchWriterMultipleHandlersTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+
+  @Test
+  public void shouldCacheEntitiesForMultipleHandlers() {
+    // given
+    final var writer =
+        Builder.begin()
+            .withHandler(new TestExportHandler("indexA"))
+            .withHandler(new TestExportHandler("indexB"))
+            .build();
+
+    // when
+    writer.addRecord(
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            builder -> builder.withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)));
+
+    // then
+    assertThat(writer.getBatchSize()).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldFlushIntoSeparateIndicesForMultipleHandlers() throws PersistenceException {
+    // given
+    final var writer =
+        Builder.begin()
+            .withHandler(new TestExportHandler("indexA"))
+            .withHandler(new TestExportHandler("indexB"))
+            .build();
+
+    final var record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            builder -> builder.withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+    writer.addRecord(record);
+
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+
+    // when
+    writer.flush(batchRequest);
+
+    // then
+    verify(batchRequest)
+        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+    verify(batchRequest)
+        .update(eq("indexB"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+    verify(batchRequest).execute();
+  }
+
+  private class TestExportHandler implements ExportHandler<TestEntity, ProcessInstanceRecordValue> {
+
+    private final String indexName;
+
+    private TestExportHandler(final String indexName) {
+      this.indexName = indexName;
+    }
+
+    @Override
+    public ValueType getHandledValueType() {
+      return ValueType.PROCESS_INSTANCE;
+    }
+
+    @Override
+    public Class<TestEntity> getEntityType() {
+      return TestEntity.class;
+    }
+
+    @Override
+    public boolean handlesRecord(final Record record) {
+      return true;
+    }
+
+    @Override
+    public List<String> generateIds(final Record record) {
+      return List.of(Long.toString(record.getKey()));
+    }
+
+    @Override
+    public TestEntity createNewEntity(final String id) {
+      return new TestEntity(id);
+    }
+
+    @Override
+    public void updateEntity(final Record record, final TestEntity entity) {
+      entity.setId(Long.toString(record.getKey())).setIntent(record.getIntent());
+    }
+
+    @Override
+    public void flush(final TestEntity entity, final BatchRequest batchRequest)
+        throws PersistenceException {
+      batchRequest.update(indexName, entity.getId(), entity);
+    }
+
+    @Override
+    public String getIndexName() {
+      return null;
+    }
+  }
+
+  private class TestEntity implements ExporterEntity<TestEntity> {
+
+    private String id;
+    private Intent intent;
+
+    private TestEntity(final String id) {
+      this.id = id;
+    }
+
+    public Intent getIntent() {
+      return intent;
+    }
+
+    public void setIntent(final Intent intent) {
+      this.intent = intent;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public TestEntity setId(final String id) {
+      this.id = id;
+      return this;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/ExporterBatchWriterMultipleHandlersTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
@@ -19,11 +20,11 @@ import io.camunda.exporter.store.ExporterBatchWriter.Builder;
 import io.camunda.webapps.schema.entities.ExporterEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 
 /** Integration test with actual exporter handlers */
@@ -32,12 +33,32 @@ public class ExporterBatchWriterMultipleHandlersTest {
   private final ProtocolFactory factory = new ProtocolFactory();
 
   @Test
-  public void shouldCacheEntitiesForMultipleHandlers() {
+  public void shouldCacheMultipleHandlersWithSameEntityOnce() {
     // given
     final var writer =
         Builder.begin()
-            .withHandler(new TestExportHandler("indexA"))
-            .withHandler(new TestExportHandler("indexB"))
+            .withHandler(TestExportHandler.defaultHandler())
+            .withHandler(TestExportHandler.defaultHandler())
+            .build();
+
+    // when
+    writer.addRecord(
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            builder -> builder.withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)));
+
+    // then
+    assertThat(writer.getBatchSize()).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldCacheMultipleDifferentEntitiesForMultipleHandlers() {
+    // given
+    final var writer =
+        Builder.begin()
+            .withHandler(
+                TestExportHandler.handlerForEntity(OtherTestEntity.class, OtherTestEntity::new))
+            .withHandler(TestExportHandler.defaultHandler())
             .build();
 
     // when
@@ -51,12 +72,39 @@ public class ExporterBatchWriterMultipleHandlersTest {
   }
 
   @Test
-  public void shouldFlushIntoSeparateIndicesForMultipleHandlers() throws PersistenceException {
+  public void shouldFlushMultipleHandlersWithSameEntity() throws PersistenceException {
     // given
     final var writer =
         Builder.begin()
-            .withHandler(new TestExportHandler("indexA"))
-            .withHandler(new TestExportHandler("indexB"))
+            .withHandler(TestExportHandler.defaultHandler())
+            .withHandler(TestExportHandler.defaultHandler())
+            .build();
+
+    final var record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            builder -> builder.withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+    writer.addRecord(record);
+
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+
+    // when
+    writer.flush(batchRequest);
+
+    // then
+    verify(batchRequest, times(2))
+        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+    verify(batchRequest).execute();
+  }
+
+  @Test
+  public void shouldFlushIntoSeparateIndicesForMultipleHandlersWithSameEntity()
+      throws PersistenceException {
+    // given
+    final var writer =
+        Builder.begin()
+            .withHandler(TestExportHandler.handlerForIndex("indexA"))
+            .withHandler(TestExportHandler.handlerForIndex("indexB"))
             .build();
 
     final var record =
@@ -78,12 +126,101 @@ public class ExporterBatchWriterMultipleHandlersTest {
     verify(batchRequest).execute();
   }
 
-  private class TestExportHandler implements ExportHandler<TestEntity, ProcessInstanceRecordValue> {
+  @Test
+  public void shouldFlushMultipleDifferentEntitiesForMultipleHandlers()
+      throws PersistenceException {
+    // given
+    final var writer =
+        Builder.begin()
+            .withHandler(
+                TestExportHandler.handlerForEntity(OtherTestEntity.class, OtherTestEntity::new))
+            .withHandler(TestExportHandler.defaultHandler())
+            .build();
+
+    final var record =
+        factory.generateRecord(
+            ValueType.PROCESS_INSTANCE,
+            builder -> builder.withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED));
+    writer.addRecord(record);
+
+    final BatchRequest batchRequest = mock(BatchRequest.class);
+
+    // when
+    writer.flush(batchRequest);
+
+    // then
+    verify(batchRequest)
+        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(TestEntity.class));
+    verify(batchRequest)
+        .update(eq("indexA"), eq(Long.toString(record.getKey())), any(OtherTestEntity.class));
+    verify(batchRequest).execute();
+  }
+
+  private static class TestEntity implements ExporterEntity<TestEntity> {
+
+    private String id;
+
+    TestEntity(final String id) {
+      this.id = id;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public TestEntity setId(final String id) {
+      this.id = id;
+      return this;
+    }
+  }
+
+  private static class OtherTestEntity implements ExporterEntity<OtherTestEntity> {
+
+    private String id;
+
+    OtherTestEntity(final String id) {
+      this.id = id;
+    }
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public OtherTestEntity setId(final String id) {
+      this.id = id;
+      return this;
+    }
+  }
+
+  private static class TestExportHandler<T extends ExporterEntity<T>>
+      implements ExportHandler<T, ProcessInstanceRecordValue> {
 
     private final String indexName;
+    private final Class<T> clazz;
+    private final Function<String, T> constructor;
 
-    private TestExportHandler(final String indexName) {
+    public TestExportHandler(
+        final String indexName, final Class<T> clazz, final Function<String, T> constructor) {
       this.indexName = indexName;
+      this.clazz = clazz;
+      this.constructor = constructor;
+    }
+
+    public static TestExportHandler<TestEntity> defaultHandler() {
+      return new TestExportHandler<>("indexA", TestEntity.class, TestEntity::new);
+    }
+
+    public static <T extends ExporterEntity<T>> TestExportHandler<T> handlerForEntity(
+        final Class<T> clazz, final Function<String, T> constructor) {
+      return new TestExportHandler<>("indexA", clazz, constructor);
+    }
+
+    public static TestExportHandler<TestEntity> handlerForIndex(final String indexName) {
+      return new TestExportHandler<>(indexName, TestEntity.class, TestEntity::new);
     }
 
     @Override
@@ -92,8 +229,8 @@ public class ExporterBatchWriterMultipleHandlersTest {
     }
 
     @Override
-    public Class<TestEntity> getEntityType() {
-      return TestEntity.class;
+    public Class<T> getEntityType() {
+      return clazz;
     }
 
     @Override
@@ -107,53 +244,23 @@ public class ExporterBatchWriterMultipleHandlersTest {
     }
 
     @Override
-    public TestEntity createNewEntity(final String id) {
-      return new TestEntity(id);
+    public T createNewEntity(final String id) {
+      return constructor.apply(id);
     }
 
     @Override
-    public void updateEntity(final Record record, final TestEntity entity) {
-      entity.setId(Long.toString(record.getKey())).setIntent(record.getIntent());
+    public void updateEntity(final Record<ProcessInstanceRecordValue> record, final T entity) {
+      entity.setId(Long.toString(record.getKey()));
     }
 
     @Override
-    public void flush(final TestEntity entity, final BatchRequest batchRequest)
-        throws PersistenceException {
+    public void flush(final T entity, final BatchRequest batchRequest) throws PersistenceException {
       batchRequest.update(indexName, entity.getId(), entity);
     }
 
     @Override
     public String getIndexName() {
       return null;
-    }
-  }
-
-  private class TestEntity implements ExporterEntity<TestEntity> {
-
-    private String id;
-    private Intent intent;
-
-    private TestEntity(final String id) {
-      this.id = id;
-    }
-
-    public Intent getIntent() {
-      return intent;
-    }
-
-    public void setIntent(final Intent intent) {
-      this.intent = intent;
-    }
-
-    @Override
-    public String getId() {
-      return id;
-    }
-
-    @Override
-    public TestEntity setId(final String id) {
-      this.id = id;
-      return this;
     }
   }
 }


### PR DESCRIPTION
## Description
### Context

> Current state:
> - In the ExporterBatchWriter we pass records to all handlers that accept the value type and want to handle the given record
> - The results of each handler are stored in a cache (with the corresponding handler)
> - Results are identified by id and entity type
> - On flush, we call for each cached entity the corresponding handler to flush
> 
> **Expectations (previous):**
> 
> - The export handlers have a one-to-one mapping to an entity. 
> - This means per entity we have one specific handler, and vice-versa
> - It could happen that the same handler is called multiple times during a batch because we see multiple events related to the same entity (ACTIVIATED-COMPLETED, etc.)
> 
> Problem:
> 
> - We have implemented multiple handlers that reuse entity types, even if they set only a subset of properties. 
> - Consequence:
>     - As they use the same type, and in some cases even generate the same id only the last handler wins. Flush is only called on the last one, which consumed the record.
>     - Only partial data is updated.
> - On creation (missing document) this is not an issue because we use mostly upserts, which uses the complete entity object. Here all data is written.
>
> https://github.com/camunda/camunda/issues/24736#issuecomment-2485444919

We were approaching this by caching all handlers related to the entity.


> [!Important]
>
> We are aware that this will cause more upserts per entity, and this might have a potential performance impact. But, we have no actual data to prove that this is for sure the case.
>
> - As we want to fix this critical bug ASAP we **[accept](https://camunda.slack.com/archives/C06F0GLJNFM/p1732020688807309?thread_ts=1731426489.455309&cid=C06F0GLJNFM)** this risk. 
> - If we see performance issues/regressions we can reconsider the solution and solve it differently.
> - As an additional task, we will extend our metric support


### In this PR

* Added new tests (first failing) that verify multiple registered handlers on the BatchWriter are called and flushing entities
* Store more handlers per entity, before we only stored one
* Call all handlers for an entity to flush all related data

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

For context https://camunda.slack.com/archives/C06F0GLJNFM/p1732015209561459?thread_ts=1731426489.455309&cid=C06F0GLJNFM

closes https://github.com/camunda/camunda/issues/24736
