### PR TITLE
feat: include form metadata in reconstructed deployment

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
+import io.camunda.zeebe.engine.state.immutable.FormState.FormIdentifier;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState.ProcessIdentifier;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -142,7 +143,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
         });
 
     formState.forEachForm(
-        null,
+        new FormIdentifier(tenantId, deploymentKey),
         form -> {
           final var formDeploymentKey = form.getDeploymentKey();
           if (formDeploymentKey == deploymentKey) {
@@ -150,7 +151,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
             BufferUtil.copy(form, copy);
             resources.add(new FormResource(copy));
           }
-          return true;
+          return form.getTenantId().equals(tenantId) && formDeploymentKey == deploymentKey;
         });
 
     // TODO: Continue with decisionState

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -258,6 +258,26 @@ public class DbFormState implements MutableFormState {
   }
 
   @Override
+  public void forEachForm(final FormIdentifier previousForm, final PersistedFormVisitor visitor) {
+    if (previousForm == null) {
+      formsByKey.whileTrue((key, value) -> visitor.visit(value));
+      return;
+    }
+
+    tenantIdKey.wrapString(previousForm.tenantId());
+    dbFormKey.wrapLong(previousForm.key());
+    formsByKey.whileTrue(
+        tenantAwareFormKey,
+        (key, value) -> {
+          if (key.tenantKey().toString().equals(previousForm.tenantId())
+              && key.wrappedKey().getValue() == previousForm.key()) {
+            return true;
+          }
+          return visitor.visit(value);
+        });
+  }
+
+  @Override
   public int getNextFormVersion(final String formId, final String tenantId) {
     return (int) versionManager.getHighestResourceVersion(formId, tenantId) + 1;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormMetadataRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+
+public final class DeploymentResourceUtil {
+  private final ChecksumGenerator checksumGenerator = new ChecksumGenerator();
+
+  public void applyProcessMetadata(final PersistedProcess source, final ProcessMetadata target) {
+    target.setKey(source.getKey());
+    target.setBpmnProcessId(source.getBpmnProcessId());
+    target.setResourceName(source.getResourceName());
+    target.setVersion(source.getVersion());
+    target.setVersionTag(source.getVersionTag());
+    target.setTenantId(source.getTenantId());
+    target.setDeploymentKey(source.getDeploymentKey());
+    target.setChecksum(checksumGenerator.checksum(source.getResource()));
+  }
+
+  public void applyFormMetadata(final PersistedForm source, final FormMetadataRecord target) {
+    target.setFormKey(source.getFormKey());
+    target.setFormId(BufferUtil.bufferAsString(source.getFormId()));
+    target.setResourceName(BufferUtil.bufferAsString(source.getResourceName()));
+    target.setVersion(source.getVersion());
+    target.setVersionTag(source.getVersionTag());
+    target.setTenantId(source.getTenantId());
+    target.setDeploymentKey(source.getDeploymentKey());
+    target.setChecksum(checksumGenerator.checksum(source.getResource()));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -56,6 +56,14 @@ public interface FormState {
       String formId, String versionTag, final String tenantId);
 
   /**
+   * Iterates over all persisted forms until the visitor returns false or all processes have been
+   * visited. If {@code previousForm} is not null, the iteration skips all forms that appear before
+   * it. The visitor is <em>not</em> called with a copy of the form to avoid needless copies of the
+   * relatively large {@link PersistedForm} instances.
+   */
+  void forEachForm(FormIdentifier previousForm, PersistedFormVisitor visitor);
+
+  /**
    * Gets the next version a form of a given id will receive. This is used, for example, when a new
    * deployment is done. Using this method we decide the version the newly deployed form receives.
    *
@@ -64,4 +72,10 @@ public interface FormState {
   int getNextFormVersion(String formId, String tenantId);
 
   void clearCache();
+
+  record FormIdentifier(String tenantId, long key) {}
+
+  interface PersistedFormVisitor {
+    boolean visit(final PersistedForm form);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -212,6 +213,128 @@ final class DeploymentReconstructProcessorTest {
                   .satisfies(
                       deploymentRecord -> {
                         assertThat(deploymentRecord.getProcessesMetadata()).hasSize(2);
+                        assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(deploymentKey);
+                      });
+            });
+  }
+
+  @Test
+  void shouldReconstructForSingleFormWithoutDeploymentKey() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    final var formKey = Protocol.encodePartitionId(1, 2);
+    state
+        .getFormState()
+        .storeFormInFormColumnFamily(
+            new FormRecord()
+                .setFormKey(formKey)
+                .setFormId("form")
+                .setResourceName("form.form")
+                .setVersion(1));
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record -> {
+              assertThat(record.getIntent()).isEqualTo(DeploymentIntent.RECONSTRUCTED);
+              assertThat(record.getKey()).isEqualTo(formKey);
+              assertThat(record.getValue())
+                  .asInstanceOf(InstanceOfAssertFactories.type(DeploymentRecord.class))
+                  .satisfies(
+                      deploymentRecord -> {
+                        assertThat(deploymentRecord.getFormMetadata()).hasSize(1);
+                        assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(formKey);
+                      });
+            });
+  }
+
+  @Test
+  void shouldReconstructForSingleFormWithDeploymentKey() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    final var deploymentKey = Protocol.encodePartitionId(1, 1);
+    final var formKey = Protocol.encodePartitionId(1, 2);
+    state
+        .getFormState()
+        .storeFormInFormColumnFamily(
+            new FormRecord()
+                .setDeploymentKey(deploymentKey)
+                .setFormKey(formKey)
+                .setFormId("form")
+                .setResourceName("form.form")
+                .setVersion(1));
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record -> {
+              assertThat(record.getIntent()).isEqualTo(DeploymentIntent.RECONSTRUCTED);
+              assertThat(record.getKey()).isEqualTo(deploymentKey);
+              assertThat(record.getValue())
+                  .asInstanceOf(InstanceOfAssertFactories.type(DeploymentRecord.class))
+                  .satisfies(
+                      deploymentRecord -> {
+                        assertThat(deploymentRecord.getFormMetadata()).hasSize(1);
+                        assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(deploymentKey);
+                      });
+            });
+  }
+
+  @Test
+  void shouldIncludeAllFormsOfDeployment() {
+    // given
+    final var command = mock(TypedRecord.class);
+    when(command.getValue()).thenReturn(new DeploymentRecord());
+
+    final var deploymentKey = Protocol.encodePartitionId(1, 1);
+    final var formKey1 = Protocol.encodePartitionId(1, 2);
+    final var formKey2 = Protocol.encodePartitionId(1, 3);
+    state
+        .getFormState()
+        .storeFormInFormColumnFamily(
+            new FormRecord()
+                .setDeploymentKey(deploymentKey)
+                .setFormKey(formKey1)
+                .setFormId("form1")
+                .setResourceName("form1.form")
+                .setVersion(1));
+    state
+        .getFormState()
+        .storeFormInFormColumnFamily(
+            new FormRecord()
+                .setDeploymentKey(deploymentKey)
+                .setFormKey(formKey2)
+                .setFormId("form2")
+                .setResourceName("form2.form")
+                .setVersion(1));
+
+    // when
+    processor.processRecord(command);
+
+    // then
+    assertThat(resultBuilder.getFollowupRecords())
+        .singleElement()
+        .satisfies(
+            record -> {
+              assertThat(record.getIntent()).isEqualTo(DeploymentIntent.RECONSTRUCTED);
+              assertThat(record.getKey()).isEqualTo(deploymentKey);
+              assertThat(record.getValue())
+                  .asInstanceOf(InstanceOfAssertFactories.type(DeploymentRecord.class))
+                  .satisfies(
+                      deploymentRecord -> {
+                        assertThat(deploymentRecord.getFormMetadata()).hasSize(2);
                         assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(deploymentKey);
                       });
             });

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -248,7 +249,12 @@ final class DeploymentReconstructProcessorTest {
                   .asInstanceOf(InstanceOfAssertFactories.type(DeploymentRecord.class))
                   .satisfies(
                       deploymentRecord -> {
-                        assertThat(deploymentRecord.getFormMetadata()).hasSize(1);
+                        assertThat(deploymentRecord.getFormMetadata())
+                            .singleElement()
+                            .returns(formKey, FormMetadataValue::getFormKey)
+                            .returns("form", FormMetadataValue::getFormId)
+                            .returns("form.form", FormMetadataValue::getResourceName)
+                            .returns(1, FormMetadataValue::getVersion);
                         assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(formKey);
                       });
             });

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import java.util.function.LongConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -85,12 +86,19 @@ public class FormStateTest {
     formState.storeFormInFormColumnFamily(form3);
 
     // when -- iterating through all forms
-    final var visitor = Mockito.mock(PersistedFormVisitor.class);
-    when(visitor.visit(any())).thenReturn(true);
-    formState.forEachForm(null, visitor);
+    final var visitor = Mockito.mock(LongConsumer.class);
+
+    formState.forEachForm(
+        null,
+        (form) -> {
+          visitor.accept(form.getFormKey());
+          return true;
+        });
 
     // then -- visited all three forms
-    verify(visitor, times(3)).visit(any());
+    verify(visitor).accept(form1.getFormKey());
+    verify(visitor).accept(form2.getFormKey());
+    verify(visitor).accept(form3.getFormKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -8,13 +8,22 @@
 package io.camunda.zeebe.engine.state.deployment;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.state.immutable.FormState.FormIdentifier;
+import io.camunda.zeebe.engine.state.immutable.FormState.PersistedFormVisitor;
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 @ExtendWith(ProcessingStateExtension.class)
 public class FormStateTest {
@@ -62,5 +71,53 @@ public class FormStateTest {
 
     // then
     assertThat(persistedForm).isEmpty();
+  }
+
+  @Test
+  void shouldIterateThroughAllForms() {
+    // give -- three forms exist in the state
+    final var form1 = createFormRecord(1);
+    final var form2 = createFormRecord(2);
+    final var form3 = createFormRecord(3);
+
+    formState.storeFormInFormColumnFamily(form1);
+    formState.storeFormInFormColumnFamily(form2);
+    formState.storeFormInFormColumnFamily(form3);
+
+    // when -- iterating through all forms
+    final var visitor = Mockito.mock(PersistedFormVisitor.class);
+    when(visitor.visit(any())).thenReturn(true);
+    formState.forEachForm(null, visitor);
+
+    // then -- visited all three forms
+    verify(visitor, times(3)).visit(any());
+  }
+
+  @Test
+  void shouldSkipBeforeIteratingThroughAllForms() {
+    // give -- three forms exist in the state
+    final var form1 = createFormRecord(1);
+    final var form2 = createFormRecord(2);
+    final var form3 = createFormRecord(3);
+
+    formState.storeFormInFormColumnFamily(form1);
+    formState.storeFormInFormColumnFamily(form2);
+    formState.storeFormInFormColumnFamily(form3);
+
+    // when -- iterating through all forms
+    final var visitor = Mockito.mock(PersistedFormVisitor.class);
+    when(visitor.visit(any())).thenReturn(true);
+    formState.forEachForm(new FormIdentifier(form1.getTenantId(), form1.getFormKey()), visitor);
+
+    // then -- visited only the last form
+    verify(visitor, times(2)).visit(any());
+  }
+
+  private FormRecord createFormRecord(final long key) {
+    return new FormRecord()
+        .setFormId("form")
+        .setResourceName("form.form")
+        .setVersion(1)
+        .setFormKey(Protocol.encodePartitionId(1, key));
   }
 }


### PR DESCRIPTION
This extends deployment reconstruction with support for Form metadata. I've followed the same pattern that we used for process metadata.

A new utility class is added to convert between the persisted resource and the metadata record.


depends on #24866
relates to  #24817
