### PR TITLE
Add first blocking iteration of the incident update task (old post-importer)

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/config/ExporterConfiguration.java
@@ -20,6 +20,7 @@ public class ExporterConfiguration {
   private ArchiverConfiguration archiver = new ArchiverConfiguration();
   private CacheConfiguration processCache = new CacheConfiguration();
   private CacheConfiguration formCache = new CacheConfiguration();
+  private PostExportConfiguration postExport = new PostExportConfiguration();
   private boolean createSchema = true;
 
   public ConnectConfiguration getConnect() {
@@ -86,6 +87,14 @@ public class ExporterConfiguration {
     this.createSchema = createSchema;
   }
 
+  public PostExportConfiguration getPostExport() {
+    return postExport;
+  }
+
+  public void setPostExport(final PostExportConfiguration postExport) {
+    this.postExport = postExport;
+  }
+
   @Override
   public String toString() {
     return "ExporterConfiguration{"
@@ -105,6 +114,8 @@ public class ExporterConfiguration {
         + processCache
         + ", formCache="
         + formCache
+        + ", postExport="
+        + postExport
         + '}';
   }
 
@@ -359,6 +370,48 @@ public class ExporterConfiguration {
     @Override
     public String toString() {
       return "CacheConfiguration{" + "cacheSize=" + maxCacheSize + '}';
+    }
+  }
+
+  public static final class PostExportConfiguration {
+    private int batchSize = 100;
+    private int delayBetweenRuns = 2000;
+    private boolean ignoreMissingData = false;
+
+    public int getBatchSize() {
+      return batchSize;
+    }
+
+    public void setBatchSize(final int batchSize) {
+      this.batchSize = batchSize;
+    }
+
+    public int getDelayBetweenRuns() {
+      return delayBetweenRuns;
+    }
+
+    public void setDelayBetweenRuns(final int delayBetweenRuns) {
+      this.delayBetweenRuns = delayBetweenRuns;
+    }
+
+    public boolean isIgnoreMissingData() {
+      return ignoreMissingData;
+    }
+
+    public void setIgnoreMissingData(final boolean ignoreMissingData) {
+      this.ignoreMissingData = ignoreMissingData;
+    }
+
+    @Override
+    public String toString() {
+      return "PostExportConfiguration{"
+          + "batchSize="
+          + batchSize
+          + ", delayBetweenRuns="
+          + delayBetweenRuns
+          + ", ignoreMissingData="
+          + ignoreMissingData
+          + '}';
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -20,6 +20,8 @@ import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
+import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
 import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
@@ -74,6 +76,8 @@ public final class BackgroundTaskManagerFactory {
     final List<Runnable> tasks = new ArrayList<>();
     int threadCount = 0;
 
+    tasks.add(buildIncidentMarkerTask());
+
     if (config.getArchiver().isRolloverEnabled()) {
       threadCount = 1;
       tasks.add(buildProcessInstanceArchiverJob());
@@ -86,6 +90,22 @@ public final class BackgroundTaskManagerFactory {
 
     executor.setCorePoolSize(threadCount);
     return tasks;
+  }
+
+  private ReschedulingTask buildIncidentMarkerTask() {
+    final var repository = new NoopIncidentUpdateRepository();
+    final var postExport = config.getPostExport();
+    return new ReschedulingTask(
+        new IncidentUpdateTask(
+            metadata,
+            repository,
+            postExport.isIgnoreMissingData(),
+            postExport.getBatchSize(),
+            logger),
+        1,
+        postExport.getDelayBetweenRuns(),
+        executor,
+        logger);
   }
 
   private ReschedulingTask buildProcessInstanceArchiverJob() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -74,15 +74,15 @@ public final class BackgroundTaskManagerFactory {
 
   private List<Runnable> buildTasks() {
     final List<Runnable> tasks = new ArrayList<>();
-    int threadCount = 0;
+    int threadCount = 1;
 
     tasks.add(buildIncidentMarkerTask());
 
     if (config.getArchiver().isRolloverEnabled()) {
-      threadCount = 1;
+      threadCount = 2;
       tasks.add(buildProcessInstanceArchiverJob());
       if (partitionId == START_PARTITION_ID) {
-        threadCount = 2;
+        threadCount = 3;
         tasks.add(buildBatchOperationArchiverJob());
         tasks.add(new ApplyRolloverPeriodJob(repository, metrics, logger));
       }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/AdditionalData.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/AdditionalData.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Copied from the old post-importer */
+public record AdditionalData(
+    Map<String, IncidentDocument> incidents,
+    Map<String, List<String>> flowNodeInstanceIndices,
+    Map<String, List<String>> flowNodeInstanceInListViewIndices,
+    Map<Long, String> processInstanceTreePaths,
+    Map<String, String> incidentTreePaths,
+    Map<String, String> processInstanceIndices,
+    Map<String, Set<String>> piIdsWithIncidentIds,
+    Map<String, Set<String>> fniIdsWithIncidentIds) {
+  public AdditionalData() {
+    this(
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>(),
+        new HashMap<>());
+  }
+
+  public boolean addPiIdsWithIncidentIds(final String piId, final String incidentId) {
+    return addIncidentIdByInstanceId(piIdsWithIncidentIds, piId, incidentId);
+  }
+
+  public boolean removeIncidentIdByPiId(final String piId, final String incidentId) {
+    return deleteIncidentIdByInstance(piIdsWithIncidentIds, piId, incidentId);
+  }
+
+  public boolean addFniIdsWithIncidentIds(final String fniId, final String incidentId) {
+    return addIncidentIdByInstanceId(fniIdsWithIncidentIds, fniId, incidentId);
+  }
+
+  public boolean removeIncidentIdByFniId(final String fniId, final String incidentId) {
+    return deleteIncidentIdByInstance(fniIdsWithIncidentIds, fniId, incidentId);
+  }
+
+  public void addFlowNodeInstanceInListView(final String id, final String index) {
+    flowNodeInstanceInListViewIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
+  }
+
+  public void addFlowNodeInstance(final String id, final String index) {
+    flowNodeInstanceIndices.computeIfAbsent(id, k -> new ArrayList<>()).add(index);
+  }
+
+  private boolean addIncidentIdByInstanceId(
+      final Map<String, Set<String>> incidentByInstanceIds,
+      final String instanceId,
+      final String incidentId) {
+    final var set = incidentByInstanceIds.computeIfAbsent(instanceId, k -> new HashSet<>());
+    final var added = set.add(incidentId);
+
+    return added && set.size() == 1;
+  }
+
+  private boolean deleteIncidentIdByInstance(
+      final Map<String, Set<String>> incidentByInstanceIds,
+      final String instanceId,
+      final String incidentId) {
+    final var incidentIds = incidentByInstanceIds.get(instanceId);
+    if (incidentIds == null) {
+      return false;
+    }
+
+    final boolean removed = incidentIds.remove(incidentId);
+    return removed && incidentIds.isEmpty();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Encapsulates all accesses to the underlying storage for the {@link IncidentUpdateTask}, allowing
+ * it to work with various databases.
+ */
+public interface IncidentUpdateRepository {
+
+  /**
+   * Returns the next batch of sorted pending incident updates.
+   *
+   * @param fromPosition the position of the update to start from; any updates with a lower position
+   *     will be ignored
+   * @param size the maximum number of pending updates to return in the batch
+   * @return a collection of pending updates, sorted by position ascending
+   */
+  CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
+      final long fromPosition, final int size);
+
+  /**
+   * Returns a map of {@link IncidentDocument} indexed by their IDs. It will only return documents
+   * whose ID is contained in the given {@code incidentIds}. Note that it may return less, as some
+   * documents may not be visible yet.
+   *
+   * @param incidentIds the IDs to filter on
+   * @return a map of {@link IncidentDocument} indexed by ID
+   */
+  CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+      final List<String> incidentIds);
+
+  /**
+   * Returns a list of flow node instance {@link Document} - that is, pairs of document ID and their
+   * index - from one of the list view indices. Only returns results whose flow node key is
+   * contained in the given {@code flowNodeKeys}. Note that it may return fewer results, as some
+   * documents may not be visible yet.
+   *
+   * @param flowNodeKeys the set of flow node instance keys to filter on
+   * @return a collection of flow node instance {@link Document}
+   */
+  CompletionStage<Collection<Document>> getFlowNodesInListView(final List<String> flowNodeKeys);
+
+  /**
+   * Returns a list of flow node instance {@link Document} - that is, pairs of document ID and their
+   * index - from one of the flow node indices. Only returns results whose flow node key is
+   * contained in the given {@code flowNodeKeys}. Note that it may return fewer results, as some
+   * documents may not be visible yet.
+   *
+   * @param flowNodeKeys the set of flow node instance keys to filter on
+   * @return a collection of flow node instance {@link Document}
+   */
+  CompletionStage<Collection<Document>> getFlowNodeInstances(final List<String> flowNodeKeys);
+
+  /**
+   * Returns a list of process instance {@link ProcessInstanceDocument} from one of the list view
+   * indices. Only returns results whose document ID is contained in the given {@code
+   * processInstanceIds}. Note that it may return fewer results, as some documents may not be
+   * visible yet.
+   *
+   * @param processInstanceIds the set of IDs to filter on
+   * @return a collection of process instance {@link ProcessInstanceDocument}
+   */
+  CompletionStage<Collection<ProcessInstanceDocument>> getProcessInstances(
+      List<String> processInstanceIds);
+
+  /**
+   * Returns whether the process instance was explicitly deleted, meaning a user executed an
+   * operation to explicitly delete it from the historic data.
+   *
+   * @param processInstanceKey the key of the process instance
+   * @return true if it was deleted, false otherwise
+   */
+  CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey);
+
+  /**
+   * Executes the given bulk update against the underlying document store, waiting until the
+   * affected indices are refreshed. This ensures you will later read your own writes.
+   *
+   * @param update the bulk update to execute
+   * @return the number of documents updated
+   */
+  CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update);
+
+  /**
+   * Returns the tree path as tokenized by an analyze request to the underlying document store.
+   *
+   * @param treePath the tree path to analyze
+   * @return a set of terms which can be used to query tree path attributes in other indices
+   */
+  CompletionStage<List<String>> analyzeTreePath(final String treePath);
+
+  /**
+   * Returns the list of active incidents from the incident indices which contain any of the terms
+   * given in their own tree path.
+   *
+   * @param treePathTerms the complete list of tree path terms to filter on
+   * @return a list of active incidents with at least one tree path term overlapping the given list
+   */
+  CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(List<String> treePathTerms);
+
+  /**
+   * Represents an incident document: the source identity and its ID and index.
+   *
+   * <p>Keeping the index is useful as we typically query by alias, so we don't know beforehand
+   * which index the document originated from.
+   */
+  record IncidentDocument(String id, String index, IncidentEntity incident) {}
+
+  /**
+   * Represents a process instance document from the list view: its ID, index, key, and tree path.
+   *
+   * <p>Keeping the index is useful as we typically query by alias, so we don't know beforehand
+   * which index the document originated from.
+   */
+  record ProcessInstanceDocument(String id, String index, long key, String treePath) {}
+
+  /**
+   * A simple ID and index pair, mostly to allow us to properly update the right document later on,
+   * as we typically query by alias and cannot deterministically encode where the original document
+   * came from otherwise.
+   */
+  record Document(String id, String index) {}
+
+  /** Represents an active incident, and the tree path which it currently affects. */
+  record ActiveIncident(String id, String treePath) {}
+
+  /**
+   * A search store agnostic representation of a bulk update for this task. It allows us to collect
+   * all the update queries into one, and pass it down to the store specific implementation to
+   * execute.
+   */
+  record IncidentBulkUpdate(
+      Map<String, DocumentUpdate> listViewRequests,
+      Map<String, DocumentUpdate> flowNodeInstanceRequests,
+      Map<String, DocumentUpdate> incidentRequests) {
+    public IncidentBulkUpdate() {
+      this(new HashMap<>(), new HashMap<>(), new HashMap<>());
+    }
+  }
+
+  /**
+   * Represents a specific document store agnostic update to execute.
+   *
+   * <p>All fields are expected to be non-null, except routing.
+   */
+  record DocumentUpdate(String id, String index, Map<String, Object> doc, String routing) {}
+
+  class NoopIncidentUpdateRepository implements IncidentUpdateRepository {
+
+    @Override
+    public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
+        final long fromPosition, final int size) {
+      return CompletableFuture.completedFuture(
+          new PendingIncidentUpdateBatch(-1, Collections.emptyMap()));
+    }
+
+    @Override
+    public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+        final List<String> incidentIds) {
+      return CompletableFuture.completedFuture(Map.of());
+    }
+
+    @Override
+    public CompletionStage<Collection<Document>> getFlowNodesInListView(
+        final List<String> flowNodeKeys) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Collection<Document>> getFlowNodeInstances(
+        final List<String> flowNodeKeys) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Collection<ProcessInstanceDocument>> getProcessInstances(
+        final List<String> processInstanceIds) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
+      return CompletableFuture.completedFuture(false);
+    }
+
+    @Override
+    public CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update) {
+      return CompletableFuture.completedFuture(0);
+    }
+
+    @Override
+    public CompletionStage<List<String>> analyzeTreePath(final String treePath) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+
+    @Override
+    public CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(
+        final List<String> treePathTerms) {
+      return CompletableFuture.completedFuture(List.of());
+    }
+  }
+
+  /**
+   * A batch of pending incident updates fetched from the post importer queue. The {@code
+   * highestPosition} returns the greatest position of the updates fetched, and the states are keyed
+   * by incident key.
+   */
+  record PendingIncidentUpdateBatch(
+      long highestPosition, Map<Long, IncidentState> newIncidentStates) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -1,0 +1,505 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.tasks.BackgroundTask;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentBulkUpdate;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import io.camunda.webapps.operate.TreePath;
+import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import io.camunda.zeebe.exporter.api.ExporterException;
+import io.camunda.zeebe.util.VisibleForTesting;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.agrona.LangUtil;
+import org.slf4j.Logger;
+
+public final class IncidentUpdateTask implements BackgroundTask {
+  private final ExporterMetadata metadata;
+  private final IncidentUpdateRepository repository;
+  private final boolean ignoreMissingData;
+  private final int batchSize;
+  private final Logger logger;
+  private final Duration waitForRefreshInterval;
+
+  public IncidentUpdateTask(
+      final ExporterMetadata metadata,
+      final IncidentUpdateRepository repository,
+      final boolean ignoreMissingData,
+      final int batchSize,
+      final Logger logger) {
+    this(metadata, repository, ignoreMissingData, batchSize, logger, Duration.ofSeconds(5));
+  }
+
+  @VisibleForTesting("allow configuring the refresh interval to speed tests up")
+  IncidentUpdateTask(
+      final ExporterMetadata metadata,
+      final IncidentUpdateRepository repository,
+      final boolean ignoreMissingData,
+      final int batchSize,
+      final Logger logger,
+      final Duration waitForRefreshInterval) {
+    this.metadata = metadata;
+    this.repository = repository;
+    this.ignoreMissingData = ignoreMissingData;
+    this.batchSize = batchSize;
+    this.logger = logger;
+    this.waitForRefreshInterval = waitForRefreshInterval;
+  }
+
+  @Override
+  public CompletionStage<Integer> execute() {
+    try {
+      return CompletableFuture.completedFuture(processNextBatch());
+    } catch (final Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private int processNextBatch() {
+    final var data = new AdditionalData();
+    final var batch = getPendingIncidentsBatch(data);
+    if (batch.newIncidentStates().isEmpty()) {
+      return 0;
+    }
+
+    logger.trace("Applying the following pending incident updates: {}", batch.newIncidentStates());
+    searchForInstances(data);
+    final var documentsUpdated = processIncidents(data, batch);
+
+    logger.trace(
+        """
+          Finished applying {} pending incident updates ({} documents updated), updating last \
+          incident update position to {}""",
+        batch.newIncidentStates().size(),
+        documentsUpdated,
+        batch.highestPosition());
+
+    if (documentsUpdated > 0) {
+      metadata.setLastIncidentUpdatePosition(batch.highestPosition());
+    }
+
+    return documentsUpdated;
+  }
+
+  private void searchForInstances(final AdditionalData data) {
+    final var incidents = data.incidents().values();
+
+    try {
+      queryData(incidents, data);
+      checkDataAndCollectParentTreePaths(incidents, data, false);
+    } catch (final ExporterException ex) {
+      // if it failed once we want to give it a chance and to import more data
+      // next failure will fail in case ignoring of missing data is not configured
+      uncheckedThreadSleep();
+      queryData(incidents, data);
+      checkDataAndCollectParentTreePaths(incidents, data, ignoreMissingData);
+    }
+
+    final var flowNodeKeys =
+        incidents.stream()
+            .map(IncidentDocument::incident)
+            .map(IncidentEntity::getFlowNodeInstanceKey)
+            .map(String::valueOf)
+            .toList();
+    repository
+        .getFlowNodesInListView(flowNodeKeys)
+        .toCompletableFuture()
+        .join()
+        .forEach(doc -> data.addFlowNodeInstanceInListView(doc.id(), doc.index()));
+  }
+
+  private void checkDataAndCollectParentTreePaths(
+      final Collection<IncidentDocument> incidents,
+      final AdditionalData data,
+      final boolean forceIgnoreMissingData) {
+    int countMissingInstance = 0;
+    for (final Iterator<IncidentDocument> iterator = incidents.iterator(); iterator.hasNext(); ) {
+      final IncidentEntity incident = iterator.next().incident();
+      String piTreePath = data.processInstanceTreePaths().get(incident.getProcessInstanceKey());
+      if (piTreePath == null || piTreePath.isEmpty()) {
+        final var wasDeleted =
+            repository
+                .wasProcessInstanceDeleted(incident.getProcessInstanceKey())
+                .toCompletableFuture()
+                .join();
+        if (wasDeleted) {
+          logger.debug(
+              """
+              Process instance with the key {} was deleted. Incident post processing will be \
+              skipped for id {}.""",
+              incident.getProcessInstanceKey(),
+              incident.getId());
+          iterator.remove();
+          continue;
+        } else {
+          if (!forceIgnoreMissingData) {
+            throw new ExporterException(
+                """
+                Process instance %d is not yet imported for incident %s; the update cannot be \
+                correctly applied."""
+                    .formatted(incident.getProcessInstanceKey(), incident.getId()));
+          } else {
+            countMissingInstance++;
+            piTreePath =
+                new TreePath()
+                    .startTreePath(String.valueOf(incident.getProcessInstanceKey()))
+                    .toString();
+            logger.warn(
+                """
+                Process instance {} is not yet imported for incident {}; the update cannot be \
+                correctly applied. Since ignoreMissingData is on, we will apply with sparse tree
+                path.""",
+                incident.getId(),
+                incident.getProcessInstanceKey());
+          }
+        }
+      }
+
+      data.incidentTreePaths()
+          .put(
+              incident.getId(),
+              new TreePath(piTreePath)
+                  .appendFlowNode(incident.getFlowNodeId())
+                  .appendFlowNodeInstance(String.valueOf(incident.getFlowNodeInstanceKey()))
+                  .toString());
+    }
+
+    if (countMissingInstance > 0 && !ignoreMissingData) {
+      throw new ExporterException(
+          """
+          "%d process instances are not yet imported for incident post processing; operation will \
+          be retried..."""
+              .formatted(countMissingInstance));
+    }
+  }
+
+  private void queryData(final Collection<IncidentDocument> incidents, final AdditionalData data) {
+    final var processInstanceIds =
+        incidents.stream()
+            .map(IncidentDocument::incident)
+            .map(IncidentEntity::getProcessInstanceKey)
+            .map(String::valueOf)
+            .toList();
+    final var processInstances =
+        repository.getProcessInstances(processInstanceIds).toCompletableFuture().join();
+
+    for (final var processInstance : processInstances) {
+      data.processInstanceIndices().put(processInstance.id(), processInstance.index());
+      data.processInstanceTreePaths().put(processInstance.key(), processInstance.treePath());
+    }
+  }
+
+  private int processIncidents(
+      final AdditionalData data, final IncidentUpdateRepository.PendingIncidentUpdateBatch batch) {
+    final var bulkUpdate = new IncidentBulkUpdate();
+    mapActiveIncidentsToAffectedInstances(data);
+
+    for (final var incident : data.incidents().values()) {
+      final var processInstanceKey = incident.incident().getProcessInstanceKey();
+      final var treePath = data.incidentTreePaths().get(incident.id());
+      final var newState = batch.newIncidentStates().get(incident.incident().getKey());
+      final var routing = String.valueOf(processInstanceKey);
+
+      if (!data.processInstanceTreePaths().containsKey(processInstanceKey)) {
+        if (!ignoreMissingData) {
+          throw new ExporterException(
+              """
+              Failed to apply incident update for incident '%s'; related process instance '%d' is \
+              not visible yet, but may be later."""
+                  .formatted(incident.id(), processInstanceKey));
+        }
+
+        logger.warn(
+            """
+            Failed to apply incident update for incident '{}'; related process instance '{}' is \
+            not visible. As ignoreMissingData is on, we will skip updating the process instance or \
+            flow node instances, and only update the incident.""",
+            incident.id(),
+            processInstanceKey);
+      } else {
+        final var parsedTreePath = new TreePath(treePath);
+        final var piIds = parsedTreePath.extractProcessInstanceIds();
+        final var fniIds = parsedTreePath.extractFlowNodeInstanceIds();
+
+        createProcessInstanceUpdates(data, incident, newState, piIds, bulkUpdate, routing);
+        createFlowNodeInstanceUpdates(data, incident, newState, fniIds, bulkUpdate, routing);
+      }
+
+      bulkUpdate
+          .incidentRequests()
+          .put(incident.id(), newIncidentUpdate(incident, newState, treePath, routing));
+    }
+
+    return repository.bulkUpdate(bulkUpdate).toCompletableFuture().join();
+  }
+
+  private void createFlowNodeInstanceUpdates(
+      final AdditionalData data,
+      final IncidentDocument incident,
+      final IncidentState newState,
+      final List<String> fniIds,
+      final IncidentBulkUpdate updates,
+      final String routing) {
+    if (!data.flowNodeInstanceIndices().keySet().containsAll(fniIds)) {
+      final var documents = repository.getFlowNodeInstances(fniIds).toCompletableFuture().join();
+      for (final var document : documents) {
+        data.addFlowNodeInstance(document.id(), document.index());
+      }
+    }
+
+    if (!data.flowNodeInstanceInListViewIndices().keySet().containsAll(fniIds)) {
+      final var documents = repository.getFlowNodesInListView(fniIds).toCompletableFuture().join();
+      for (final var document : documents) {
+        data.addFlowNodeInstanceInListView(document.id(), document.index());
+      }
+    }
+
+    for (final var fniId : fniIds) {
+      final var listViewIndices = data.flowNodeInstanceInListViewIndices().get(fniId);
+      final var flowNodeIndices = data.flowNodeInstanceIndices().get(fniId);
+      if (listViewIndices != null
+          && !listViewIndices.isEmpty()
+          && flowNodeIndices != null
+          && !flowNodeIndices.isEmpty()) {
+        createFlowNodeInstanceUpdate(
+            data,
+            incident.id(),
+            newState,
+            fniId,
+            flowNodeIndices,
+            updates,
+            listViewIndices,
+            routing);
+      } else {
+        if (!ignoreMissingData) {
+          throw new ExporterException(
+              """
+              Flow node instance %s affected by incident %s cannot be updated because there is no \
+              document for it in the list view index yet; this will be retried later."""
+                  .formatted(fniId, incident.id()));
+        }
+
+        logger.warn(
+            """
+            Flow node instance {} affected by incident {} cannot be updated because there is no \
+            document for it in the list view index yet; since ignoreMissingData is on, we will \
+            skip updating for now, which may result in inconsistencies.""",
+            fniId,
+            incident.id());
+      }
+    }
+  }
+
+  private void createFlowNodeInstanceUpdate(
+      final AdditionalData data,
+      final String incidentId,
+      final IncidentState newState,
+      final String fniId,
+      final List<String> flowNodeIndices,
+      final IncidentBulkUpdate updates,
+      final List<String> listViewIndices,
+      final String routing) {
+    final var hasIncident = IncidentState.ACTIVE == newState;
+    final boolean changedState;
+    if (hasIncident) {
+      changedState = data.addFniIdsWithIncidentIds(fniId, incidentId);
+    } else {
+      changedState = data.removeIncidentIdByFniId(fniId, incidentId);
+    }
+
+    if (changedState) {
+      flowNodeIndices.forEach(
+          index ->
+              updates
+                  .flowNodeInstanceRequests()
+                  .put(fniId, newFlowNodeInstanceUpdate(fniId, index, hasIncident, routing)));
+      listViewIndices.forEach(
+          index ->
+              updates
+                  .listViewRequests()
+                  .put(fniId, newListViewInstanceUpdate(fniId, index, hasIncident, routing)));
+    }
+  }
+
+  private void createProcessInstanceUpdates(
+      final AdditionalData data,
+      final IncidentDocument incident,
+      final IncidentState newState,
+      final List<String> piIds,
+      final IncidentBulkUpdate updates,
+      final String routing) {
+    if (!data.processInstanceIndices().keySet().containsAll(piIds)) {
+      final var processInstances =
+          repository.getProcessInstances(piIds).toCompletableFuture().join();
+      for (final var processInstance : processInstances) {
+        data.processInstanceIndices().put(processInstance.id(), processInstance.index());
+      }
+    }
+
+    for (final var piId : piIds) {
+      final var index = data.processInstanceIndices().get(piId);
+      if (index != null) {
+        createProcessInstanceUpdate(data, incident.id(), newState, piId, updates, index, routing);
+      } else {
+        if (!ignoreMissingData) {
+          throw new ExporterException(
+              """
+              Process instance %s affected by incident %s cannot be updated because there is no \
+              document for it in the list view index yet; this will be retried later."""
+                  .formatted(piId, incident.id()));
+        }
+
+        logger.warn(
+            """
+          Process instance {} affected by incident {} cannot be updated because there is no \
+          document for it in the list view index yet; since ignoreMissingData is on, we will \
+          skip updating for now, which may result in inconsistencies.""",
+            piId,
+            incident.id());
+      }
+    }
+  }
+
+  private void createProcessInstanceUpdate(
+      final AdditionalData data,
+      final String incidentId,
+      final IncidentState newState,
+      final String piId,
+      final IncidentBulkUpdate updates,
+      final String index,
+      final String routing) {
+    final var hasIncident = IncidentState.ACTIVE == newState;
+    final boolean changedState;
+    if (hasIncident) {
+      changedState = data.addPiIdsWithIncidentIds(piId, incidentId);
+    } else {
+      changedState = data.removeIncidentIdByPiId(piId, incidentId);
+    }
+
+    if (changedState) {
+      updates
+          .listViewRequests()
+          .put(piId, newListViewInstanceUpdate(piId, index, hasIncident, routing));
+    }
+  }
+
+  private DocumentUpdate newIncidentUpdate(
+      final IncidentDocument incident,
+      final IncidentState state,
+      final String treePath,
+      final String routing) {
+    final Map<String, Object> fields = new HashMap<>();
+    fields.put(IncidentTemplate.STATE, state);
+    if (IncidentState.ACTIVE == state) {
+      fields.put(IncidentTemplate.TREE_PATH, treePath);
+    }
+
+    return new DocumentUpdate(incident.id(), incident.index(), fields, routing);
+  }
+
+  private DocumentUpdate newListViewInstanceUpdate(
+      final String id, final String index, final boolean hasIncident, final String routing) {
+    return new DocumentUpdate(id, index, Map.of(ListViewTemplate.INCIDENT, hasIncident), routing);
+  }
+
+  private DocumentUpdate newFlowNodeInstanceUpdate(
+      final String id, final String index, final boolean hasIncident, final String routing) {
+    return new DocumentUpdate(
+        id, index, Map.of(FlowNodeInstanceTemplate.INCIDENT, hasIncident), routing);
+  }
+
+  private void mapActiveIncidentsToAffectedInstances(final AdditionalData data) {
+    final List<String> treePathTerms =
+        data.incidentTreePaths().values().stream()
+            .map(repository::analyzeTreePath)
+            .map(CompletionStage::toCompletableFuture)
+            .map(CompletableFuture::join)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    final List<ActiveIncident> activeIncidentTreePaths =
+        repository.getActiveIncidentsByTreePaths(treePathTerms).toCompletableFuture().join();
+    for (final var activeIncidentTreePath : activeIncidentTreePaths) {
+      final var treePath = new TreePath(activeIncidentTreePath.treePath());
+      final var piIds = treePath.extractProcessInstanceIds();
+      final var fniIds = treePath.extractFlowNodeInstanceIds();
+
+      piIds.forEach(id -> data.addPiIdsWithIncidentIds(id, activeIncidentTreePath.id()));
+      fniIds.forEach(id -> data.addFniIdsWithIncidentIds(id, activeIncidentTreePath.id()));
+    }
+  }
+
+  private IncidentUpdateRepository.PendingIncidentUpdateBatch getPendingIncidentsBatch(
+      final AdditionalData data) {
+    final IncidentUpdateRepository.PendingIncidentUpdateBatch pendingIncidentsBatch =
+        repository
+            .getPendingIncidentsBatch(metadata.getLastIncidentUpdatePosition(), batchSize)
+            .toCompletableFuture()
+            .join();
+
+    if (pendingIncidentsBatch.newIncidentStates().isEmpty()) {
+      return pendingIncidentsBatch;
+    }
+
+    logger.trace(
+        "Processing incident ids <-> intents: {}", pendingIncidentsBatch.newIncidentStates());
+
+    final var incidentIds =
+        pendingIncidentsBatch.newIncidentStates().keySet().stream().map(String::valueOf).toList();
+    final Map<String, IncidentDocument> incidents =
+        repository.getIncidentDocuments(incidentIds).toCompletableFuture().join();
+    data.incidents().putAll(incidents);
+
+    if (pendingIncidentsBatch.newIncidentStates().size() > incidents.size()) {
+      final var absentIncidents = new HashSet<>(pendingIncidentsBatch.newIncidentStates().keySet());
+      absentIncidents.removeAll(
+          incidents.values().stream().map(i -> i.incident().getKey()).collect(Collectors.toSet()));
+      if (!ignoreMissingData) {
+        throw new ExporterException(
+            """
+                Failed to fetch incidents associated with post-export updates; it's possible they \
+                are simply not visible yet. Missing incident IDs: [%s]"""
+                .formatted(absentIncidents));
+      }
+
+      logger.warn(
+          """
+            Not all incidents to update are visible yet; as ignoreMissingData flag is on, we will \
+            ignore this for now, which means updates to the following incidents will be missing: \
+            [{}]""",
+          absentIncidents);
+    }
+
+    return pendingIncidentsBatch;
+  }
+
+  // TODO: replace this when moving the pipeline to an asynchronous model
+  private void uncheckedThreadSleep() {
+    try {
+      Thread.sleep(waitForRefreshInterval.toMillis(), waitForRefreshInterval.toNanosPart());
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LangUtil.rethrowUnchecked(e);
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
+import io.camunda.webapps.operate.TreePath;
+import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import io.camunda.zeebe.exporter.api.ExporterException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class IncidentUpdateTaskTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IncidentUpdateTaskTest.class);
+  private final ExporterMetadata metadata = new ExporterMetadata();
+  private final TestRepository repository = Mockito.spy(new TestRepository());
+
+  @Test
+  void shouldReturnNothingDoneOnEmptyPendingBatch() {
+    // given
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+
+    // when
+    final var result = task.execute();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(0);
+  }
+
+  @Test
+  void shouldUseMetadataPositionToFetchPendingBatch() {
+    // given
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+    metadata.setLastIncidentUpdatePosition(5);
+
+    // when
+    task.execute().toCompletableFuture().join();
+
+    // then
+    Mockito.verify(repository).getPendingIncidentsBatch(Mockito.eq(5L), Mockito.anyInt());
+  }
+
+  @Test
+  void shouldUseBatchSizeToFetchPendingBatch() {
+    // given
+    final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+
+    // when
+    task.execute().toCompletableFuture().join();
+
+    // then
+    Mockito.verify(repository).getPendingIncidentsBatch(Mockito.anyLong(), Mockito.eq(10));
+  }
+
+  private static final class TestRepository extends NoopIncidentUpdateRepository {
+    private CompletableFuture<PendingIncidentUpdateBatch> batch;
+    private CompletableFuture<Map<String, IncidentDocument>> incidents;
+    private CompletableFuture<Collection<ProcessInstanceDocument>> processInstances;
+    private CompletableFuture<List<ActiveIncident>> activeIncidentsByTreePaths;
+    private CompletableFuture<Integer> bulkUpdate;
+    private CompletableFuture<Collection<Document>> flowNodesInListView;
+    private CompletableFuture<Collection<Document>> flowNodeInstances;
+    private CompletableFuture<Boolean> wasProcessInstanceDeleted;
+
+    private IncidentBulkUpdate updated;
+
+    @Override
+    public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
+        final long fromPosition, final int size) {
+      return batch != null ? batch : super.getPendingIncidentsBatch(fromPosition, size);
+    }
+
+    @Override
+    public CompletionStage<Map<String, IncidentDocument>> getIncidentDocuments(
+        final List<String> incidentIds) {
+      return incidents != null ? incidents : super.getIncidentDocuments(incidentIds);
+    }
+
+    @Override
+    public CompletionStage<Collection<Document>> getFlowNodesInListView(
+        final List<String> flowNodeKeys) {
+      return flowNodesInListView != null
+          ? flowNodesInListView
+          : super.getFlowNodesInListView(flowNodeKeys);
+    }
+
+    @Override
+    public CompletionStage<Collection<Document>> getFlowNodeInstances(
+        final List<String> flowNodeKeys) {
+      return flowNodeInstances != null
+          ? flowNodeInstances
+          : super.getFlowNodeInstances(flowNodeKeys);
+    }
+
+    @Override
+    public CompletionStage<Collection<ProcessInstanceDocument>> getProcessInstances(
+        final List<String> processInstanceIds) {
+      return processInstances != null
+          ? processInstances
+          : super.getProcessInstances(processInstanceIds);
+    }
+
+    @Override
+    public CompletionStage<Boolean> wasProcessInstanceDeleted(final long processInstanceKey) {
+      return wasProcessInstanceDeleted != null
+          ? wasProcessInstanceDeleted
+          : super.wasProcessInstanceDeleted(processInstanceKey);
+    }
+
+    @Override
+    public CompletionStage<Integer> bulkUpdate(final IncidentBulkUpdate update) {
+      updated = update;
+      return bulkUpdate != null
+          ? bulkUpdate
+          : CompletableFuture.completedFuture(
+              update.incidentRequests().size()
+                  + update.listViewRequests().size()
+                  + update.flowNodeInstanceRequests().size());
+    }
+
+    @Override
+    public CompletionStage<List<String>> analyzeTreePath(final String treePath) {
+      return CompletableFuture.completedFuture(Arrays.asList(treePath.split("/")));
+    }
+
+    @Override
+    public CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(
+        final List<String> treePathTerms) {
+      return activeIncidentsByTreePaths != null
+          ? activeIncidentsByTreePaths
+          : super.getActiveIncidentsByTreePaths(treePathTerms);
+    }
+  }
+
+  /**
+   * All tests in this class have the following set up:
+   *
+   * <p>A single incident (3), a single process instance (1), and a single flow node (2). The
+   * incident was pending, and now has a single update to set it active.
+   *
+   * <p>The pending update has a position of 10.
+   */
+  @Nested
+  final class SingleIncidentTest {
+    private final int highestPosition = 10;
+
+    private final ProcessInstanceDocument processInstance =
+        new ProcessInstanceDocument(
+            "1", "list-view", 1, new TreePath().startTreePath(1).toString());
+    private final Document flowNodeInstance = new Document("2", "flow-nodes");
+    private final Document flowNodeInstanceInListView = new Document("2", "list-view");
+    private final IncidentEntity incidentEntity =
+        new IncidentEntity()
+            .setKey(3L)
+            .setId("3")
+            .setState(IncidentState.PENDING)
+            .setProcessInstanceKey(1L)
+            .setFlowNodeInstanceKey(2L)
+            .setTreePath(new TreePath().startTreePath(1).appendFlowNodeInstance(2).toString());
+    private final IncidentDocument incident =
+        new IncidentDocument("3", "incidents", incidentEntity);
+
+    @BeforeEach
+    void beforeEach() {
+      repository.batch =
+          CompletableFuture.completedFuture(
+              new PendingIncidentUpdateBatch(
+                  highestPosition, Map.of(incident.incident().getKey(), IncidentState.ACTIVE)));
+      repository.incidents = CompletableFuture.completedFuture(Map.of(incident.id(), incident));
+      repository.flowNodesInListView =
+          CompletableFuture.completedFuture(List.of(flowNodeInstanceInListView));
+      repository.flowNodeInstances = CompletableFuture.completedFuture(List.of(flowNodeInstance));
+      repository.processInstances = CompletableFuture.completedFuture(List.of(processInstance));
+    }
+
+    @Test
+    void shouldUpdateMetadataOnSuccess() {
+      // given
+      final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+
+      // when
+      task.execute().toCompletableFuture().join();
+
+      // then
+      assertThat(metadata.getLastIncidentUpdatePosition()).isEqualTo(highestPosition);
+    }
+
+    @Test
+    void shouldReturnNumberOfDocumentsUpdated() {
+      // given
+      final var task = new IncidentUpdateTask(metadata, repository, false, 10, LOGGER);
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result)
+          .succeedsWithin(Duration.ZERO)
+          .asInstanceOf(InstanceOfAssertFactories.INTEGER)
+          .isEqualTo(4);
+    }
+
+    @Test
+    void shouldFailOnMissingIncident() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      repository.incidents = CompletableFuture.completedFuture(Map.of());
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ZERO)
+          .withThrowableThat()
+          .withRootCauseExactlyInstanceOf(ExporterException.class)
+          .withMessageContaining("Failed to fetch incidents");
+    }
+
+    @Test
+    void shouldFailOnMissingProcessInstance() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      repository.processInstances = CompletableFuture.completedFuture(List.of());
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ZERO)
+          .withThrowableThat()
+          .withRootCauseExactlyInstanceOf(ExporterException.class)
+          .withMessageContaining("Process instance 1 is not yet imported for incident 3");
+    }
+
+    @Test
+    void shouldFailOnMissingFlowNodeInstance() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      repository.flowNodesInListView = CompletableFuture.completedFuture(List.of());
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ZERO)
+          .withThrowableThat()
+          .withRootCauseExactlyInstanceOf(ExporterException.class)
+          .withMessageContaining("Flow node instance 2 affected by incident 3");
+    }
+
+    @Test
+    void shouldFailOnMissingFlowNode() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      repository.flowNodeInstances = CompletableFuture.completedFuture(List.of());
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result)
+          .failsWithin(Duration.ZERO)
+          .withThrowableThat()
+          .withRootCauseExactlyInstanceOf(ExporterException.class)
+          .withMessageContaining("Flow node instance 2 affected by incident 3");
+    }
+
+    @Test
+    void shouldUpdateIncidents() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.incidentRequests())
+          .hasSize(1)
+          .containsEntry(
+              "3",
+              new DocumentUpdate(
+                  "3",
+                  "incidents",
+                  Map.of(
+                      IncidentTemplate.STATE,
+                      IncidentState.ACTIVE,
+                      IncidentTemplate.TREE_PATH,
+                      "PI_1/FNI_2"),
+                  "1"));
+    }
+
+    @Test
+    void shouldUpdateListView() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.listViewRequests())
+          .hasSize(2)
+          .containsEntry(
+              "1",
+              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"))
+          .containsEntry(
+              "2",
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"));
+    }
+
+    @Test
+    void shouldUpdateFlowNode() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.flowNodeInstanceRequests())
+          .hasSize(1)
+          .containsEntry(
+              "2",
+              new DocumentUpdate("2", "flow-nodes", Map.of(ListViewTemplate.INCIDENT, true), "1"));
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds two things:

