### PR TITLE
Fix for #21436 to avoid double push attempt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,11 +780,3 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile
           push: true
-      - uses: ./.github/actions/build-platform-docker
-        id: build-operate-docker
-        with:
-          repository: camunda/operate
-          version: SNAPSHOT
-          push: true
-          platforms: ${{ env.DOCKER_PLATFORMS }}
-          dockerfile: operate.Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -780,3 +780,12 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
           dockerfile: camunda.Dockerfile
           push: true
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

I noticed that all `main` branch builds since merge of https://github.com/camunda/camunda/pull/24522 have a failing `deploy-camunda-docker-snapshot` job in the very last step. That step tries to upload the `camunda/operate:SNAPSHOT` Docker image and was added when the `operate-ci-merge.yml` was removed. It fails because the credentials it uses (rightfully) lack permission to write `camunda/operate` DockerHub repository - the job is only meant to write `camunda/camunda` (yay least privilege!).

This failure on `main` did not impact anyone since the upload of `camunda/camunda:SNAPSHOT` is done before the always failing step. The [operate-ci.yml](https://github.com/camunda/camunda/actions/runs/11954148122/job/33323598412#step:9:2441) is responsible for the upload of `camunda/operate:SNAPSHOT` and continued to do so fine.

The failure went unnoticed for 2 days since `deploy-camunda-docker-snapshot` was never instrumented to report CI Health data (otherwise alerts would've cought it) since [its introduction](https://github.com/camunda/camunda/commit/ec1c2c8e41e5b6f01992d4443916a14b696fca0d).

This PR does 2 things:

* remove the unnecessary (failing) last step of `deploy-camunda-docker-snapshot` job that tries to upload `camunda/operate:SNAPSHOT`
* adds CI Health reporting to `deploy-camunda-docker-snapshot` job to allow future detection

Mini incident review:

* what went well: "least privilege principle" works
* we got lucky: spotted failing `main` builds, failure did not impact any functionality, discovered lack of CI Health instrumentation (maybe some linter needed 🤔)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21436
