### PR TITLE
ci: exclude stable/optimize-8.6 from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,8 +36,7 @@
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
         "/^stable\\/8\\..*/",
-        "stable/operate-8.5",
-        "stable/optimize-8.6"
+        "stable/operate-8.5"
       ],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,7 +8,6 @@
   "baseBranches": [
     "/^stable\\/8\\..*/",
     "stable/operate-8.5",
-    "stable/optimize-8.6",
     "main"
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
This PR disable the updates on the `stable/optimize-8.6` branch since we do not currently have an easy solution to resolve the existing PRs. 

See discussion here:
https://camunda.slack.com/archives/C071KP5BTHB/p1731906196396619

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [X] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24658
