### PR TITLE
fix: enable the old backup endpoint for gateway when it is deployed standalone

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -7,19 +7,19 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import io.camunda.zeebe.shared.profiles.ProfileStandaloneBrokerOrGateway;
 import org.springframework.boot.actuate.endpoint.annotation.DeleteOperation;
 import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
 import org.springframework.boot.actuate.endpoint.annotation.Selector;
 import org.springframework.boot.actuate.endpoint.annotation.WriteOperation;
 import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint;
-import org.springframework.context.annotation.Profile;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 
 @Component
 @WebEndpoint(id = "backups")
-@Profile("broker & standalone")
+@ProfileStandaloneBrokerOrGateway
 public final class BackupEndpointStandalone {
   private final BackupEndpoint backupEndpoint;
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/profiles/ProfileStandaloneBrokerOrGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/profiles/ProfileStandaloneBrokerOrGateway.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.profiles;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Profile;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@Profile("(broker | gateway) & standalone")
+public @interface ProfileStandaloneBrokerOrGateway {}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneGatewayTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneGatewayTest.java
@@ -9,5 +9,5 @@ package io.camunda.zeebe.shared.management;
 
 import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles({"broker", "standalone"})
-public class BackupEndpointStandaloneBrokerTest extends BackupEndpointStandaloneTest {}
+@ActiveProfiles({"gateway", "standalone"})
+public class BackupEndpointStandaloneGatewayTest extends BackupEndpointStandaloneTest {}

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/BackupEndpointStandaloneTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {BackupEndpointStandalone.class})
+public abstract class BackupEndpointStandaloneTest {
+
+  @MockBean private BackupEndpoint backupEndpoint;
+  @Autowired private BackupEndpointStandalone backupEndpointStandalone;
+
+  @Test
+  public void shouldCallTakeWhenIsStandalone() {
+    backupEndpointStandalone.take(11L);
+    verify(backupEndpoint).take(11L);
+  }
+
+  @Test
+  public void shouldCallListWhenIsStandalone() {
+    backupEndpointStandalone.list();
+    verify(backupEndpoint).list();
+  }
+
+  @Test
+  public void shouldCallGetWhenIsStandalone() {
+    backupEndpointStandalone.status(11L);
+    verify(backupEndpoint).status(11L);
+  }
+
+  @Test
+  public void shouldCallDeleteWhenIsStandalone() {
+    backupEndpointStandalone.delete(11L);
+    verify(backupEndpoint).delete(11L);
+  }
+}


### PR DESCRIPTION
## Description
Added a new Profiles class that contain these expression for reusability and so they can be tested in a unit test

## Related issues

closes #24850

