### PR TITLE
[Backport stable/8.3] ci: use non-preemptible runners for jobs with highest disconnect rate

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -192,7 +192,7 @@ jobs:
           - os: linux
             runner: gcp-perf-core-8-default
           - os: linux
-            runner: "aws-arm-core-4-default"
+            runner: "aws-arm-core-4-longrunning"
             arch: arm64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description
Backport of #24370 to `stable/8.3`.

relates to 
original author: @cmur2