### PR TITLE
[Backport stable/8.6] ci: use non-preemptible runners for jobs with highest disconnect rate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -52,6 +52,11 @@ self-hosted-runner:
   - gcp-perf-core-4-default
   - gcp-perf-core-8-default
   - gcp-perf-core-16-default
-  # by Zeebe team, to be deprecated after https://github.com/camunda/camunda/issues/18212
-  - amd64
-  - '16'
+  - gcp-perf-core-2-release
+  - gcp-perf-core-4-release
+  - gcp-perf-core-8-release
+  - gcp-perf-core-16-release
+  - gcp-perf-core-2-longrunning
+  - gcp-perf-core-4-longrunning
+  - gcp-perf-core-8-longrunning
+  - gcp-perf-core-16-longrunning

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
-            runs-on: gcp-perf-core-8-default
+            runs-on: gcp-perf-core-8-longrunning
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
             maven-modules: "zeebe/qa/integration-tests"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -31,7 +31,7 @@ jobs:
           - os: linux
             runner: gcp-perf-core-8-default
           - os: linux
-            runner: "aws-arm-core-4-default"
+            runner: "aws-arm-core-4-longrunning"
             arch: arm64
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description
Backport of #24370 to `stable/8.6`.

relates to 
original author: @cmur2