### PR TITLE
refactor: reference users with keys instead of usernames

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/UserAuthorizationQueryTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/auth/UserAuthorizationQueryTransformer.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.U
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
 
 import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
@@ -24,7 +25,7 @@ public class UserAuthorizationQueryTransformer implements AuthorizationQueryTran
       final PermissionType permissionType,
       final List<String> resourceKeys) {
     if (resourceType == USER && permissionType == READ) {
-      return stringTerms("username", resourceKeys);
+      return stringTerms(UserIndex.KEY, resourceKeys);
     }
     throw new IllegalArgumentException(
         "Unsupported authorizations with resource:%s and permission:%s: "

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/UserCreateProcessor.java
@@ -87,7 +87,7 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     command.getValue().setUserKey(key);
 
     stateWriter.appendFollowUpEvent(key, UserIntent.CREATED, command.getValue());
-    addUserPermissions(key, username);
+    addUserPermissions(key);
     responseWriter.writeEventOnCommand(key, UserIntent.CREATED, command.getValue(), command);
 
     distributionBehavior
@@ -103,16 +103,16 @@ public class UserCreateProcessor implements DistributedTypedRecordProcessor<User
     distributionBehavior.acknowledgeCommand(command);
   }
 
-  private void addUserPermissions(final long key, final String username) {
+  private void addUserPermissions(final long key) {
     final var authorizationRecord =
         new AuthorizationRecord()
             .setOwnerKey(key)
             .setOwnerType(AuthorizationOwnerType.USER)
             .setResourceType(AuthorizationResourceType.USER)
             .addPermission(
-                new Permission().setPermissionType(PermissionType.READ).addResourceId(username))
+                new Permission().setPermissionType(PermissionType.READ).addResourceId(key))
             .addPermission(
-                new Permission().setPermissionType(PermissionType.UPDATE).addResourceId(username));
+                new Permission().setPermissionType(PermissionType.UPDATE).addResourceId(key));
     commandWriter.appendFollowUpCommand(
         key, AuthorizationIntent.ADD_PERMISSION, authorizationRecord);
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/Permission.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/Permission.java
@@ -68,4 +68,8 @@ public final class Permission extends ObjectValue implements PermissionValue {
     resourceIdsProp.add().wrap(BufferUtil.wrapString(resourceId));
     return this;
   }
+
+  public Permission addResourceId(final long key) {
+    return addResourceId(Long.toString(key));
+  }
 }


### PR DESCRIPTION
Using keys for all entity references will simplify how we implement common functionality.
