### PR TITLE
fix: export only Job-based User Tasks

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskJobBasedHandler.java
@@ -73,7 +73,8 @@ public class UserTaskJobBasedHandler implements ExportHandler<TaskEntity, JobRec
 
   @Override
   public boolean handlesRecord(final Record<JobRecordValue> record) {
-    return SUPPORTED_INTENTS.contains(record.getIntent());
+    return SUPPORTED_INTENTS.contains(record.getIntent())
+        && record.getValue().getType().equals(Protocol.USER_TASK_JOB_TYPE);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskJobBasedHandlerTest.java
@@ -66,10 +66,17 @@ public class UserTaskJobBasedHandlerTest {
   @Test
   void shouldHandleRecord() {
     // given
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType(Protocol.USER_TASK_JOB_TYPE)
+            .build();
+
     SUPPORTED_INTENTS.forEach(
         intent -> {
           final Record<JobRecordValue> jobRecord =
-              factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+              factory.generateRecord(
+                  ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
           // when - then
           assertThat(underTest.handlesRecord(jobRecord)).isTrue();
         });
@@ -87,6 +94,25 @@ public class UserTaskJobBasedHandlerTest {
               // when - then
               assertThat(underTest.handlesRecord(jobRecord)).isFalse();
             });
+  }
+
+  @Test
+  void shouldNotHandleNoneUserTaskJobBased() {
+    // given
+    final JobRecordValue jobRecordValue =
+        ImmutableJobRecordValue.builder()
+            .from(factory.generateObject(JobRecordValue.class))
+            .withType("not-user-task-job-based")
+            .build();
+
+    SUPPORTED_INTENTS.forEach(
+        intent -> {
+          final Record<JobRecordValue> jobRecord =
+              factory.generateRecord(
+                  ValueType.JOB, r -> r.withIntent(intent).withValue(jobRecordValue));
+          // when - then
+          assertThat(underTest.handlesRecord(jobRecord)).isFalse();
+        });
   }
 
   @Test


### PR DESCRIPTION
## Description

Ensure that only Job-based User tasks are handled in the `camunda-exporter`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24665 
