### PR TITLE
feat: c8run keystore flag to support TLS in c8run

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -38,6 +38,10 @@ jobs:
         run: go build
         working-directory: ./c8run
 
+      - name: Unit tests
+        run: go test
+        working-directory: ./c8run
+
       - name: make a package
         run: ./c8run package
         working-directory: ./c8run
@@ -146,6 +150,13 @@ jobs:
 
       - name: Set env
         run: echo "JAVA_HOME=$env:JAVA_HOME_22_x64" >> $env:GITHUB_ENV
+
+      - name: Unit tests
+        run: go test
+        working-directory: .\c8run
+        shell: cmd
+        env:
+          JAVA_VERSION: "22.0.2"
 
       - name: Run c8run
         run: .\c8run.exe start

--- a/c8run/go.mod
+++ b/c8run/go.mod
@@ -1,3 +1,11 @@
 module github.com/camunda/camunda/c8run
 
 go 1.23.1
+
+require github.com/stretchr/testify v1.9.0
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/c8run/go.sum
+++ b/c8run/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-func (w *UnixC8Run) OpenBrowser() error {
+func (w *UnixC8Run) OpenBrowser(protocol string) error {
 	panic("Platform was not built for unix")
 }
 
@@ -28,6 +28,6 @@ func (w *UnixC8Run) ConnectorsCmd(javaBinary string, parentDir string, camundaVe
 
 }
 
-func (w *UnixC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string) *exec.Cmd {
+func (w *UnixC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd {
 	panic("Platform was not built for unix")
 }

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -12,8 +12,8 @@ import (
 	"syscall"
 )
 
-func (w *UnixC8Run) OpenBrowser() error {
-	operateUrl := "http://localhost:8080/operate/login"
+func (w *UnixC8Run) OpenBrowser(protocol string) error {
+	operateUrl := protocol + "://localhost:8080/operate/login"
 	var openBrowserCmdString string
 	if runtime.GOOS == "darwin" {
 		openBrowserCmdString = "open"
@@ -58,9 +58,12 @@ func (w *UnixC8Run) ConnectorsCmd(javaBinary string, parentDir string, camundaVe
 	return connectorsCmd
 }
 
-func (w *UnixC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string) *exec.Cmd {
+func (w *UnixC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd {
 	camundaCmdString := parentDir + "/camunda-zeebe-" + camundaVersion + "/bin/camunda"
 	camundaCmd := exec.Command(camundaCmdString, extraArgs)
+	if javaOpts != "" {
+		camundaCmd.Env = append(os.Environ(), "JAVA_OPTS="+javaOpts)
+	}
 	camundaCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	return camundaCmd
 }

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-func (w *WindowsC8Run) OpenBrowser() error {
+func (w *WindowsC8Run) OpenBrowser(protocol string) error {
 	panic("Platform was not built for windows")
 }
 
@@ -28,6 +28,6 @@ func (w *WindowsC8Run) ConnectorsCmd(javaBinary string, parentDir string, camund
 
 }
 
-func (w *WindowsC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string) *exec.Cmd {
+func (w *WindowsC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd {
 	panic("Platform was not built for windows")
 }

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -11,8 +11,8 @@ import (
 	"syscall"
 )
 
-func (w *WindowsC8Run) OpenBrowser() error {
-	operateUrl := "http://localhost:8080/operate/login"
+func (w *WindowsC8Run) OpenBrowser(protocol string) error {
+	operateUrl := protocol + "://localhost:8080/operate/login"
 	openBrowserCmdString := "start " + operateUrl
 	openBrowserCmd := exec.Command("cmd", "/C", openBrowserCmdString)
 	openBrowserCmd.SysProcAttr = &syscall.SysProcAttr{
@@ -54,8 +54,11 @@ func (w *WindowsC8Run) ConnectorsCmd(javaBinary string, parentDir string, camund
 	return connectorsCmd
 }
 
-func (w *WindowsC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string) *exec.Cmd {
+func (w *WindowsC8Run) CamundaCmd(camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd {
 	camundaCmd := exec.Command(".\\camunda-zeebe-"+camundaVersion+"\\bin\\camunda.bat", extraArgs)
+	if javaOpts != "" {
+		camundaCmd.Env = append(os.Environ(), "JAVA_OPTS="+javaOpts)
+	}
 	camundaCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000008 | 0x00000200, // DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -110,6 +110,13 @@ func getC8RunPlatform() C8Run {
 	panic("Unsupported operating system")
 }
 
+func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
+	if settings.keystore != "" && settings.keystorePassword != "" {
+		javaOpts = javaOpts + " -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
+	}
+	return javaOpts
+}
+
 func main() {
 	c8 := getC8RunPlatform()
 	baseDir, _ := os.Getwd()
@@ -149,7 +156,7 @@ func main() {
 	} else if os.Args[1] == "clean" {
 		baseCommand = "clean"
 	} else if os.Args[1] == "-h" || os.Args[1] == "--help" {
-		fmt.Println("Usage: c8run [command] [options]\nCommands:\n  start\n  stop\n  package\n")
+		fmt.Println("Usage: c8run [command] [options]\nCommands:\n  start\n  stop\n  package")
 		os.Exit(0)
 	} else {
 		panic("Unsupported operation")
@@ -256,9 +263,7 @@ func main() {
 		if javaOpts != "" {
 			fmt.Print("JAVA_OPTS: " + javaOpts + "\n")
 		}
-		if settings.keystore != "" && settings.keystorePassword != "" {
-			javaOpts = javaOpts + " -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
-		}
+		javaOpts = adjustJavaOpts(javaOpts, settings)
 
 		os.Setenv("ES_JAVA_OPTS", "-Xms1g -Xmx1g")
 

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -117,6 +117,20 @@ func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
 	return javaOpts
 }
 
+func validateKeystore(settings C8RunSettings, parentDir string) error {
+	if settings.keystore != "" {
+		if settings.keystorePassword == "" {
+			return fmt.Errorf("You must provide a password with --keystorePassword to unlock your keystore.")
+		}
+		if settings.keystore != "" {
+			if !strings.HasPrefix(settings.keystore, "/") {
+				settings.keystore = filepath.Join(parentDir, settings.keystore)
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
 	c8 := getC8RunPlatform()
 	baseDir, _ := os.Getwd()
@@ -175,16 +189,10 @@ func main() {
 		startFlagSet.Parse(os.Args[2:])
 	}
 
-	if settings.keystore != "" {
-		if settings.keystorePassword == "" {
-			fmt.Println("You must provide a password with --keystorePassword to unlock your keystore.")
-			os.Exit(1)
-		}
-		if settings.keystore != "" {
-			if !strings.HasPrefix(settings.keystore, "/") {
-				settings.keystore = filepath.Join(parentDir, settings.keystore)
-			}
-		}
+	err := validateKeystore(settings, parentDir)
+	if err != nil {
+		fmt.Println(err.Error())
+		os.Exit(1)
 	}
 
 	javaHome := os.Getenv("JAVA_HOME")

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package main
+
+import (
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+)
+
+func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
+
+	settings := C8RunSettings{
+		config:           "",
+		detached:         false,
+		keystore:         "/tmp/camundatest/certs/secret.jks",
+		keystorePassword: "changeme",
+	}
+	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
+
+	javaOpts := adjustJavaOpts("", settings)
+	c8runPlatform := getC8RunPlatform()
+
+	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
+
+	foundVar := ""
+	for _, envVar := range cmd.Env {
+		if strings.Contains(envVar, "JAVA_OPTS") {
+			foundVar = envVar
+			break
+		}
+	}
+	assert.Equal(t, expectedJavaOpts, foundVar)
+}
+
+func TestCamundaCmdHasNoJavaOpts(t *testing.T) {
+
+	settings := C8RunSettings{
+		config:           "",
+		detached:         false,
+		keystore:         "",
+		keystorePassword: "",
+	}
+
+	javaOpts := adjustJavaOpts("", settings)
+	c8runPlatform := getC8RunPlatform()
+
+	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
+
+	for _, envVar := range cmd.Env {
+		if strings.Contains(envVar, "JAVA_OPTS") {
+			assert.Fail(t, "JAVA_OPTS should not be set")
+		}
+	}
+}

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -25,6 +25,8 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 
 	javaOpts := adjustJavaOpts("", settings)
 	c8runPlatform := getC8RunPlatform()
+	err := validateKeystore(settings, "/tmp/camundatest/")
+	assert.Nil(t, err)
 
 	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
 
@@ -49,6 +51,8 @@ func TestCamundaCmdHasNoJavaOpts(t *testing.T) {
 
 	javaOpts := adjustJavaOpts("", settings)
 	c8runPlatform := getC8RunPlatform()
+	err := validateKeystore(settings, "/tmp/camundatest/")
+	assert.Nil(t, err)
 
 	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
 
@@ -57,4 +61,18 @@ func TestCamundaCmdHasNoJavaOpts(t *testing.T) {
 			assert.Fail(t, "JAVA_OPTS should not be set")
 		}
 	}
+}
+
+func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {
+
+	settings := C8RunSettings{
+		config:           "",
+		detached:         false,
+		keystore:         "/tmp/camundatest/certs/secret.jks",
+		keystorePassword: "",
+	}
+	err := validateKeystore(settings, "/tmp/camundatest/")
+
+	assert.NotNil(t, err)
+	assert.Error(t, err, "You must provide a password with --keystorePassword to unlock your keystore.")
 }

--- a/c8run/types.go
+++ b/c8run/types.go
@@ -6,15 +6,17 @@ import (
 )
 
 type C8Run interface {
-	OpenBrowser() error
+	OpenBrowser(protocol string) error
 	ProcessTree(commandPid int) []*os.Process
 	VersionCmd(javaBinaryPath string) *exec.Cmd
 	ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd
 	ConnectorsCmd(javaBinary string, parentDir string, camundaVersion string) *exec.Cmd
-	CamundaCmd(camundaVersion string, parentDir string, extraArgs string) *exec.Cmd
+	CamundaCmd(camundaVersion string, parentDir string, extraArgs string, javaOpts string) *exec.Cmd
 }
 
 type C8RunSettings struct {
-	config   string
-	detached bool
+	config           string
+	detached         bool
+	keystore         string
+	keystorePassword string
 }


### PR DESCRIPTION
## Description

closes #25000 ,

This PR adds the options `--keystore` and `--keystorePassword` which will enable TLS support in c8run when set. 

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
