### PR TITLE
[Backport stable/8.6] fix: apply nested configuration properties

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 public class ZeebeClientProperties extends ApiProperties {
   private Integer executionThreads;

--- a/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/clients/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -29,8 +29,8 @@ public class ZeebeClientProperties extends ApiProperties {
   private String caCertificatePath;
   private Duration keepAlive;
   private String overrideAuthority;
-  private ZeebeWorkerValue defaults;
-  private Map<String, ZeebeWorkerValue> override;
+  @NestedConfigurationProperty private ZeebeWorkerValue defaults;
+  @NestedConfigurationProperty private Map<String, ZeebeWorkerValue> override;
   private boolean preferRestOverGrpc;
   private URI grpcAddress;
   private URI restAddress;


### PR DESCRIPTION
# Description
Backport of #24957 to `stable/8.6`.

relates to 
original author: @jonathanlukas