### PR TITLE
CI: add composite action for fork detection

### DIFF
--- a/.github/actions/is-fork/action.yml
+++ b/.github/actions/is-fork/action.yml
@@ -1,0 +1,22 @@
+---
+name: Is Fork
+
+description: |
+  Checks if current job runs on code from a forked repository (via PR).
+  This information can be used to disable certain CI features that are not
+  available on forks (e.g. access to secrets).
+
+inputs: {}
+
+outputs:
+  is-fork:
+    description: Output whether the current job runs on code from a forked repository
+    value: ${{ steps.detect-fork.outputs.is-fork == 'true' }}
+
+runs:
+  using: composite
+  steps:
+  - id: detect-fork
+    shell: bash
+    run: |
+      echo is-fork="${{ github.event.pull_request.head.repo.fork }}" | tee -a $GITHUB_OUTPUT

--- a/.github/actions/is-fork/action.yml
+++ b/.github/actions/is-fork/action.yml
@@ -17,6 +17,8 @@ runs:
   using: composite
   steps:
   - id: detect-fork
+    env:
+      GH_EVENT_PR_FORK: ${{ github.event.pull_request.head.repo.fork }}
     shell: bash
     run: |
-      echo is-fork="${{ github.event.pull_request.head.repo.fork }}" | tee -a $GITHUB_OUTPUT
+      echo is-fork="$GH_EVENT_PR_FORK" | tee -a $GITHUB_OUTPUT

--- a/.github/actions/setup-build/action.yml
+++ b/.github/actions/setup-build/action.yml
@@ -77,6 +77,9 @@ outputs: {}
 runs:
   using: composite
   steps:
+  - name: Check for Fork
+    uses: ./.github/actions/is-fork
+    id: is-fork
   - name: Preliminary checks
     id: checks
     env:
@@ -101,17 +104,13 @@ runs:
             "path": "secret/data/products/zeebe/ci/zeebe"
           }
         }
-      IS_FORK: >-
-        ${{ 
-          github.event.name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name != 'camunda/camunda'
-        }}
       WORKFLOW_REF: ${{ github.workflow_ref }}
+    shell: bash
     run: |
       ## Preliminary checks
 
       # Check if current workflow run is related to a fork PR
-      if [[ "${IS_FORK}" == "true" ]]; then
+      if [[ "${{ steps.is-fork.outputs.is-fork }}" == "true" ]]; then
         echo "The current workflow run is related to a fork PR."
         echo "As a result, Vault secrets cannot be recovered, Camunda Nexus and DockerHub/Harbor login will be disabled."
       fi
@@ -133,11 +132,9 @@ runs:
       dockerhub_vault_path=$(echo ${DOCKERHUB_VAULT_PATHS} | jq -r --arg team "$team" '.[$team].path')
 
       echo dockerhub-vault-path="${dockerhub_vault_path}" | tee -a $GITHUB_OUTPUT
-      echo is-fork="${IS_FORK}" | tee -a $GITHUB_OUTPUT
-    shell: bash
   - name: Import Secrets
     # Secrets are imported only if current workflow run is not related to a fork PR
-    if: steps.checks.outputs.is-fork != 'true'
+    if: steps.is-fork.outputs.is-fork != 'true'
     id: secrets
     uses: hashicorp/vault-action@v3.0.0
     with:
@@ -171,8 +168,8 @@ runs:
     env:
       # Camunda Nexus is disabled for fork PRs
       CAMUNDA_NEXUS_ENABLED: >-
-        ${{ 
-          steps.checks.outputs.is-fork != 'true' &&
+        ${{
+          steps.is-fork.outputs.is-fork != 'true' &&
           inputs.camunda-nexus == 'true'
         }}
       CAMUNDA_NEXUS_MAVEN_MIRROR: >-
@@ -210,7 +207,7 @@ runs:
         --argjson maven_servers "${EXTRA_MAVEN_SERVERS}" \
         '[ $nexus_server + $maven_servers | group_by(.id)[] | add ]'
       )
-      
+
       echo mirrors=$mirrors >> $GITHUB_OUTPUT
       echo servers=$servers >> $GITHUB_OUTPUT
     shell: bash
@@ -227,14 +224,14 @@ runs:
     run: |
       # tzdata is not installed in self-hosted runners
       sudo apt-get update && sudo apt-get install -y tzdata
-      echo ${TZ_IDENTIFIER} | sudo tee /etc/timezone 
+      echo ${TZ_IDENTIFIER} | sudo tee /etc/timezone
       sudo rm -rf /etc/localtime
       sudo ln -s /usr/share/zoneinfo/${TZ_IDENTIFIER} /etc/localtime
     shell: bash
   - name: Logs on to DockerHub
     # DockerHub login is disabled for fork PRs
     if: >-
-      steps.checks.outputs.is-fork != 'true' &&
+      steps.is-fork.outputs.is-fork != 'true' &&
       (
         inputs.dockerhub == 'true' ||
         inputs.dockerhub-readonly == 'true'
@@ -246,7 +243,7 @@ runs:
   - name: Logs on to Harbor
     # Harbor login is disabled for fork PRs
     if: >-
-      steps.checks.outputs.is-fork != 'true' &&
+      steps.is-fork.outputs.is-fork != 'true' &&
       inputs.harbor == 'true'
     uses: docker/login-action@v3
     with:


### PR DESCRIPTION
## Description

This PR introduces a new, small composite action that checks if current job runs on code from a forked repository (via PR). This information can be used to disable certain CI features that are not available on forks (e.g. access to secrets).

Why have a new composite action for a simple check like this? Rationale: a composite action allows reuse (predicted to affect many/all GHA workflows in this repository) and encapsulates the logic which might need updates later.

Before merging check that the action works correctly on:

- on PRs in `camunda/camunda` (all CI checks should run) ✔️ ([link](https://github.com/camunda/camunda/actions/runs/11934300012/job/33263175160?pr=24895))
- on PRs from forks (`setup-build` should not attempt to fetch secrets) ✔️ ([link](https://github.com/camunda/camunda/actions/runs/11952224899/job/33317563410?pr=24676))
- on merge queue (cannot be checked in `camunda/camunda`, demo repo acceptable) ✔️ ([link](https://github.com/camunda/infra-camunda24737-poc/actions/runs/11952652011/job/33318833437))
- on push ✔️ ([link](https://github.com/camunda/infra-camunda24737-poc/actions/runs/11952607180/job/33318692631))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24737
