### PR TITLE
feat: implement search and get tenant endpoint

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -16,6 +16,7 @@ import io.camunda.search.clients.transformers.entity.FlowNodeInstanceEntityTrans
 import io.camunda.search.clients.transformers.entity.FormEntityTransformer;
 import io.camunda.search.clients.transformers.entity.ProcessDefinitionEntityTransfomer;
 import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
+import io.camunda.search.clients.transformers.entity.TenantEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
 import io.camunda.search.clients.transformers.filter.AuthorizationFilterTransformer;
@@ -30,6 +31,7 @@ import io.camunda.search.clients.transformers.filter.FormFilterTransformer;
 import io.camunda.search.clients.transformers.filter.IncidentFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessDefinitionFilterTransformer;
 import io.camunda.search.clients.transformers.filter.ProcessInstanceFilterTransformer;
+import io.camunda.search.clients.transformers.filter.TenantFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserTaskFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
@@ -45,6 +47,7 @@ import io.camunda.search.clients.transformers.sort.FlowNodeInstanceFieldSortingT
 import io.camunda.search.clients.transformers.sort.FormFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessDefinitionFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.ProcessInstanceFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.TenantFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
 import io.camunda.search.filter.AuthorizationFilter;
@@ -59,6 +62,7 @@ import io.camunda.search.filter.FormFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
+import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
@@ -72,6 +76,7 @@ import io.camunda.search.query.FormQuery;
 import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
+import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
@@ -87,6 +92,7 @@ import io.camunda.search.sort.FormSort;
 import io.camunda.search.sort.ProcessDefinitionSort;
 import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.SortOption;
+import io.camunda.search.sort.TenantSort;
 import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
@@ -98,6 +104,7 @@ import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionRequire
 import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
 import io.camunda.webapps.schema.entities.tasklist.FormEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
