### PR TITLE
Operate import metric

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -58,6 +58,9 @@ public class Metrics {
   public static final String GAUGE_BPMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.bpmn.count";
   public static final String GAUGE_DMN_MODEL_COUNT = OPERATE_NAMESPACE + "model.dmn.count";
 
+  public static final String GAUGE_NAME_IMPORT_POSITION_COMPLETED =
+      OPERATE_NAMESPACE + "import.completed";
+
   public static final String GAUGE_NAME_IMPORT_FNI_TREE_PATH_CACHE_SIZE =
       OPERATE_NAMESPACE + "import.fni.tree.path.cache.size";
 
@@ -66,6 +69,7 @@ public class Metrics {
   //  Keys:
   public static final String TAG_KEY_NAME = "name",
       TAG_KEY_TYPE = "type",
+      TAG_KEY_IMPORT_POS_ALIAS = "importPositionAlias",
       TAG_KEY_PARTITION = "partition",
       TAG_KEY_STATUS = "status",
       TAG_KEY_ORGANIZATIONID = "organizationId";

--- a/operate/common/src/main/java/io/camunda/operate/Metrics.java
+++ b/operate/common/src/main/java/io/camunda/operate/Metrics.java
@@ -96,12 +96,18 @@ public class Metrics {
     registry.counter(OPERATE_NAMESPACE + name, tags).increment(count);
   }
 
-  public <T> void registerGauge(
+  public <T> Gauge registerGauge(
       final String name,
       final T stateObject,
       final ToDoubleFunction<T> valueFunction,
       final String... tags) {
-    Gauge.builder(name, stateObject, valueFunction).tags(tags).register(registry);
+    return Gauge.builder(name, () -> valueFunction.applyAsDouble(stateObject))
+        .tags(tags)
+        .register(registry);
+  }
+
+  public Gauge getGauge(final String name, final String... tags) {
+    return registry.get(name).tags(tags).gauge();
   }
 
   public void registerGaugeSupplier(

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
@@ -11,6 +11,7 @@ import io.camunda.operate.Metrics;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ImportStore;
 import io.camunda.webapps.schema.entities.operate.ImportPositionEntity;
+import io.micrometer.core.instrument.Gauge;
 import jakarta.annotation.PostConstruct;
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -42,6 +43,7 @@ public class ImportPositionHolder {
       new HashMap<>();
   private final Map<String, ImportPositionEntity> inflightImportPositions = new HashMap<>();
   private final Map<String, ImportPositionEntity> inflightPostImportPositions = new HashMap<>();
+  private final Map<String, Gauge> importPositionCompletedGauges = new HashMap<>();
 
   private ScheduledFuture<?> scheduledImportPositionUpdateTask;
   private final ReentrantLock inflightImportPositionLock = new ReentrantLock();
@@ -128,14 +130,16 @@ public class ImportPositionHolder {
           if (importPosition == null) {
             importPosition = lastProcessedPosition;
             LOGGER.error("SET import position {}; NOT EXIST BEFORE", importPosition);
-            metrics.registerGauge(
-                Metrics.GAUGE_NAME_IMPORT_POSITION_COMPLETED,
-                importPosition,
-                (pos) -> pos.getCompleted() ? 1.0 : 0.0,
-                Metrics.TAG_KEY_PARTITION,
-                Integer.toString(partition),
-                Metrics.TAG_KEY_IMPORT_POS_ALIAS,
-                aliasName);
+            importPositionCompletedGauges.put(
+                key,
+                metrics.registerGauge(
+                    Metrics.GAUGE_NAME_IMPORT_POSITION_COMPLETED,
+                    importPosition,
+                    (pos) -> pos.getCompleted() ? 1.0 : 0.0,
+                    Metrics.TAG_KEY_PARTITION,
+                    Integer.toString(partition),
+                    Metrics.TAG_KEY_IMPORT_POS_ALIAS,
+                    aliasName));
           } else {
             importPosition
                 .setPosition(lastProcessedPosition.getPosition())
@@ -145,7 +149,8 @@ public class ImportPositionHolder {
             LOGGER.error("SET import position {}; HAS EXIST BEFORE", importPosition);
           }
           inflightImportPositions.put(key, importPosition);
-        });
+        },
+        "record last loaded pos");
   }
 
   public void recordLatestPostImportedPosition(
@@ -164,7 +169,8 @@ public class ImportPositionHolder {
                 lastPostImportedPosition.getPostImporterPosition());
           }
           inflightPostImportPositions.put(key, importPosition);
-        });
+        },
+        "record latest post import");
   }
 
   public void updateImportPositions() {
@@ -174,7 +180,8 @@ public class ImportPositionHolder {
           inflightImportPositions.clear();
           pendingPostImportPositionUpdates.putAll(inflightPostImportPositions);
           inflightPostImportPositions.clear();
-        });
+        },
+        "update positions");
 
     final var result =
         importStore.updateImportPositions(
@@ -196,24 +203,28 @@ public class ImportPositionHolder {
     lastScheduledPositions.clear();
     pendingImportPositionUpdates.clear();
     pendingPostImportPositionUpdates.clear();
+    importPositionCompletedGauges.clear();
 
     withInflightImportPositionLock(
         () -> {
           inflightImportPositions.clear();
           inflightPostImportPositions.clear();
-        });
+        },
+        "clear");
   }
 
   private String getKey(final String aliasTemplate, final int partitionId) {
     return String.format("%s-%d", aliasTemplate, partitionId);
   }
 
