### PR TITLE
Introduce and apply new User Task `CORRECTED` event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -411,6 +411,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
     register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));
+    register(UserTaskIntent.CORRECTED, new UserTaskCorrectedApplier(state));
     register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCorrectedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCorrectedApplier(final MutableProcessingState state) {
+    userTaskState = state.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateIntermediateState(
+        key,
+        intermediateStateValue ->
+            intermediateStateValue
+                .getRecord()
+                .setAssignee(value.getAssigneeBuffer())
+                .setDueDate(value.getDueDateBuffer())
+                .setFollowUpDate(value.getFollowUpDateBuffer())
+                .setCandidateGroupsList(value.getCandidateGroupsList())
+                .setCandidateUsersList(value.getCandidateUsersList())
+                .setPriority(value.getPriority()));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbUserTaskState.java
@@ -119,6 +119,15 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
+  public void storeIntermediateState(final UserTaskRecord record, final LifecycleState lifecycle) {
+    userTaskIntermediateStateKey.wrapLong(record.getUserTaskKey());
+    userTaskIntermediateStateToWrite.setRecord(record);
+    userTaskIntermediateStateToWrite.setLifecycleState(lifecycle);
+    userTasksIntermediateStatesColumnFamily.insert(
+        userTaskIntermediateStateKey, userTaskIntermediateStateToWrite);
+  }
+
+  @Override
   public void updateIntermediateState(
       final long key, final Consumer<UserTaskIntermediateStateValue> updater) {
     userTaskIntermediateStateKey.wrapLong(key);
@@ -131,6 +140,25 @@ public class DbUserTaskState implements MutableUserTaskState {
     userTaskIntermediateStateToWrite.setLifecycleState(intermediateState.getLifecycleState());
     userTasksIntermediateStatesColumnFamily.update(
         userTaskIntermediateStateKey, userTaskIntermediateStateToWrite);
+  }
+
+  @Override
+  public void deleteIntermediateState(final long key) {
+    userTaskIntermediateStateKey.wrapLong(key);
+    userTasksIntermediateStatesColumnFamily.deleteExisting(userTaskIntermediateStateKey);
+  }
+
+  @Override
+  public void storeRecordRequestMetadata(
+      final long key, final UserTaskRecordRequestMetadata recordRequestMetadata) {
+    userTaskKey.wrapLong(key);
+    userTasksRecordRequestMetadataColumnFamily.insert(userTaskKey, recordRequestMetadata);
+  }
+
+  @Override
+  public void deleteRecordRequestMetadata(final long key) {
+    userTaskKey.wrapLong(key);
+    userTasksRecordRequestMetadataColumnFamily.deleteIfExists(userTaskKey);
   }
 
   @Override
@@ -168,37 +196,9 @@ public class DbUserTaskState implements MutableUserTaskState {
   }
 
   @Override
-  public void storeIntermediateState(final UserTaskRecord record, final LifecycleState lifecycle) {
-    userTaskIntermediateStateKey.wrapLong(record.getUserTaskKey());
-    userTaskIntermediateStateToWrite.setRecord(record);
-    userTaskIntermediateStateToWrite.setLifecycleState(lifecycle);
-    userTasksIntermediateStatesColumnFamily.insert(
-        userTaskIntermediateStateKey, userTaskIntermediateStateToWrite);
-  }
-
-  @Override
-  public void deleteIntermediateState(final long key) {
-    userTaskIntermediateStateKey.wrapLong(key);
-    userTasksIntermediateStatesColumnFamily.deleteExisting(userTaskIntermediateStateKey);
-  }
-
-  @Override
   public Optional<UserTaskRecordRequestMetadata> findRecordRequestMetadata(final long key) {
     userTaskKey.wrapLong(key);
     return Optional.ofNullable(userTasksRecordRequestMetadataColumnFamily.get(userTaskKey));
-  }
-
-  @Override
-  public void storeRecordRequestMetadata(
-      final long key, final UserTaskRecordRequestMetadata recordRequestMetadata) {
-    userTaskKey.wrapLong(key);
-    userTasksRecordRequestMetadataColumnFamily.insert(userTaskKey, recordRequestMetadata);
-  }
-
-  @Override
-  public void deleteRecordRequestMetadata(final long key) {
-    userTaskKey.wrapLong(key);
-    userTasksRecordRequestMetadataColumnFamily.deleteIfExists(userTaskKey);
   }
 
   private List<String> getAuthorizedTenantIds(final Map<String, Object> authorizations) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableUserTaskState.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.engine.state.mutable;
 
 import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.instance.UserTaskIntermediateStateValue;
 import io.camunda.zeebe.engine.state.instance.UserTaskRecordRequestMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import java.util.function.Consumer;
 
 public interface MutableUserTaskState extends UserTaskState {
 
@@ -22,6 +24,8 @@ public interface MutableUserTaskState extends UserTaskState {
   void delete(final long userTaskKey);
 
   void storeIntermediateState(final UserTaskRecord userTask, final LifecycleState lifecycleState);
+
+  void updateIntermediateState(long key, Consumer<UserTaskIntermediateStateValue> updater);
 
   void deleteIntermediateState(final long userTaskKey);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplierTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskCorrectedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskCorrectedApplier userTaskCorrectedApplier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private TestSetup testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskCorrectedApplier = new UserTaskCorrectedApplier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new TestSetup(processingState);
+  }
+
+  /**
+   * Returns a stream of test case arguments. In order, these arguments are:
+   *
+   * <ul>
+   *   <li>the user task key
+   *   <li>a list of intents to apply to the state before applying the corrected event
+   *   <li>the expected lifecycle state after applying the corrected event
+   * </ul>
+   */
+  public static Stream<Arguments> testCases() {
+    return Stream.of(
+        Arguments.of(1, List.of(), LifecycleState.CREATING),
+        Arguments.of(
+            2, List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED), LifecycleState.ASSIGNING),
+        Arguments.of(
+            3, List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED), LifecycleState.UPDATING),
+        Arguments.of(
+            4,
+            List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED),
+            LifecycleState.COMPLETING));
+  }
+
+  @ParameterizedTest(name = "on {2}")
+  @MethodSource("testCases")
+  void shouldCorrectIntermediateUserTaskDataOnIntent(
+      final long userTaskKey, final List<UserTaskIntent> setup, final LifecycleState state) {
+    // given
+    final var given =
+        new UserTaskRecord()
+            .setUserTaskKey(userTaskKey)
+            .setAssignee("initial")
+            .setCandidateGroupsList(List.of("initial"))
+            .setCandidateUsersList(List.of("initial"))
+            .setDueDate("initial")
+            .setFollowUpDate("initial")
+            .setPriority(1);
+
+    setup.forEach(setupIntent -> testSetup.applyEventToState(userTaskKey, setupIntent, given));
+    testSetup.applyEventToState(userTaskKey, mapLifecycleStateToIntent(state), given);
+
+    Assumptions.assumeThat(userTaskState.getUserTask(userTaskKey)).isNotNull();
+    Assumptions.assumeThat(userTaskState.getLifecycleState(userTaskKey)).isEqualTo(state);
+    Assumptions.assumeThat(userTaskState.getIntermediateState(userTaskKey)).isNotNull();
+
+    // when
+    userTaskCorrectedApplier.applyState(
+        userTaskKey,
+        given
+            .setAssignee("overwritten")
+            .setCandidateGroupsList(List.of("overwritten"))
+            .setCandidateUsersList(List.of("overwritten"))
+            .setDueDate("overwritten")
+            .setFollowUpDate("overwritten")
+            .setPriority(99)
+            .setCandidateGroupsChanged()
+            .setCandidateUsersChanged()
+            .setDueDateChanged()
+            .setFollowUpDateChanged()
+            .setPriorityChanged());
+
+    // then
+    Assertions.assertThat(userTaskState.getIntermediateState(userTaskKey).getRecord())
+        .describedAs("Expect that intermediate state is updated")
+        .isEqualTo(
+            new UserTaskRecord()
+                .setUserTaskKey(userTaskKey)
+                .setAssignee("overwritten")
+                .setCandidateGroupsList(List.of("overwritten"))
+                .setCandidateUsersList(List.of("overwritten"))
+                .setDueDate("overwritten")
+                .setFollowUpDate("overwritten")
+                .setPriority(99))
+        .satisfies(
+            intermediateState ->
+                Assertions.assertThat(intermediateState.getChangedAttributes())
+                    .describedAs("Expect that the changed attributes are not persisted")
+                    .isEmpty());
+    Assertions.assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expect that lifecycle state is not changed")
+        .isEqualTo(state);
+  }
+
+  private static UserTaskIntent mapLifecycleStateToIntent(final LifecycleState state) {
+    return switch (state) {
+      case CREATING -> UserTaskIntent.CREATING;
+      case ASSIGNING -> UserTaskIntent.ASSIGNING;
+      case UPDATING -> UserTaskIntent.UPDATING;
+      case CANCELING -> UserTaskIntent.CANCELING;
+      case COMPLETING -> UserTaskIntent.COMPLETING;
+      default ->
+          throw new IllegalArgumentException(
+              "Unexpected lifecycle state %s received".formatted(state));
+    };
+  }
+
+  private static final class TestSetup {
+
+    private final EventAppliers eventAppliers;
+
+    TestSetup(final MutableProcessingState processingState) {
+      eventAppliers = new EventAppliers();
+      eventAppliers.registerEventAppliers(processingState);
+    }
+
+    /**
+     * Applies the event of the given intent to the state.
+     *
+     * @implNote applies the event using the latest version of the record.
+     * @param intent the intent of the event to apply
+     * @param userTaskRecord data of the event to apply
+     */
+    private void applyEventToState(
+        final long userTaskKey, final UserTaskIntent intent, final UserTaskRecord userTaskRecord) {
+      final int latestVersion = eventAppliers.getLatestVersion(intent);
+      eventAppliers.applyState(userTaskKey, intent, userTaskRecord, latestVersion);
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -68,7 +68,15 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * Represents the intent indicating that the User Task will not be completed, but rather will be
    * reverted to the CREATED state.
    */
-  COMPLETION_DENIED(17);
+  COMPLETION_DENIED(17),
+
+  /**
+   * Represents the intent indicating that the User Task data was corrected by a Task Listener. This
+   * means the user task data available to any subsequent Task Listeners uses the corrected values.
+   * Note that the changes are only applied to the User Task instance after all Task Listeners have
+   * been handled and none denied the operation.
+   */
+  CORRECTED(18);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -124,6 +132,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return DENY_TASK_LISTENER;
       case 17:
         return COMPLETION_DENIED;
+      case 18:
+        return CORRECTED;
       default:
         return UNKNOWN;
     }
@@ -149,6 +159,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case UPDATED:
       case MIGRATED:
       case COMPLETION_DENIED:
+      case CORRECTED:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Introduces a new `CORRECTED` intent and event applier. This stores the changes in the intermediate state, allowing consecutive task listeners to use this data or to roll them back by denying it.

Tests have been added to show that the event can be applied (i.e. appended) while the user task is: `CREATING`, `ASSIGNING`, `UPDATING`, `CANCELING`, or `COMPLETING`. Note that the test cases for `CREATING` and `UPDATING` are not supported yet and are skipped, but will be automatically supported when we introduce those listeners.

## Related issues

closes #24756 