### PR TITLE
Preparation work for post importer migration

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTask.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.exporter.tasks;
 
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface BackgroundTask {
-  CompletableFuture<Integer> execute();
+  CompletionStage<Integer> execute();
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -7,46 +7,22 @@
  */
 package io.camunda.exporter.tasks;
 
-import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
-
-import io.camunda.exporter.ExporterResourceProvider;
-import io.camunda.exporter.config.ConnectionTypes;
-import io.camunda.exporter.config.ExporterConfiguration;
-import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
-import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
-import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
-import io.camunda.exporter.tasks.archiver.ElasticsearchRepository;
-import io.camunda.exporter.tasks.archiver.OpenSearchRepository;
-import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
-import io.camunda.search.connect.es.ElasticsearchConnector;
-import io.camunda.search.connect.os.OpensearchConnector;
-import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
-import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
-import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
-import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
-import io.camunda.zeebe.util.error.FatalErrorHandler;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadFactory;
 import javax.annotation.WillCloseWhenClosed;
 import org.agrona.CloseHelper;
 import org.slf4j.Logger;
 
 public final class BackgroundTaskManager implements CloseableSilently {
-
   private final int partitionId;
   private final ArchiverRepository repository;
   private final Logger logger;
   private final ScheduledThreadPoolExecutor executor;
   private final List<Runnable> tasks;
-  private final ArchiverConfiguration config;
 
   private int submittedTasks = 0;
 
@@ -56,14 +32,12 @@ public final class BackgroundTaskManager implements CloseableSilently {
       final @WillCloseWhenClosed ArchiverRepository repository,
       final Logger logger,
       final @WillCloseWhenClosed ScheduledThreadPoolExecutor executor,
-      final List<Runnable> tasks,
-      final ArchiverConfiguration config) {
+      final List<Runnable> tasks) {
     this.partitionId = partitionId;
     this.repository = Objects.requireNonNull(repository, "must specify a repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");
-    this.config = Objects.requireNonNull(config, "must specify a config");
   }
 
   @Override
@@ -95,170 +69,9 @@ public final class BackgroundTaskManager implements CloseableSilently {
         unsubmittedTasks,
         submittedTasks,
         tasks.size());
-
     for (; submittedTasks < tasks.size(); submittedTasks++) {
       final var task = tasks.get(submittedTasks);
       executor.submit(task);
-    }
-  }
-
-  public static BackgroundTaskManager create(
-      final int partitionId,
-      final String exporterId,
-      final ExporterConfiguration config,
-      final ExporterResourceProvider resourceProvider,
-      final CamundaExporterMetrics metrics,
-      final Logger logger) {
-    final var threadFactory =
-        Thread.ofPlatform()
-            .name("exporter-" + exporterId + "-p" + partitionId + "-tasks-", 0)
-            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(logger))
-            .factory();
-    final var executor = defaultExecutor(threadFactory);
-    final var repository =
-        createRepository(config, resourceProvider, partitionId, executor, metrics, logger);
-    final List<Runnable> tasks = new ArrayList<>();
-    int threadCount = 1;
-
-    tasks.add(
-        createProcessInstanceTask(
-            metrics, logger, resourceProvider, repository, executor, config.getArchiver()));
-    if (partitionId == START_PARTITION_ID) {
-      threadCount = 2;
-      tasks.add(
-          createBatchOperationTask(
-              metrics, logger, resourceProvider, repository, executor, config.getArchiver()));
-      tasks.add(createApplyRolloverPeriodTask(metrics, logger, repository));
-    }
-
-    executor.setCorePoolSize(threadCount);
-    return new BackgroundTaskManager(
-        partitionId, repository, logger, executor, tasks, config.getArchiver());
-  }
-
-  private static ReschedulingTask createProcessInstanceTask(
-      final CamundaExporterMetrics metrics,
-      final Logger logger,
-      final ExporterResourceProvider resourceProvider,
-      final ArchiverRepository repository,
-      final ScheduledThreadPoolExecutor executor,
-      final ArchiverConfiguration config) {
-    final var dependantTemplates = new ArrayList<ProcessInstanceDependant>();
-    resourceProvider.getIndexTemplateDescriptors().stream()
-        .filter(ProcessInstanceDependant.class::isInstance)
-        .map(ProcessInstanceDependant.class::cast)
-        .forEach(dependantTemplates::add);
-
-    // add a special case just for TaskTemplate, which has 2 kinds of documents in the same
-    // index
-    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
-    dependantTemplates.add(
-        new ProcessInstanceDependantAdapter(taskTemplate.getFullQualifiedName(), TaskTemplate.ID));
-
-    return new ReschedulingTask(
-        new ProcessInstancesArchiverJob(
-            repository,
-            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
-            dependantTemplates,
-            metrics,
-            logger,
-            executor),
-        config.getRolloverBatchSize(),
-        config.getDelayBetweenRuns(),
-        executor,
-        logger);
-  }
-
-  private static ApplyRolloverPeriodJob createApplyRolloverPeriodTask(
-      final CamundaExporterMetrics metrics,
-      final Logger logger,
-      final ArchiverRepository repository) {
-
-    return new ApplyRolloverPeriodJob(repository, metrics, logger);
-  }
-
-  private static ReschedulingTask createBatchOperationTask(
-      final CamundaExporterMetrics metrics,
-      final Logger logger,
-      final ExporterResourceProvider resourceProvider,
-      final ArchiverRepository repository,
-      final ScheduledThreadPoolExecutor executor,
-      final ArchiverConfiguration config) {
-
-    return new ReschedulingTask(
-        new BatchOperationArchiverJob(
-            repository,
-            resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class),
-            metrics,
-            logger,
-            executor),
-        config.getRolloverBatchSize(),
-        config.getDelayBetweenRuns(),
-        executor,
-        logger);
-  }
-
-  private static ScheduledThreadPoolExecutor defaultExecutor(final ThreadFactory threadFactory) {
-    final var executor = new ScheduledThreadPoolExecutor(0, threadFactory);
-    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
-    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
-    executor.setRemoveOnCancelPolicy(true);
-
-    return executor;
-  }
-
-  private static ArchiverRepository createRepository(
-      final ExporterConfiguration config,
-      final ExporterResourceProvider resourceProvider,
-      final int partitionId,
-      final Executor executor,
-      final CamundaExporterMetrics metrics,
-      final Logger logger) {
-    final var listViewTemplate =
-        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
-    final var batchOperationTemplate =
-        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
-    return switch (ConnectionTypes.from(config.getConnect().getType())) {
-      case ELASTICSEARCH -> {
-        final var connector = new ElasticsearchConnector(config.getConnect());
-        yield new ElasticsearchRepository(
-            partitionId,
-            config.getArchiver(),
-            config.getRetention(),
-            listViewTemplate.getFullQualifiedName(),
-            batchOperationTemplate.getFullQualifiedName(),
-            connector.createAsyncClient(),
-            executor,
-            metrics,
-            logger);
-      }
-      case OPENSEARCH -> {
-        final var connector = new OpensearchConnector(config.getConnect());
-        yield new OpenSearchRepository(
-            partitionId,
-            config.getArchiver(),
-            config.getRetention(),
-            listViewTemplate.getFullQualifiedName(),
-            batchOperationTemplate.getFullQualifiedName(),
-            connector.createAsyncClient(),
-            executor,
-            metrics,
-            logger);
-      }
-    };
-  }
-
-  private record ProcessInstanceDependantAdapter(String name, String field)
-      implements ProcessInstanceDependant {
-
-    @Override
-    public String getFullQualifiedName() {
-      return name;
-    }
-
-    @Override
-    public String getProcessInstanceDependantField() {
-      return field;
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks;
+
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
+import io.camunda.exporter.ExporterResourceProvider;
+import io.camunda.exporter.config.ConnectionTypes;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.metrics.CamundaExporterMetrics;
+import io.camunda.exporter.tasks.archiver.ApplyRolloverPeriodJob;
+import io.camunda.exporter.tasks.archiver.ArchiverRepository;
+import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
+import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
+import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
+import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.zeebe.util.error.FatalErrorHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+
+public final class BackgroundTaskManagerFactory {
+  private final int partitionId;
+  private final String exporterId;
+  private final ExporterConfiguration config;
+  private final ExporterResourceProvider resourceProvider;
+  private final CamundaExporterMetrics metrics;
+  private final Logger logger;
+
+  private ScheduledThreadPoolExecutor executor;
+  private ArchiverRepository repository;
+
+  public BackgroundTaskManagerFactory(
+      final int partitionId,
+      final String exporterId,
+      final ExporterConfiguration config,
+      final ExporterResourceProvider resourceProvider,
+      final CamundaExporterMetrics metrics,
+      final Logger logger) {
+    this.partitionId = partitionId;
+    this.exporterId = exporterId;
+    this.config = config;
+    this.resourceProvider = resourceProvider;
+    this.metrics = metrics;
+    this.logger = logger;
+  }
+
+  public BackgroundTaskManager build() {
+    executor = buildExecutor();
+    repository = buildRepository();
+    final List<Runnable> tasks = buildTasks();
+
+    return new BackgroundTaskManager(partitionId, repository, logger, executor, tasks);
+  }
+
+  private List<Runnable> buildTasks() {
+    final List<Runnable> tasks = new ArrayList<>();
+    int threadCount = 0;
+
+    if (config.getArchiver().isRolloverEnabled()) {
+      threadCount = 1;
+      tasks.add(buildProcessInstanceArchiverJob());
+      if (partitionId == START_PARTITION_ID) {
+        threadCount = 2;
+        tasks.add(buildBatchOperationArchiverJob());
+        tasks.add(new ApplyRolloverPeriodJob(repository, metrics, logger));
+      }
+    }
+
+    executor.setCorePoolSize(threadCount);
+    return tasks;
+  }
+
+  private ReschedulingTask buildProcessInstanceArchiverJob() {
+    final var dependantTemplates = new ArrayList<ProcessInstanceDependant>();
+    resourceProvider.getIndexTemplateDescriptors().stream()
+        .filter(ProcessInstanceDependant.class::isInstance)
+        .map(ProcessInstanceDependant.class::cast)
+        .forEach(dependantTemplates::add);
+
+    // add a special case just for TaskTemplate, which has 2 kinds of documents in the same
+    // index
+    final var taskTemplate = resourceProvider.getIndexTemplateDescriptor(TaskTemplate.class);
+    dependantTemplates.add(
+        new ProcessInstanceDependantAdapter(taskTemplate.getFullQualifiedName(), TaskTemplate.ID));
+
+    return buildReschedulingArchiverTask(
+        new ProcessInstancesArchiverJob(
+            repository,
+            resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class),
+            dependantTemplates,
+            metrics,
+            logger,
+            executor));
+  }
+
+  private ReschedulingTask buildBatchOperationArchiverJob() {
+    return buildReschedulingArchiverTask(
+        new BatchOperationArchiverJob(
+            repository,
+            resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class),
+            metrics,
+            logger,
+            executor));
+  }
+
+  private ReschedulingTask buildReschedulingArchiverTask(final BackgroundTask task) {
+    return new ReschedulingTask(
+        task,
+        config.getArchiver().getRolloverBatchSize(),
+        config.getArchiver().getDelayBetweenRuns(),
+        executor,
+        logger);
+  }
+
+  private ScheduledThreadPoolExecutor buildExecutor() {
+    final var threadFactory =
+        Thread.ofPlatform()
+            .name("exporter-" + exporterId + "-p" + partitionId + "-tasks-", 0)
+            .uncaughtExceptionHandler(FatalErrorHandler.uncaughtExceptionHandler(logger))
+            .factory();
+    final var executor = new ScheduledThreadPoolExecutor(0, threadFactory);
+    executor.setContinueExistingPeriodicTasksAfterShutdownPolicy(false);
+    executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
+    executor.setRemoveOnCancelPolicy(true);
+    executor.allowCoreThreadTimeOut(true);
+    executor.setKeepAliveTime(1, TimeUnit.MINUTES);
+
+    return executor;
+  }
+
+  private ArchiverRepository buildRepository() {
+    final var listViewTemplate =
+        resourceProvider.getIndexTemplateDescriptor(ListViewTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+    return switch (ConnectionTypes.from(config.getConnect().getType())) {
+      case ELASTICSEARCH -> {
+        final var connector = new ElasticsearchConnector(config.getConnect());
+        yield new ElasticsearchArchiverRepository(
+            partitionId,
+            config.getArchiver(),
+            config.getRetention(),
+            listViewTemplate.getFullQualifiedName(),
+            batchOperationTemplate.getFullQualifiedName(),
+            connector.createAsyncClient(),
+            executor,
+            metrics,
+            logger);
+      }
+      case OPENSEARCH -> {
+        final var connector = new OpensearchConnector(config.getConnect());
+        yield new OpenSearchArchiverRepository(
+            partitionId,
+            config.getArchiver(),
+            config.getRetention(),
+            listViewTemplate.getFullQualifiedName(),
+            batchOperationTemplate.getFullQualifiedName(),
+            connector.createAsyncClient(),
+            executor,
+            metrics,
+            logger);
+      }
+    };
+  }
+
+  private record ProcessInstanceDependantAdapter(String name, String field)
+      implements ProcessInstanceDependant {
+
+    @Override
+    public String getFullQualifiedName() {
+      return name;
+    }
+
+    @Override
+    public String getProcessInstanceDependantField() {
+      return field;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ArchiverJob.java
@@ -8,13 +8,13 @@
 package io.camunda.exporter.tasks.archiver;
 
 import io.camunda.exporter.tasks.BackgroundTask;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public interface ArchiverJob extends BackgroundTask {
-  CompletableFuture<Integer> archiveNextBatch();
+  CompletionStage<Integer> archiveNextBatch();
 
   @Override
-  default CompletableFuture<Integer> execute() {
+  default CompletionStage<Integer> execute() {
     return archiveNextBatch();
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJob.java
@@ -12,6 +12,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemp
 import io.camunda.zeebe.util.FunctionUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
@@ -37,11 +38,11 @@ public class BatchOperationArchiverJob implements ArchiverJob {
   }
 
   @Override
-  public CompletableFuture<Integer> archiveNextBatch() {
+  public CompletionStage<Integer> archiveNextBatch() {
     return repository.getBatchOperationsNextBatch().thenComposeAsync(this::archiveBatch, executor);
   }
 
-  public CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
+  private CompletableFuture<Integer> archiveBatch(final ArchiveBatch archiveBatch) {
 
     if (archiveBatch != null) {
       logger.trace("Following batch operations are found for archiving: {}", archiveBatch);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepository.java
@@ -7,70 +7,69 @@
  */
 package io.camunda.exporter.tasks.archiver;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.Conflicts;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.Slices;
+import co.elastic.clients.elasticsearch._types.SlicesCalculation;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.CalendarInterval;
+import co.elastic.clients.elasticsearch._types.aggregations.DateHistogramBucket;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryRequest;
+import co.elastic.clients.elasticsearch.core.DeleteByQueryResponse;
+import co.elastic.clients.elasticsearch.core.ReindexRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.reindex.Source;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.PutIndicesSettingsRequest;
+import co.elastic.clients.json.JsonData;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
-import io.camunda.zeebe.exporter.api.ExporterException;
 import io.micrometer.core.instrument.Timer;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import javax.annotation.WillCloseWhenClosed;
-import org.opensearch.client.json.JsonData;
-import org.opensearch.client.opensearch.OpenSearchAsyncClient;
-import org.opensearch.client.opensearch._types.Conflicts;
-import org.opensearch.client.opensearch._types.FieldValue;
-import org.opensearch.client.opensearch._types.SortOrder;
-import org.opensearch.client.opensearch._types.Time;
-import org.opensearch.client.opensearch._types.aggregations.Aggregation;
-import org.opensearch.client.opensearch._types.aggregations.AggregationBuilders;
-import org.opensearch.client.opensearch._types.aggregations.CalendarInterval;
-import org.opensearch.client.opensearch._types.aggregations.DateHistogramBucket;
-import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
-import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
-import org.opensearch.client.opensearch.core.DeleteByQueryRequest;
-import org.opensearch.client.opensearch.core.DeleteByQueryResponse;
-import org.opensearch.client.opensearch.core.ReindexRequest;
-import org.opensearch.client.opensearch.core.SearchRequest;
-import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.core.reindex.Source;
-import org.opensearch.client.opensearch.core.search.Hit;
-import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
-import org.opensearch.client.opensearch.generic.Requests;
 import org.slf4j.Logger;
 
-public final class OpenSearchRepository implements ArchiverRepository {
+public final class ElasticsearchArchiverRepository implements ArchiverRepository {
   private static final String DATES_AGG = "datesAgg";
   private static final String INSTANCES_AGG = "instancesAgg";
   private static final String DATES_SORTED_AGG = "datesSortedAgg";
   private static final Time REINDEX_SCROLL_TIMEOUT = Time.of(t -> t.time("30s"));
-  private static final long AUTO_SLICES = 0; // see OS docs; 0 means auto
+  private static final Slices AUTO_SLICES =
+      Slices.of(slices -> slices.computed(SlicesCalculation.Auto));
 
   private final int partitionId;
   private final ArchiverConfiguration config;
   private final RetentionConfiguration retention;
   private final String processInstanceIndex;
   private final String batchOperationIndex;
-  private final OpenSearchAsyncClient client;
+  private final ElasticsearchAsyncClient client;
   private final Executor executor;
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
-  private final OpenSearchGenericClient genericClient;
+
   private final CalendarInterval rolloverInterval;
 
-  public OpenSearchRepository(
+  public ElasticsearchArchiverRepository(
       final int partitionId,
       final ArchiverConfiguration config,
       final RetentionConfiguration retention,
       final String processInstanceIndex,
       final String batchOperationIndex,
-      @WillCloseWhenClosed final OpenSearchAsyncClient client,
+      @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
       final CamundaExporterMetrics metrics,
       final Logger logger) {
@@ -84,7 +83,6 @@ public final class OpenSearchRepository implements ArchiverRepository {
     this.metrics = metrics;
     this.logger = logger;
 
-    genericClient = new OpenSearchGenericClient(client._transport(), client._transportOptions());
     rolloverInterval = mapCalendarInterval(config.getRolloverInterval());
   }
 
@@ -92,10 +90,11 @@ public final class OpenSearchRepository implements ArchiverRepository {
   public CompletableFuture<ArchiveBatch> getProcessInstancesNextBatch() {
     final var aggregation =
         createFinishedEntityAggregation(ListViewTemplate.END_DATE, ListViewTemplate.ID);
-    final var request = createFinishedInstancesSearchRequest(aggregation);
+    final var searchRequest = createFinishedInstancesSearchRequest(aggregation);
 
     final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(request, Object.class))
+    return client
+        .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
         .thenApplyAsync(this::createArchiveBatch, executor);
   }
@@ -107,7 +106,8 @@ public final class OpenSearchRepository implements ArchiverRepository {
     final var searchRequest = createFinishedBatchOperationsSearchRequest(aggregation);
 
     final var timer = Timer.start();
-    return sendRequestAsync(() -> client.search(searchRequest, Object.class))
+    return client
+        .search(searchRequest, Object.class)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverSearch(timer), executor)
         .thenApplyAsync(this::createArchiveBatch, executor);
   }
@@ -118,29 +118,17 @@ public final class OpenSearchRepository implements ArchiverRepository {
       return CompletableFuture.completedFuture(null);
     }
 
-    final AddPolicyRequestBody value = new AddPolicyRequestBody(retention.getPolicyName());
-    final var request =
-        Requests.builder().method("POST").endpoint("_plugins/_ism/add/" + destinationIndexName);
+    final var settingsRequest =
+        new PutIndicesSettingsRequest.Builder()
+            .settings(
+                settings ->
+                    settings.lifecycle(lifecycle -> lifecycle.name(retention.getPolicyName())))
+            .index(destinationIndexName)
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .build();
 
-    return sendRequestAsync(
-            () ->
-                genericClient.executeAsync(
-                    request.json(value, genericClient._transport().jsonpMapper()).build()))
-        .thenComposeAsync(
-            response -> {
-              if (response.getStatus() >= 400) {
-                return CompletableFuture.failedFuture(
-                    new ExporterException(
-                        "Failed to set index lifecycle policy for index: "
-                            + destinationIndexName
-                            + ".\n"
-                            + "Status: "
-                            + response.getStatus()
-                            + ", Reason: "
-                            + response.getReason()));
-              }
-              return CompletableFuture.completedFuture(null);
-            });
+    return client.indices().putSettings(settingsRequest).thenApplyAsync(ok -> null, executor);
   }
 
   @Override
@@ -163,7 +151,8 @@ public final class OpenSearchRepository implements ArchiverRepository {
             .build();
 
     final var timer = Timer.start();
-    return sendRequestAsync(() -> client.deleteByQuery(request))
+    return client
+        .deleteByQuery(request)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverDelete(timer), executor)
         .thenApplyAsync(DeleteByQueryResponse::total, executor)
         .thenApplyAsync(ok -> null, executor);
@@ -190,7 +179,8 @@ public final class OpenSearchRepository implements ArchiverRepository {
             .build();
 
     final var timer = Timer.start();
-    return sendRequestAsync(() -> client.reindex(request))
+    return client
+        .reindex(request)
         .whenCompleteAsync((ignored, error) -> metrics.measureArchiverReindex(timer), executor)
         .thenApplyAsync(ignored -> null, executor);
   }
@@ -200,24 +190,33 @@ public final class OpenSearchRepository implements ArchiverRepository {
     client._transport().close();
   }
 
-  private SearchRequest createFinishedBatchOperationsSearchRequest(final Aggregation aggregation) {
+  private SearchRequest createFinishedInstancesSearchRequest(final Aggregation aggregation) {
     final var endDateQ =
-        QueryBuilders.range()
-            .field(BatchOperationTemplate.END_DATE)
-            .lte(JsonData.of(config.getArchivingTimePoint()))
-            .build();
+        QueryBuilders.range(
+            q ->
+                q.field(ListViewTemplate.END_DATE)
+                    .lte(JsonData.of(config.getArchivingTimePoint())));
+    final var isProcessInstanceQ =
+        QueryBuilders.term(
+            q ->
+                q.field(ListViewTemplate.JOIN_RELATION)
+                    .value(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION));
+    final var partitionQ =
+        QueryBuilders.term(q -> q.field(ListViewTemplate.PARTITION_ID).value(partitionId));
+    final var combinedQuery =
+        QueryBuilders.bool(q -> q.must(endDateQ, isProcessInstanceQ, partitionQ));
 
     return createSearchRequest(
-        batchOperationIndex, endDateQ.toQuery(), aggregation, BatchOperationTemplate.END_DATE);
+        processInstanceIndex, combinedQuery, aggregation, ListViewTemplate.END_DATE);
   }
 
   private ArchiveBatch createArchiveBatch(final SearchResponse<?> search) {
-    final var aggregation = search.aggregations().get(DATES_AGG);
-    if (aggregation == null) {
+    final var aggregate = search.aggregations().get(DATES_AGG);
+    if (aggregate == null) {
       return null;
     }
 
-    final List<DateHistogramBucket> buckets = aggregation.dateHistogram().buckets().array();
+    final List<DateHistogramBucket> buckets = aggregate.dateHistogram().buckets().array();
     if (buckets.isEmpty()) {
       return null;
     }
@@ -246,41 +245,6 @@ public final class OpenSearchRepository implements ArchiverRepository {
         .orElseThrow();
   }
 
-  private <T> CompletableFuture<T> sendRequestAsync(final RequestSender<T> sender) {
-    try {
-      return sender.sendRequest();
-    } catch (final IOException e) {
-      return CompletableFuture.failedFuture(
-          new ExporterException(
-              "Failed to send request, likely because we failed to parse the request", e));
-    }
-  }
-
-  private SearchRequest createFinishedInstancesSearchRequest(final Aggregation aggregation) {
-    final var endDateQ =
-        QueryBuilders.range()
-            .field(ListViewTemplate.END_DATE)
-            .lte(JsonData.of(config.getArchivingTimePoint()))
-            .build();
-    final var isProcessInstanceQ =
-        QueryBuilders.term()
-            .field(ListViewTemplate.JOIN_RELATION)
-            .value(FieldValue.of(ListViewTemplate.PROCESS_INSTANCE_JOIN_RELATION))
-            .build();
-    final var partitionQ =
-        QueryBuilders.term()
-            .field(ListViewTemplate.PARTITION_ID)
-            .value(FieldValue.of(partitionId))
-            .build();
-    final var combinedQuery =
-        QueryBuilders.bool()
-            .must(endDateQ.toQuery(), isProcessInstanceQ.toQuery(), partitionQ.toQuery())
-            .build();
-
-    return createSearchRequest(
-        processInstanceIndex, combinedQuery.toQuery(), aggregation, ListViewTemplate.END_DATE);
-  }
-
   private Aggregation createFinishedEntityAggregation(final String endDate, final String id) {
     final var dateAggregation =
         AggregationBuilders.dateHistogram()
@@ -307,6 +271,17 @@ public final class OpenSearchRepository implements ArchiverRepository {
         .build();
   }
 
+  private SearchRequest createFinishedBatchOperationsSearchRequest(final Aggregation aggregation) {
+    final var endDateQ =
+        QueryBuilders.range(
+            q ->
+                q.field(BatchOperationTemplate.END_DATE)
+                    .lte(JsonData.of(config.getArchivingTimePoint())));
+
+    return createSearchRequest(
+        batchOperationIndex, endDateQ, aggregation, BatchOperationTemplate.END_DATE);
+  }
+
   private SearchRequest createSearchRequest(
       final String indexName,
       final Query filterQuery,
@@ -328,12 +303,5 @@ public final class OpenSearchRepository implements ArchiverRepository {
         .sort(sort -> sort.field(field -> field.field(sortField).order(SortOrder.Asc)))
         .size(0)
         .build();
-  }
-
-  private record AddPolicyRequestBody(@JsonProperty("policy_id") String policyId) {}
-
-  @FunctionalInterface
-  private interface RequestSender<T> {
-    CompletableFuture<T> sendRequest() throws IOException;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJob.java
@@ -13,6 +13,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.zeebe.util.FunctionUtil;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
 
@@ -41,11 +42,11 @@ public class ProcessInstancesArchiverJob implements ArchiverJob {
   }
 
   @Override
-  public CompletableFuture<Integer> archiveNextBatch() {
+  public CompletionStage<Integer> archiveNextBatch() {
     return repository.getProcessInstancesNextBatch().thenComposeAsync(this::archiveBatch, executor);
   }
 
-  private CompletableFuture<Integer> archiveBatch(final ArchiveBatch batch) {
+  private CompletionStage<Integer> archiveBatch(final ArchiveBatch batch) {
     if (batch != null && !(batch.ids() == null || batch.ids().isEmpty())) {
       logger.trace("Following process instances are found for archiving: {}", batch);
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -10,7 +10,6 @@ package io.camunda.exporter.tasks;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
@@ -38,8 +37,7 @@ final class BackgroundTaskManagerTest {
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
             // return unfinished futures to have a deterministic count of submitted tasks
-            List.of(CompletableFuture::new, CompletableFuture::new),
-            new ArchiverConfiguration());
+            List.of(CompletableFuture::new, CompletableFuture::new));
 
     @Test
     void shouldNotResubmitTasksOnStart() {
@@ -95,8 +93,7 @@ final class BackgroundTaskManagerTest {
             repository,
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
-            List.of(),
-            new ArchiverConfiguration());
+            List.of());
 
     @Test
     void shouldCloseExecutorOnClose() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/BatchOperationArchiverJobTest.java
@@ -79,7 +79,9 @@ final class BatchOperationArchiverJobTest {
     repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // when
-    final var count = job.archiveNextBatch().join() + job.archiveNextBatch().join();
+    final var count =
+        job.archiveNextBatch().toCompletableFuture().join()
+            + job.archiveNextBatch().toCompletableFuture().join();
 
     // then
     assertThat(meterRegistry.counter("zeebe.camunda.exporter.archived.batch.operations").count())

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryIT.java
@@ -9,11 +9,19 @@ package io.camunda.exporter.tasks.archiver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.mapping.Property;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.ilm.Phase;
+import co.elastic.clients.elasticsearch.indices.IndexSettingsLifecycle;
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.config.ExporterConfiguration.ArchiverConfiguration;
 import io.camunda.exporter.config.ExporterConfiguration.RetentionConfiguration;
 import io.camunda.exporter.metrics.CamundaExporterMetrics;
-import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
@@ -30,42 +38,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.http.HttpHost;
-import org.awaitility.Awaitility;
+import org.elasticsearch.client.RestClient;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.RestClient;
-import org.opensearch.client.json.jackson.JacksonJsonpMapper;
-import org.opensearch.client.opensearch.OpenSearchAsyncClient;
-import org.opensearch.client.opensearch.OpenSearchClient;
-import org.opensearch.client.opensearch._types.mapping.Property;
-import org.opensearch.client.opensearch._types.mapping.TypeMapping;
-import org.opensearch.client.opensearch.core.search.Hit;
-import org.opensearch.client.opensearch.generic.OpenSearchGenericClient;
-import org.opensearch.client.opensearch.generic.Requests;
-import org.opensearch.client.transport.rest_client.RestClientTransport;
-import org.opensearch.testcontainers.OpensearchContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SuppressWarnings("resource")
 @Testcontainers
 @AutoCloseResources
-final class OpenSearchRepositoryIT {
-  private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchRepositoryIT.class);
+final class ElasticsearchArchiverRepositoryIT {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchArchiverRepositoryIT.class);
 
   @Container
-  private static final OpensearchContainer<?> OPENSEARCH =
-      TestSearchContainers.createDefaultOpensearchContainer();
+  private static final ElasticsearchContainer ELASTIC =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
 
-  private static final ObjectMapper MAPPER = new ObjectMapper();
   @AutoCloseResource private final RestClientTransport transport = createRestClient();
   private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
   private final ArchiverConfiguration config = new ArchiverConfiguration();
   private final RetentionConfiguration retention = new RetentionConfiguration();
   private final String processInstanceIndex = "process-instance-" + UUID.randomUUID();
   private final String batchOperationIndex = "batch-operation-" + UUID.randomUUID();
-  private final OpenSearchClient testClient = new OpenSearchClient(transport);
+  private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
 
   @Test
   void shouldDeleteDocuments() throws IOException {
@@ -101,21 +99,35 @@ final class OpenSearchRepositoryIT {
     final var indexName = UUID.randomUUID().toString();
     final var repository = createRepository();
     testClient.indices().create(r -> r.index(indexName));
-
+    final var initialLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .lifecycle();
+    assertThat(initialLifecycle).isNull();
     retention.setEnabled(true);
     retention.setPolicyName("operate_delete_archived_indices");
+    putLifecyclePolicy();
 
     // when
-    createLifeCyclePolicy();
     final var result = repository.setIndexLifeCycle(indexName);
 
     // then
     assertThat(result).succeedsWithin(Duration.ofSeconds(30));
-
-    // Takes a while for the policy to be applied
-    Awaitility.await("until the policy has been visibly applied")
-        .untilAsserted(
-            () -> assertThat(fetchPolicyForIndex(indexName)).isEqualTo(retention.getPolicyName()));
+    final var actualLifecycle =
+        testClient
+            .indices()
+            .getSettings(r -> r.index(indexName))
+            .get(indexName)
+            .settings()
+            .index()
+            .lifecycle();
+    assertThat(actualLifecycle)
+        .isNotNull()
+        .extracting(IndexSettingsLifecycle::name)
+        .isEqualTo("operate_delete_archived_indices");
   }
 
   @Test
@@ -264,22 +276,6 @@ final class OpenSearchRepositoryIT {
     assertThat(batch.finishDate()).isEqualTo(dateFormatter.format(now.minus(Duration.ofHours(2))));
   }
 
-  private void createBatchOperationIndex() throws IOException {
-    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
-    final var endDateProp =
-        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
-    final var properties =
-        TypeMapping.of(
-            m ->
-                m.properties(
-                    Map.of(
-                        BatchOperationTemplate.ID,
-                        idProp,
-                        BatchOperationTemplate.END_DATE,
-                        endDateProp)));
-    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
-  }
-
   private <T extends TDocument> void index(final String index, final T document) {
     try {
       testClient.index(b -> b.index(index).document(document).id(document.id()));
@@ -288,43 +284,21 @@ final class OpenSearchRepositoryIT {
     }
   }
 
-  private void createLifeCyclePolicy() {
-    final var engineClient = new OpensearchEngineClient(testClient);
-    try {
-      engineClient.putIndexLifeCyclePolicy(retention.getPolicyName(), retention.getMinimumAge());
-    } catch (final Exception e) {
-      // policy was already created
-    }
-  }
-
-  private String fetchPolicyForIndex(final String indexName) {
-    final var genericClient =
-        new OpenSearchGenericClient(testClient._transport(), testClient._transportOptions());
-    final var request =
-        Requests.builder().method("get").endpoint("_plugins/_ism/explain/" + indexName).build();
-    try {
-      final var response = genericClient.execute(request);
-      final var jsonString = response.getBody().orElseThrow().bodyAsString();
-      final var json = MAPPER.readTree(jsonString);
-      final var index = json.get(indexName);
-      if (index == null) {
-        throw new AssertionError(
-            "Failed to explain non-existent index '%s'; see response: %s"
-                .formatted(indexName, jsonString));
-      }
-
-      return index.findPath("index.plugins.index_state_management.policy_id").asText();
-    } catch (final IOException e) {
-      throw new AssertionError("Failed to fetch policy for index " + indexName, e);
-    }
+  private void putLifecyclePolicy() throws IOException {
+    final var ilmClient = testClient.ilm();
+    final var phase =
+        Phase.of(
+            d -> d.minAge(t -> t.time("30d")).actions(JsonData.of(Map.of("delete", Map.of()))));
+    ilmClient.putLifecycle(
+        l -> l.name(retention.getPolicyName()).policy(p -> p.phases(h -> h.delete(phase))));
   }
 
   // no need to close resource returned here, since the transport is closed above anyway
-  private OpenSearchRepository createRepository() {
-    final var client = new OpenSearchAsyncClient(transport);
+  private ElasticsearchArchiverRepository createRepository() {
+    final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(meterRegistry);
 
-    return new OpenSearchRepository(
+    return new ElasticsearchArchiverRepository(
         1,
         config,
         retention,
@@ -334,6 +308,12 @@ final class OpenSearchRepositoryIT {
         Runnable::run,
         metrics,
         LOGGER);
+  }
+
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(ELASTIC.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
   }
 
   private void createProcessInstanceIndex() throws IOException {
@@ -355,15 +335,25 @@ final class OpenSearchRepositoryIT {
     testClient.indices().create(r -> r.index(processInstanceIndex).mappings(properties));
   }
 
-  private RestClientTransport createRestClient() {
-    final var restClient =
-        RestClient.builder(HttpHost.create(OPENSEARCH.getHttpHostAddress())).build();
-    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  private void createBatchOperationIndex() throws IOException {
+    final var idProp = Property.of(p -> p.keyword(k -> k.index(true)));
+    final var endDateProp =
+        Property.of(p -> p.date(d -> d.index(true).format("date_time || epoch_millis")));
+    final var properties =
+        TypeMapping.of(
+            m ->
+                m.properties(
+                    Map.of(
+                        BatchOperationTemplate.ID,
+                        idProp,
+                        BatchOperationTemplate.END_DATE,
+                        endDateProp)));
+    testClient.indices().create(r -> r.index(batchOperationIndex).mappings(properties));
   }
 
-  private record TestBatchOperation(String id, String endDate) implements TDocument {}
-
   private record TestDocument(String id) implements TDocument {}
+
+  private record TestBatchOperation(String id, String endDate) implements TDocument {}
 
   private record TestProcessInstance(
       String id, String endDate, String joinRelation, int partitionId) implements TDocument {}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ElasticsearchArchiverRepositoryTest.java
@@ -25,8 +25,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("resource")
-final class ElasticsearchRepositoryTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRepositoryTest.class);
+final class ElasticsearchArchiverRepositoryTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
 
   private final RestClientTransport transport = Mockito.spy(createRestClient());
   private final RetentionConfiguration retention = new RetentionConfiguration();
@@ -58,11 +59,11 @@ final class ElasticsearchRepositoryTest {
         .succeedsWithin(Duration.ZERO);
   }
 
-  private ElasticsearchRepository createRepository() {
+  private ElasticsearchArchiverRepository createRepository() {
     final var client = new ElasticsearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
 
-    return new ElasticsearchRepository(
+    return new ElasticsearchArchiverRepository(
         1,
         new ArchiverConfiguration(),
         retention,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/OpenSearchArchiverRepositoryTest.java
@@ -24,8 +24,9 @@ import org.opensearch.client.transport.rest_client.RestClientTransport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class OpenSearchRepositoryTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchRepositoryTest.class);
+final class OpenSearchArchiverRepositoryTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchArchiverRepositoryTest.class);
 
   private final RestClientTransport transport = Mockito.spy(createRestClient());
   private final RetentionConfiguration retention = new RetentionConfiguration();
@@ -57,11 +58,11 @@ final class OpenSearchRepositoryTest {
         .succeedsWithin(Duration.ZERO);
   }
 
-  private OpenSearchRepository createRepository() {
+  private OpenSearchArchiverRepository createRepository() {
     final var client = new OpenSearchAsyncClient(transport);
     final var metrics = new CamundaExporterMetrics(new SimpleMeterRegistry());
 
-    return new OpenSearchRepository(
+    return new OpenSearchArchiverRepository(
         1,
         new ArchiverConfiguration(),
         retention,

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/archiver/ProcessInstancesArchiverJobTest.java
@@ -155,7 +155,9 @@ final class ProcessInstancesArchiverJobTest {
     repository.batch = new ArchiveBatch("2024-01-01", List.of("1", "2", "3"));
 
     // when
-    final var count = job.archiveNextBatch().join() + job.archiveNextBatch().join();
+    final var count =
+        job.archiveNextBatch().toCompletableFuture().join()
+            + job.archiveNextBatch().toCompletableFuture().join();
 
     // then
     assertThat(meterRegistry.counter("zeebe.camunda.exporter.archived.process.instances").count())


### PR DESCRIPTION
## Description

This PR includes some preparation work for the migration of the post importer:

- Renames the `ElasticsearchRepository` and `OpenSearchRepository` to include `Archiver` in the name, since we will soon have similar repository patterns but specifically for the incident update task.
- Extracts the construction of the `BackgroundTaskManager` to a factory, as we were starting to have a _lot_ of static methods in there to do so, and each had to carry the state around as arguments.
- Changes the signature of the repositories to return `CompletionStage` instead of `CompletableFuture`, to indicate only the repositories should be able to complete the results.

## Related issues

related to #24297
