### PR TITLE
fix: remove stack wrapper from node selection

### DIFF
--- a/optimize/client/src/modules/filter/modals/NodeSelection/NodeSelection.scss
+++ b/optimize/client/src/modules/filter/modals/NodeSelection/NodeSelection.scss
@@ -1,21 +1,15 @@
-@use '@carbon/styles/scss/spacing';
-
 .NodeSelection {
   .cds--modal-container {
     height: 100%;
-
-    .filterContentContainer {
-      grid-template-rows: auto auto 1fr;
-      height: 100%;
-    }
   }
 
   .modalContent {
     display: flex;
     flex-direction: column;
 
+    .instructions,
     .diagramActions {
-      margin-bottom: spacing.$spacing-06;
+      margin-bottom: var(--cds-spacing-04);
     }
 
     .diagramContainer {

--- a/optimize/client/src/modules/filter/modals/NodeSelection/NodeSelection.tsx
+++ b/optimize/client/src/modules/filter/modals/NodeSelection/NodeSelection.tsx
@@ -8,7 +8,7 @@
 
 import {useEffect, useState} from 'react';
 import Viewer from 'bpmn-js/lib/NavigatedViewer';
-import {Button, ButtonSet, Stack} from '@carbon/react';
+import {Button, ButtonSet} from '@carbon/react';
 import classnames from 'classnames';
 
 import {
@@ -114,34 +114,32 @@ export default function NodeSelection({
           applyTo={applyTo}
           setApplyTo={setApplyTo}
         />
-        <Stack className="filterContentContainer" gap={6}>
-          {!xml ? (
-            <Loading />
-          ) : (
-            <>
-              <p>{t('common.filter.UnselectFlowNodes')}</p>
-              <div className="diagramActions">
-                <ButtonSet>
-                  <Button size="md" kind="tertiary" onClick={() => setSelectedNodes(allFlowNodes)}>
-                    {t('common.selectAll')}
-                  </Button>
-                  <Button size="md" kind="tertiary" onClick={() => setSelectedNodes([])}>
-                    {t('common.deselectAll')}
-                  </Button>
-                </ButtonSet>
-              </div>
-              <div className="diagramContainer">
-                <BPMNDiagram xml={xml}>
-                  <ClickBehavior
-                    onClick={toggleNode}
-                    selectedNodes={selectedNodes}
-                    nodeTypes={['FlowNode']}
-                  />
-                </BPMNDiagram>
-              </div>
-            </>
-          )}
-        </Stack>
+        {!xml ? (
+          <Loading />
+        ) : (
+          <>
+            <p className="instructions">{t('common.filter.UnselectFlowNodes')}</p>
+            <div className="diagramActions">
+              <ButtonSet>
+                <Button size="md" kind="tertiary" onClick={() => setSelectedNodes(allFlowNodes)}>
+                  {t('common.selectAll')}
+                </Button>
+                <Button size="md" kind="tertiary" onClick={() => setSelectedNodes([])}>
+                  {t('common.deselectAll')}
+                </Button>
+              </ButtonSet>
+            </div>
+            <div className="diagramContainer">
+              <BPMNDiagram xml={xml}>
+                <ClickBehavior
+                  onClick={toggleNode}
+                  selectedNodes={selectedNodes}
+                  nodeTypes={['FlowNode']}
+                />
+              </BPMNDiagram>
+            </div>
+          </>
+        )}
       </Modal.Content>
       <Modal.Footer>
         <Button kind="secondary" className="cancel" onClick={close}>


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
It seems that the stack wrapper is causing the flex layout inside to collapse. I removed it and added a spacing between the elements instead.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24814
