### PR TITLE
feat: reconstruct deployment for process resources

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -401,7 +401,7 @@ public final class EngineProcessors {
     typedRecordProcessors.onCommand(
         ValueType.DEPLOYMENT,
         DeploymentIntent.RECONSTRUCT,
-        new DeploymentReconstructProcessor(keyGenerator, writers));
+        new DeploymentReconstructProcessor(keyGenerator, processingState, writers));
 
     typedRecordProcessors.withListener(
         new DeploymentReconstructionStarter(processingState.getDeploymentState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/ChecksumGenerator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/ChecksumGenerator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.agrona.DirectBuffer;
+
+/** Generates a checksum for deployment resources. */
+public final class ChecksumGenerator {
+  private final MessageDigest md5;
+
+  {
+    try {
+      // Only used as a hash function, so MD5 is sufficient and does not pose a security risk.
+      md5 = MessageDigest.getInstance("MD5");
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  /** Generates a checksum for the given resource. */
+  public byte[] checksum(final byte[] resource) {
+    return md5.digest(resource);
+  }
+
+  /** Generates a checksum for the given resource. */
+  public DirectBuffer checksum(final DirectBuffer resource) {
+    final var bytes = BufferUtil.bufferAsArray(resource);
+    final var checksum = checksum(bytes);
+    return BufferUtil.wrapArray(checksum);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -68,7 +68,8 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
     } else {
       deploymentRecord = createNewDeploymentForResource(resource);
     }
-    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED, deploymentRecord);
+    stateWriter.appendFollowUpEvent(
+        deploymentRecord.getDeploymentKey(), DeploymentIntent.RECONSTRUCTED, deploymentRecord);
   }
 
   private Resource findNextResource() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -124,7 +124,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
       case ProcessResource(final var process) -> {
         deploymentRecord.setDeploymentKey(process.getKey());
         deploymentRecord.setTenantId(process.getTenantId());
-        attachResourceToDeployment(deploymentRecord, resource);
+        attachResourceMetadataToDeployment(deploymentRecord, resource);
       }
     }
     return deploymentRecord;
@@ -139,20 +139,15 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
     deploymentRecord.setDeploymentKey(deploymentKey);
     deploymentRecord.setTenantId(tenantId);
     for (final var resource : resources) {
-      attachResourceToDeployment(deploymentRecord, resource);
+      attachResourceMetadataToDeployment(deploymentRecord, resource);
     }
     return deploymentRecord;
   }
 
-  private void attachResourceToDeployment(
+  private void attachResourceMetadataToDeployment(
       final DeploymentRecord deploymentRecord, final Resource resource) {
     switch (resource) {
       case ProcessResource(final var process) -> {
-        deploymentRecord
-            .resources()
-            .add()
-            .setResourceName(process.getResourceName())
-            .setResource(process.getResource());
         deploymentRecord
             .processesMetadata()
             .add()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -11,6 +11,10 @@ import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.FormState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -18,11 +22,20 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
 @ExcludeAuthorizationCheck
 public class DeploymentReconstructProcessor implements TypedRecordProcessor<DeploymentRecord> {
-  private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final ProcessState processState;
+  private final FormState formState;
+  private final DecisionState decisionState;
+  private final StateWriter stateWriter;
 
-  public DeploymentReconstructProcessor(final KeyGenerator keyGenerator, final Writers writers) {
+  public DeploymentReconstructProcessor(
+      final KeyGenerator keyGenerator,
+      final ProcessingState processingState,
+      final Writers writers) {
     this.keyGenerator = keyGenerator;
+    processState = processingState.getProcessState();
+    formState = processingState.getFormState();
+    decisionState = processingState.getDecisionState();
     stateWriter = writers.state();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -8,10 +8,13 @@
 package io.camunda.zeebe.engine.processing.deployment;
 
 import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.deployment.DeploymentReconstructProcessor.Resource.ProcessResource;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -19,10 +22,17 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.HashSet;
+import java.util.Set;
+import org.agrona.collections.MutableReference;
 
 @ExcludeAuthorizationCheck
 public class DeploymentReconstructProcessor implements TypedRecordProcessor<DeploymentRecord> {
+  private static final long NO_DEPLOYMENT_KEY = -1;
+  private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
   private final KeyGenerator keyGenerator;
+  private final DeploymentState deploymentState;
   private final ProcessState processState;
   private final FormState formState;
   private final DecisionState decisionState;
@@ -33,6 +43,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
       final ProcessingState processingState,
       final Writers writers) {
     this.keyGenerator = keyGenerator;
+    deploymentState = processingState.getDeploymentState();
     processState = processingState.getProcessState();
     formState = processingState.getFormState();
     decisionState = processingState.getDecisionState();
@@ -42,7 +53,134 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
   @Override
   public void processRecord(final TypedRecord<DeploymentRecord> record) {
     final var key = keyGenerator.nextKey();
-    // TODO: Only append the event when there are no more deployments to reconstruct
-    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED_ALL, record.getValue());
+    final var resource = findNextResource();
+    if (resource == null) {
+      stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED_ALL, record.getValue());
+      return;
+    }
+
+    final DeploymentRecord deploymentRecord;
+    if (resource.deploymentKey() != NO_DEPLOYMENT_KEY) {
+      final var allResourcesOfDeployment = findResourcesWithDeploymentKey(resource.deploymentKey());
+      deploymentRecord =
+          recreateDeploymentForResources(
+              resource.deploymentKey(), resource.tenantId(), allResourcesOfDeployment);
+    } else {
+      deploymentRecord = createNewDeploymentForResource(resource);
+    }
+    stateWriter.appendFollowUpEvent(key, DeploymentIntent.RECONSTRUCTED, deploymentRecord);
+  }
+
+  private Resource findNextResource() {
+    final var foundProcess = new MutableReference<PersistedProcess>();
+    processState.forEachProcess(
+        null, // TODO: Continue where we left off
+        process -> {
+          final var deploymentKey = process.getDeploymentKey();
+          if (deploymentKey != NO_DEPLOYMENT_KEY
+              && deploymentState.hasStoredDeploymentRecord(deploymentKey)) {
+            return true;
+          }
+          final var copy = new PersistedProcess();
+          BufferUtil.copy(process, copy);
+          foundProcess.set(copy);
+          return false;
+        });
+
+    if (foundProcess.get() != null) {
+      new ProcessResource(foundProcess.get());
+    }
+    // TODO: Continue with formState and decisionState
+
+    return null;
+  }
+
+  private Set<Resource> findResourcesWithDeploymentKey(final long deploymentKey) {
+    // Iterate through processState, formState, and decisionState to find resources that are marked
+    // with the given deployment key.
+    final var resources = new HashSet<Resource>();
+    processState.forEachProcess(
+        null,
+        process -> {
+          final var processDeploymentKey = process.getDeploymentKey();
+          if (processDeploymentKey == deploymentKey) {
+            final var copy = new PersistedProcess();
+            BufferUtil.copy(process, copy);
+            resources.add(new ProcessResource(copy));
+          }
+          return true;
+        });
+    // TODO: Continue with formState and decisionState
+    return resources;
+  }
+
+  /**
+   * Creates a new deployment for a given resource that was not marked with a deployment key. We
+   * reuse the resource key as new deployment key.
+   */
+  private DeploymentRecord createNewDeploymentForResource(final Resource resource) {
+    final var deploymentRecord = new DeploymentRecord();
+    switch (resource) {
+      case ProcessResource(final var process) -> {
+        deploymentRecord.setDeploymentKey(process.getKey());
+        deploymentRecord.setTenantId(process.getTenantId());
+        attachResourceToDeployment(deploymentRecord, resource);
+      }
+    }
+    return deploymentRecord;
+  }
+
+  /**
+   * Recreates a deployment for all resources that are already marked with a given deployment key.
+   */
+  private DeploymentRecord recreateDeploymentForResources(
+      final long deploymentKey, final String tenantId, final Set<Resource> resources) {
+    final var deploymentRecord = new DeploymentRecord();
+    deploymentRecord.setDeploymentKey(deploymentKey);
+    deploymentRecord.setTenantId(tenantId);
+    for (final var resource : resources) {
+      attachResourceToDeployment(deploymentRecord, resource);
+    }
+    return deploymentRecord;
+  }
+
+  private void attachResourceToDeployment(
+      final DeploymentRecord deploymentRecord, final Resource resource) {
+    switch (resource) {
+      case ProcessResource(final var process) -> {
+        deploymentRecord
+            .resources()
+            .add()
+            .setResourceName(process.getResourceName())
+            .setResource(process.getResource());
+        deploymentRecord
+            .processesMetadata()
+            .add()
+            .setBpmnProcessId(process.getBpmnProcessId())
+            .setVersion(process.getVersion())
+            .setKey(process.getKey())
+            .setResourceName(process.getResourceName())
+            .setChecksum(checksumGenerator.checksum(process.getResource()))
+            .setTenantId(process.getTenantId());
+      }
+    }
+  }
+
+  sealed interface Resource {
+    long deploymentKey();
+
+    String tenantId();
+
+    record ProcessResource(PersistedProcess process) implements Resource {
+      @Override
+      public long deploymentKey() {
+        return process.getDeploymentKey();
+      }
+
+      @Override
+      public String tenantId() {
+        return process.getTenantId();
+      }
+    }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -88,7 +88,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
         });
 
     if (foundProcess.get() != null) {
-      new ProcessResource(foundProcess.get());
+      return new ProcessResource(foundProcess.get());
     }
     // TODO: Continue with formState and decisionState
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -64,4 +65,18 @@ public interface ProcessState {
 
   /** TODO: Remove the cache entirely from the immutable state */
   void clearCache();
+
+  /**
+   * Iterates over all persisted processes until the visitor returns false or all processes have
+   * been visited. if {@code previousProcess} is not null, the iteration skips all processes that
+   * appear before it. The visitor is <em>not</em> called with a copy of the process to avoid
+   * needless copies of the relatively large {@link PersistedProcess} instances.
+   */
+  void forEachProcess(ProcessIdentifier previousProcess, PersistedProcessVisitor visitor);
+
+  record ProcessIdentifier(String tenantId, long processDefinitionKey) {}
+
+  interface PersistedProcessVisitor {
+    boolean visit(PersistedProcess process);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@SuppressWarnings({"unchecked", "unused"})
+@ExtendWith(ProcessingStateExtension.class)
+final class DeploymentReconstructProcessorTest {
+  private ZeebeDb<?> zeebeDb;
+  private TransactionContext transactionContext;
+  private MutableProcessingState state;
+  private DeploymentReconstructProcessor processor;
+  private FakeProcessingResultBuilder<UnifiedRecordValue> resultBuilder;
+
+  @BeforeEach
+  void setUp() {
+    final var keyGenerator = new DbKeyGenerator(1, zeebeDb, transactionContext);
+    final var eventAppliers = new EventAppliers().registerEventAppliers(state);
+    final var writers = new Writers(() -> resultBuilder, eventAppliers);
+
+    resultBuilder = new FakeProcessingResultBuilder<>();
+    processor = new DeploymentReconstructProcessor(keyGenerator, state, writers);
+  }
+
+  @Test
+  void shouldEndReconstructionOnEmptyState() {
+    // given
+
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    Assertions.assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record ->
+                Assertions.assertThat(record.getIntent())
+                    .isEqualTo(DeploymentIntent.RECONSTRUCTED_ALL));
+  }
+
+  @Test
+  void shouldIgnoreProcessWithExistingDeployment() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    final var deploymentKey = Protocol.encodePartitionId(1, 1);
+    final var processKey = Protocol.encodePartitionId(1, 2);
+    state
+        .getProcessState()
+        .putProcess(
+            processKey,
+            new ProcessRecord()
+                .setDeploymentKey(deploymentKey)
+                .setBpmnProcessId("process")
+                .setResourceName("process.bpmn")
+                .setVersion(1));
+    state.getDeploymentState().storeDeploymentRecord(deploymentKey, new DeploymentRecord());
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    Assertions.assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record ->
+                Assertions.assertThat(record.getIntent())
+                    .isEqualTo(DeploymentIntent.RECONSTRUCTED_ALL));
+  }
+
+  @Test
+  void shouldReconstructForSingleProcessWithoutDeploymentKey() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    final var deploymentKey = Protocol.encodePartitionId(1, 1);
+    final var processKey = Protocol.encodePartitionId(1, 2);
+    state
+        .getProcessState()
+        .putProcess(
+            processKey,
+            new ProcessRecord()
+                .setDeploymentKey(deploymentKey)
+                .setBpmnProcessId("process")
+                .setResourceName("process.bpmn")
+                .setVersion(1));
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    Assertions.assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record ->
+                Assertions.assertThat(record.getIntent())
+                    .isEqualTo(DeploymentIntent.RECONSTRUCTED));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.function.LongConsumer;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1057,14 +1058,20 @@ public final class ProcessStateTest {
     processState.putProcess(process1.getKey(), process1);
     processState.putProcess(process2.getKey(), process2);
     processState.putProcess(process3.getKey(), process3);
-    final var visitor = mock(PersistedProcessVisitor.class);
-    when(visitor.visit(any())).thenReturn(true);
+    final var visitor = mock(LongConsumer.class);
 
     // when
-    processState.forEachProcess(null, visitor);
+    processState.forEachProcess(
+        null,
+        (process) -> {
+          visitor.accept(process.getKey());
+          return true;
+        });
 
     // then
-    verify(visitor, times(3)).visit(any());
+    verify(visitor).accept(process1.getKey());
+    verify(visitor).accept(process2.getKey());
+    verify(visitor).accept(process3.getKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateTest.java
@@ -9,10 +9,17 @@ package io.camunda.zeebe.engine.state.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
 import io.camunda.zeebe.engine.state.deployment.PersistedProcess.PersistedProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState.PersistedProcessVisitor;
+import io.camunda.zeebe.engine.state.immutable.ProcessState.ProcessIdentifier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
@@ -1039,6 +1046,45 @@ public final class ProcessStateTest {
 
     assertThat(processState.getLatestProcessVersion(processId, TENANT_ID)).isEqualTo(2);
     assertThat(processState.getNextProcessVersion(processId, TENANT_ID)).isEqualTo(3);
+  }
+
+  @Test
+  public void shouldIterateThroughAllProcesses() {
+    // given
+    final var process1 = creatingProcessRecord(processingState, "process1", 1);
+    final var process2 = creatingProcessRecord(processingState, "process2", 1);
+    final var process3 = creatingProcessRecord(processingState, "process3", 1);
+    processState.putProcess(process1.getKey(), process1);
+    processState.putProcess(process2.getKey(), process2);
+    processState.putProcess(process3.getKey(), process3);
+    final var visitor = mock(PersistedProcessVisitor.class);
+    when(visitor.visit(any())).thenReturn(true);
+
+    // when
+    processState.forEachProcess(null, visitor);
+
+    // then
+    verify(visitor, times(3)).visit(any());
+  }
+
+  @Test
+  public void shouldSkipBeforeIteratingThroughProcesses() {
+    // given
+    final var process1 = creatingProcessRecord(processingState, "process1", 1);
+    final var process2 = creatingProcessRecord(processingState, "process2", 1);
+    final var process3 = creatingProcessRecord(processingState, "process3", 1);
+    processState.putProcess(process1.getKey(), process1);
+    processState.putProcess(process2.getKey(), process2);
+    processState.putProcess(process3.getKey(), process3);
+    final var visitor = mock(PersistedProcessVisitor.class);
+    when(visitor.visit(any())).thenReturn(true);
+
+    // when
+    processState.forEachProcess(
+        new ProcessIdentifier(process1.getTenantId(), process1.getProcessDefinitionKey()), visitor);
+
+    // then
+    verify(visitor, times(2)).visit(any());
   }
 
   public static DeploymentRecord creatingDeploymentRecord(


### PR DESCRIPTION
Adds support for finding the first process resource and reconstructing a matching deployment for it.
If the process is already marked with a deployment key, we reuse that key and also attach all other processes with the same deployment key.
Otherwise, we create a new deployment with key equal to the key of the process resource.

relates to #24817