### PR TITLE
[Backport stable/8.4] All Zeebe CI jobs need to specify GHA timeouts

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -517,6 +517,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
@@ -709,6 +710,7 @@ jobs:
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
+    timeout-minutes: 15
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -735,6 +737,7 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
   deploy-benchmark-images:
     name: Deploy benchmark images
+    timeout-minutes: 5
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -770,6 +773,7 @@ jobs:
         run: ./mvnw -pl benchmarks/project jib:build -P worker
   deploy-snyk-projects:
     name: Deploy Snyk development projects
+    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -773,7 +773,6 @@ jobs:
         run: ./mvnw -pl benchmarks/project jib:build -P worker
   deploy-snyk-projects:
     name: Deploy Snyk development projects
-    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -82,6 +82,7 @@ defaults:
 jobs:
   scan:
     name: Snyk Scan
+    timeout-minutes: 15
     # Run on self-hosted to make building Zeebe much faster
     runs-on: gcp-perf-core-8-default
     permissions:


### PR DESCRIPTION
# Description
Backport of #24880 to `stable/8.4`.

relates to #21766
original author: @berkaycanbc