### PR TITLE
All Zeebe CI jobs need to specify GHA timeouts

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -251,6 +251,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
@@ -331,6 +332,7 @@ jobs:
 
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
+    timeout-minutes: 15
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -368,6 +370,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
   deploy-benchmark-images:
     name: Deploy benchmark images
+    timeout-minutes: 5
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -413,6 +416,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   deploy-snyk-projects:
     name: Deploy Snyk development projects
+    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -416,7 +416,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   deploy-snyk-projects:
     name: Deploy Snyk development projects
-    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -82,6 +82,7 @@ defaults:
 jobs:
   scan:
     name: Snyk Scan
+    timeout-minutes: 15
     # Run on self-hosted to make building Zeebe much faster
     runs-on: gcp-perf-core-8-default
     permissions:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

feat: all Zeebe CI jobs need to specify GHA timeouts

Some jobs were running for 6h (default GitHub Actions timeout) and causing waste of resources. Missing timeouts are added for the following jobs:
- docker-checks -> timeout-minutes: 20 // was running around 11 min
- deploy-docker-snapshot -> timeout-minutes: 15 // was running around 7 min
- deploy-benchmark-images -> timeout-minutes: 5 // was running around 2 min
- deploy-snyk-projects -> timeout-minutes: 15 // was running around 8 min

`go-lint`, `go-apidiff` jobs also need timeouts (both are running ~1min, so should be enough to set 5min timeout) to be defined, but they are removed on main. They are needed to be added in backport PRs for 8.5, 8.4, 8.3.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21766 