- A new configuration class to configure the post-export tasks (i.e. incident update task)
- The `IncidentUpdateTask`, which is a port of the old post import action from Operate.

The code is largely copied from a mix of Operate's `AbstractPostImportAction`, `ElasticsearchPostImportAction`, and `OpensearchPostImportAction`. The difference is we've extracted every single access to the document store into a repository - `IncidentUpdateRepository` - and introduced some new types related to the repository.

> [!Note]
> The repository is asynchronous in preparation for the second iteration which will make this task asynchronous, and because in general in background tasks we only have access to an asynchronous client.

The task implementation copies `AdditionalData` - into which we collect state over the lifetime of a single execution of the task - and adapts `PendingIncidentsBatch`. Other types added are all under the `IncidentUpdateRepository`.

The current task is blocking because the original was blocking, and to increase confidence here, I tried and kept the logic as close as possible (so some parts are almost verbatim the same, e.g. variable and method names). This is to make it easier to compare implementations at the moment. A second pass will try and simplify the logic (which is quite complex) in order to make it easier to test, and then a final pass will make it asynchronous to avoid pinning threads via joining or plain `Thread.sleep`-ing.

> [!Note]
> [See this comment for some high level explanation of the post-import task.](https://github.com/camunda/camunda/issues/24297#issuecomment-2488588134)
> It's quite complex generally, so hopefully we can simplify as it's unclear how long we will have to maintain this.

## Related issues

closes #24929