+import io.camunda.webapps.schema.entities.usermanagement.TenantEntity;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -153,6 +160,7 @@ public final class ServiceTransformers {
         FlowNodeInstanceQuery.class,
         new TypedSearchQueryTransformer<FlowNodeInstanceFilter, FlowNodeInstanceSort>(mappers));
     mappers.put(ProcessDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(TenantQuery.class, new TypedSearchQueryTransformer<>(mappers));
 
     // document entity -> domain entity
     mappers.put(DecisionDefinitionEntity.class, new DecisionDefinitionEntityTransformer());
@@ -162,6 +170,7 @@ public final class ServiceTransformers {
     mappers.put(ProcessInstanceForListViewEntity.class, new ProcessInstanceEntityTransformer());
     mappers.put(FlowNodeInstanceEntity.class, new FlowNodeInstanceEntityTransformer());
     mappers.put(TaskEntity.class, new UserTaskEntityTransformer());
+    mappers.put(TenantEntity.class, new TenantEntityTransformer());
     mappers.put(FormEntity.class, new FormEntityTransformer());
     mappers.put(VariableEntity.class, new VariableEntityTransformer());
 
@@ -171,6 +180,7 @@ public final class ServiceTransformers {
     mappers.put(DecisionInstanceSort.class, new DecisionInstanceFieldSortingTransformer());
     mappers.put(ProcessDefinitionSort.class, new ProcessDefinitionFieldSortingTransformer());
     mappers.put(ProcessInstanceSort.class, new ProcessInstanceFieldSortingTransformer());
+    mappers.put(TenantSort.class, new TenantFieldSortingTransformer());
     mappers.put(FlowNodeInstanceSort.class, new FlowNodeInstanceFieldSortingTransformer());
     mappers.put(UserTaskSort.class, new UserTaskFieldSortingTransformer());
     mappers.put(FormSort.class, new FormFieldSortingTransformer());
@@ -193,6 +203,7 @@ public final class ServiceTransformers {
     mappers.put(IncidentFilter.class, new IncidentFilterTransformer(mappers));
     mappers.put(FormFilter.class, new FormFilterTransformer(mappers));
     mappers.put(ProcessDefinitionFilter.class, new ProcessDefinitionFilterTransformer(mappers));
+    mappers.put(TenantFilter.class, new TenantFilterTransformer());
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/AuthorizationQueryTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/AuthorizationQueryTransformers.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.clients.transformers.auth;
 
+import static java.util.Map.entry;
+
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
 import io.camunda.search.query.DecisionRequirementsQuery;
@@ -15,6 +17,7 @@ import io.camunda.search.query.IncidentQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.SearchQueryBase;
+import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -23,27 +26,26 @@ import java.util.Map;
 public final class AuthorizationQueryTransformers {
   private static final Map<Class<? extends SearchQueryBase>, AuthorizationQueryTransformer>
       TRANSFORMERS =
-          Map.of(
-              DecisionDefinitionQuery.class,
-              new DecisionDefinitionAuthorizationQueryTransformer(),
-              DecisionInstanceQuery.class,
-              new DecisionInstanceAuthorizationQueryTransformer(),
-              DecisionRequirementsQuery.class,
-              new DecisionRequirementsAuthorizationQueryTransformer(),
-              FlowNodeInstanceQuery.class,
-              new FlowNodeInstanceAuthorizationQueryTransformer(),
-              IncidentQuery.class,
-              new IncidentAuthorizationQueryTransformer(),
-              ProcessDefinitionQuery.class,
-              new ProcessDefinitionAuthorizationQueryTransformer(),
-              ProcessInstanceQuery.class,
-              new ProcessInstanceAuthorizationQueryTransformer(),
-              UserQuery.class,
-              new UserAuthorizationQueryTransformer(),
-              UserTaskQuery.class,
-              new UserTaskAuthorizationQueryTransformer(),
-              VariableQuery.class,
-              new VariableAuthorizationQueryTransformer());
+          Map.ofEntries(
+              entry(
+                  DecisionDefinitionQuery.class,
+                  new DecisionDefinitionAuthorizationQueryTransformer()),
+              entry(
+                  DecisionInstanceQuery.class, new DecisionInstanceAuthorizationQueryTransformer()),
+              entry(
+                  DecisionRequirementsQuery.class,
+                  new DecisionRequirementsAuthorizationQueryTransformer()),
+              entry(
+                  FlowNodeInstanceQuery.class, new FlowNodeInstanceAuthorizationQueryTransformer()),
+              entry(IncidentQuery.class, new IncidentAuthorizationQueryTransformer()),
+              entry(
+                  ProcessDefinitionQuery.class,
+                  new ProcessDefinitionAuthorizationQueryTransformer()),
+              entry(ProcessInstanceQuery.class, new ProcessInstanceAuthorizationQueryTransformer()),
+              entry(TenantQuery.class, new TenantAuthorizationQueryTransformer()),
+              entry(UserQuery.class, new UserAuthorizationQueryTransformer()),
+              entry(UserTaskQuery.class, new UserTaskAuthorizationQueryTransformer()),
+              entry(VariableQuery.class, new VariableAuthorizationQueryTransformer()));
 
   private AuthorizationQueryTransformers() {}
 

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/TenantAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/TenantAuthorizationQueryTransformer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.auth;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.TENANT;
+import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
+
+public class TenantAuthorizationQueryTransformer implements AuthorizationQueryTransformer {
+
+  @Override
+  public SearchQuery toSearchQuery(
+      final AuthorizationResourceType resourceType,
+      final PermissionType permissionType,
+      final List<String> resourceKeys) {
+    if (resourceType == TENANT && permissionType == READ) {
+      return stringTerms("tenantId", resourceKeys);
+    }
+    throw new IllegalArgumentException(
+        "Unsupported authorizations with resource:%s and permission:%s: "
+            .formatted(resourceType, permissionType));
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.TenantEntity;
+import java.util.Set;
+
+public class TenantEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.usermanagement.TenantEntity, TenantEntity> {
+
+  @Override
+  public TenantEntity apply(
+      final io.camunda.webapps.schema.entities.usermanagement.TenantEntity source) {
+    return new TenantEntity(
+        source.getKey(),
+        source.getTenantId(),
+        source.getName(),
+        source.getAssignedMemberKeys() != null
+            ? Set.copyOf(source.getAssignedMemberKeys())
+            : Set.of());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.KEY;
+import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.NAME;
+import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex.TENANT_ID;
+
+public class TenantFieldSortingTransformer implements FieldSortingTransformer {
+
+  @Override
+  public String apply(final String domainField) {
+    return switch (domainField) {
+      case "key" -> KEY;
+      case "tenantId" -> TENANT_ID;
+      case "name" -> NAME;
+      default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);
+    };
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import org.junit.jupiter.api.Test;
+
+public class TenantQueryTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  public void shouldQueryByTenantKey() {
+    // given
+    final var filter = FilterBuilders.tenant((f) -> f.key(12345L));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (termQuery) -> {
+              assertThat(termQuery.field()).isEqualTo("key");
+              assertThat(termQuery.value().longValue()).isEqualTo(12345L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByTenantId() {
+    // given
+    final var filter = FilterBuilders.tenant((f) -> f.tenantId("tenant1"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (termQuery) -> {
+              assertThat(termQuery.field()).isEqualTo("tenantId");
+              assertThat(termQuery.value().stringValue()).isEqualTo("tenant1");
+            });
+  }
+
+  @Test
+  public void shouldQueryByTenantName() {
+    // given
+    final var filter = FilterBuilders.tenant((f) -> f.name("TestTenant"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (termQuery) -> {
+              assertThat(termQuery.field()).isEqualTo("name");
+              assertThat(termQuery.value().stringValue()).isEqualTo("TestTenant");
+            });
+  }
+
+  @Test
+  public void shouldQueryByMultipleTenantFields() {
+    // given
+    final var filter =
+        FilterBuilders.tenant((f) -> f.key(12345L).tenantId("tenant1").name("TestTenant"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            (boolQuery) -> {
+              assertThat(boolQuery.must()).hasSize(3);
+
+              // Verify "key" filter
+              assertThat(boolQuery.must().get(0).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      (termQuery) -> {
+                        assertThat(termQuery.field()).isEqualTo("key");
+                        assertThat(termQuery.value().longValue()).isEqualTo(12345L);
+                      });
+
+              // Verify "tenantId" filter
+              assertThat(boolQuery.must().get(1).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      (termQuery) -> {
+                        assertThat(termQuery.field()).isEqualTo("tenantId");
+                        assertThat(termQuery.value().stringValue()).isEqualTo("tenant1");
+                      });
+
+              // Verify "name" filter
+              assertThat(boolQuery.must().get(2).queryOption())
+                  .isInstanceOfSatisfying(
+                      SearchTermQuery.class,
+                      (termQuery) -> {
+                        assertThat(termQuery.field()).isEqualTo("name");
+                        assertThat(termQuery.value().stringValue()).isEqualTo("TestTenant");
+                      });
+            });
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/TenantSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/TenantSortTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.search.sort.TenantSort;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TenantSortTest extends AbstractSortTransformerTest {
+
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("key", SortOrder.ASC, s -> s.key().asc()),
+        new TestArguments("tenantId", SortOrder.DESC, s -> s.tenantId().desc()),
+        new TestArguments("name", SortOrder.ASC, s -> s.name().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<TenantSort.Builder, ObjectBuilder<TenantSort>> fn) {
+
+    // when
+    final var request = SearchQueryBuilders.tenantSearchQuery(q -> q.sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    assertThat(sort).hasSize(2); // Primary field and default "key" sort
+    assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo(field);
+              assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              assertThat(t.field().field()).isEqualTo("key"); // Default sorting
+              assertThat(t.field().order()).isEqualTo(SortOrder.ASC); // Default order
+            });
+  }
+
+  private record TestArguments(
+      String field, SortOrder sortOrder, Function<TenantSort.Builder, ObjectBuilder<TenantSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -9,12 +9,11 @@ package io.camunda.service;
 
 import io.camunda.search.clients.TenantSearchClient;
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.search.exception.NotFoundException;
-import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
+import io.camunda.service.exception.ForbiddenException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -22,7 +21,6 @@ import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantCreateReq
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantDeleteRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class TenantServices extends SearchQueryService<TenantServices, TenantQuery, TenantEntity> {
@@ -66,17 +64,19 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return sendBrokerRequest(new BrokerTenantDeleteRequest(key).setTenantKey(key));
   }
 
-  public TenantEntity getTenant(final Long tenantKey) {
-    return findTenant(tenantKey)
-        .orElseThrow(
-            () -> new NotFoundException("Tenant with key %d not found".formatted(tenantKey)));
-  }
-
-  public Optional<TenantEntity> findTenant(final Long tenantKey) {
-    return search(SearchQueryBuilders.tenantSearchQuery().filter(f -> f.key(tenantKey)).build())
-        .items()
-        .stream()
-        .findFirst();
+  public TenantEntity getByKey(final Long tenantKey) {
+    final var tenantQuery = TenantQuery.of(q -> q.filter(f -> f.key(tenantKey)));
+    final var result =
+        tenantSearchClient
+            .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+            .searchTenants(tenantQuery);
+    final var tenantEntity = getSingleResultOrThrow(result, tenantKey, "Tenant");
+    final var authorization = Authorization.of(a -> a.tenant().read());
+    if (!securityContextProvider.isAuthorized(
+        tenantEntity.tenantId(), authentication, authorization)) {
+      throw new ForbiddenException(authorization);
+    }
+    return tenantEntity;
   }
 
   public record TenantDTO(Long key, String tenantId, String name) {}

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantCreateReq
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantDeleteRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.tenant.BrokerTenantUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 public class TenantServices extends SearchQueryService<TenantServices, TenantQuery, TenantEntity> {
@@ -65,14 +66,17 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
     return sendBrokerRequest(new BrokerTenantDeleteRequest(key).setTenantKey(key));
   }
 
-  public TenantEntity getByKey(final Long key) {
-    final SearchQueryResult<TenantEntity> result =
-        search(SearchQueryBuilders.tenantSearchQuery().filter(f -> f.key(key)).build());
-    if (result.total() < 1) {
-      throw new NotFoundException(String.format("Tenant with key %d not found", key));
-    } else {
-      return result.items().stream().findFirst().orElseThrow();
-    }
+  public TenantEntity getTenant(final Long tenantKey) {
+    return findTenant(tenantKey)
+        .orElseThrow(
+            () -> new NotFoundException("Tenant with key %d not found".formatted(tenantKey)));
+  }
+
+  public Optional<TenantEntity> findTenant(final Long tenantKey) {
+    return search(SearchQueryBuilders.tenantSearchQuery().filter(f -> f.key(tenantKey)).build())
+        .items()
+        .stream()
+        .findFirst();
   }
 
   public record TenantDTO(Long key, String tenantId, String name) {}

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -76,10 +76,10 @@ public class TenantServiceTest {
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getByKey(1L);
+    final var searchQueryResult = services.findTenant(1L);
 
     // then
-    assertThat(searchQueryResult).isEqualTo(entity);
+    assertThat(searchQueryResult).contains(entity);
   }
 
   @Test
@@ -90,10 +90,10 @@ public class TenantServiceTest {
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.getByKey(1L);
+    final var searchQueryResult = services.findTenant(1L);
 
     // then
-    assertThat(searchQueryResult).isEqualTo(entity);
+    assertThat(searchQueryResult).contains(entity);
   }
 
   @Test
@@ -104,7 +104,7 @@ public class TenantServiceTest {
 
     // when / then
     final var exception =
-        assertThrowsExactly(NotFoundException.class, () -> services.getByKey(key));
+        assertThrowsExactly(NotFoundException.class, () -> services.getTenant(key));
     assertThat(exception.getMessage()).isEqualTo("Tenant with key 100 not found");
   }
 

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.filter.TenantFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.auth.Authorization;
 import io.camunda.service.TenantServices.TenantDTO;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.gateway.api.util.StubbedBrokerClient;
@@ -30,6 +31,7 @@ import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import java.util.List;
+import java.util.Set;
 import org.assertj.core.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -38,18 +40,23 @@ public class TenantServiceTest {
 
   private TenantServices services;
   private TenantSearchClient client;
-  private Authentication authentication;
   private StubbedBrokerClient stubbedBrokerClient;
+  private final TenantEntity tenantEntity =
+      new TenantEntity(100L, "tenant-id", "Tenant name", Set.of());
 
   @BeforeEach
   public void before() {
     stubbedBrokerClient = new StubbedBrokerClient();
-    authentication = Authentication.of(builder -> builder.user(1234L).token("auth_token"));
+    final Authentication authentication =
+        Authentication.of(builder -> builder.user(1234L).token("auth_token"));
     client = mock(TenantSearchClient.class);
+    final SecurityContextProvider securityContextProvider = mock(SecurityContextProvider.class);
     when(client.withSecurityContext(any())).thenReturn(client);
+    when(securityContextProvider.isAuthorized(
+            "tenant-id", authentication, Authorization.of(a -> a.tenant().read())))
+        .thenReturn(true);
     services =
-        new TenantServices(
-            stubbedBrokerClient, mock(SecurityContextProvider.class), client, authentication);
+        new TenantServices(stubbedBrokerClient, securityContextProvider, client, authentication);
   }
 
   @Test
@@ -71,29 +78,27 @@ public class TenantServiceTest {
   @Test
   public void shouldReturnSingleTenant() {
     // given
-    final var entity = mock(TenantEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array());
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findTenant(1L);
+    final var searchQueryResult = services.getByKey(100L);
 
     // then
-    assertThat(searchQueryResult).contains(entity);
+    assertThat(searchQueryResult).isEqualTo(tenantEntity);
   }
 
   @Test
   public void shouldReturnSingleVariableForGet() {
     // given
-    final var entity = mock(TenantEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array());
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
-    final var searchQueryResult = services.findTenant(1L);
+    final var searchQueryResult = services.getByKey(100L);
 
     // then
-    assertThat(searchQueryResult).contains(entity);
+    assertThat(searchQueryResult).isEqualTo(tenantEntity);
   }
 
   @Test
@@ -104,7 +109,7 @@ public class TenantServiceTest {
 
     // when / then
     final var exception =
-        assertThrowsExactly(NotFoundException.class, () -> services.getTenant(key));
+        assertThrowsExactly(NotFoundException.class, () -> services.getByKey(key));
     assertThat(exception.getMessage()).isEqualTo("Tenant with key 100 not found");
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -13,6 +13,10 @@ public class TenantIndex extends UserManagementIndexDescriptor {
   public static final String INDEX_NAME = "tenants";
   public static final String INDEX_VERSION = "8.7.0";
 
+  public static final String KEY = "key";
+  public static final String TENANT_ID = "tenantId";
+  public static final String NAME = "name";
+
   public TenantIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);
   }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3025,16 +3025,20 @@ components:
         - $ref: "#/components/schemas/SearchQueryRequest"
       properties:
         filter:
+          description: The tenant search filters.
           allOf:
             - $ref: "#/components/schemas/TenantFilterRequest"
 
     TenantFilterRequest:
+      description: Tenant filter request
       type: object
       properties:
         tenantId:
           type: string
+          description: The ID of the tenant.
         name:
           type: string
+          description: The name of the tenant.
 
     TenantSearchQueryResponse:
       description: Tenant search response.
@@ -3043,6 +3047,7 @@ components:
       type: object
       properties:
         items:
+          description: The matching tenants.
           type: array
           items:
             $ref: "#/components/schemas/TenantItem"

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2986,7 +2986,7 @@ components:
     TenantUpdateResponse:
       type: object
       properties:
-        key:
+        tenantKey:
           type: integer
           description: The unique system-generated internal tenant ID
           format: int64
@@ -3001,7 +3001,7 @@ components:
       description: Tenant search response item.
       type: object
       properties:
-        key:
+        tenantKey:
           type: integer
           description: The unique system-generated internal tenant ID.
           format: int64

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -468,6 +468,48 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+
+  /tenants/search:
+    post:
+      tags:
+        - Tenant
+      operationId: searchTenants
+      summary: Query tenants
+      description: Retrieves a filtered and sorted list of tenants.
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TenantSearchQueryRequest"
+      responses:
+        "200":
+          description: The tenants search result
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantSearchQueryResponse"
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Not found
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /user-tasks/{userTaskKey}/completion:
     post:
       tags:
@@ -2912,6 +2954,56 @@ components:
         name:
           type: string
           description: The name of the tenant.
+
+    TenantItem:
+      description: Tenant search response item.
+      type: object
+      properties:
+        key:
+          type: integer
+          description: The unique system-generated internal tenant ID.
+          format: int64
+        name:
+          type: string
+          description: The tenant name.
+        tenantId:
+          type: string
+          description: The unique external tenant ID.
+        assignedMemberKeys:
+          type: array
+          description: The set of keys of members assigned to the tenant.
+          items:
+            type: integer
+            format: int64
+
+    TenantSearchQueryRequest:
+      description: Tenant search request
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      properties:
+        filter:
+          allOf:
+            - $ref: "#/components/schemas/TenantFilterRequest"
+
+    TenantFilterRequest:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        name:
+          type: string
+
+    TenantSearchQueryResponse:
+      description: Tenant search response.
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/TenantItem"
 
     UserTaskSearchQueryRequest:
       allOf:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -430,6 +430,48 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+    get:
+      tags:
+        - Tenant
+      operationId: getTenant
+      summary: Get tenant
+      description: Retrieves a single tenant by tenant Key.
+      parameters:
+        - name: tenantKey
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: The tenant was retrieved successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TenantItem"
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          description: Forbidden
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Tenant not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
     delete:
       tags:
         - Tenant

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -341,7 +341,7 @@ public final class ResponseMapper {
   public static ResponseEntity<Object> toTenantUpdateResponse(final TenantRecord record) {
     final var response =
         new TenantUpdateResponse()
-            .key(record.getTenantKey())
+            .tenantKey(record.getTenantKey())
             .tenantId(record.getTenantId())
             .name(record.getName());
     return new ResponseEntity<>(response, HttpStatus.OK);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -47,6 +47,7 @@ import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQueryBuilder;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
@@ -62,6 +63,7 @@ import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.RoleSort;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.search.sort.TenantSort;
 import io.camunda.search.sort.UserSort;
 import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
@@ -124,6 +126,20 @@ public final class SearchQueryRequestMapper {
             SortOptionBuilders::role,
             SearchQueryRequestMapper::applyRoleSortField);
     return buildSearchQuery(null, sort, page, SearchQueryBuilders::roleSearchQuery);
+  }
+
+  public static Either<ProblemDetail, TenantQuery> toTenantQuery(
+      final TenantSearchQueryRequest request) {
+    if (request == null) {
+      return Either.right(SearchQueryBuilders.tenantSearchQuery().build());
+    }
+    final var page = toSearchQueryPage(request.getPage());
+    final var sort =
+        toSearchQuerySort(
+            request.getSort(),
+            SortOptionBuilders::tenant,
+            SearchQueryRequestMapper::applyTenantSortField);
+    return buildSearchQuery(null, sort, page, SearchQueryBuilders::tenantSearchQuery);
   }
 
   public static Either<ProblemDetail, DecisionDefinitionQuery> toDecisionDefinitionQuery(
@@ -620,6 +636,22 @@ public final class SearchQueryRequestMapper {
       switch (field) {
         case "roleKey" -> builder.roleKey();
         case "name" -> builder.name();
+        default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
+      }
+    }
+    return validationErrors;
+  }
+
+  private static List<String> applyTenantSortField(
+      final String field, final TenantSort.Builder builder) {
+    final List<String> validationErrors = new ArrayList<>();
+    if (field == null) {
+      validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
+    } else {
+      switch (field) {
+        case "tenantKey" -> builder.key();
+        case "name" -> builder.name();
+        case "tenantId" -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));
       }
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -262,7 +262,7 @@ public final class SearchQueryResponseMapper {
 
   public static TenantItem toTenant(final TenantEntity tenantEntity) {
     return new TenantItem()
-        .key(tenantEntity.key())
+        .tenantKey(tenantEntity.key())
         .name(tenantEntity.name())
         .tenantId(tenantEntity.tenantId())
         .assignedMemberKeys(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -260,7 +260,7 @@ public final class SearchQueryResponseMapper {
     return tenants.stream().map(SearchQueryResponseMapper::toTenant).toList();
   }
 
-  private static TenantItem toTenant(final TenantEntity tenantEntity) {
+  public static TenantItem toTenant(final TenantEntity tenantEntity) {
     return new TenantItem()
         .key(tenantEntity.key())
         .name(tenantEntity.name())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -24,6 +24,7 @@ import io.camunda.search.entities.IncidentEntity;
 import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
+import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -59,6 +60,8 @@ import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.RoleItem;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
+import io.camunda.zeebe.gateway.protocol.rest.TenantItem;
+import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
@@ -103,6 +106,17 @@ public final class SearchQueryResponseMapper {
         .page(page)
         .items(
             ofNullable(result.items()).map(SearchQueryResponseMapper::toRoles).orElseGet(List::of));
+  }
+
+  public static TenantSearchQueryResponse toTenantSearchQueryResponse(
+      final SearchQueryResult<TenantEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new TenantSearchQueryResponse()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toTenants)
+                .orElseGet(List::of));
   }
 
   public static DecisionDefinitionSearchQueryResponse toDecisionDefinitionSearchQueryResponse(
@@ -240,6 +254,21 @@ public final class SearchQueryResponseMapper {
             roleEntity.assignedMemberKeys() == null
                 ? null
                 : roleEntity.assignedMemberKeys().stream().sorted().toList());
+  }
+
+  private static List<TenantItem> toTenants(final List<TenantEntity> tenants) {
+    return tenants.stream().map(SearchQueryResponseMapper::toTenant).toList();
+  }
+
+  private static TenantItem toTenant(final TenantEntity tenantEntity) {
+    return new TenantItem()
+        .key(tenantEntity.key())
+        .name(tenantEntity.name())
+        .tenantId(tenantEntity.tenantId())
+        .assignedMemberKeys(
+            tenantEntity.assignedMemberKeys() == null
+                ? null
+                : tenantEntity.assignedMemberKeys().stream().sorted().toList());
   }
 
   private static List<DecisionDefinitionItem> toDecisionDefinitions(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
@@ -11,6 +11,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.TenantQuery;
 import io.camunda.service.TenantServices;
+import io.camunda.zeebe.gateway.protocol.rest.TenantItem;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
@@ -28,6 +29,18 @@ public class TenantQueryController {
 
   public TenantQueryController(final TenantServices tenantServices) {
     this.tenantServices = tenantServices;
+  }
+
+  @GetMapping(
+      path = "/{tenantKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public ResponseEntity<TenantItem> getTenant(@PathVariable final long tenantKey) {
+    try {
+      return ResponseEntity.ok()
+          .body(SearchQueryResponseMapper.toTenant(tenantServices.getTenant(tenantKey)));
+    } catch (final Exception exception) {
+      return RestErrorMapper.mapErrorToResponse(exception);
+    }
   }
 
   @PostMapping(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.tenant;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.TenantQuery;
+import io.camunda.service.TenantServices;
+import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.controller.CamundaRestQueryController;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@CamundaRestQueryController
+@RequestMapping("/v2/tenants")
+public class TenantQueryController {
+  private final TenantServices tenantServices;
+
+  public TenantQueryController(final TenantServices tenantServices) {
+    this.tenantServices = tenantServices;
+  }
+
+  @PostMapping(
+      path = "/search",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<TenantSearchQueryResponse> searchTenants(
+      @RequestBody(required = false) final TenantSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toTenantQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<TenantSearchQueryResponse> search(final TenantQuery query) {
+    try {
+      final var result = tenantServices.search(query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toTenantSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryController.java
@@ -37,7 +37,7 @@ public class TenantQueryController {
   public ResponseEntity<TenantItem> getTenant(@PathVariable final long tenantKey) {
     try {
       return ResponseEntity.ok()
-          .body(SearchQueryResponseMapper.toTenant(tenantServices.getTenant(tenantKey)));
+          .body(SearchQueryResponseMapper.toTenant(tenantServices.getByKey(tenantKey)));
     } catch (final Exception exception) {
       return RestErrorMapper.mapErrorToResponse(exception);
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -127,7 +127,7 @@ public class TenantControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "key": %d,
+              "tenantKey": %d,
               "tenantId": "%s",
               "name": "%s"
             }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -49,19 +49,19 @@ public class TenantQueryControllerTest extends RestControllerTest {
       {
          "items": [
            {
-             "key": %d,
+             "tenantKey": %d,
              "name": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
            },
            {
-             "key": %d,
+             "tenantKey": %d,
              "name": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
            },
            {
-             "key": %d,
+             "tenantKey": %d,
              "name": "%s",
              "tenantId": "%s",
              "assignedMemberKeys": %s
@@ -120,7 +120,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .json(
             """
             {
-              "key": %d,
+              "tenantKey": %d,
               "name": "%s",
               "tenantId": "%s",
               "assignedMemberKeys": []

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -106,7 +106,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     final var tenantName = "Tenant Name";
     final var tenantId = "tenant-id";
     final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
-    when(tenantServices.getTenant(tenant.key())).thenReturn(tenant);
+    when(tenantServices.getByKey(tenant.key())).thenReturn(tenant);
 
     // when
     webClient
@@ -129,7 +129,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
                 .formatted(tenant.key(), tenantName, tenantId));
 
     // then
-    verify(tenantServices, times(1)).getTenant(tenant.key());
+    verify(tenantServices, times(1)).getByKey(tenant.key());
   }
 
   @Test
@@ -137,7 +137,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
     // given
     final var tenantKey = 100L;
     final var path = "%s/%s".formatted(TENANT_BASE_URL, tenantKey);
-    when(tenantServices.getTenant(tenantKey)).thenThrow(new NotFoundException("tenant not found"));
+    when(tenantServices.getByKey(tenantKey)).thenThrow(new NotFoundException("tenant not found"));
 
     // when
     webClient
@@ -160,7 +160,7 @@ public class TenantQueryControllerTest extends RestControllerTest {
                 .formatted(path));
 
     // then
-    verify(tenantServices, times(1)).getTenant(tenantKey);
+    verify(tenantServices, times(1)).getByKey(tenantKey);
   }
 
   @Test


### PR DESCRIPTION
## Description
 - added endpoints : 
     - Get a single tenant - GET /v2/tenants/{key}
     -  Search tenants - POST /v2/tenants/search
  - added tests
 - added spec to zeebe/gateway-protocol/src/main/proto/rest-api.yaml
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues
part of 
 - https://github.com/camunda/camunda/issues/22390
