### PR TITLE
refactor: add webapp user fields to central user object to support auth transition

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -64,6 +64,10 @@
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>camunda-search-domain</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-annotations</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -7,8 +7,13 @@
  */
 package io.camunda.authentication.entity;
 
+import io.camunda.search.entities.TenantEntity;
+import io.camunda.security.entity.ClusterMetadata;
+import io.camunda.security.entity.Permission;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -17,8 +22,13 @@ public class CamundaUser extends User {
 
   private final Long userKey;
   private final String displayName;
-
-  private boolean canLogout = true;
+  private List<Permission> permissions = List.of();
+  private List<TenantEntity> tenants = List.of();
+  private List<String> groups = List.of();
+  private String salesPlanType;
+  private Map<ClusterMetadata.AppName, String> c8Links = new HashMap<>();
+  private boolean canLogout;
+  private boolean apiUser;
 
   public CamundaUser(
       final Long userKey, final String displayName, final String username, final String password) {
@@ -35,6 +45,31 @@ public class CamundaUser extends User {
     super(username, password, prepareAuthorities(roles));
     userKey = null;
     this.displayName = displayName;
+  }
+
+  public CamundaUser(
+      final Long userKey,
+      final String displayName,
+      final String username,
+      final String password,
+      final List<String> roles,
+      final List<Permission> permissions,
+      final List<TenantEntity> tenants,
+      final List<String> groups,
+      final String salesPlanType,
+      final Map<ClusterMetadata.AppName, String> c8Links,
+      final boolean canLogout,
+      final boolean apiUser) {
+    super(username, password, prepareAuthorities(roles));
+    this.userKey = userKey;
+    this.displayName = displayName;
+    this.permissions = permissions;
+    this.tenants = tenants;
+    this.groups = groups;
+    this.salesPlanType = salesPlanType;
+    this.c8Links = c8Links;
+    this.canLogout = canLogout;
+    this.apiUser = apiUser;
   }
 
   public Long getUserKey() {
@@ -57,7 +92,23 @@ public class CamundaUser extends User {
     return getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
   }
 
-  public boolean isCanLogout() {
+  public List<Permission> getPermissions() {
+    return permissions;
+  }
+
+  public List<TenantEntity> getTenants() {
+    return tenants;
+  }
+
+  public String getSalesPlanType() {
+    return salesPlanType;
+  }
+
+  public Map<ClusterMetadata.AppName, String> getC8Links() {
+    return c8Links;
+  }
+
+  public boolean canLogout() {
     return canLogout;
   }
 
@@ -70,6 +121,14 @@ public class CamundaUser extends User {
     private String name;
     private String username;
     private String password;
+    private List<String> roles;
+    private List<Permission> permissions;
+    private List<TenantEntity> tenants;
+    private List<String> groups;
+    private String salesPlanType;
+    private Map<ClusterMetadata.AppName, String> c8Links;
+    private boolean canLogout;
+    private boolean apiUser;
 
     private CamundaUserBuilder() {}
 
@@ -97,8 +156,60 @@ public class CamundaUser extends User {
       return this;
     }
 
+    public CamundaUserBuilder withRoles(final List<String> roles) {
+      this.roles = roles;
+      return this;
+    }
+
+    public CamundaUserBuilder withPermissions(final List<Permission> permissions) {
+      this.permissions = permissions;
+      return this;
+    }
+
+    public CamundaUserBuilder withTenants(final List<TenantEntity> tenants) {
+      this.tenants = tenants;
+      return this;
+    }
+
+    public CamundaUserBuilder withGroups(final List<String> groups) {
+      this.groups = groups;
+      return this;
+    }
+
+    public CamundaUserBuilder withSalesPlanType(final String salesPlanType) {
+      this.salesPlanType = salesPlanType;
+      return this;
+    }
+
+    public CamundaUserBuilder withC8Links(final Map<ClusterMetadata.AppName, String> c8Links) {
+      this.c8Links = c8Links;
+      return this;
+    }
+
+    public CamundaUserBuilder withCanLogout(final boolean canLogout) {
+      this.canLogout = canLogout;
+      return this;
+    }
+
+    public CamundaUserBuilder withApiUser(final boolean apiUser) {
+      this.apiUser = apiUser;
+      return this;
+    }
+
     public CamundaUser build() {
-      return new CamundaUser(userKey, name, username, password);
+      return new CamundaUser(
+          userKey,
+          name,
+          username,
+          password,
+          roles,
+          permissions,
+          tenants,
+          groups,
+          salesPlanType,
+          c8Links,
+          canLogout,
+          apiUser);
     }
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -121,10 +121,10 @@ public class CamundaUser extends User {
     private String name;
     private String username;
     private String password;
-    private List<String> roles;
-    private List<Permission> permissions;
-    private List<TenantEntity> tenants;
-    private List<String> groups;
+    private List<String> roles = List.of();
+    private List<Permission> permissions = List.of();
+    private List<TenantEntity> tenants = List.of();
+    private List<String> groups = List.of();
     private String salesPlanType;
     private Map<ClusterMetadata.AppName, String> c8Links;
     private boolean canLogout;

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -28,9 +28,6 @@ public class BasicCamundaUserService implements CamundaUserService {
 
   @Override
   public String getCurrentUsername() {
-    final var authenticatedUser =
-        (CamundaUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-    return authenticatedUser.getUsername();
+    return getCurrentUser().getUsername();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import io.camunda.authentication.entity.CamundaUser;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Profile("auth-basic")
+@Service
+public class BasicCamundaUserService implements CamundaUserService {
+
+  @Override
+  public CamundaUser getCurrentUser() {
+    return (CamundaUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+
+  @Override
+  public String getUserToken() {
+    return null;
+  }
+
+  @Override
+  public String getCurrentUsername() {
+    final var authenticatedUser =
+        (CamundaUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    return authenticatedUser.getUsername();
+  }
+}

--- a/authentication/src/main/java/io/camunda/authentication/service/CamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/CamundaUserService.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.service;
+
+import io.camunda.authentication.entity.CamundaUser;
+
+public interface CamundaUserService {
+  CamundaUser getCurrentUser();
+
+  String getUserToken();
+
+  String getCurrentUsername();
+}

--- a/security/security-core/pom.xml
+++ b/security/security-core/pom.xml
@@ -17,4 +17,11 @@
   <groupId>io.camunda</groupId>
   <artifactId>camunda-security-core</artifactId>
   <name>Camunda Security Core</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+  </dependencies>
 </project>

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -7,16 +7,12 @@
  */
 package io.camunda.security.entity;
 
-/*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
- * under one or more contributor license agreements. Licensed under a proprietary license.
- * See the License.txt file for more information. You may not use this file
- * except in compliance with the proprietary license.
- */
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class ClusterMetadata implements Serializable {
@@ -79,17 +75,7 @@ public class ClusterMetadata implements Serializable {
 
   @Override
   public String toString() {
-    return "ClusterMetadata{"
-        + "uuid='"
-        + uuid
-        + '\''
-        + ", name='"
-        + name
-        + '\''
-        + ", urls="
-        + urls
-        + '\''
-        + '}';
+    return "ClusterMetadata{uuid='%s', name='%s', urls='%s'}".formatted(uuid, name, urls);
   }
 
   public record C8AppLink(String name, String link) {}

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.entity;
+
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH
+ * under one or more contributor license agreements. Licensed under a proprietary license.
+ * See the License.txt file for more information. You may not use this file
+ * except in compliance with the proprietary license.
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.camunda.tasklist.webapp.graphql.entity.C8AppLink;
+import java.io.Serializable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ClusterMetadata implements Serializable {
+
+  private String uuid;
+  private String name;
+  private Map<AppName, String> urls = new HashMap<>();
+
+  public String getUuid() {
+    return uuid;
+  }
+
+  public ClusterMetadata setUuid(final String uuid) {
+    this.uuid = uuid;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public ClusterMetadata setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Map<AppName, String> getUrls() {
+    return urls;
+  }
+
+  public ClusterMetadata setUrls(final Map<AppName, String> urls) {
+    this.urls = urls;
+    return this;
+  }
+
+  public List<C8AppLink> getUrlsAsC8AppLinks() {
+    return urls.keySet().stream()
+        .map(name -> new C8AppLink(name.name(), urls.get(name)))
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uuid, name, urls);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ClusterMetadata that = (ClusterMetadata) o;
+    return Objects.equals(uuid, that.uuid)
+        && Objects.equals(name, that.name)
+        && Objects.equals(urls, that.urls);
+  }
+
+  @Override
+  public String toString() {
+    return "ClusterMetadata{"
+        + "uuid='"
+        + uuid
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", urls="
+        + urls
+        + '\''
+        + '}';
+  }
+
+  public record C8AppLink(String name, String link) {}
+
+  public enum AppName {
+    @JsonProperty("console")
+    CONSOLE,
+    @JsonProperty("operate")
+    OPERATE,
+    @JsonProperty("optimize")
+    OPTIMIZE,
+    @JsonProperty("modeler")
+    MODELER,
+    @JsonProperty("tasklist")
+    TASKLIST,
+    @JsonProperty("zeebe")
+    ZEEBE,
+    @JsonProperty("connectors")
+    CONNECTORS;
+
+    @Override
+    public String toString() {
+      return super.toString().toLowerCase();
+    }
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
+++ b/security/security-core/src/main/java/io/camunda/security/entity/ClusterMetadata.java
@@ -15,7 +15,6 @@ package io.camunda.security.entity;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.camunda.tasklist.webapp.graphql.entity.C8AppLink;
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->

This PR ensures that the fields on the `CamundaUser` central object can support the existing fields on the webapp specific user objects, this is important as it allows us to transition the webapp auth implementations to the `camunda-authentication` and reduce the impact on the webapp UIs.
