### PR TITLE
ci: refactor Maven spotless linter into dedicated job

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -14,8 +14,8 @@ outputs:
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true'
       }}
-  java-code-changes:  # Also runs spotless for Markdown linting
-    description: Output whether jobs depending on Java code changes should be run, related checks are based on GitHub events and java files changes
+  maven-spotless-linter:
+    description: Output whether jobs depending on files relevant for Maven spotless should be run, related checks are based on GitHub events and file changes
     value: >-
       ${{
         github.event_name == 'push' ||
@@ -23,6 +23,15 @@ outputs:
         steps.filter-common.outputs.java-code-change == 'true' ||
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.markdown-change == 'true'
+      }}
+  java-code-changes:
+    description: Output whether jobs depending on Java code changes should be run, related checks are based on GitHub events and java files changes
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.java-code-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true'
       }}
   identity-frontend-tests:
     description: Output whether Identity frontend tests should be run based on GitHub event and files changed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
   detect-changes:
     outputs:
       actionlint: ${{ steps.filter.outputs.actionlint }}
+      maven-spotless-linter: ${{ steps.filter.outputs.maven-spotless-linter }}
       java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
       camunda-docker-tests: ${{ steps.filter.outputs.camunda-docker-tests}}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
@@ -74,6 +75,30 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  maven-spotless-linter:
+    if: needs.detect-changes.outputs.maven-spotless-linter == 'true'
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          maven-cache-key-modifier: maven-spotless-linter
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - run: ./mvnw spotless:check
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
   java-checks:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
@@ -88,7 +113,8 @@ jobs:
           vault-address: ${{ secrets.VAULT_ADDR }}
           vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
           vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
-      - run: ./mvnw -T1C -B -D skipTests -D skipOptimize -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
+      # Not running Maven Spotless here since it is checked in a dedicated job
+      - run: ./mvnw -T1C -B -D skipTests -Dspotless.check.skip=true -D skipOptimize -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -626,6 +652,7 @@ jobs:
       - integration-tests
       - java-checks
       - java-unit-tests
+      - maven-spotless-linter
       - openapi-lint
       - optimize-backend-unit-tests
       - optimize-frontend-unit-tests
@@ -641,6 +668,7 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ check-results ]


### PR DESCRIPTION
## Description

This PR implements the solution from #21383 to decouple Java checks (that don't care about Markdown file linting e.g.) from running Maven spotless plugin which lints all the *.java and *.md files in the repo - thus needing different path filters.

See the demo PR https://github.com/camunda/camunda/pull/24853 that intentionally mis-formats a Markdown file to trigger the linter and fails the build correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21383
