### PR TITLE
feat: add more logging to schema manager

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -51,17 +51,17 @@ public class SchemaManager {
     initialiseResources();
 
     //  used to update existing indices/templates
-    LOG.info("Update index schema. {} indices need to be updated", newIndexProperties.size());
+    LOG.info("Update index schema. '{}' indices need to be updated", newIndexProperties.size());
     updateSchema(newIndexProperties);
     LOG.info(
-        "Update index template schema. {} index templates need to be updated",
+        "Update index template schema. '{}' index templates need to be updated",
         newIndexProperties.size());
     updateSchema(newIndexTemplateProperties);
 
     final RetentionConfiguration retention = config.getRetention();
     if (retention.isEnabled()) {
       LOG.info(
-          "Retention is enabled. Create ILM policy [name: {}, retention: {}]",
+          "Retention is enabled. Create ILM policy [name: '{}', retention: '{}']",
           retention.getPolicyName(),
           retention.getMinimumAge());
       searchEngineClient.putIndexLifeCyclePolicy(
@@ -85,14 +85,14 @@ public class SchemaManager {
         searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX).keySet();
 
     LOG.info(
-        "Create missing indices. [existing: {}, missing: {}]",
+        "Found '{}' existing indices. Create missing index templates based on '{}' descriptors.",
         existingIndexNames.size(),
-        indexDescriptors.size() - existingIndexNames.size());
+        indexTemplateDescriptors.size());
     indexDescriptors.stream()
         .filter(descriptor -> !existingIndexNames.contains(descriptor.getFullQualifiedName()))
         .forEach(
             descriptor -> {
-              LOG.info("Create missing index {}", descriptor.getFullQualifiedName());
+              LOG.info("Create missing index '{}'", descriptor.getFullQualifiedName());
               searchEngineClient.createIndex(
                   descriptor, getIndexSettings(descriptor.getIndexName()));
             });
@@ -110,18 +110,18 @@ public class SchemaManager {
             .keySet();
 
     LOG.info(
-        "Create missing index templates. [existing: {}, missing: {}]",
+        "Found '{}' existing index templates. Create missing index templates based on '{}' descriptors.",
         existingTemplateNames.size(),
-        indexTemplateDescriptors.size() - existingTemplateNames.size());
+        indexTemplateDescriptors.size());
     indexTemplateDescriptors.stream()
         .filter(descriptor -> !existingTemplateNames.contains(descriptor.getTemplateName()))
         .forEach(
             descriptor -> {
-              LOG.info("Create missing index template {}", descriptor.getTemplateName());
+              LOG.info("Create missing index template '{}'", descriptor.getTemplateName());
               searchEngineClient.createIndexTemplate(
                   descriptor, getIndexSettings(descriptor.getIndexName()), true);
               LOG.info(
-                  "Create missing index {} for template {}",
+                  "Create missing index '{}', for template '{}'",
                   descriptor.getFullQualifiedName(),
                   descriptor.getTemplateName());
               searchEngineClient.createIndex(
@@ -135,14 +135,15 @@ public class SchemaManager {
       final var newProperties = newFieldEntry.getValue();
 
       if (descriptor instanceof IndexTemplateDescriptor) {
-        LOG.info("Updating template: {}", ((IndexTemplateDescriptor) descriptor).getTemplateName());
+        LOG.info(
+            "Updating template: '{}'", ((IndexTemplateDescriptor) descriptor).getTemplateName());
         searchEngineClient.createIndexTemplate(
             (IndexTemplateDescriptor) descriptor,
             getIndexSettings(descriptor.getIndexName()),
             false);
       } else {
         LOG.info(
-            "Index alias: {}. New fields will be added {}",
+            "Index alias: '{}'. New fields will be added '{}'",
             descriptor.getFullQualifiedName(),
             newProperties);
 
@@ -179,7 +180,7 @@ public class SchemaManager {
 
     final var currentIndices = searchEngineClient.getMappings(allIndexNames(), MappingSource.INDEX);
     LOG.info(
-        "Validate {} existing indices based on {} descriptors",
+        "Validate '{}' existing indices based on '{}' descriptors",
         currentIndices.size(),
         indexDescriptors.size());
     return schemaValidator.validateIndexMappings(currentIndices, indexDescriptors);
@@ -197,7 +198,7 @@ public class SchemaManager {
             config.getIndex().getPrefix() + "*", MappingSource.INDEX_TEMPLATE);
 
     LOG.info(
-        "Validate {} existing index templates based on {} template descriptors",
+        "Validate '{}' existing index templates based on '{}' template descriptors",
         currentTemplates.size(),
         indexTemplateDescriptors.size());
     return schemaValidator.validateIndexMappings(


### PR DESCRIPTION
## Description

I was investigating integration tests, and realized that the Camunda Exporter was quite a black box. It was unclear what it is happening and doing on start up. this is the reason why added more extensive logging, which I think is beneficial especially on start up to understand what the Exporter is creating, updating, etc. This is also the reason why I put everything to info. We can discuss whether we want to put things like: `Create missing index` to debug though. Right now I find it useful, but this can easily changed anyway later as well.


Startup before:

```
21:38:13.309 [Broker-0] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.exporter - Use default exporter factory to create instance of class io.camunda.exporter.CamundaExporter
21:38:15.443 [Broker-0] [Exporter-1] [zb-fs-workers-1] INFO  io.camunda.exporter.CamundaExporter - Exporter opened
```

Startup now:
```
21:33:09.995 [Broker-0] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.exporter - Use default exporter factory to create instance of class io.camunda.exporter.CamundaExporter
21:33:10.023 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Schema creation is enabled. Start Schema management.
21:33:10.065 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Validate 0 existing indices based on 12 descriptors
21:33:10.394 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Validate 20 existing index templates based on 11 template descriptors
21:33:10.409 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing indices. [existing: 0, missing: 12]
21:33:10.410 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-groups-8.7.0_
21:33:10.528 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-role-8.7.0_
21:33:10.653 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index tasklist-form-8.4.0_
21:33:10.781 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-tenants-8.7.0_
21:33:10.887 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index operate-decision-requirements-8.3.0_
21:33:10.996 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-authorizations-8.7.0_
21:33:11.133 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index operate-metric-8.3.0_
21:33:11.314 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index operate-decision-8.3.0_
21:33:11.449 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index operate-process-8.3.0_
21:33:11.591 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-users-8.7.0_
21:33:11.717 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index identity-mappings-8.7.0_
21:33:11.853 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index tasklist-metric-8.3.0_
21:33:12.014 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index templates. [existing: 26, missing: -15]
21:33:12.015 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index template tasklist-task-8.5.0_template
21:33:12.085 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Create missing index tasklist-task-8.5.0_ for template tasklist-task-8.5.0_template
21:33:12.240 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Update index schema. 0 indices need to be updated
21:33:12.240 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Update index template schema. 0 index templates need to be updated
21:33:12.240 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.schema.SchemaManager - Schema management completed.
21:33:12.245 [Broker-0] [Exporter-1] [zb-fs-workers-0] INFO  io.camunda.exporter.CamundaExporter - Exporter opened
```


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
