### PR TITLE
fix: missing @ReadOperation for GET /backup/{id} in BackupEndpointStandalone

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/BackupEndpointStandalone.java
@@ -32,6 +32,7 @@ public final class BackupEndpointStandalone {
     return backupEndpoint.take(backupId);
   }
 
+  @ReadOperation
   public WebEndpointResponse<?> status(@Selector @NonNull final long id) {
     return backupEndpoint.status(id);
   }


### PR DESCRIPTION
## Related issues


closes #24850