-  private void withInflightImportPositionLock(final Runnable action) {
+  private void withInflightImportPositionLock(final Runnable action, final String name) {
     try {
+      LOGGER.error("access LOCK {} - {}", Thread.currentThread().getName(), name);
       inflightImportPositionLock.lock();
       action.run();
     } finally {
       inflightImportPositionLock.unlock();
+      LOGGER.error("release LOCK {} - {}", Thread.currentThread().getName(), name);
     }
   }
 }

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportPositionHolder.java
@@ -127,6 +127,7 @@ public class ImportPositionHolder {
           ImportPositionEntity importPosition = inflightImportPositions.get(key);
           if (importPosition == null) {
             importPosition = lastProcessedPosition;
+            LOGGER.error("SET import position {}; NOT EXIST BEFORE", importPosition);
             metrics.registerGauge(
                 Metrics.GAUGE_NAME_IMPORT_POSITION_COMPLETED,
                 importPosition,
@@ -141,6 +142,7 @@ public class ImportPositionHolder {
                 .setSequence(lastProcessedPosition.getSequence())
                 .setIndexName(lastProcessedPosition.getIndexName())
                 .setCompleted(lastProcessedPosition.getCompleted());
+            LOGGER.error("SET import position {}; HAS EXIST BEFORE", importPosition);
           }
           inflightImportPositions.put(key, importPosition);
         });

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/RecordsReaderHolder.java
@@ -110,6 +110,11 @@ public class RecordsReaderHolder {
     countEmptyBatchesAfterImportingDone.replaceAll((k, v) -> v = 0);
   }
 
+  @VisibleForTesting
+  public void resetPartitionsCompletedImporting() {
+    partitionsCompletedImporting.clear();
+  }
+
   public RecordsReader getRecordsReader(
       final int partitionId, final ImportValueType importValueType) {
     for (final RecordsReader recordsReader : recordsReaders) {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/FinishedImportingIT.java
@@ -76,6 +76,7 @@ public class FinishedImportingIT extends OperateZeebeAbstractIT {
     EXPORTER.open(new ExporterTestController());
 
     recordsReaderHolder.resetCountEmptyBatches();
+    importPositionHolder.clearCache();
 
     final MeterRegistry metrics = beanFactory.getBean(MeterRegistry.class);
     metrics.clear();


### PR DESCRIPTION
## Description

* Add new gauge to communicate that importing is done by partition and value type
     * This is useful for users to know when to stop the importer
     * This is useful for us to understand where importing stands, and which value type might not complete
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related https://github.com/camunda/camunda/issues/23913
