### PR TITLE
Allow tracking the last updated incident position from the exporter metadata

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -22,7 +22,6 @@ import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
 
-import co.elastic.clients.util.VisibleForTesting;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConfigValidator;
 import io.camunda.exporter.config.ExporterConfiguration;
@@ -41,6 +40,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.util.Set;
 import org.agrona.CloseHelper;
@@ -58,7 +58,7 @@ public class CamundaExporter implements Exporter {
   private final ExporterResourceProvider provider;
   private CamundaExporterMetrics metrics;
   private BackgroundTaskManager taskManager;
-  private final ExporterMetadata metadata = new ExporterMetadata();
+  private final ExporterMetadata metadata;
 
   public CamundaExporter() {
     this(new DefaultExporterResourceProvider());
@@ -66,7 +66,13 @@ public class CamundaExporter implements Exporter {
 
   @VisibleForTesting
   public CamundaExporter(final ExporterResourceProvider provider) {
+    this(provider, new ExporterMetadata());
+  }
+
+  @VisibleForTesting
+  public CamundaExporter(final ExporterResourceProvider provider, final ExporterMetadata metadata) {
     this.provider = provider;
+    this.metadata = metadata;
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -203,7 +203,8 @@ public class CamundaExporter implements Exporter {
   }
 
   private void updateLastExportedPosition() {
-    controller.updateLastExportedRecordPosition(lastPosition);
+    final var serialized = metadata.serialize();
+    controller.updateLastExportedRecordPosition(lastPosition, serialized);
   }
 
   private record CamundaExporterRecordFilter() implements RecordFilter {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/ExporterMetadata.java
@@ -26,12 +26,12 @@ public final class ExporterMetadata {
   // if you ever need to do any comparisons, make sure to use a better approach (e.g. CAS)
   private volatile long lastIncidentUpdatePosition = UNSET_POSITION;
 
-  public void setLastIncidentUpdatePosition(final long lastIncidentUpdatePosition) {
-    this.lastIncidentUpdatePosition = lastIncidentUpdatePosition;
+  public long getLastIncidentUpdatePosition() {
+    return lastIncidentUpdatePosition;
   }
 
-  public long lastIncidentUpdatePosition() {
-    return lastIncidentUpdatePosition;
+  public void setLastIncidentUpdatePosition(final long lastIncidentUpdatePosition) {
+    this.lastIncidentUpdatePosition = lastIncidentUpdatePosition;
   }
 
   public void deserialize(final byte[] bytes) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -9,6 +9,7 @@ package io.camunda.exporter.tasks;
 
 import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
 
+import io.camunda.exporter.ExporterMetadata;
 import io.camunda.exporter.ExporterResourceProvider;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
@@ -39,6 +40,7 @@ public final class BackgroundTaskManagerFactory {
   private final ExporterResourceProvider resourceProvider;
   private final CamundaExporterMetrics metrics;
   private final Logger logger;
+  private final ExporterMetadata metadata;
 
   private ScheduledThreadPoolExecutor executor;
   private ArchiverRepository repository;
@@ -49,13 +51,15 @@ public final class BackgroundTaskManagerFactory {
       final ExporterConfiguration config,
       final ExporterResourceProvider resourceProvider,
       final CamundaExporterMetrics metrics,
-      final Logger logger) {
+      final Logger logger,
+      final ExporterMetadata metadata) {
     this.partitionId = partitionId;
     this.exporterId = exporterId;
     this.config = config;
     this.resourceProvider = resourceProvider;
     this.metrics = metrics;
     this.logger = logger;
+    this.metadata = metadata;
   }
 
   public BackgroundTaskManager build() {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -132,8 +132,10 @@ final class CamundaExporterIT {
     exporter.export(record);
     exporter.export(record2);
     // then
-    verify(controllerSpy, never()).updateLastExportedRecordPosition(record.getPosition());
-    verify(controllerSpy).updateLastExportedRecordPosition(record2.getPosition());
+    verify(controllerSpy, never())
+        .updateLastExportedRecordPosition(Mockito.eq(record.getPosition()), Mockito.any());
+    verify(controllerSpy)
+        .updateLastExportedRecordPosition(Mockito.eq(record2.getPosition()), Mockito.any());
   }
 
   @ParameterizedTest

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -7,5 +7,114 @@
  */
 package io.camunda.exporter;
 
-public class CamundaExporterTest {
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.cache.ExporterEntityCacheProvider;
+import io.camunda.exporter.cache.form.CachedFormEntity;
+import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.schema.SearchEngineClient;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.exporter.utils.XMLUtil;
+import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
+import io.camunda.zeebe.exporter.test.ExporterTestContext;
+import io.camunda.zeebe.exporter.test.ExporterTestController;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+@AutoCloseResources
+final class CamundaExporterTest {
+  private final MockedStatic<ClientAdapter> mockedClientAdapterFactory =
+      Mockito.mockStatic(ClientAdapter.class);
+
+  private final ExporterResourceProvider resourceProvider = new DefaultExporterResourceProvider();
+  private final ExporterConfiguration configuration = new ExporterConfiguration();
+  private final ExporterTestContext testContext =
+      new ExporterTestContext()
+          .setConfiguration(new ExporterTestConfiguration<>("test", configuration));
+
+  @SuppressWarnings("FieldCanBeLocal")
+  @AutoCloseResource
+  private CamundaExporter exporter;
+
+  @BeforeEach
+  void beforeEach() {
+    mockedClientAdapterFactory
+        .when(() -> ClientAdapter.of(configuration))
+        .thenReturn(new StubClientAdapter());
+  }
+
+  private static final class NoopExporterEntityCacheProvider
+      implements ExporterEntityCacheProvider {
+
+    @Override
+    public CacheLoader<Long, CachedProcessEntity> getProcessCacheLoader(
+        final String processIndexName, final XMLUtil xmlUtil) {
+      return k -> null;
+    }
+
+    @Override
+    public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
+      return k -> null;
+    }
+  }
+
+  private static final class StubClientAdapter implements ClientAdapter {
+    private final ExporterEntityCacheProvider entityCacheProvider =
+        new NoopExporterEntityCacheProvider();
+    private final SearchEngineClient client =
+        Mockito.mock(
+            SearchEngineClient.class,
+            Mockito.withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+
+    @Override
+    public SearchEngineClient getSearchEngineClient() {
+      return client;
+    }
+
+    @Override
+    public BatchRequest createBatchRequest() {
+      return Mockito.mock(
+          BatchRequest.class, Mockito.withSettings().defaultAnswer(Answers.RETURNS_SMART_NULLS));
+    }
+
+    @Override
+    public ExporterEntityCacheProvider getExporterEntityCacheProvider() {
+      return entityCacheProvider;
+    }
+
+    @Override
+    public void close() {}
+  }
+
+  @Nested
+  final class OpenTest {
+    private final ExporterTestController testController = new ExporterTestController();
+
+    @Test
+    void shouldDeserializeMetadataOnOpen() {
+      // given
+      final var expected = new ExporterMetadata();
+      final var metadata = new ExporterMetadata();
+      exporter = new CamundaExporter(resourceProvider, metadata);
+      expected.setLastIncidentUpdatePosition(3);
+      metadata.setLastIncidentUpdatePosition(-1);
+      testController.updateLastExportedRecordPosition(-1, expected.serialize());
+
+      // when
+      exporter.configure(testContext);
+      exporter.open(testController);
+
+      // then
+      assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(3);
+    }
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+public class CamundaExporterTest {
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class ExporterMetadataTest {
+  @Test
+  void shouldSerializeToJson() {
+    // given
+    final var source = new ExporterMetadata();
+    final var destination = new ExporterMetadata();
+    source.setLastIncidentUpdatePosition(3);
+    destination.setLastIncidentUpdatePosition(-1);
+
+    // when
+    final var bytes = source.serialize();
+    destination.deserialize(bytes);
+
+    // then
+    assertThat(destination.lastIncidentUpdatePosition()).isEqualTo(3);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
@@ -25,6 +25,6 @@ final class ExporterMetadataTest {
     destination.deserialize(bytes);
 
     // then
-    assertThat(destination.lastIncidentUpdatePosition()).isEqualTo(3);
+    assertThat(destination.getLastIncidentUpdatePosition()).isEqualTo(3);
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/ExporterMetadataTest.java
@@ -27,4 +27,17 @@ final class ExporterMetadataTest {
     // then
     assertThat(destination.getLastIncidentUpdatePosition()).isEqualTo(3);
   }
+
+  @Test
+  void shouldNotUpdateIncidentPositionWithALowerValue() {
+    // given
+    final var metadata = new ExporterMetadata();
+    metadata.setLastIncidentUpdatePosition(3);
+
+    // when
+    metadata.setLastIncidentUpdatePosition(2);
+
+    // then
+    assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(3);
+  }
 }


### PR DESCRIPTION
## Description

This PR adds a new `ExporterMetadata` class with a single field: `lastIncidentUpdatePosition`. This allows us to track where we are in the post-import queue, which is crucial for the upcoming post-importer migration and the incident update task.

We can't treat the post-import queue as a normal queue, because the exporter writes to it, and the exporter will sometimes re-export records. To avoid reprocessing the same things (or worse, things that could fail!), we will keep track of the last process incident update position in the exporter metadata, such that it's persisted along with the exporter state.

## Related issues

related to #24297
