### PR TITLE
fix: use seperate itemToString between single and multi-user input

### DIFF
--- a/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.test.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.test.tsx
@@ -170,3 +170,22 @@ it('should invoke onAdd when selecting an identity even if it is not in loaded i
 
   expect(spy).toHaveBeenCalledWith({id: 'testUserID'});
 });
+
+it('should display all info in the item string to ensure correct filtering', () => {
+  const items = [
+    {id: '1', label: 'John Doe', subText: 'john@example.com'},
+    {id: '2', label: '', subText: 'jane@example.com'},
+    {id: '3', label: '', subText: ''},
+  ];
+
+  const node = shallow(<MultiUserInput {...props} />);
+
+  expect(node.find(FilterableMultiSelect).prop('itemToString')?.(items[0])).toBe(
+    'John Doejohn@example.com1'
+  );
+  expect(node.find(FilterableMultiSelect).prop('itemToString')?.(items[1])).toBe(
+    'jane@example.com2'
+  );
+  expect(node.find(FilterableMultiSelect).prop('itemToString')?.(items[2])).toBe('3');
+  expect(node.find(FilterableMultiSelect).prop('itemToString')?.(null)).toBe('');
+});

--- a/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/MultiUserInput.tsx
@@ -12,14 +12,7 @@ import {FilterableMultiSelect} from '@carbon/react';
 import {t} from 'translation';
 import {getRandomId} from 'services';
 
-import {
-  itemToString,
-  itemToElement,
-  identityToItem,
-  getItems,
-  getSelectedIdentity,
-  Item,
-} from './service';
+import {itemToElement, identityToItem, getItems, getSelectedIdentity} from './service';
 import useLoadIdentities from './useLoadIdentities';
 import {UserInputProps} from './UserTypeahead';
 
@@ -132,7 +125,16 @@ export default function MultiUserInput({
         }
       }}
       items={items}
-      itemToString={itemToString}
+      itemToString={(item) => {
+        if (!item) {
+          return '';
+        }
+
+        const {label, subText, id} = item;
+        // the FilterableMultiSelect filters items based on the string below
+        // we have to include all relevant information to ensure they appear in the menu
+        return label + subText + (id || '');
+      }}
       itemToElement={(item) => itemToElement(item, textValue)}
     />
   );

--- a/optimize/client/src/modules/components/UserTypeahead/SingleUserInput.test.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/SingleUserInput.test.tsx
@@ -102,3 +102,18 @@ it('should not call onAdd when loading is true', () => {
   node.find(ComboBox).prop('onChange')({selectedItem});
   expect(props.onAdd).not.toHaveBeenCalled();
 });
+
+it('should return the correct string representation of an item', () => {
+  const items = [
+    {id: '1', label: 'John Doe', subText: 'john@example.com'},
+    {id: '2', label: '', subText: 'jane@example.com'},
+    {id: '3', label: '', subText: ''},
+  ];
+
+  const node = shallow(<SingleUserInput {...props} />);
+
+  expect(node.find(ComboBox).prop('itemToString')?.(items[0])).toBe('John Doe');
+  expect(node.find(ComboBox).prop('itemToString')?.(items[1])).toBe('jane@example.com');
+  expect(node.find(ComboBox).prop('itemToString')?.(items[2])).toBe('3');
+  expect(node.find(ComboBox).prop('itemToString')?.(null)).toBe('');
+});

--- a/optimize/client/src/modules/components/UserTypeahead/SingleUserInput.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/SingleUserInput.tsx
@@ -12,13 +12,7 @@ import {ComboBox} from '@carbon/react';
 import {t} from 'translation';
 import {getRandomId} from 'services';
 
-import {
-  itemToElement,
-  itemToString,
-  getItems,
-  identityToItem,
-  getSelectedIdentity,
-} from './service';
+import {itemToElement, getItems, identityToItem, getSelectedIdentity} from './service';
 import useLoadIdentities from './useLoadIdentities';
 import {UserInputProps} from './UserTypeahead';
 
@@ -80,7 +74,13 @@ export default function SingleUserInput({
           onClear();
         }
       }}
-      itemToString={itemToString}
+      itemToString={(item) => {
+        if (!item) {
+          return '';
+        }
+        const {label, subText, id} = item;
+        return label || subText || id;
+      }}
       itemToElement={(item) => itemToElement(item, textValue)}
     />
   );

--- a/optimize/client/src/modules/components/UserTypeahead/service.test.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.test.tsx
@@ -9,7 +9,6 @@ import {
   getUserId,
   identityToItem,
   itemToElement,
-  itemToString,
   searchIdentities,
 } from './service';
 
@@ -55,19 +54,6 @@ describe('UserTypeahead service', () => {
       expect(getUserId('123')).toBe('USER:123');
       expect(getUserId('USER:123')).toBe('USER:123');
       expect(getUserId(null)).toBe('USER:null');
-    });
-  });
-
-  describe('itemToString', () => {
-    it('should return the correct string representation of an item', () => {
-      expect(itemToString({id: '1', label: 'John Doe', subText: 'john@example.com'})).toBe(
-        'John Doe'
-      );
-      expect(itemToString({id: '2', label: '', subText: 'jane@example.com'})).toBe(
-        'jane@example.com'
-      );
-      expect(itemToString({id: '3', label: '', subText: ''})).toBe('3');
-      expect(itemToString(null)).toBe('');
     });
   });
 

--- a/optimize/client/src/modules/components/UserTypeahead/service.tsx
+++ b/optimize/client/src/modules/components/UserTypeahead/service.tsx
@@ -49,14 +49,6 @@ export function getUserId(id: string | null): string {
   return `USER:${id}`;
 }
 
-export function itemToString(item: Item | null): string {
-  if (!item) {
-    return '';
-  }
-  const {label, subText, id} = item;
-  return label || subText || id;
-}
-
 export function itemToElement(item: Item | null, textValue: string): JSX.Element {
   if (!item) {
     return <></>;


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR is a backport of this bug fix:
https://github.com/camunda/camunda-optimize/pull/14735


This PR fixes the following bug:
- Create a collection
- Go the users section inside the collection
- Click on add user
- Search for a user ID where the ID string is not included in the name
Example:
id: Aetherins94
name: Cầm Lưu
- The user does not appear in the search menu


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to Optimize 8 camunda/camunda#23483
