### PR TITLE
[Backport stable/8.5] All Zeebe CI jobs need to specify GHA timeouts

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -526,6 +526,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
@@ -697,6 +698,7 @@ jobs:
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
+    timeout-minutes: 15
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -723,6 +725,7 @@ jobs:
           distball: ${{ steps.build-zeebe.outputs.distball }}
   deploy-benchmark-images:
     name: Deploy benchmark images
+    timeout-minutes: 5
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
@@ -758,6 +761,7 @@ jobs:
         run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker
   deploy-snyk-projects:
     name: Deploy Snyk development projects
+    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -761,7 +761,6 @@ jobs:
         run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker
   deploy-snyk-projects:
     name: Deploy Snyk development projects
-    timeout-minutes: 15
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -82,6 +82,7 @@ defaults:
 jobs:
   scan:
     name: Snyk Scan
+    timeout-minutes: 15
     # Run on self-hosted to make building Zeebe much faster
     runs-on: gcp-perf-core-8-default
     permissions:


### PR DESCRIPTION
# Description
Backport of #24880 to `stable/8.5`.

relates to #21766
original author: @berkaycanbc