### PR TITLE
feat: support patch permissions of an authorizations

### DIFF
--- a/identity/client/package.json
+++ b/identity/client/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@camunda/camunda-composite-components": "0.11.0",
+    "@carbon/elements": "^11.57.0",
     "@carbon/react": "1.71.0",
     "i18next": "23.16.8",
     "react": "18.3.1",
@@ -29,6 +30,8 @@
     "styled-components": "6.1.13"
   },
   "devDependencies": {
+    "@types/carbon-components-react": "^7.55.13",
+    "@types/carbon__elements": "^11.10.3",
     "@types/event-source-polyfill": "1.0.5",
     "@types/node": "22.10.0",
     "@types/react": "18.3.12",

--- a/identity/client/src/components/documentation/index.tsx
+++ b/identity/client/src/components/documentation/index.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { linkInverse, spacing04 } from "@carbon/themes";
+import { linkInverse, spacing04 } from "@carbon/elements";
 import { Link } from "@carbon/react";
 import { FC, ReactNode } from "react";
 import useTranslate from "../../utility/localization";

--- a/identity/client/src/components/entityList/components.tsx
+++ b/identity/client/src/components/entityList/components.tsx
@@ -7,7 +7,7 @@
 
 import styled from "styled-components";
 import { TableContainer } from "@carbon/react";
-import { layer01, productiveHeading01, spacing04 } from "@carbon/themes";
+import { layer01, productiveHeading01, spacing04 } from "@carbon/elements";
 
 export const NoDataContainer = styled.div`
   padding: ${spacing04};

--- a/identity/client/src/components/form/Text.tsx
+++ b/identity/client/src/components/form/Text.tsx
@@ -1,4 +1,4 @@
-import { helperText01, textSecondary } from "@carbon/themes";
+import { helperText01, textSecondary } from "@carbon/elements";
 import styled from "styled-components";
 
 export const PrimaryText = styled.p`

--- a/identity/client/src/components/global/AppRoot.tsx
+++ b/identity/client/src/components/global/AppRoot.tsx
@@ -8,13 +8,13 @@
 
 import styled, { createGlobalStyle } from "styled-components";
 import { FC, ReactNode } from "react";
-import { background, bodyShort01 } from "@carbon/themes";
+import { background, bodyShort01 } from "@carbon/elements";
 import AppHeader from "src/components/layout/AppHeader";
 import ErrorBoundary from "src/components/global/ErrorBoundary";
 
 const GlobalStyle = createGlobalStyle`
   body {
-    background: ${background.background};
+    background: ${background};
     font-size: ${bodyShort01.fontSize};
     font-weight: ${bodyShort01.fontSize};
     line-height: ${bodyShort01.lineHeight};

--- a/identity/client/src/components/layout/Flex.tsx
+++ b/identity/client/src/components/layout/Flex.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 import styled from "styled-components";
-import { spacing02, spacing04, spacing06 } from "@carbon/themes";
+import { spacing02, spacing04, spacing06 } from "@carbon/elements";
 
 const spacingOptions = {
   small: spacing02,

--- a/identity/client/src/components/layout/Page.tsx
+++ b/identity/client/src/components/layout/Page.tsx
@@ -9,7 +9,7 @@
 import { FC, PointerEvent, ReactNode } from "react";
 import styled from "styled-components";
 import { Breadcrumb, BreadcrumbItem, Content, Stack } from "@carbon/react";
-import { spacing06 } from "@carbon/themes";
+import { spacing06 } from "@carbon/elements";
 import { cssSize } from "src/utility/style";
 import { useNavigate } from "react-router";
 

--- a/identity/client/src/components/layout/PageHeadline.tsx
+++ b/identity/client/src/components/layout/PageHeadline.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 import styled from "styled-components";
-import { spacing04, spacing05 } from "@carbon/themes";
+import { spacing04, spacing05 } from "@carbon/elements";
 
 const PageHeadline = styled.h1`
   display: flex;

--- a/identity/client/src/components/modal/FormModal.tsx
+++ b/identity/client/src/components/modal/FormModal.tsx
@@ -1,6 +1,6 @@
 import { FC, FormEvent } from "react";
 import { Form, Stack } from "@carbon/react";
-import { spacing04 } from "@carbon/themes";
+import { spacing04 } from "@carbon/elements";
 import styled from "styled-components";
 import Modal, { ModalProps } from "./Modal";
 import useTranslate from "../../utility/localization";

--- a/identity/client/src/components/modal/Modal.tsx
+++ b/identity/client/src/components/modal/Modal.tsx
@@ -11,9 +11,9 @@ import {
 import styled from "styled-components";
 import useTranslate from "src/utility/localization";
 
-const ModalWrapper = styled.div<{ overflowVisible: boolean }>`
-  ${({ overflowVisible }) =>
-    overflowVisible
+const ModalWrapper = styled.div<{ $overflowVisible: boolean }>`
+  ${({ $overflowVisible }) =>
+    $overflowVisible
       ? `
   & .cds--modal-content,
   & .cds--modal-container {
@@ -123,7 +123,9 @@ const Modal: FC<ModalProps> = ({
       </ComposedModal>
     );
 
-  return <ModalWrapper overflowVisible={overflowVisible}>{modal}</ModalWrapper>;
+  return (
+    <ModalWrapper $overflowVisible={overflowVisible}>{modal}</ModalWrapper>
+  );
 };
 
 export const DeleteModal: FC<

--- a/identity/client/src/components/notifications/InlineNotification.tsx
+++ b/identity/client/src/components/notifications/InlineNotification.tsx
@@ -4,7 +4,7 @@ import {
   ActionableNotification,
   InlineNotification as CarbonInlineNotification,
 } from "@carbon/react";
-import { spacing05 } from "@carbon/themes";
+import { spacing05 } from "@carbon/elements";
 import useTranslate from "src/utility/localization";
 import { NotificationOptions } from "./NotificationContext";
 

--- a/identity/client/src/components/notifications/Notification.tsx
+++ b/identity/client/src/components/notifications/Notification.tsx
@@ -2,7 +2,7 @@ import { FC, useEffect, useState } from "react";
 import { CSSTransition } from "react-transition-group";
 import styled from "styled-components";
 import { ToastNotification } from "@carbon/react";
-import { spacing03 } from "@carbon/themes";
+import { spacing03 } from "@carbon/elements";
 import { NotificationOptions } from "./NotificationContext";
 
 const NOTIFICATION_TIMEOUT = 5000;

--- a/identity/client/src/components/notifications/NotificationContainer.tsx
+++ b/identity/client/src/components/notifications/NotificationContainer.tsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { spacing03 } from "@carbon/themes";
+import { spacing03 } from "@carbon/elements";
 import { FC, ReactNode } from "react";
 import { TransitionGroup } from "react-transition-group";
 

--- a/identity/client/src/pages/groups/detail/index.tsx
+++ b/identity/client/src/pages/groups/detail/index.tsx
@@ -9,7 +9,7 @@
 import { FC } from "react";
 import { useNavigate, useParams } from "react-router";
 import { OverflowMenu, OverflowMenuItem, Section, Stack } from "@carbon/react";
-import { spacing02 } from "@carbon/themes";
+import { spacing02 } from "@carbon/elements";
 import useTranslate from "src/utility/localization";
 import { useApi } from "src/utility/api/hooks";
 import NotFound from "src/pages/not-found";

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -47,6 +47,7 @@ import { useEntityModal } from "src/components/modal";
 import { Authorization } from "src/utility/api/authorizations";
 import { DataTableRenderProps } from "@carbon/react/lib/components/DataTable/DataTable";
 import styled from "styled-components";
+import { gray30, spacing02, spacing04, spacing05 } from "@carbon/elements";
 
 type AuthorizationsListProps = {
   user: User;
@@ -59,18 +60,18 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
   const ToolbarContent = styled.div`
     display: flex;
     justify-content: flex-end;
-    gap: 16px; /* Replace with the appropriate Carbon spacing token */
+    gap: ${spacing05};
   `;
 
   const StyledListItem = styled(ListItem)`
     display: flex;
     justify-content: space-between;
     align-items: center;
-    padding-left: 10px;
+    padding-left: ${spacing04};
   `;
   const StyledDivider = styled(Section)`
-    margin: 5px 0;
-    border-top: 1px solid #ccc;
+    margin: ${spacing02} 0;
+    border-top: 1px solid ${gray30};
   `;
 
   const {

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -253,27 +253,6 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
                                 )}
                               </ul>
                             )}
-                            {/* Add button if not all permissions are present */}
-                            {/*{checkMissingPermissions(dataMap[row.id].permissions).length > 0 && (
-                                                    <div style={{ marginTop: '16px', textAlign: 'right' }}>
-                                                      <button
-                                                          type="button"
-                                                          onClick={() => onAddPermission(row)}
-                                                          style={{
-                                                            border: 'none',
-                                                            background: '#0f62fe',
-                                                            color: 'white',
-                                                            cursor: 'pointer',
-                                                            padding: '8px 16px',
-                                                            borderRadius: '4px',
-                                                          }}
-                                                          aria-label="Add permission"
-                                                      >
-                                                        <Add style={{ marginRight: '8px' }} />
-                                                        Add Permission
-                                                      </button>
-                                                    </div>
-                                                )}*/}
                           </TableExpandedRow>
                         )}
                       </React.Fragment>

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -40,7 +40,7 @@ import {
 } from "@carbon/react";
 
 import { useEntityModal } from "src/components/modal";
-import { Authorization, Permission } from "src/utility/api/authorizations";
+import { Authorization } from "src/utility/api/authorizations";
 import { DataTableRenderProps } from "@carbon/react/lib/components/DataTable/DataTable";
 
 type AuthorizationsListProps = {

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -92,7 +92,7 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
 
   const rows = rowsWithoutId.map((item, index) => ({
     ...item,
-    id: index,
+    id: String(index),
   }));
 
   // Create a lookup map for rows by ID
@@ -173,7 +173,10 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
                   <TableRow>
                     <TableExpandHeader />
                     {headers.map((header) => (
-                      <TableHeader {...getHeaderProps({ header })}>
+                      <TableHeader
+                        {...getHeaderProps({ header })}
+                        key={header.key}
+                      >
                         {header.header}
                       </TableHeader>
                     ))}
@@ -185,6 +188,7 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
                       <React.Fragment key={row.id}>
                         <TableExpandRow
                           {...getRowProps({ row })}
+                          key={row.key}
                           onClick={() => handleExpand(row.id)}
                           isExpanded={expandedRows[row.id]}
                         >
@@ -215,7 +219,7 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
                                           </div>
                                           <Button
                                             kind="ghost"
-                                            size="small"
+                                            size="sm"
                                             iconDescription={t(
                                               "Edit permission",
                                             )}

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -5,219 +5,253 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import React, {FC, useState} from "react";
-import {DocumentationDescription, NoDataBody, NoDataContainer, NoDataHeader,} from "src/components/entityList";
-import PatchModal, {ResourceType} from "src/pages/users/detail/authorization/PatchModal";
-import {Add, Edit} from "@carbon/react/icons";
-import useTranslate from "src/utility/localization";
-import {User} from "src/utility/api/users";
-import {getUserAuthorizations} from "src/utility/api/users/authorizations";
-import {DocumentationLink} from "src/components/documentation";
-import {TranslatedErrorInlineNotification} from "src/components/notifications/InlineNotification";
-import {useApi} from "src/utility/api";
+import React, { FC, useState } from "react";
 import {
-    DataTable,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableExpandedRow,
-    TableExpandHeader,
-    TableExpandRow,
-    TableHead,
-    TableHeader,
-    TableRow,
-    TableToolbar,
-    TableToolbarContent,
-    TableToolbarSearch
+  DocumentationDescription,
+  NoDataBody,
+  NoDataContainer,
+  NoDataHeader,
+} from "src/components/entityList";
+import PatchModal, {
+  ResourceType,
+} from "src/pages/users/detail/authorization/PatchModal";
+import { Add, Edit } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { User } from "src/utility/api/users";
+import { getUserAuthorizations } from "src/utility/api/users/authorizations";
+import { DocumentationLink } from "src/components/documentation";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import { useApi } from "src/utility/api";
+import {
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableExpandedRow,
+  TableExpandHeader,
+  TableExpandRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TableToolbarSearch,
 } from "@carbon/react";
 
-import {useEntityModal} from "src/components/modal";
-import {Authorization, Permission} from "src/utility/api/authorizations";
-import {DataTableRenderProps} from "@carbon/react/lib/components/DataTable/DataTable";
-
+import { useEntityModal } from "src/components/modal";
+import { Authorization, Permission } from "src/utility/api/authorizations";
+import { DataTableRenderProps } from "@carbon/react/lib/components/DataTable/DataTable";
 
 type AuthorizationsListProps = {
-    user: User;
-    loadingUser: boolean;
+  user: User;
+  loadingUser: boolean;
 };
 
-const List: FC<AuthorizationsListProps> = ({user, loadingUser}) => {
-    const {t, Translate} = useTranslate();
+const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
+  const { t, Translate } = useTranslate();
 
-    const {
-        data: authorizations,
-        loading: loadingAuthorizations,
-        success,
-        reload,
-    } = useApi(getUserAuthorizations, {key: user.key});
+  const {
+    data: authorizations,
+    loading: loadingAuthorizations,
+    success,
+    reload,
+  } = useApi(getUserAuthorizations, { key: user.key });
 
-    const loading = loadingUser || loadingAuthorizations;
+  const loading = loadingUser || loadingAuthorizations;
 
-    const areAuthorizationsEmpty =
-        !authorizations || authorizations.items.length === 0;
+  const areAuthorizationsEmpty =
+    !authorizations || authorizations.items.length === 0;
 
-    const headers = [
-        {header: t("ResourceType"), key: "resourceType"}
-    ];
+  const headers = [{ header: t("ResourceType"), key: "resourceType" }];
 
-    const rows = authorizations == null ? [] : authorizations.items
-    // Create a lookup map for rows by ID
-    const dataMap = rows.reduce((map, item) => {
-        map[item.key] = item;
-        return map;
-    }, {} as { [key: string]: typeof rows[0] });
-    console.log("ROWS", rows);
-    console.log("MAP", dataMap);
+  const rows = authorizations == null ? [] : authorizations.items;
+  // Create a lookup map for rows by ID
+  const dataMap = rows.reduce(
+    (map, item) => {
+      map[item.key] = item;
+      return map;
+    },
+    {} as { [key: string]: (typeof rows)[0] },
+  );
+  console.log("ROWS", rows);
+  console.log("MAP", dataMap);
 
-    const [expandedRows, setExpandedRows] = useState({});
+  const [expandedRows, setExpandedRows] = useState({});
 
-    const handleExpand = (rowId) => {
-        setExpandedRows((prev) => ({
-            ...prev,
-            [rowId]: !prev[rowId],
-        }));
-    };
+  const handleExpand = (rowId) => {
+    setExpandedRows((prev) => ({
+      ...prev,
+      [rowId]: !prev[rowId],
+    }));
+  };
 
-    const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
+  const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
 
-    const onEditPermission = (rowId: string, permissionIndex: number) => {
-        // Find the row by its ID and remove the permission at the given index
-        console.log(`Editing permission at index ${permissionIndex} for row with id: ${rowId}`);
-        // Logic to update state or trigger an API call to remove the permission
-        handleOpenPatchModal({
-            ownerKey: user.key,
-            resourceType: ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
-            permissionType: dataMap[rowId].permissions[permissionIndex].permissionType,
-            currentAuthorizations: rows
-        })
-    };
-
-    const documentationReference = (
-        <Translate>
-            Learn more about assigning authorizations to users in our{" "}
-            <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user"/>
-            .
-        </Translate>
+  const onEditPermission = (rowId: string, permissionIndex: number) => {
+    // Find the row by its ID and remove the permission at the given index
+    console.log(
+      `Editing permission at index ${permissionIndex} for row with id: ${rowId}`,
     );
+    // Logic to update state or trigger an API call to remove the permission
+    handleOpenPatchModal({
+      ownerKey: user.key,
+      resourceType:
+        ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
+      permissionType:
+        dataMap[rowId].permissions[permissionIndex].permissionType,
+      currentAuthorizations: rows,
+    });
+  };
 
-    return (
-        <>
-            <TableContainer title="Authorizations" description="Authorizations's of the user">
-                <DataTable<Authorization> rows={rows} headers={headers}>
-                    {({
-                          rows,
-                          headers,
-                          getHeaderProps,
-                          getRowProps,
-                          getTableProps
-                      }: DataTableRenderProps<Authorization, unknown[]>) => (
-                        <div>
-                            {/* Table Toolbar with Add Row Button */}
-                            <TableToolbar>
-                                <TableToolbarContent style={{display: 'flex', justifyContent: 'flex-end', gap: '16px'}}>
+  const documentationReference = (
+    <Translate>
+      Learn more about assigning authorizations to users in our{" "}
+      <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user" />
+      .
+    </Translate>
+  );
 
-                                    <TableToolbarSearch/>
-                                    <button
-                                        onClick={() => handleOpenPatchModal({ownerKey: user.key
-                                            , resourceType: null
-                                            , permissionType: null
-                                            , currentAuthorizations: rows})}
+  return (
+    <>
+      <TableContainer
+        title="Authorizations"
+        description="Authorizations's of the user"
+      >
+        <DataTable<Authorization> rows={rows} headers={headers}>
+          {({
+            rows,
+            headers,
+            getHeaderProps,
+            getRowProps,
+            getTableProps,
+          }: DataTableRenderProps<Authorization, unknown[]>) => (
+            <div>
+              {/* Table Toolbar with Add Row Button */}
+              <TableToolbar>
+                <TableToolbarContent
+                  style={{
+                    display: "flex",
+                    justifyContent: "flex-end",
+                    gap: "16px",
+                  }}
+                >
+                  <TableToolbarSearch />
+                  <button
+                    onClick={() =>
+                      handleOpenPatchModal({
+                        ownerKey: user.key,
+                        resourceType: null,
+                        permissionType: null,
+                        currentAuthorizations: rows,
+                      })
+                    }
+                    style={{
+                      border: "none",
+                      background: "#0f62fe",
+                      color: "white",
+                      cursor: "pointer",
+                      padding: "8px 16px",
+                      borderRadius: "4px",
+                      display: "flex",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Add style={{ marginRight: "8px" }} />
+                    Add Authorizations
+                  </button>
+                </TableToolbarContent>
+              </TableToolbar>
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    <TableExpandHeader />
+                    {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({ header })}>
+                        {header.header}
+                      </TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row) => {
+                    // Log the row object to the console for inspection
+                    console.log("Current Row:");
+                    console.log(row);
+
+                    return (
+                      <React.Fragment key={row.id}>
+                        <TableExpandRow
+                          {...getRowProps({ row })}
+                          onClick={() => handleExpand(row.id)}
+                          isExpanded={!!expandedRows[row.id]}
+                        >
+                          <TableCell>
+                            {
+                              row.cells.find(
+                                (cell) => cell.info.header === "resourceType",
+                              )?.value
+                            }
+                          </TableCell>
+                        </TableExpandRow>
+                        {expandedRows[row.id] && (
+                          <TableExpandedRow colSpan={headers.length + 2}>
+                            {/* Displaying list of permissions */}
+                            {dataMap[row.id]?.permissions && (
+                              <ul>
+                                {dataMap[row.id].permissions.map(
+                                  (permission, index) => (
+                                    <React.Fragment key={index}>
+                                      <li
                                         style={{
-                                            border: 'none',
-                                            background: '#0f62fe',
-                                            color: 'white',
-                                            cursor: 'pointer',
-                                            padding: '8px 16px',
-                                            borderRadius: '4px',
-                                            display: 'flex',
-                                            alignItems: 'center',
+                                          display: "flex",
+                                          justifyContent: "space-between",
+                                          alignItems: "center",
+                                          padding: "10px 0",
                                         }}
-                                    >
-                                        <Add style={{marginRight: '8px'}}/>
-                                        Add Authorizations
-                                    </button>
-
-                                </TableToolbarContent>
-                            </TableToolbar>
-                            <Table {...getTableProps()}>
-                                <TableHead>
-                                    <TableRow>
-                                        <TableExpandHeader/>
-                                        {headers.map((header) => (
-                                            <TableHeader {...getHeaderProps({header})}>
-                                                {header.header}
-                                            </TableHeader>
-                                        ))}
-                                    </TableRow>
-                                </TableHead>
-                                <TableBody>
-                                    {rows.map((row) => {
-                                        // Log the row object to the console for inspection
-                                        console.log("Current Row:");
-                                        console.log(row);
-
-                                        return (
-                                            <React.Fragment key={row.id}>
-                                                <TableExpandRow
-                                                    {...getRowProps({row})}
-                                                    onClick={() => handleExpand(row.id)}
-                                                    isExpanded={!!expandedRows[row.id]}
-                                                >
-                                                    <TableCell>
-                                                        {row.cells.find((cell) => cell.info.header === 'resourceType')?.value}
-                                                    </TableCell>
-                                                </TableExpandRow>
-                                                {expandedRows[row.id] && (
-                                                    <TableExpandedRow colSpan={headers.length + 2}>
-                                                        {/* Displaying list of permissions */}
-                                                        {dataMap[row.id]?.permissions && (
-                                                            <ul>
-                                                                {dataMap[row.id].permissions.map((permission, index) => (
-                                                                    <React.Fragment key={index}>
-                                                                        <li
-                                                                            style={{
-                                                                                display: 'flex',
-                                                                                justifyContent: 'space-between',
-                                                                                alignItems: 'center',
-                                                                                padding: '10px 0',
-                                                                            }}
-                                                                        >
-                                                                            <div>
-                                                                                <strong>Permission
-                                                                                    Type:</strong> {permission.permissionType}
-                                                                                <br/>
-                                                                                <strong>Resource
-                                                                                    IDs:</strong> {permission.resourceIds.join(', ')}
-                                                                            </div>
-                                                                            {/* Delete button at the end */}
-                                                                            <button
-                                                                                type="button"
-                                                                                onClick={() => onEditPermission(row.id, index)}
-                                                                                style={{
-                                                                                    border: 'none',
-                                                                                    background: 'none',
-                                                                                    cursor: 'pointer',
-                                                                                }}
-                                                                                aria-label="Delete permission"
-                                                                            >
-                                                                                <Edit/>
-                                                                            </button>
-                                                                        </li>
-                                                                        {/* Divider between permission rows */}
-                                                                        {index < dataMap[row.id].permissions.length - 1 && (
-                                                                            <hr style={{
-                                                                                border: 'none',
-                                                                                borderTop: '1px solid #ccc',
-                                                                                margin: '5px 0'
-                                                                            }}/>
-                                                                        )}
-                                                                    </React.Fragment>
-                                                                ))}
-                                                            </ul>
-                                                        )}
-                                                        {/* Add button if not all permissions are present */}
-                                                        {/*{checkMissingPermissions(dataMap[row.id].permissions).length > 0 && (
+                                      >
+                                        <div>
+                                          <strong>Permission Type:</strong>{" "}
+                                          {permission.permissionType}
+                                          <br />
+                                          <strong>Resource IDs:</strong>{" "}
+                                          {permission.resourceIds.join(", ")}
+                                        </div>
+                                        {/* Delete button at the end */}
+                                        <button
+                                          type="button"
+                                          onClick={() =>
+                                            onEditPermission(row.id, index)
+                                          }
+                                          style={{
+                                            border: "none",
+                                            background: "none",
+                                            cursor: "pointer",
+                                          }}
+                                          aria-label="Delete permission"
+                                        >
+                                          <Edit />
+                                        </button>
+                                      </li>
+                                      {/* Divider between permission rows */}
+                                      {index <
+                                        dataMap[row.id].permissions.length -
+                                          1 && (
+                                        <hr
+                                          style={{
+                                            border: "none",
+                                            borderTop: "1px solid #ccc",
+                                            margin: "5px 0",
+                                          }}
+                                        />
+                                      )}
+                                    </React.Fragment>
+                                  ),
+                                )}
+                              </ul>
+                            )}
+                            {/* Add button if not all permissions are present */}
+                            {/*{checkMissingPermissions(dataMap[row.id].permissions).length > 0 && (
                                                     <div style={{ marginTop: '16px', textAlign: 'right' }}>
                                                       <button
                                                           type="button"
@@ -237,47 +271,44 @@ const List: FC<AuthorizationsListProps> = ({user, loadingUser}) => {
                                                       </button>
                                                     </div>
                                                 )}*/}
-                                                    </TableExpandedRow>
-                                                )}
-                                            </React.Fragment>
-                                        );
-                                    })}
-                                </TableBody>
-                            </Table>
-                        </div>
-                    )}
-                </DataTable>
-            </TableContainer>
+                          </TableExpandedRow>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </DataTable>
+      </TableContainer>
 
-            {success && !areAuthorizationsEmpty && (
-                <DocumentationDescription>
-                    {documentationReference}
-                </DocumentationDescription>
-            )}
-            {!loading && areAuthorizationsEmpty && (
-                <div>
-                    {success && (
-                        <NoDataContainer>
-                            <NoDataHeader>
-                                <Translate>No authorizations assigned to this user</Translate>
-                            </NoDataHeader>
-                            <NoDataBody>{documentationReference}</NoDataBody>
-                        </NoDataContainer>
-                    )}
-                </div>
-            )}
-            {!loading && !success && (
-                <TranslatedErrorInlineNotification
-                    title="The list of authorizations could not be loaded."
-                    actionButton={{label: "Retry", onClick: reload}}
-                />
-            )}
-            {patchModal}
-        </>
-    );
+      {success && !areAuthorizationsEmpty && (
+        <DocumentationDescription>
+          {documentationReference}
+        </DocumentationDescription>
+      )}
+      {!loading && areAuthorizationsEmpty && (
+        <div>
+          {success && (
+            <NoDataContainer>
+              <NoDataHeader>
+                <Translate>No authorizations assigned to this user</Translate>
+              </NoDataHeader>
+              <NoDataBody>{documentationReference}</NoDataBody>
+            </NoDataContainer>
+          )}
+        </div>
+      )}
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title="The list of authorizations could not be loaded."
+          actionButton={{ label: "Retry", onClick: reload }}
+        />
+      )}
+      {patchModal}
+    </>
+  );
 };
 
 export default List;
-
-
-

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -54,25 +54,25 @@ type AuthorizationsListProps = {
   loadingUser: boolean;
 };
 
+const ToolbarContent = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${spacing05};
+`;
+
+const StyledListItem = styled(ListItem)`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-left: ${spacing04};
+`;
+const StyledDivider = styled(Section)`
+  margin: ${spacing02} 0;
+  border-top: 1px solid ${gray30};
+`;
+
 const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
   const { t, Translate } = useTranslate();
-
-  const ToolbarContent = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    gap: ${spacing05};
-  `;
-
-  const StyledListItem = styled(ListItem)`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding-left: ${spacing04};
-  `;
-  const StyledDivider = styled(Section)`
-    margin: ${spacing02} 0;
-    border-top: 1px solid ${gray30};
-  `;
 
   const {
     data: authorizations,

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -5,283 +5,269 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import React, { FC, useState } from "react";
-import {
-  DocumentationDescription,
-  NoDataBody,
-  NoDataContainer,
-  NoDataHeader,
-} from "src/components/entityList";
-import PatchModal, {
-  ResourceType,
-} from "src/pages/users/detail/authorization/PatchModal";
-import { Add, Edit } from "@carbon/react/icons";
+import React, {FC, useState} from "react";
+import {DocumentationDescription, NoDataBody, NoDataContainer, NoDataHeader,} from "src/components/entityList";
+import PatchModal, {ResourceType,} from "src/pages/users/detail/authorization/PatchModal";
+import {Edit} from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
-import { User } from "src/utility/api/users";
-import { getUserAuthorizations } from "src/utility/api/users/authorizations";
-import { DocumentationLink } from "src/components/documentation";
-import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
-import { useApi } from "src/utility/api";
+import {User} from "src/utility/api/users";
+import {getUserAuthorizations} from "src/utility/api/users/authorizations";
+import {DocumentationLink} from "src/components/documentation";
+import {TranslatedErrorInlineNotification} from "src/components/notifications/InlineNotification";
+import {useApi} from "src/utility/api";
 import {
-  DataTable,
-  Table,
-  TableBody,
-  TableCell,
-  TableContainer,
-  TableExpandedRow,
-  TableExpandHeader,
-  TableExpandRow,
-  TableHead,
-  TableHeader,
-  TableRow,
-  TableToolbar,
-  TableToolbarContent,
-  TableToolbarSearch,
+    Button,
+    DataTable,
+    ListItem,
+    Section,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableExpandedRow,
+    TableExpandHeader,
+    TableExpandRow,
+    TableHead,
+    TableHeader,
+    TableRow,
+    TableToolbar,
+    TableToolbarContent,
+    TableToolbarSearch,
+    UnorderedList,
 } from "@carbon/react";
 
-import { useEntityModal } from "src/components/modal";
-import { Authorization } from "src/utility/api/authorizations";
-import { DataTableRenderProps } from "@carbon/react/lib/components/DataTable/DataTable";
+import {useEntityModal} from "src/components/modal";
+import {Authorization} from "src/utility/api/authorizations";
+import {DataTableRenderProps} from "@carbon/react/lib/components/DataTable/DataTable";
+import styled from "styled-components";
 
 type AuthorizationsListProps = {
-  user: User;
-  loadingUser: boolean;
+    user: User;
+    loadingUser: boolean;
 };
 
-const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
-  const { t, Translate } = useTranslate();
+const List: FC<AuthorizationsListProps> = ({user, loadingUser}) => {
+    const {t, Translate} = useTranslate();
 
-  const {
-    data: authorizations,
-    loading: loadingAuthorizations,
-    success,
-    reload,
-  } = useApi(getUserAuthorizations, { key: user.key });
+    const ToolbarContent = styled.div`
+        display: flex;
+        justify-content: flex-end;
+        gap: 16px; /* Replace with the appropriate Carbon spacing token */
+    `;
 
-  const loading = loadingUser || loadingAuthorizations;
+    const StyledListItem = styled(ListItem)`
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding-left: 10px;
+    `;
+    const StyledDivider = styled(Section)`
+        margin: 5px 0;
+        border-top: 1px solid #ccc;
+    `;
 
-  const areAuthorizationsEmpty =
-    !authorizations || authorizations.items.length === 0;
+    const {
+        data: authorizations,
+        loading: loadingAuthorizations,
+        success,
+        reload,
+    } = useApi(getUserAuthorizations, {key: user.key});
 
-  const headers = [{ header: t("ResourceType"), key: "resourceType" }];
+    const loading = loadingUser || loadingAuthorizations;
 
-  const rows = authorizations == null ? [] : authorizations.items;
-  // Create a lookup map for rows by ID
-  const dataMap = rows.reduce(
-    (map, item) => {
-      if (typeof item.key === "string") {
-        map[item.key] = item;
-      }
+    const areAuthorizationsEmpty =
+        !authorizations || authorizations.items.length === 0;
 
-      return map;
-    },
-    {} as { [key: string]: (typeof rows)[0] },
-  );
+    const headers = [{header: t("ResourceType"), key: "resourceType"}];
 
-  const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+    const rowsWithoutId: Authorization[] = authorizations == null ? [] : authorizations.items;
 
-  const handleExpand = (rowId: string) => {
-    setExpandedRows((prev) => ({
-      ...prev,
-      [rowId]: !prev[rowId],
+    const rows = rowsWithoutId.map((item, index) => ({
+        ...item,
+        id: index,
     }));
-  };
 
-  const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
+    // Create a lookup map for rows by ID
+    const dataMap = rows.reduce(
+        (map, item) => {
+            map[item.id] = item;
+            return map;
+        },
+        {} as { [key: string]: (typeof rows)[0] },
+    );
 
-  const onEditPermission = (rowId: string, permissionIndex: number) => {
-    // Find the row by its ID and remove the permission at the given index
-    // Logic to update state or trigger an API call to remove the permission
-    handleOpenPatchModal({
-      ownerKey: user.key,
-      resourceType:
-        ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
-      permissionType:
-        dataMap[rowId].permissions[permissionIndex].permissionType,
-      currentAuthorizations: rows,
-    });
-  };
+    const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
 
-  const documentationReference = (
-    <Translate>
-      Learn more about assigning authorizations to users in our{" "}
-      <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user" />
-      .
-    </Translate>
-  );
+    const handleExpand = (rowId: string) => {
+        setExpandedRows((prev) => ({
+            ...prev,
+            [rowId]: !prev[rowId],
+        }));
+    };
 
-  return (
-    <>
-      <TableContainer
-        title="Authorizations"
-        description="Authorizations's of the user"
-      >
-        <DataTable<Authorization> rows={rows} headers={headers}>
-          {({
-            rows,
-            headers,
-            getHeaderProps,
-            getRowProps,
-            getTableProps,
-          }: DataTableRenderProps<Authorization, unknown[]>) => (
-            <div>
-              {/* Table Toolbar with Add Row Button */}
-              <TableToolbar>
-                <TableToolbarContent
-                  style={{
-                    display: "flex",
-                    justifyContent: "flex-end",
-                    gap: "16px",
-                  }}
-                >
-                  <TableToolbarSearch />
-                  <button
-                    onClick={() =>
-                      handleOpenPatchModal({
-                        ownerKey: user.key,
-                        resourceType: null,
-                        permissionType: null,
-                        currentAuthorizations: rows,
-                      })
-                    }
-                    style={{
-                      border: "none",
-                      background: "#0f62fe",
-                      color: "white",
-                      cursor: "pointer",
-                      padding: "8px 16px",
-                      borderRadius: "4px",
-                      display: "flex",
-                      alignItems: "center",
-                    }}
-                  >
-                    <Add style={{ marginRight: "8px" }} />
-                    Add Authorizations
-                  </button>
-                </TableToolbarContent>
-              </TableToolbar>
-              <Table {...getTableProps()}>
-                <TableHead>
-                  <TableRow>
-                    <TableExpandHeader />
-                    {headers.map((header) => (
-                      <TableHeader {...getHeaderProps({ header })}>
-                        {header.header}
-                      </TableHeader>
-                    ))}
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {rows.map((row) => {
-                    return (
-                      <React.Fragment key={row.id}>
-                        <TableExpandRow
-                          {...getRowProps({ row })}
-                          onClick={() => handleExpand(row.id)}
-                          isExpanded={!!expandedRows[row.id]}
-                        >
-                          <TableCell>
-                            {
-                              row.cells.find(
-                                (cell) => cell.info.header === "resourceType",
-                              )?.value
-                            }
-                          </TableCell>
-                        </TableExpandRow>
-                        {expandedRows[row.id] && (
-                          <TableExpandedRow colSpan={headers.length + 2}>
-                            {/* Displaying list of permissions */}
-                            {dataMap[row.id]?.permissions && (
-                              <ul>
-                                {dataMap[row.id].permissions.map(
-                                  (permission, index) => (
-                                    <React.Fragment key={index}>
-                                      <li
-                                        style={{
-                                          display: "flex",
-                                          justifyContent: "space-between",
-                                          alignItems: "center",
-                                          padding: "10px 0",
-                                        }}
-                                      >
-                                        <div>
-                                          <strong>Permission Type:</strong>{" "}
-                                          {permission.permissionType}
-                                          <br />
-                                          <strong>Resource IDs:</strong>{" "}
-                                          {permission.resourceIds.join(", ")}
-                                        </div>
-                                        {/* Delete button at the end */}
-                                        <button
-                                          type="button"
-                                          onClick={() =>
-                                            onEditPermission(row.id, index)
-                                          }
-                                          style={{
-                                            border: "none",
-                                            background: "none",
-                                            cursor: "pointer",
-                                          }}
-                                          aria-label="Delete permission"
-                                        >
-                                          <Edit />
-                                        </button>
-                                      </li>
-                                      {/* Divider between permission rows */}
-                                      {index <
-                                        dataMap[row.id].permissions.length -
-                                          1 && (
-                                        <hr
-                                          style={{
-                                            border: "none",
-                                            borderTop: "1px solid #ccc",
-                                            margin: "5px 0",
-                                          }}
-                                        />
-                                      )}
-                                    </React.Fragment>
-                                  ),
-                                )}
-                              </ul>
-                            )}
-                          </TableExpandedRow>
-                        )}
-                      </React.Fragment>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </DataTable>
-      </TableContainer>
+    const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
 
-      {success && !areAuthorizationsEmpty && (
-        <DocumentationDescription>
-          {documentationReference}
-        </DocumentationDescription>
-      )}
-      {!loading && areAuthorizationsEmpty && (
-        <div>
-          {success && (
-            <NoDataContainer>
-              <NoDataHeader>
-                <Translate>No authorizations assigned to this user</Translate>
-              </NoDataHeader>
-              <NoDataBody>{documentationReference}</NoDataBody>
-            </NoDataContainer>
-          )}
-        </div>
-      )}
-      {!loading && !success && (
-        <TranslatedErrorInlineNotification
-          title="The list of authorizations could not be loaded."
-          actionButton={{ label: "Retry", onClick: reload }}
-        />
-      )}
-      {patchModal}
-    </>
-  );
+    const onEditPermission = (rowId: string, permissionIndex: number) => {
+        // Find the row by its ID and remove the permission at the given index
+        // Logic to update state or trigger an API call to remove the permission
+        handleOpenPatchModal({
+            ownerKey: user.key,
+            resourceType:
+                ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
+            permissionType:
+            dataMap[rowId].permissions[permissionIndex].permissionType,
+            currentAuthorizations: rowsWithoutId,
+        });
+    };
+
+    const documentationReference = (
+        <Translate>
+            Learn more about assigning authorizations to users in our{" "}
+            <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user"/>
+            .
+        </Translate>
+    );
+
+
+    return (
+        <>
+            <TableContainer
+                title="Authorizations"
+                description="Authorizations's of the user"
+            >
+                <DataTable<Authorization> rows={rows} headers={headers}>
+                    {({
+                          headers,
+                          rows,
+                          getHeaderProps,
+                          getRowProps,
+                          getTableProps,
+                      }: DataTableRenderProps<Authorization, unknown[]>) => (
+                        <div>
+                            <TableToolbar>
+                                <TableToolbarContent
+                                    as={ToolbarContent}
+                                >
+                                    <TableToolbarSearch/>
+                                    <Button onClick={() =>
+                                        handleOpenPatchModal({
+                                            ownerKey: user.key,
+                                            resourceType: null,
+                                            permissionType: null,
+                                            currentAuthorizations: rows,
+                                        })
+                                    }>
+                                        {t('Add Authorizations')}
+                                    </Button>
+
+                                </TableToolbarContent>
+                            </TableToolbar>
+                            <Table {...getTableProps()}>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableExpandHeader/>
+                                        {headers.map((header) => (
+                                            <TableHeader {...getHeaderProps({header})}>
+                                                {header.header}
+                                            </TableHeader>
+                                        ))}
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {rows.map((row) => {
+                                        return (
+                                            <React.Fragment key={row.id}>
+                                                <TableExpandRow
+                                                    {...getRowProps({row})}
+                                                    onClick={() => handleExpand(row.id)}
+                                                    isExpanded={expandedRows[row.id]}
+                                                >
+                                                    <TableCell>
+                                                        {
+                                                            row.cells.find(
+                                                                (cell) => cell.info.header === "resourceType",
+                                                            )?.value
+                                                        }
+                                                    </TableCell>
+                                                </TableExpandRow>
+                                                {expandedRows[row.id] && (
+                                                    <TableExpandedRow colSpan={headers.length + 2}>
+                                                        {/* Displaying list of permissions */}
+                                                        {dataMap[row.id]?.permissions && (
+                                                            <ul>
+                                                                {dataMap[row.id].permissions.map(
+                                                                    (permission, index) => (
+                                                                        <React.Fragment key={index}>
+                                                                            <UnorderedList>
+                                                                                <StyledListItem>
+                                                                                    <div>
+                                                                                        <strong>Permission
+                                                                                            Type:</strong>{" "}
+                                                                                        {permission.permissionType}
+                                                                                        <br/>
+                                                                                        <strong>Resource
+                                                                                            IDs:</strong>{" "}
+                                                                                        {permission.resourceIds.join(", ")}
+                                                                                    </div>
+                                                                                    <Button
+                                                                                        kind="ghost"
+                                                                                        size="small"
+                                                                                        iconDescription={t("Edit permission")}
+                                                                                        onClick={() =>
+                                                                                            onEditPermission(row.id, index)
+                                                                                        }>
+                                                                                        <Edit/>
+                                                                                    </Button>
+                                                                                </StyledListItem>
+                                                                            </UnorderedList>
+                                                                            {index <
+                                                                                dataMap[row.id].permissions.length -
+                                                                                1 && (
+                                                                                    <StyledDivider/>
+                                                                                )}
+                                                                        </React.Fragment>
+                                                                    ),
+                                                                )}
+                                                            </ul>
+                                                        )}
+                                                    </TableExpandedRow>
+                                                )}
+                                            </React.Fragment>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    )}
+                </DataTable>
+            </TableContainer>
+
+            {success && !areAuthorizationsEmpty && (
+                <DocumentationDescription>
+                    {documentationReference}
+                </DocumentationDescription>
+            )}
+            {!loading && areAuthorizationsEmpty && (
+                <div>
+                    {success && (
+                        <NoDataContainer>
+                            <NoDataHeader>
+                                <Translate>No authorizations assigned to this user</Translate>
+                            </NoDataHeader>
+                            <NoDataBody>{documentationReference}</NoDataBody>
+                        </NoDataContainer>
+                    )}
+                </div>
+            )}
+            {!loading && !success && (
+                <TranslatedErrorInlineNotification
+                    title="The list of authorizations could not be loaded."
+                    actionButton={{label: "Retry", onClick: reload}}
+                />
+            )}
+            {patchModal}
+        </>
+    );
 };
 
 export default List;

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -69,7 +69,10 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
   // Create a lookup map for rows by ID
   const dataMap = rows.reduce(
     (map, item) => {
-      map[item.key] = item;
+      if (typeof item.key === "string") {
+        map[item.key] = item;
+      }
+
       return map;
     },
     {} as { [key: string]: (typeof rows)[0] },
@@ -77,9 +80,9 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
   console.log("ROWS", rows);
   console.log("MAP", dataMap);
 
-  const [expandedRows, setExpandedRows] = useState({});
+  const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
 
-  const handleExpand = (rowId) => {
+  const handleExpand = (rowId: string) => {
     setExpandedRows((prev) => ({
       ...prev,
       [rowId]: !prev[rowId],

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -5,269 +5,274 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import React, {FC, useState} from "react";
-import {DocumentationDescription, NoDataBody, NoDataContainer, NoDataHeader,} from "src/components/entityList";
-import PatchModal, {ResourceType,} from "src/pages/users/detail/authorization/PatchModal";
-import {Edit} from "@carbon/react/icons";
-import useTranslate from "src/utility/localization";
-import {User} from "src/utility/api/users";
-import {getUserAuthorizations} from "src/utility/api/users/authorizations";
-import {DocumentationLink} from "src/components/documentation";
-import {TranslatedErrorInlineNotification} from "src/components/notifications/InlineNotification";
-import {useApi} from "src/utility/api";
+import React, { FC, useState } from "react";
 import {
-    Button,
-    DataTable,
-    ListItem,
-    Section,
-    Table,
-    TableBody,
-    TableCell,
-    TableContainer,
-    TableExpandedRow,
-    TableExpandHeader,
-    TableExpandRow,
-    TableHead,
-    TableHeader,
-    TableRow,
-    TableToolbar,
-    TableToolbarContent,
-    TableToolbarSearch,
-    UnorderedList,
+  DocumentationDescription,
+  NoDataBody,
+  NoDataContainer,
+  NoDataHeader,
+} from "src/components/entityList";
+import PatchModal, {
+  ResourceType,
+} from "src/pages/users/detail/authorization/PatchModal";
+import { Edit } from "@carbon/react/icons";
+import useTranslate from "src/utility/localization";
+import { User } from "src/utility/api/users";
+import { getUserAuthorizations } from "src/utility/api/users/authorizations";
+import { DocumentationLink } from "src/components/documentation";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+import { useApi } from "src/utility/api";
+import {
+  Button,
+  DataTable,
+  ListItem,
+  Section,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableExpandedRow,
+  TableExpandHeader,
+  TableExpandRow,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TableToolbarSearch,
+  UnorderedList,
 } from "@carbon/react";
 
-import {useEntityModal} from "src/components/modal";
-import {Authorization} from "src/utility/api/authorizations";
-import {DataTableRenderProps} from "@carbon/react/lib/components/DataTable/DataTable";
+import { useEntityModal } from "src/components/modal";
+import { Authorization } from "src/utility/api/authorizations";
+import { DataTableRenderProps } from "@carbon/react/lib/components/DataTable/DataTable";
 import styled from "styled-components";
 
 type AuthorizationsListProps = {
-    user: User;
-    loadingUser: boolean;
+  user: User;
+  loadingUser: boolean;
 };
 
-const List: FC<AuthorizationsListProps> = ({user, loadingUser}) => {
-    const {t, Translate} = useTranslate();
+const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
+  const { t, Translate } = useTranslate();
 
-    const ToolbarContent = styled.div`
-        display: flex;
-        justify-content: flex-end;
-        gap: 16px; /* Replace with the appropriate Carbon spacing token */
-    `;
+  const ToolbarContent = styled.div`
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px; /* Replace with the appropriate Carbon spacing token */
+  `;
 
-    const StyledListItem = styled(ListItem)`
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding-left: 10px;
-    `;
-    const StyledDivider = styled(Section)`
-        margin: 5px 0;
-        border-top: 1px solid #ccc;
-    `;
+  const StyledListItem = styled(ListItem)`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding-left: 10px;
+  `;
+  const StyledDivider = styled(Section)`
+    margin: 5px 0;
+    border-top: 1px solid #ccc;
+  `;
 
-    const {
-        data: authorizations,
-        loading: loadingAuthorizations,
-        success,
-        reload,
-    } = useApi(getUserAuthorizations, {key: user.key});
+  const {
+    data: authorizations,
+    loading: loadingAuthorizations,
+    success,
+    reload,
+  } = useApi(getUserAuthorizations, { key: user.key });
 
-    const loading = loadingUser || loadingAuthorizations;
+  const loading = loadingUser || loadingAuthorizations;
 
-    const areAuthorizationsEmpty =
-        !authorizations || authorizations.items.length === 0;
+  const areAuthorizationsEmpty =
+    !authorizations || authorizations.items.length === 0;
 
-    const headers = [{header: t("ResourceType"), key: "resourceType"}];
+  const headers = [{ header: t("ResourceType"), key: "resourceType" }];
 
-    const rowsWithoutId: Authorization[] = authorizations == null ? [] : authorizations.items;
+  const rowsWithoutId: Authorization[] =
+    authorizations == null ? [] : authorizations.items;
 
-    const rows = rowsWithoutId.map((item, index) => ({
-        ...item,
-        id: index,
+  const rows = rowsWithoutId.map((item, index) => ({
+    ...item,
+    id: index,
+  }));
+
+  // Create a lookup map for rows by ID
+  const dataMap = rows.reduce(
+    (map, item) => {
+      map[item.id] = item;
+      return map;
+    },
+    {} as { [key: string]: (typeof rows)[0] },
+  );
+
+  const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+
+  const handleExpand = (rowId: string) => {
+    setExpandedRows((prev) => ({
+      ...prev,
+      [rowId]: !prev[rowId],
     }));
+  };
 
-    // Create a lookup map for rows by ID
-    const dataMap = rows.reduce(
-        (map, item) => {
-            map[item.id] = item;
-            return map;
-        },
-        {} as { [key: string]: (typeof rows)[0] },
-    );
+  const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
 
-    const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
+  const onEditPermission = (rowId: string, permissionIndex: number) => {
+    // Find the row by its ID and remove the permission at the given index
+    // Logic to update state or trigger an API call to remove the permission
+    handleOpenPatchModal({
+      ownerKey: user.key,
+      resourceType:
+        ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
+      permissionType:
+        dataMap[rowId].permissions[permissionIndex].permissionType,
+      currentAuthorizations: rowsWithoutId,
+    });
+  };
 
-    const handleExpand = (rowId: string) => {
-        setExpandedRows((prev) => ({
-            ...prev,
-            [rowId]: !prev[rowId],
-        }));
-    };
+  const documentationReference = (
+    <Translate>
+      Learn more about assigning authorizations to users in our{" "}
+      <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user" />
+      .
+    </Translate>
+  );
 
-    const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
+  return (
+    <>
+      <TableContainer
+        title="Authorizations"
+        description="Authorizations's of the user"
+      >
+        <DataTable<Authorization> rows={rows} headers={headers}>
+          {({
+            headers,
+            rows,
+            getHeaderProps,
+            getRowProps,
+            getTableProps,
+          }: DataTableRenderProps<Authorization, unknown[]>) => (
+            <div>
+              <TableToolbar>
+                <TableToolbarContent as={ToolbarContent}>
+                  <TableToolbarSearch />
+                  <Button
+                    onClick={() =>
+                      handleOpenPatchModal({
+                        ownerKey: user.key,
+                        resourceType: null,
+                        permissionType: null,
+                        currentAuthorizations: rows,
+                      })
+                    }
+                  >
+                    {t("Add Authorizations")}
+                  </Button>
+                </TableToolbarContent>
+              </TableToolbar>
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    <TableExpandHeader />
+                    {headers.map((header) => (
+                      <TableHeader {...getHeaderProps({ header })}>
+                        {header.header}
+                      </TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row) => {
+                    return (
+                      <React.Fragment key={row.id}>
+                        <TableExpandRow
+                          {...getRowProps({ row })}
+                          onClick={() => handleExpand(row.id)}
+                          isExpanded={expandedRows[row.id]}
+                        >
+                          <TableCell>
+                            {
+                              row.cells.find(
+                                (cell) => cell.info.header === "resourceType",
+                              )?.value
+                            }
+                          </TableCell>
+                        </TableExpandRow>
+                        {expandedRows[row.id] && (
+                          <TableExpandedRow colSpan={headers.length + 2}>
+                            {/* Displaying list of permissions */}
+                            {dataMap[row.id]?.permissions && (
+                              <ul>
+                                {dataMap[row.id].permissions.map(
+                                  (permission, index) => (
+                                    <React.Fragment key={index}>
+                                      <UnorderedList>
+                                        <StyledListItem>
+                                          <div>
+                                            <strong>Permission Type:</strong>{" "}
+                                            {permission.permissionType}
+                                            <br />
+                                            <strong>Resource IDs:</strong>{" "}
+                                            {permission.resourceIds.join(", ")}
+                                          </div>
+                                          <Button
+                                            kind="ghost"
+                                            size="small"
+                                            iconDescription={t(
+                                              "Edit permission",
+                                            )}
+                                            onClick={() =>
+                                              onEditPermission(row.id, index)
+                                            }
+                                          >
+                                            <Edit />
+                                          </Button>
+                                        </StyledListItem>
+                                      </UnorderedList>
+                                      {index <
+                                        dataMap[row.id].permissions.length -
+                                          1 && <StyledDivider />}
+                                    </React.Fragment>
+                                  ),
+                                )}
+                              </ul>
+                            )}
+                          </TableExpandedRow>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </DataTable>
+      </TableContainer>
 
-    const onEditPermission = (rowId: string, permissionIndex: number) => {
-        // Find the row by its ID and remove the permission at the given index
-        // Logic to update state or trigger an API call to remove the permission
-        handleOpenPatchModal({
-            ownerKey: user.key,
-            resourceType:
-                ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
-            permissionType:
-            dataMap[rowId].permissions[permissionIndex].permissionType,
-            currentAuthorizations: rowsWithoutId,
-        });
-    };
-
-    const documentationReference = (
-        <Translate>
-            Learn more about assigning authorizations to users in our{" "}
-            <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user"/>
-            .
-        </Translate>
-    );
-
-
-    return (
-        <>
-            <TableContainer
-                title="Authorizations"
-                description="Authorizations's of the user"
-            >
-                <DataTable<Authorization> rows={rows} headers={headers}>
-                    {({
-                          headers,
-                          rows,
-                          getHeaderProps,
-                          getRowProps,
-                          getTableProps,
-                      }: DataTableRenderProps<Authorization, unknown[]>) => (
-                        <div>
-                            <TableToolbar>
-                                <TableToolbarContent
-                                    as={ToolbarContent}
-                                >
-                                    <TableToolbarSearch/>
-                                    <Button onClick={() =>
-                                        handleOpenPatchModal({
-                                            ownerKey: user.key,
-                                            resourceType: null,
-                                            permissionType: null,
-                                            currentAuthorizations: rows,
-                                        })
-                                    }>
-                                        {t('Add Authorizations')}
-                                    </Button>
-
-                                </TableToolbarContent>
-                            </TableToolbar>
-                            <Table {...getTableProps()}>
-                                <TableHead>
-                                    <TableRow>
-                                        <TableExpandHeader/>
-                                        {headers.map((header) => (
-                                            <TableHeader {...getHeaderProps({header})}>
-                                                {header.header}
-                                            </TableHeader>
-                                        ))}
-                                    </TableRow>
-                                </TableHead>
-                                <TableBody>
-                                    {rows.map((row) => {
-                                        return (
-                                            <React.Fragment key={row.id}>
-                                                <TableExpandRow
-                                                    {...getRowProps({row})}
-                                                    onClick={() => handleExpand(row.id)}
-                                                    isExpanded={expandedRows[row.id]}
-                                                >
-                                                    <TableCell>
-                                                        {
-                                                            row.cells.find(
-                                                                (cell) => cell.info.header === "resourceType",
-                                                            )?.value
-                                                        }
-                                                    </TableCell>
-                                                </TableExpandRow>
-                                                {expandedRows[row.id] && (
-                                                    <TableExpandedRow colSpan={headers.length + 2}>
-                                                        {/* Displaying list of permissions */}
-                                                        {dataMap[row.id]?.permissions && (
-                                                            <ul>
-                                                                {dataMap[row.id].permissions.map(
-                                                                    (permission, index) => (
-                                                                        <React.Fragment key={index}>
-                                                                            <UnorderedList>
-                                                                                <StyledListItem>
-                                                                                    <div>
-                                                                                        <strong>Permission
-                                                                                            Type:</strong>{" "}
-                                                                                        {permission.permissionType}
-                                                                                        <br/>
-                                                                                        <strong>Resource
-                                                                                            IDs:</strong>{" "}
-                                                                                        {permission.resourceIds.join(", ")}
-                                                                                    </div>
-                                                                                    <Button
-                                                                                        kind="ghost"
-                                                                                        size="small"
-                                                                                        iconDescription={t("Edit permission")}
-                                                                                        onClick={() =>
-                                                                                            onEditPermission(row.id, index)
-                                                                                        }>
-                                                                                        <Edit/>
-                                                                                    </Button>
-                                                                                </StyledListItem>
-                                                                            </UnorderedList>
-                                                                            {index <
-                                                                                dataMap[row.id].permissions.length -
-                                                                                1 && (
-                                                                                    <StyledDivider/>
-                                                                                )}
-                                                                        </React.Fragment>
-                                                                    ),
-                                                                )}
-                                                            </ul>
-                                                        )}
-                                                    </TableExpandedRow>
-                                                )}
-                                            </React.Fragment>
-                                        );
-                                    })}
-                                </TableBody>
-                            </Table>
-                        </div>
-                    )}
-                </DataTable>
-            </TableContainer>
-
-            {success && !areAuthorizationsEmpty && (
-                <DocumentationDescription>
-                    {documentationReference}
-                </DocumentationDescription>
-            )}
-            {!loading && areAuthorizationsEmpty && (
-                <div>
-                    {success && (
-                        <NoDataContainer>
-                            <NoDataHeader>
-                                <Translate>No authorizations assigned to this user</Translate>
-                            </NoDataHeader>
-                            <NoDataBody>{documentationReference}</NoDataBody>
-                        </NoDataContainer>
-                    )}
-                </div>
-            )}
-            {!loading && !success && (
-                <TranslatedErrorInlineNotification
-                    title="The list of authorizations could not be loaded."
-                    actionButton={{label: "Retry", onClick: reload}}
-                />
-            )}
-            {patchModal}
-        </>
-    );
+      {success && !areAuthorizationsEmpty && (
+        <DocumentationDescription>
+          {documentationReference}
+        </DocumentationDescription>
+      )}
+      {!loading && areAuthorizationsEmpty && (
+        <div>
+          {success && (
+            <NoDataContainer>
+              <NoDataHeader>
+                <Translate>No authorizations assigned to this user</Translate>
+              </NoDataHeader>
+              <NoDataBody>{documentationReference}</NoDataBody>
+            </NoDataContainer>
+          )}
+        </div>
+      )}
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title="The list of authorizations could not be loaded."
+          actionButton={{ label: "Retry", onClick: reload }}
+        />
+      )}
+      {patchModal}
+    </>
+  );
 };
 
 export default List;

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -77,8 +77,6 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
     },
     {} as { [key: string]: (typeof rows)[0] },
   );
-  console.log("ROWS", rows);
-  console.log("MAP", dataMap);
 
   const [expandedRows, setExpandedRows] = useState<Record<string, boolean>>({});
 
@@ -93,9 +91,6 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
 
   const onEditPermission = (rowId: string, permissionIndex: number) => {
     // Find the row by its ID and remove the permission at the given index
-    console.log(
-      `Editing permission at index ${permissionIndex} for row with id: ${rowId}`,
-    );
     // Logic to update state or trigger an API call to remove the permission
     handleOpenPatchModal({
       ownerKey: user.key,
@@ -178,10 +173,6 @@ const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
                 </TableHead>
                 <TableBody>
                   {rows.map((row) => {
-                    // Log the row object to the console for inspection
-                    console.log("Current Row:");
-                    console.log(row);
-
                     return (
                       <React.Fragment key={row.id}>
                         <TableExpandRow

--- a/identity/client/src/pages/users/detail/authorization/List.tsx
+++ b/identity/client/src/pages/users/detail/authorization/List.tsx
@@ -1,94 +1,283 @@
-import { FC } from "react";
-import { TrashCan } from "@carbon/react/icons";
-import EntityList, {
-  DocumentationDescription,
-  NoDataBody,
-  NoDataContainer,
-  NoDataHeader,
-} from "src/components/entityList";
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import React, {FC, useState} from "react";
+import {DocumentationDescription, NoDataBody, NoDataContainer, NoDataHeader,} from "src/components/entityList";
+import PatchModal, {ResourceType} from "src/pages/users/detail/authorization/PatchModal";
+import {Add, Edit} from "@carbon/react/icons";
 import useTranslate from "src/utility/localization";
-import { User } from "src/utility/api/users";
-import { getUserAuthorizations } from "src/utility/api/users/authorizations";
-import { DocumentationLink } from "src/components/documentation";
-import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
-import { useApi } from "src/utility/api";
-import { Authorization } from "src/utility/api/authorizations";
+import {User} from "src/utility/api/users";
+import {getUserAuthorizations} from "src/utility/api/users/authorizations";
+import {DocumentationLink} from "src/components/documentation";
+import {TranslatedErrorInlineNotification} from "src/components/notifications/InlineNotification";
+import {useApi} from "src/utility/api";
+import {
+    DataTable,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableExpandedRow,
+    TableExpandHeader,
+    TableExpandRow,
+    TableHead,
+    TableHeader,
+    TableRow,
+    TableToolbar,
+    TableToolbarContent,
+    TableToolbarSearch
+} from "@carbon/react";
+
+import {useEntityModal} from "src/components/modal";
+import {Authorization, Permission} from "src/utility/api/authorizations";
+import {DataTableRenderProps} from "@carbon/react/lib/components/DataTable/DataTable";
+
 
 type AuthorizationsListProps = {
-  user: User;
-  loadingUser: boolean;
+    user: User;
+    loadingUser: boolean;
 };
 
-const List: FC<AuthorizationsListProps> = ({ user, loadingUser }) => {
-  const { t, Translate } = useTranslate();
+const List: FC<AuthorizationsListProps> = ({user, loadingUser}) => {
+    const {t, Translate} = useTranslate();
 
-  const {
-    data: authorizations,
-    loading: loadingAuthorizations,
-    success,
-    reload,
-  } = useApi(getUserAuthorizations, { key: user.key });
+    const {
+        data: authorizations,
+        loading: loadingAuthorizations,
+        success,
+        reload,
+    } = useApi(getUserAuthorizations, {key: user.key});
 
-  const loading = loadingUser || loadingAuthorizations;
+    const loading = loadingUser || loadingAuthorizations;
 
-  const areAuthorizationsEmpty =
-    !authorizations || authorizations.items.length === 0;
+    const areAuthorizationsEmpty =
+        !authorizations || authorizations.items.length === 0;
 
-  const showAuthorizationDetails = (authorization: Authorization) =>
-    console.log(authorization);
+    const headers = [
+        {header: t("ResourceType"), key: "resourceType"}
+    ];
 
-  const documentationReference = (
-    <Translate>
-      Learn more about assigning authorizations to users in our{" "}
-      <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user" />
-      .
-    </Translate>
-  );
+    const rows = authorizations == null ? [] : authorizations.items
+    // Create a lookup map for rows by ID
+    const dataMap = rows.reduce((map, item) => {
+        map[item.key] = item;
+        return map;
+    }, {} as { [key: string]: typeof rows[0] });
+    console.log("ROWS", rows);
+    console.log("MAP", dataMap);
 
-  return (
-    <>
-      <EntityList
-        title={t("Authorizations assigned to user")}
-        data={authorizations == null ? [] : authorizations.items}
-        headers={[{ header: t("ResourceType"), key: "resourceType" }]}
-        onEntityClick={showAuthorizationDetails}
-        addEntityLabel="Assign authorization"
-        onAddEntity={() => {}}
-        menuItems={[
-          {
-            label: t("Delete"),
-            onClick: () => {},
-            isDangerous: true,
-            icon: TrashCan,
-          },
-        ]}
-        loading={loadingAuthorizations}
-      />
-      {success && !areAuthorizationsEmpty && (
-        <DocumentationDescription>
-          {documentationReference}
-        </DocumentationDescription>
-      )}
-      {!loading && areAuthorizationsEmpty && (
-        <div>
-          {success && (
-            <NoDataContainer>
-              <NoDataHeader>
-                <Translate>No authorizations assigned to this user</Translate>
-              </NoDataHeader>
-              <NoDataBody>{documentationReference}</NoDataBody>
-            </NoDataContainer>
-          )}
-        </div>
-      )}
-      {!loading && !success && (
-        <TranslatedErrorInlineNotification
-          title="The list of authorizations could not be loaded."
-          actionButton={{ label: "Retry", onClick: reload }}
-        />
-      )}
-    </>
-  );
+    const [expandedRows, setExpandedRows] = useState({});
+
+    const handleExpand = (rowId) => {
+        setExpandedRows((prev) => ({
+            ...prev,
+            [rowId]: !prev[rowId],
+        }));
+    };
+
+    const [handleOpenPatchModal, patchModal] = useEntityModal(PatchModal, reload);
+
+    const onEditPermission = (rowId: string, permissionIndex: number) => {
+        // Find the row by its ID and remove the permission at the given index
+        console.log(`Editing permission at index ${permissionIndex} for row with id: ${rowId}`);
+        // Logic to update state or trigger an API call to remove the permission
+        handleOpenPatchModal({
+            ownerKey: user.key,
+            resourceType: ResourceType[dataMap[rowId].resourceType as keyof typeof ResourceType],
+            permissionType: dataMap[rowId].permissions[permissionIndex].permissionType,
+            currentAuthorizations: rows
+        })
+    };
+
+    const documentationReference = (
+        <Translate>
+            Learn more about assigning authorizations to users in our{" "}
+            <DocumentationLink path="/identity/user-guide/assigning-an-authorization-to-a-user"/>
+            .
+        </Translate>
+    );
+
+    return (
+        <>
+            <TableContainer title="Authorizations" description="Authorizations's of the user">
+                <DataTable<Authorization> rows={rows} headers={headers}>
+                    {({
+                          rows,
+                          headers,
+                          getHeaderProps,
+                          getRowProps,
+                          getTableProps
+                      }: DataTableRenderProps<Authorization, unknown[]>) => (
+                        <div>
+                            {/* Table Toolbar with Add Row Button */}
+                            <TableToolbar>
+                                <TableToolbarContent style={{display: 'flex', justifyContent: 'flex-end', gap: '16px'}}>
+
+                                    <TableToolbarSearch/>
+                                    <button
+                                        onClick={() => handleOpenPatchModal({ownerKey: user.key
+                                            , resourceType: null
+                                            , permissionType: null
+                                            , currentAuthorizations: rows})}
+                                        style={{
+                                            border: 'none',
+                                            background: '#0f62fe',
+                                            color: 'white',
+                                            cursor: 'pointer',
+                                            padding: '8px 16px',
+                                            borderRadius: '4px',
+                                            display: 'flex',
+                                            alignItems: 'center',
+                                        }}
+                                    >
+                                        <Add style={{marginRight: '8px'}}/>
+                                        Add Authorizations
+                                    </button>
+
+                                </TableToolbarContent>
+                            </TableToolbar>
+                            <Table {...getTableProps()}>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableExpandHeader/>
+                                        {headers.map((header) => (
+                                            <TableHeader {...getHeaderProps({header})}>
+                                                {header.header}
+                                            </TableHeader>
+                                        ))}
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    {rows.map((row) => {
+                                        // Log the row object to the console for inspection
+                                        console.log("Current Row:");
+                                        console.log(row);
+
+                                        return (
+                                            <React.Fragment key={row.id}>
+                                                <TableExpandRow
+                                                    {...getRowProps({row})}
+                                                    onClick={() => handleExpand(row.id)}
+                                                    isExpanded={!!expandedRows[row.id]}
+                                                >
+                                                    <TableCell>
+                                                        {row.cells.find((cell) => cell.info.header === 'resourceType')?.value}
+                                                    </TableCell>
+                                                </TableExpandRow>
+                                                {expandedRows[row.id] && (
+                                                    <TableExpandedRow colSpan={headers.length + 2}>
+                                                        {/* Displaying list of permissions */}
+                                                        {dataMap[row.id]?.permissions && (
+                                                            <ul>
+                                                                {dataMap[row.id].permissions.map((permission, index) => (
+                                                                    <React.Fragment key={index}>
+                                                                        <li
+                                                                            style={{
+                                                                                display: 'flex',
+                                                                                justifyContent: 'space-between',
+                                                                                alignItems: 'center',
+                                                                                padding: '10px 0',
+                                                                            }}
+                                                                        >
+                                                                            <div>
+                                                                                <strong>Permission
+                                                                                    Type:</strong> {permission.permissionType}
+                                                                                <br/>
+                                                                                <strong>Resource
+                                                                                    IDs:</strong> {permission.resourceIds.join(', ')}
+                                                                            </div>
+                                                                            {/* Delete button at the end */}
+                                                                            <button
+                                                                                type="button"
+                                                                                onClick={() => onEditPermission(row.id, index)}
+                                                                                style={{
+                                                                                    border: 'none',
+                                                                                    background: 'none',
+                                                                                    cursor: 'pointer',
+                                                                                }}
+                                                                                aria-label="Delete permission"
+                                                                            >
+                                                                                <Edit/>
+                                                                            </button>
+                                                                        </li>
+                                                                        {/* Divider between permission rows */}
+                                                                        {index < dataMap[row.id].permissions.length - 1 && (
+                                                                            <hr style={{
+                                                                                border: 'none',
+                                                                                borderTop: '1px solid #ccc',
+                                                                                margin: '5px 0'
+                                                                            }}/>
+                                                                        )}
+                                                                    </React.Fragment>
+                                                                ))}
+                                                            </ul>
+                                                        )}
+                                                        {/* Add button if not all permissions are present */}
+                                                        {/*{checkMissingPermissions(dataMap[row.id].permissions).length > 0 && (
+                                                    <div style={{ marginTop: '16px', textAlign: 'right' }}>
+                                                      <button
+                                                          type="button"
+                                                          onClick={() => onAddPermission(row)}
+                                                          style={{
+                                                            border: 'none',
+                                                            background: '#0f62fe',
+                                                            color: 'white',
+                                                            cursor: 'pointer',
+                                                            padding: '8px 16px',
+                                                            borderRadius: '4px',
+                                                          }}
+                                                          aria-label="Add permission"
+                                                      >
+                                                        <Add style={{ marginRight: '8px' }} />
+                                                        Add Permission
+                                                      </button>
+                                                    </div>
+                                                )}*/}
+                                                    </TableExpandedRow>
+                                                )}
+                                            </React.Fragment>
+                                        );
+                                    })}
+                                </TableBody>
+                            </Table>
+                        </div>
+                    )}
+                </DataTable>
+            </TableContainer>
+
+            {success && !areAuthorizationsEmpty && (
+                <DocumentationDescription>
+                    {documentationReference}
+                </DocumentationDescription>
+            )}
+            {!loading && areAuthorizationsEmpty && (
+                <div>
+                    {success && (
+                        <NoDataContainer>
+                            <NoDataHeader>
+                                <Translate>No authorizations assigned to this user</Translate>
+                            </NoDataHeader>
+                            <NoDataBody>{documentationReference}</NoDataBody>
+                        </NoDataContainer>
+                    )}
+                </div>
+            )}
+            {!loading && !success && (
+                <TranslatedErrorInlineNotification
+                    title="The list of authorizations could not be loaded."
+                    actionButton={{label: "Retry", onClick: reload}}
+                />
+            )}
+            {patchModal}
+        </>
+    );
 };
 
 export default List;
+
+
+

--- a/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
+++ b/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import {FC, useEffect, useState} from "react";
+import TextField from "src/components/form/TextField";
+import {useApiCall} from "src/utility/api";
+import useTranslate from "src/utility/localization";
+import {FormModal, UseEntityModalProps} from "src/components/modal";
+import {Dropdown, Tag} from "@carbon/react";
+import styled from "styled-components";
+import {
+    Authorization,
+    PatchAuthorizationAction,
+    patchAuthorizations,
+    PermissionType
+} from "src/utility/api/authorizations";
+import {ApiDefinition} from "src/utility/api/request";
+import useDebounce from "react-debounced";
+
+const SelectedResources = styled.div`
+    margin-top: 0;
+`;
+
+export enum ResourceType  {
+    AUTHORIZATION = "AUTHORIZATION",
+    MAPPING_RULE = "MAPPING_RULE",
+    MESSAGE = 'MESSAGE',
+    BATCH = 'BATCH',
+    APPLICATION = 'APPLICATION',
+    SYSTEM = 'SYSTEM',
+    TENANT = 'TENANT',
+    DEPLOYMENT = 'DEPLOYMENT',
+    PROCESS_DEFINITION =  'PROCESS_DEFINITION',
+    DECISION_REQUIREMENTS_DEFINITION =  'DECISION_REQUIREMENTS_DEFINITION',
+    DECISION_DEFINITION = 'DECISION_DEFINITION',
+    GROUP =  'GROUP',
+    USER = 'USER',
+    ROLE = 'ROLE'
+}
+
+
+export type PatchAuthorizationUIParams = {
+    ownerKey: number,
+    resourceType: string,
+    permissionType: PermissionType
+    addedResourceIds: string[]
+    removedResourceIds: string[]
+};
+
+
+export type PatchAuthorizationModalParams = {
+    ownerKey: number,
+    resourceType: ResourceType | null,
+    permissionType: PermissionType | null,
+    currentAuthorizations: Authorization[]
+};
+
+const findAvailableResourceIds = (resourceType: string|null, permissionType: PermissionType|null,
+                                  currentAuthorizations: Authorization[]) => {
+    if ( resourceType && resourceType != ""){
+        if ( permissionType ){
+            return currentAuthorizations
+                .filter((a) => a.resourceType == resourceType)
+                .flatMap( (a) => a.permissions)
+                .filter( (p) => p.permissionType == permissionType )
+                .flatMap( (p) => p.resourceIds);
+        }
+    }
+    return [];
+}
+
+
+const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
+                                                                                open,
+                                                                                onClose,
+                                                                                onSuccess,
+                                                                                entity,
+                                                                            }) => {
+    const {t} = useTranslate();
+
+    const [resourceType, setResourceType] = useState( entity.resourceType);
+    const [permissionType, setPermissionType] = useState( entity.permissionType);
+    const [selectedResources, setSelectedResources] = useState<string[]>(findAvailableResourceIds(entity.resourceType, entity.permissionType, entity.currentAuthorizations));
+    const [resourceId, setResourceId] = useState<string>("");
+
+    const findAddedAndRemoveResourceIds = () => {
+        const currentResourceIds = findAvailableResourceIds(resourceType, permissionType, entity.currentAuthorizations)
+        const removedResourceIds = currentResourceIds.filter((item) => !selectedResources.includes(item));
+        const addedResourceIds = selectedResources.filter((item) => !currentResourceIds.includes(item));
+        return [addedResourceIds, removedResourceIds]
+    }
+
+    const patchRemovedAuthorization: ApiDefinition<undefined, PatchAuthorizationUIParams> = (params) => {
+        return patchAuthorizations({
+            ownerKey: params.ownerKey,
+            action: PatchAuthorizationAction.REMOVE,
+            resourceType: params.resourceType,
+            permissions: [
+                {
+                    permissionType: params.permissionType,
+                    resourceIds: params.removedResourceIds,
+                }
+            ]
+        });
+    };
+
+    const patchAddedAuthorization: ApiDefinition<undefined, PatchAuthorizationUIParams> = (params) => {
+        return patchAuthorizations({
+            ownerKey: params.ownerKey,
+            action: PatchAuthorizationAction.ADD,
+            resourceType: params.resourceType,
+            permissions: [
+                {
+                    permissionType: params.permissionType,
+                    resourceIds: params.addedResourceIds,
+                }
+            ]
+        });
+    };
+
+    const [patchRemovedAuthorizationCall, ] = useApiCall(patchRemovedAuthorization);
+    const [patchAddedAuthorizationCall, {loading, }] = useApiCall(patchAddedAuthorization);
+
+    const handleSubmit = async () => {
+        const [addedResourceIds, removedResourceIds] = findAddedAndRemoveResourceIds();
+        if ( removedResourceIds.length == 0 || await patchRemovedAuthorizationCall({
+            ownerKey: entity.ownerKey,
+            resourceType: resourceType!,
+            permissionType: permissionType!,
+            addedResourceIds: addedResourceIds,
+            removedResourceIds: removedResourceIds
+        })) {
+            if ( addedResourceIds.length == 0 || await patchAddedAuthorizationCall({
+                ownerKey: entity.ownerKey,
+                resourceType: resourceType!,
+                permissionType: permissionType!,
+                addedResourceIds: addedResourceIds,
+                removedResourceIds: removedResourceIds
+            })) {
+                onSuccess();
+            }
+        }
+    };
+
+
+    const resourceTypeItems =
+        Object.values(ResourceType)
+
+
+    const permissionTypeItems = Object.values(PermissionType)
+
+
+    const onSelectResource = (resource: string) => {
+       setSelectedResources([...selectedResources, resource]);
+    };
+
+    const onUnselectResource =
+        (resource: string) =>
+            () => {
+                setSelectedResources(selectedResources.filter((r) => resource !== r));
+            };
+
+    useEffect(() => {
+        setSelectedResources(findAvailableResourceIds(resourceType, permissionType, entity.currentAuthorizations))
+    }, [resourceType, permissionType, entity.currentAuthorizations]);
+
+
+    const debounce = useDebounce();
+
+    return (
+        <FormModal
+            open={open}
+            headline={t("Edit Authorizations")}
+            onClose={onClose}
+            onSubmit={handleSubmit}
+            loading={loading}
+            loadingDescription={t("Updating authorizations")}
+            confirmLabel={t("Update authorizations")}
+        >
+
+            <Dropdown
+                id="resource-type-dropdown"
+                label="Select Resource type"
+                items={resourceTypeItems}
+                onChange={(item: { selectedItem: ResourceType }) => setResourceType(item.selectedItem)}
+                itemToString={(item: ResourceType) => (item ? t(item) : '')}
+                selectedItem={resourceTypeItems.find((item) => item === resourceType)}
+            />
+
+            <Dropdown
+                id="permission-type-dropdown"
+                label="Select Permission type"
+                onChange={(item: { selectedItem: PermissionType }) => setPermissionType(item.selectedItem)}
+                items={permissionTypeItems}
+                itemToString={(item: PermissionType) => (item ? t(item) : '')}
+                selectedItem={permissionTypeItems.find((item) => item === permissionType)}
+            />
+
+
+            <SelectedResources>
+                {selectedResources.map((r) => (
+                    <Tag
+                        key={r}
+                        onClose={onUnselectResource(r)}
+                        size="md"
+                        type="blue"
+                        filter
+                    >
+                        {r}
+                    </Tag>
+                ))}
+            </SelectedResources>
+            <TextField
+                label={t("Resource ID")}
+                placeholder={t("Resource ID")}
+                onChange={(newValue: string) => {
+                    setResourceId(newValue)
+                    debounce( () => {
+                        onSelectResource(newValue)
+                        setResourceId("")
+                    })
+                }}
+                autoFocus
+                value={resourceId}
+            />
+
+        </FormModal>
+    );
+};
+
+export default PatchModal;

--- a/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
+++ b/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
@@ -212,6 +212,7 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
       <Dropdown
         id="resource-type-dropdown"
         label="Select Resource type"
+        titleText="Select Resource type"
         items={resourceTypeItems}
         onChange={(item: { selectedItem: ResourceType }) =>
           setResourceType(item.selectedItem)
@@ -223,6 +224,7 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
       <Dropdown
         id="permission-type-dropdown"
         label="Select Permission type"
+        titleText="Select Permission type"
         onChange={(item: { selectedItem: PermissionType }) =>
           setPermissionType(item.selectedItem)
         }

--- a/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
+++ b/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
@@ -208,6 +208,7 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
       loading={loading}
       loadingDescription={t("Updating authorizations")}
       confirmLabel={t("Update authorizations")}
+      submitDisabled={!resourceType && !permissionType}
     >
       <Dropdown
         id="resource-type-dropdown"
@@ -218,7 +219,9 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
           setResourceType(item.selectedItem)
         }
         itemToString={(item: ResourceType) => (item ? t(item) : "")}
-        selectedItem={resourceTypeItems.find((item) => item === resourceType)}
+        selectedItem={
+          resourceTypeItems.find((item) => item === resourceType) || ""
+        }
       />
 
       <Dropdown
@@ -230,9 +233,9 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
         }
         items={permissionTypeItems}
         itemToString={(item: PermissionType) => (item ? t(item) : "")}
-        selectedItem={permissionTypeItems.find(
-          (item) => item === permissionType,
-        )}
+        selectedItem={
+          permissionTypeItems.find((item) => item === permissionType) || ""
+        }
       />
 
       <SelectedResources>

--- a/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
+++ b/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
@@ -5,231 +5,262 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import {FC, useEffect, useState} from "react";
+import { FC, useEffect, useState } from "react";
 import TextField from "src/components/form/TextField";
-import {useApiCall} from "src/utility/api";
+import { useApiCall } from "src/utility/api";
 import useTranslate from "src/utility/localization";
-import {FormModal, UseEntityModalProps} from "src/components/modal";
-import {Dropdown, Tag} from "@carbon/react";
+import { FormModal, UseEntityModalProps } from "src/components/modal";
+import { Dropdown, Tag } from "@carbon/react";
 import styled from "styled-components";
 import {
-    Authorization,
-    PatchAuthorizationAction,
-    patchAuthorizations,
-    PermissionType
+  Authorization,
+  PatchAuthorizationAction,
+  patchAuthorizations,
+  PermissionType,
 } from "src/utility/api/authorizations";
-import {ApiDefinition} from "src/utility/api/request";
+import { ApiDefinition } from "src/utility/api/request";
 import useDebounce from "react-debounced";
 
 const SelectedResources = styled.div`
-    margin-top: 0;
+  margin-top: 0;
 `;
 
-export enum ResourceType  {
-    AUTHORIZATION = "AUTHORIZATION",
-    MAPPING_RULE = "MAPPING_RULE",
-    MESSAGE = 'MESSAGE',
-    BATCH = 'BATCH',
-    APPLICATION = 'APPLICATION',
-    SYSTEM = 'SYSTEM',
-    TENANT = 'TENANT',
-    DEPLOYMENT = 'DEPLOYMENT',
-    PROCESS_DEFINITION =  'PROCESS_DEFINITION',
-    DECISION_REQUIREMENTS_DEFINITION =  'DECISION_REQUIREMENTS_DEFINITION',
-    DECISION_DEFINITION = 'DECISION_DEFINITION',
-    GROUP =  'GROUP',
-    USER = 'USER',
-    ROLE = 'ROLE'
+export enum ResourceType {
+  AUTHORIZATION = "AUTHORIZATION",
+  MAPPING_RULE = "MAPPING_RULE",
+  MESSAGE = "MESSAGE",
+  BATCH = "BATCH",
+  APPLICATION = "APPLICATION",
+  SYSTEM = "SYSTEM",
+  TENANT = "TENANT",
+  DEPLOYMENT = "DEPLOYMENT",
+  PROCESS_DEFINITION = "PROCESS_DEFINITION",
+  DECISION_REQUIREMENTS_DEFINITION = "DECISION_REQUIREMENTS_DEFINITION",
+  DECISION_DEFINITION = "DECISION_DEFINITION",
+  GROUP = "GROUP",
+  USER = "USER",
+  ROLE = "ROLE",
 }
-
 
 export type PatchAuthorizationUIParams = {
-    ownerKey: number,
-    resourceType: string,
-    permissionType: PermissionType
-    addedResourceIds: string[]
-    removedResourceIds: string[]
+  ownerKey: number;
+  resourceType: string;
+  permissionType: PermissionType;
+  addedResourceIds: string[];
+  removedResourceIds: string[];
 };
-
 
 export type PatchAuthorizationModalParams = {
-    ownerKey: number,
-    resourceType: ResourceType | null,
-    permissionType: PermissionType | null,
-    currentAuthorizations: Authorization[]
+  ownerKey: number;
+  resourceType: ResourceType | null;
+  permissionType: PermissionType | null;
+  currentAuthorizations: Authorization[];
 };
 
-const findAvailableResourceIds = (resourceType: string|null, permissionType: PermissionType|null,
-                                  currentAuthorizations: Authorization[]) => {
-    if ( resourceType && resourceType != ""){
-        if ( permissionType ){
-            return currentAuthorizations
-                .filter((a) => a.resourceType == resourceType)
-                .flatMap( (a) => a.permissions)
-                .filter( (p) => p.permissionType == permissionType )
-                .flatMap( (p) => p.resourceIds);
-        }
+const findAvailableResourceIds = (
+  resourceType: string | null,
+  permissionType: PermissionType | null,
+  currentAuthorizations: Authorization[],
+) => {
+  if (resourceType && resourceType != "") {
+    if (permissionType) {
+      return currentAuthorizations
+        .filter((a) => a.resourceType == resourceType)
+        .flatMap((a) => a.permissions)
+        .filter((p) => p.permissionType == permissionType)
+        .flatMap((p) => p.resourceIds);
     }
-    return [];
-}
-
+  }
+  return [];
+};
 
 const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
-                                                                                open,
-                                                                                onClose,
-                                                                                onSuccess,
-                                                                                entity,
-                                                                            }) => {
-    const {t} = useTranslate();
+  open,
+  onClose,
+  onSuccess,
+  entity,
+}) => {
+  const { t } = useTranslate();
 
-    const [resourceType, setResourceType] = useState( entity.resourceType);
-    const [permissionType, setPermissionType] = useState( entity.permissionType);
-    const [selectedResources, setSelectedResources] = useState<string[]>(findAvailableResourceIds(entity.resourceType, entity.permissionType, entity.currentAuthorizations));
-    const [resourceId, setResourceId] = useState<string>("");
+  const [resourceType, setResourceType] = useState(entity.resourceType);
+  const [permissionType, setPermissionType] = useState(entity.permissionType);
+  const [selectedResources, setSelectedResources] = useState<string[]>(
+    findAvailableResourceIds(
+      entity.resourceType,
+      entity.permissionType,
+      entity.currentAuthorizations,
+    ),
+  );
+  const [resourceId, setResourceId] = useState<string>("");
 
-    const findAddedAndRemoveResourceIds = () => {
-        const currentResourceIds = findAvailableResourceIds(resourceType, permissionType, entity.currentAuthorizations)
-        const removedResourceIds = currentResourceIds.filter((item) => !selectedResources.includes(item));
-        const addedResourceIds = selectedResources.filter((item) => !currentResourceIds.includes(item));
-        return [addedResourceIds, removedResourceIds]
-    }
-
-    const patchRemovedAuthorization: ApiDefinition<undefined, PatchAuthorizationUIParams> = (params) => {
-        return patchAuthorizations({
-            ownerKey: params.ownerKey,
-            action: PatchAuthorizationAction.REMOVE,
-            resourceType: params.resourceType,
-            permissions: [
-                {
-                    permissionType: params.permissionType,
-                    resourceIds: params.removedResourceIds,
-                }
-            ]
-        });
-    };
-
-    const patchAddedAuthorization: ApiDefinition<undefined, PatchAuthorizationUIParams> = (params) => {
-        return patchAuthorizations({
-            ownerKey: params.ownerKey,
-            action: PatchAuthorizationAction.ADD,
-            resourceType: params.resourceType,
-            permissions: [
-                {
-                    permissionType: params.permissionType,
-                    resourceIds: params.addedResourceIds,
-                }
-            ]
-        });
-    };
-
-    const [patchRemovedAuthorizationCall, ] = useApiCall(patchRemovedAuthorization);
-    const [patchAddedAuthorizationCall, {loading, }] = useApiCall(patchAddedAuthorization);
-
-    const handleSubmit = async () => {
-        const [addedResourceIds, removedResourceIds] = findAddedAndRemoveResourceIds();
-        if ( removedResourceIds.length == 0 || await patchRemovedAuthorizationCall({
-            ownerKey: entity.ownerKey,
-            resourceType: resourceType!,
-            permissionType: permissionType!,
-            addedResourceIds: addedResourceIds,
-            removedResourceIds: removedResourceIds
-        })) {
-            if ( addedResourceIds.length == 0 || await patchAddedAuthorizationCall({
-                ownerKey: entity.ownerKey,
-                resourceType: resourceType!,
-                permissionType: permissionType!,
-                addedResourceIds: addedResourceIds,
-                removedResourceIds: removedResourceIds
-            })) {
-                onSuccess();
-            }
-        }
-    };
-
-
-    const resourceTypeItems =
-        Object.values(ResourceType)
-
-
-    const permissionTypeItems = Object.values(PermissionType)
-
-
-    const onSelectResource = (resource: string) => {
-       setSelectedResources([...selectedResources, resource]);
-    };
-
-    const onUnselectResource =
-        (resource: string) =>
-            () => {
-                setSelectedResources(selectedResources.filter((r) => resource !== r));
-            };
-
-    useEffect(() => {
-        setSelectedResources(findAvailableResourceIds(resourceType, permissionType, entity.currentAuthorizations))
-    }, [resourceType, permissionType, entity.currentAuthorizations]);
-
-
-    const debounce = useDebounce();
-
-    return (
-        <FormModal
-            open={open}
-            headline={t("Edit Authorizations")}
-            onClose={onClose}
-            onSubmit={handleSubmit}
-            loading={loading}
-            loadingDescription={t("Updating authorizations")}
-            confirmLabel={t("Update authorizations")}
-        >
-
-            <Dropdown
-                id="resource-type-dropdown"
-                label="Select Resource type"
-                items={resourceTypeItems}
-                onChange={(item: { selectedItem: ResourceType }) => setResourceType(item.selectedItem)}
-                itemToString={(item: ResourceType) => (item ? t(item) : '')}
-                selectedItem={resourceTypeItems.find((item) => item === resourceType)}
-            />
-
-            <Dropdown
-                id="permission-type-dropdown"
-                label="Select Permission type"
-                onChange={(item: { selectedItem: PermissionType }) => setPermissionType(item.selectedItem)}
-                items={permissionTypeItems}
-                itemToString={(item: PermissionType) => (item ? t(item) : '')}
-                selectedItem={permissionTypeItems.find((item) => item === permissionType)}
-            />
-
-
-            <SelectedResources>
-                {selectedResources.map((r) => (
-                    <Tag
-                        key={r}
-                        onClose={onUnselectResource(r)}
-                        size="md"
-                        type="blue"
-                        filter
-                    >
-                        {r}
-                    </Tag>
-                ))}
-            </SelectedResources>
-            <TextField
-                label={t("Resource ID")}
-                placeholder={t("Resource ID")}
-                onChange={(newValue: string) => {
-                    setResourceId(newValue)
-                    debounce( () => {
-                        onSelectResource(newValue)
-                        setResourceId("")
-                    })
-                }}
-                autoFocus
-                value={resourceId}
-            />
-
-        </FormModal>
+  const findAddedAndRemoveResourceIds = () => {
+    const currentResourceIds = findAvailableResourceIds(
+      resourceType,
+      permissionType,
+      entity.currentAuthorizations,
     );
+    const removedResourceIds = currentResourceIds.filter(
+      (item) => !selectedResources.includes(item),
+    );
+    const addedResourceIds = selectedResources.filter(
+      (item) => !currentResourceIds.includes(item),
+    );
+    return [addedResourceIds, removedResourceIds];
+  };
+
+  const patchRemovedAuthorization: ApiDefinition<
+    undefined,
+    PatchAuthorizationUIParams
+  > = (params) => {
+    return patchAuthorizations({
+      ownerKey: params.ownerKey,
+      action: PatchAuthorizationAction.REMOVE,
+      resourceType: params.resourceType,
+      permissions: [
+        {
+          permissionType: params.permissionType,
+          resourceIds: params.removedResourceIds,
+        },
+      ],
+    });
+  };
+
+  const patchAddedAuthorization: ApiDefinition<
+    undefined,
+    PatchAuthorizationUIParams
+  > = (params) => {
+    return patchAuthorizations({
+      ownerKey: params.ownerKey,
+      action: PatchAuthorizationAction.ADD,
+      resourceType: params.resourceType,
+      permissions: [
+        {
+          permissionType: params.permissionType,
+          resourceIds: params.addedResourceIds,
+        },
+      ],
+    });
+  };
+
+  const [patchRemovedAuthorizationCall] = useApiCall(patchRemovedAuthorization);
+  const [patchAddedAuthorizationCall, { loading }] = useApiCall(
+    patchAddedAuthorization,
+  );
+
+  const handleSubmit = async () => {
+    const [addedResourceIds, removedResourceIds] =
+      findAddedAndRemoveResourceIds();
+    if (
+      removedResourceIds.length == 0 ||
+      (await patchRemovedAuthorizationCall({
+        ownerKey: entity.ownerKey,
+        resourceType: resourceType!,
+        permissionType: permissionType!,
+        addedResourceIds: addedResourceIds,
+        removedResourceIds: removedResourceIds,
+      }))
+    ) {
+      if (
+        addedResourceIds.length == 0 ||
+        (await patchAddedAuthorizationCall({
+          ownerKey: entity.ownerKey,
+          resourceType: resourceType!,
+          permissionType: permissionType!,
+          addedResourceIds: addedResourceIds,
+          removedResourceIds: removedResourceIds,
+        }))
+      ) {
+        onSuccess();
+      }
+    }
+  };
+
+  const resourceTypeItems = Object.values(ResourceType);
+
+  const permissionTypeItems = Object.values(PermissionType);
+
+  const onSelectResource = (resource: string) => {
+    setSelectedResources([...selectedResources, resource]);
+  };
+
+  const onUnselectResource = (resource: string) => () => {
+    setSelectedResources(selectedResources.filter((r) => resource !== r));
+  };
+
+  useEffect(() => {
+    setSelectedResources(
+      findAvailableResourceIds(
+        resourceType,
+        permissionType,
+        entity.currentAuthorizations,
+      ),
+    );
+  }, [resourceType, permissionType, entity.currentAuthorizations]);
+
+  const debounce = useDebounce();
+
+  return (
+    <FormModal
+      open={open}
+      headline={t("Edit Authorizations")}
+      onClose={onClose}
+      onSubmit={handleSubmit}
+      loading={loading}
+      loadingDescription={t("Updating authorizations")}
+      confirmLabel={t("Update authorizations")}
+    >
+      <Dropdown
+        id="resource-type-dropdown"
+        label="Select Resource type"
+        items={resourceTypeItems}
+        onChange={(item: { selectedItem: ResourceType }) =>
+          setResourceType(item.selectedItem)
+        }
+        itemToString={(item: ResourceType) => (item ? t(item) : "")}
+        selectedItem={resourceTypeItems.find((item) => item === resourceType)}
+      />
+
+      <Dropdown
+        id="permission-type-dropdown"
+        label="Select Permission type"
+        onChange={(item: { selectedItem: PermissionType }) =>
+          setPermissionType(item.selectedItem)
+        }
+        items={permissionTypeItems}
+        itemToString={(item: PermissionType) => (item ? t(item) : "")}
+        selectedItem={permissionTypeItems.find(
+          (item) => item === permissionType,
+        )}
+      />
+
+      <SelectedResources>
+        {selectedResources.map((r) => (
+          <Tag
+            key={r}
+            onClose={onUnselectResource(r)}
+            size="md"
+            type="blue"
+            filter
+          >
+            {r}
+          </Tag>
+        ))}
+      </SelectedResources>
+      <TextField
+        label={t("Resource ID")}
+        placeholder={t("Resource ID")}
+        onChange={(newValue: string) => {
+          setResourceId(newValue);
+          debounce(() => {
+            onSelectResource(newValue);
+            setResourceId("");
+          });
+        }}
+        autoFocus
+        value={resourceId}
+      />
+    </FormModal>
+  );
 };
 
 export default PatchModal;

--- a/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
+++ b/identity/client/src/pages/users/detail/authorization/PatchModal.tsx
@@ -239,15 +239,15 @@ const PatchModal: FC<UseEntityModalProps<PatchAuthorizationModalParams>> = ({
       />
 
       <SelectedResources>
-        {selectedResources.map((r) => (
+        {selectedResources.map((resource) => (
           <Tag
-            key={r}
-            onClose={onUnselectResource(r)}
+            key={resource}
+            onClose={onUnselectResource(resource)}
             size="md"
             type="blue"
             filter
           >
-            {r}
+            {resource}
           </Tag>
         ))}
       </SelectedResources>

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 import { EntityData } from "src/components/entityList/EntityList";
-import {ApiDefinition, apiPatch, pathBuilder} from "src/utility/api/request";
+import { ApiDefinition, apiPatch, pathBuilder } from "src/utility/api/request";
 
 const path = pathBuilder("/authorizations");
 
@@ -34,15 +34,18 @@ export type Authorization = EntityData & {
 };
 
 export enum PatchAuthorizationAction {
-  ADD = "ADD", REMOVE = "REMOVE"
+  ADD = "ADD",
+  REMOVE = "REMOVE",
 }
 
 export type PatchAuthorizationParams = {
-  ownerKey: number,
-  action: PatchAuthorizationAction,
-  resourceType: string,
-  permissions: readonly Permission[]
+  ownerKey: number;
+  action: PatchAuthorizationAction;
+  resourceType: string;
+  permissions: readonly Permission[];
 };
 
-export const patchAuthorizations: ApiDefinition<undefined, PatchAuthorizationParams> = (params) => apiPatch(path(params.ownerKey), params);
-
+export const patchAuthorizations: ApiDefinition<
+  undefined,
+  PatchAuthorizationParams
+> = (params) => apiPatch(path(params.ownerKey), params);

--- a/identity/client/src/utility/api/authorizations/index.ts
+++ b/identity/client/src/utility/api/authorizations/index.ts
@@ -6,14 +6,43 @@
  * except in compliance with the Camunda License 1.0.
  */
 import { EntityData } from "src/components/entityList/EntityList";
+import {ApiDefinition, apiPatch, pathBuilder} from "src/utility/api/request";
+
+const path = pathBuilder("/authorizations");
+
+export enum PermissionType {
+  CREATE = "CREATE",
+  READ = "READ",
+  READ_INSTANCE = "READ_INSTANCE",
+  READ_USER_TASK = "READ_USER_TASK",
+  UPDATE = "UPDATE",
+  DELETE = "DELETE",
+  DELETE_PROCESS = "DELETE_PROCESS",
+  DELETE_DRD = "DELETE_DRD",
+  DELETE_FORM = "DELETE_FORM",
+}
 
 export type Permission = {
-  permissionType: string;
+  permissionType: PermissionType;
   resourceIds: string[];
 };
 export type Authorization = EntityData & {
   ownerKey: number;
   ownerType: string;
   resourceType: string;
-  permissions: Permission[];
+  permissions: readonly Permission[];
 };
+
+export enum PatchAuthorizationAction {
+  ADD = "ADD", REMOVE = "REMOVE"
+}
+
+export type PatchAuthorizationParams = {
+  ownerKey: number,
+  action: PatchAuthorizationAction,
+  resourceType: string,
+  permissions: readonly Permission[]
+};
+
+export const patchAuthorizations: ApiDefinition<undefined, PatchAuthorizationParams> = (params) => apiPatch(path(params.ownerKey), params);
+

--- a/identity/client/src/utility/api/request.ts
+++ b/identity/client/src/utility/api/request.ts
@@ -129,6 +129,8 @@ export const apiPut = apiRequestWrapper("PUT");
 
 export const apiDelete = apiRequestWrapper("DELETE");
 
+export const apiPatch = apiRequestWrapper("PATCH");
+
 export const namedErrorsReducer = (
   result: Record<string, string[]>,
   current: string,

--- a/identity/client/src/utility/api/request.ts
+++ b/identity/client/src/utility/api/request.ts
@@ -127,8 +127,6 @@ export const apiPost = apiRequestWrapper("POST");
 
 export const apiPut = apiRequestWrapper("PUT");
 
-export const apiPatch = apiRequestWrapper("PATCH");
-
 export const apiDelete = apiRequestWrapper("DELETE");
 
 export const namedErrorsReducer = (

--- a/identity/client/src/utility/api/request.ts
+++ b/identity/client/src/utility/api/request.ts
@@ -54,7 +54,8 @@ const apiRequest: <R, P>(
   options: ApiRequestParams<P>,
 ) => ApiPromise<R> = async ({ url, method, headers, params, baseUrl }) => {
   const hasBody =
-    !!params && ["PUT", "POST", "PATCH"].includes(method.toUpperCase());
+    !!params &&
+    ["PUT", "POST", "DELETE", "PATCH"].includes(method.toUpperCase());
   const body = hasBody ? JSON.stringify(params) : undefined;
 
   // default handling for content-type

--- a/identity/client/src/utility/style.ts
+++ b/identity/client/src/utility/style.ts
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-import { spacing03 } from "@carbon/themes";
+import { spacing03 } from "@carbon/elements";
 import { moderate02 } from "@carbon/motion";
 
 export const minUnit = spacing03;

--- a/identity/client/yarn.lock
+++ b/identity/client/yarn.lock
@@ -277,6 +277,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@carbon/elements@npm:^11.57.0":
+  version: 11.57.0
+  resolution: "@carbon/elements@npm:11.57.0"
+  dependencies:
+    "@carbon/colors": "npm:^11.28.0"
+    "@carbon/grid": "npm:^11.29.0"
+    "@carbon/icons": "npm:^11.53.0"
+    "@carbon/layout": "npm:^11.28.0"
+    "@carbon/motion": "npm:^11.24.0"
+    "@carbon/themes": "npm:^11.43.0"
+    "@carbon/type": "npm:^11.33.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
+  checksum: 10c0/5b9dac344bdc025689baf054d6bbba148c3ec21c99bfba4e64b76375ae55043005828dab733de6a2d2cbfb87a69f4af329be939e99e1ec19edc8518d8ea25fc3
+  languageName: node
+  linkType: hard
+
 "@carbon/feature-flags@npm:^0.24.0":
   version: 0.24.0
   resolution: "@carbon/feature-flags@npm:0.24.0"
@@ -315,6 +331,15 @@ __metadata:
   peerDependencies:
     react: ">=16"
   checksum: 10c0/f218ae63ec3bd111baa57f3b909cb77f47c00bac0fbb068b3d5091869172d5cbea19d2b758f47b60e3e17accca8fc562419b5c9e460cd50d02c83672095da4e8
+  languageName: node
+  linkType: hard
+
+"@carbon/icons@npm:^11.53.0":
+  version: 11.53.0
+  resolution: "@carbon/icons@npm:11.53.0"
+  dependencies:
+    "@ibm/telemetry-js": "npm:^1.5.0"
+  checksum: 10c0/ec19179cafb629d2354f906d70d44f85a911009c39f65602d2ad432ecd5264541110286a79fcd9566d569e78a8680190c84f4294839915a388ce07d8a72d6fa8
   languageName: node
   linkType: hard
 
@@ -1284,6 +1309,23 @@ __metadata:
   dependencies:
     "@babel/types": "npm:^7.20.7"
   checksum: 10c0/7ba7db61a53e28cac955aa99af280d2600f15a8c056619c05b6fc911cbe02c61aa4f2823299221b23ce0cce00b294c0e5f618ec772aa3f247523c2e48cf7b888
+  languageName: node
+  linkType: hard
+
+"@types/carbon-components-react@npm:^7.55.13":
+  version: 7.55.13
+  resolution: "@types/carbon-components-react@npm:7.55.13"
+  dependencies:
+    "@types/react": "npm:*"
+    flatpickr: "npm:4.6.9"
+  checksum: 10c0/fe5422084a45b669db25b882f541a5ee3fce20b5a98b751117e0f66d24c11e32188a8996a1b5186b15cd1d1e02be81765270fd24effd384c318301ded1144825
+  languageName: node
+  linkType: hard
+
+"@types/carbon__elements@npm:^11.10.3":
+  version: 11.10.3
+  resolution: "@types/carbon__elements@npm:11.10.3"
+  checksum: 10c0/a5708886e5059ade6cab49477c228be075e1d72eebeb7eeb60be9ae607668bba56791953c62e31ca20eb7dcf5d8c1857f0d178edd580849762bba565e79774cc
   languageName: node
   linkType: hard
 
@@ -2619,6 +2661,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"flatpickr@npm:4.6.9":
+  version: 4.6.9
+  resolution: "flatpickr@npm:4.6.9"
+  checksum: 10c0/9301fbd14ebfe550b532119d2bf1f208bb057faf50ddc1cef8019371061f9d4d86492673ea4df60bc1b3d755494a7d08e63903b514a3fcf2215356c8676816d3
+  languageName: node
+  linkType: hard
+
 "flatted@npm:^3.2.9":
   version: 3.3.1
   resolution: "flatted@npm:3.3.1"
@@ -2911,7 +2960,10 @@ __metadata:
   resolution: "identity-frontend@workspace:."
   dependencies:
     "@camunda/camunda-composite-components": "npm:0.11.0"
+    "@carbon/elements": "npm:^11.57.0"
     "@carbon/react": "npm:1.71.0"
+    "@types/carbon-components-react": "npm:^7.55.13"
+    "@types/carbon__elements": "npm:^11.10.3"
     "@types/event-source-polyfill": "npm:1.0.5"
     "@types/node": "npm:22.10.0"
     "@types/react": "npm:18.3.12"


### PR DESCRIPTION
## Description

Camunda service allows to update permissions of an authorization assigned to an entity.
As part of this PR, we also changed the way the authorizations' list is displayed and switched to an expandable data table to reflect the API response.

## Related issues

closes #20451
