### PR TITLE
feat: implement aws document store

### DIFF
--- a/document/store/pom.xml
+++ b/document/store/pom.xml
@@ -42,6 +42,22 @@
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>s3</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>aws-core</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -81,7 +97,18 @@
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
-
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies>
+            <ignoredNonTestScopedDependency>software.amazon.awssdk:aws-core</ignoredNonTestScopedDependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStore.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+import io.camunda.document.api.DocumentCreationRequest;
+import io.camunda.document.api.DocumentError;
+import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentNotFound;
+import io.camunda.document.api.DocumentError.InvalidInput;
+import io.camunda.document.api.DocumentError.UnknownDocumentError;
+import io.camunda.document.api.DocumentLink;
+import io.camunda.document.api.DocumentMetadataModel;
+import io.camunda.document.api.DocumentReference;
+import io.camunda.document.api.DocumentStore;
+import io.camunda.zeebe.util.Either;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+public class AwsDocumentStore implements DocumentStore {
+
+  private final String bucketName;
+  private final S3Client client;
+  private final ExecutorService executor;
+  private final S3Presigner preSigner;
+
+  public AwsDocumentStore(final String bucketName) {
+    this(bucketName, S3Client.create(), Executors.newSingleThreadExecutor(), S3Presigner.create());
+  }
+
+  public AwsDocumentStore(
+      final String bucketName,
+      final S3Client client,
+      final ExecutorService executor,
+      final S3Presigner preSigner) {
+    this.bucketName = bucketName;
+    this.client = client;
+    this.executor = executor;
+    this.preSigner = preSigner;
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, DocumentReference>> createDocument(
+      final DocumentCreationRequest request) {
+    return CompletableFuture.supplyAsync(() -> createDocumentInternal(request), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, InputStream>> getDocument(
+      final String documentId) {
+    return CompletableFuture.supplyAsync(() -> getDocumentInternal(documentId), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, Void>> deleteDocument(final String documentId) {
+    return CompletableFuture.supplyAsync(() -> deleteDocumentInternal(documentId), executor);
+  }
+
+  @Override
+  public CompletableFuture<Either<DocumentError, DocumentLink>> createLink(
+      final String documentId, final long durationInMillis) {
+    return CompletableFuture.supplyAsync(
+        () -> linkDocumentInternal(documentId, durationInMillis), executor);
+  }
+
+  private Either<DocumentError, DocumentReference> createDocumentInternal(
+      final DocumentCreationRequest request) {
+    try {
+      final String documentId =
+          Objects.requireNonNullElse(request.documentId(), UUID.randomUUID().toString());
+
+      if (checkDocumentExists(documentId)) {
+        return Either.left(new DocumentAlreadyExists(documentId));
+      }
+
+      return uploadDocument(request, documentId);
+    } catch (final Exception e) {
+      return Either.left(new UnknownDocumentError(e));
+    }
+  }
+
+  private Either<DocumentError, InputStream> getDocumentInternal(final String documentId) {
+    try {
+      final GetObjectRequest getObjectRequest =
+          GetObjectRequest.builder().key(documentId).bucket(bucketName).build();
+
+      final InputStream inputStream = client.getObject(getObjectRequest);
+
+      return Either.right(inputStream);
+    } catch (final Exception e) {
+      return Either.left(getDocumentError(documentId, e));
+    }
+  }
+
+  private Either<DocumentError, Void> deleteDocumentInternal(final String documentId) {
+    try {
+      client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(documentId).build());
+
+      return Either.right(null);
+    } catch (final Exception e) {
+      return Either.left(getDocumentError(documentId, e));
+    }
+  }
+
+  private Either<DocumentError, DocumentLink> linkDocumentInternal(
+      final String documentId, final long durationInMillis) {
+    try {
+      if (durationInMillis <= 0) {
+        return Either.left(new InvalidInput("Duration must be greater than 0"));
+      }
+
+      if (!checkDocumentExists(documentId)) {
+        return Either.left(new DocumentNotFound(documentId));
+      }
+
+      final GetObjectRequest objectRequest =
+          GetObjectRequest.builder().bucket(bucketName).key(documentId).build();
+
+      final GetObjectPresignRequest preSignRequest =
+          GetObjectPresignRequest.builder()
+              .signatureDuration(Duration.ofMillis(durationInMillis))
+              .getObjectRequest(objectRequest)
+              .build();
+
+      final PresignedGetObjectRequest preSignedRequest = preSigner.presignGetObject(preSignRequest);
+      final Instant expiration = Instant.now().plusMillis(durationInMillis);
+
+      return Either.right(
+          new DocumentLink(
+              preSignedRequest.url().toString(),
+              OffsetDateTime.ofInstant(expiration, ZoneId.systemDefault())));
+    } catch (final Exception e) {
+      return Either.left(getDocumentError(documentId, e));
+    }
+  }
+
+  private boolean checkDocumentExists(final String documentId) throws S3Exception {
+    final HeadObjectRequest headObjectRequest =
+        HeadObjectRequest.builder().bucket(bucketName).key(documentId).build();
+
+    try {
+      client.headObject(headObjectRequest);
+      return true;
+    } catch (final S3Exception e) {
+      if (e.statusCode() == HttpStatusCode.NOT_FOUND) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private Either<DocumentError, DocumentReference> uploadDocument(
+      final DocumentCreationRequest request, final String documentId) {
+    final PutObjectRequest putObjectRequest =
+        PutObjectRequest.builder()
+            .key(documentId)
+            .bucket(bucketName)
+            .metadata(toS3MetaData(request.metadata()))
+            .build();
+
+    client.putObject(
+        putObjectRequest,
+        RequestBody.fromInputStream(request.contentInputStream(), request.metadata().size()));
+
+    return Either.right(new DocumentReference(documentId, request.metadata()));
+  }
+
+  private Map<String, String> toS3MetaData(final DocumentMetadataModel metadata) {
+    if (metadata == null) {
+      return Collections.emptyMap();
+    }
+
+    final Map<String, String> metadataMap = new HashMap<>();
+
+    putIfPresent("content-type", metadata.contentType(), metadataMap);
+    putIfPresent("size", metadata.size(), metadataMap);
+    putIfPresent("filename", metadata.fileName(), metadataMap);
+    putIfPresent("expires-at", metadata.expiresAt(), metadataMap);
+
+    if (metadata.customProperties() != null) {
+      metadata
+          .customProperties()
+          .forEach((key, value) -> metadataMap.put(key, String.valueOf(value)));
+    }
+
+    return metadataMap;
+  }
+
+  private <T> void putIfPresent(
+      final String key, final T value, final Map<String, String> metadataMap) {
+    if (value != null) {
+      metadataMap.put(key, value.toString());
+    }
+  }
+
+  private static DocumentError getDocumentError(final String documentId, final Exception e) {
+    if (e instanceof final S3Exception s3Exception
+        && s3Exception.statusCode() == HttpStatusCode.NOT_FOUND) {
+      return new DocumentNotFound(documentId);
+    }
+    return new UnknownDocumentError(e);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+public class AwsDocumentStoreFactory {
+  public static AwsDocumentStore create(final String bucketName) {
+    return new AwsDocumentStore(bucketName);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -8,7 +8,8 @@
 package io.camunda.document.store.aws;
 
 public class AwsDocumentStoreFactory {
-  public static AwsDocumentStore create(final String bucketName, final Long defaultTTL) {
-    return new AwsDocumentStore(bucketName, defaultTTL);
+  public static AwsDocumentStore create(
+      final String bucketName, final Long defaultTTL, final String bucketPath) {
+    return new AwsDocumentStore(bucketName, defaultTTL, bucketPath);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreFactory.java
@@ -8,7 +8,7 @@
 package io.camunda.document.store.aws;
 
 public class AwsDocumentStoreFactory {
-  public static AwsDocumentStore create(final String bucketName) {
-    return new AwsDocumentStore(bucketName);
+  public static AwsDocumentStore create(final String bucketName, final Long defaultTTL) {
+    return new AwsDocumentStore(bucketName, defaultTTL);
   }
 }

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import io.camunda.document.api.DocumentStoreProvider;
+import java.util.Optional;
+
+public class AwsDocumentStoreProvider implements DocumentStoreProvider {
+
+  private static final String BUCKET_NAME_PROPERTY = "BUCKET";
+
+  @Override
+  public DocumentStore createDocumentStore(final DocumentStoreConfigurationRecord configuration) {
+    final String bucketName =
+        Optional.ofNullable(configuration.properties().get(BUCKET_NAME_PROPERTY))
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Failed to configure document store with id '"
+                            + configuration.id()
+                            + "': missing required property '"
+                            + BUCKET_NAME_PROPERTY
+                            + "'"));
+    return AwsDocumentStoreFactory.create(bucketName);
+  }
+}

--- a/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
+++ b/document/store/src/main/java/io/camunda/document/store/aws/AwsDocumentStoreProvider.java
@@ -10,15 +10,20 @@ package io.camunda.document.store.aws;
 import io.camunda.document.api.DocumentStore;
 import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
 import io.camunda.document.api.DocumentStoreProvider;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class AwsDocumentStoreProvider implements DocumentStoreProvider {
 
+  private static final Logger LOG = LoggerFactory.getLogger(AwsDocumentStoreProvider.class);
+  private static final Pattern INVALID_CHARACTERS = Pattern.compile("[\\u0000-\\u001F\\\\]");
+
   private static final String BUCKET_NAME_PROPERTY = "BUCKET";
   private static final String BUCKET_TTL = "BUCKET_TTL";
-  private static final Logger log = LoggerFactory.getLogger(AwsDocumentStoreProvider.class);
+  private static final String BUCKET_PATH = "BUCKET_PATH";
 
   @Override
   public DocumentStore createDocumentStore(final DocumentStoreConfigurationRecord configuration) {
@@ -33,14 +38,15 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
                             + BUCKET_NAME_PROPERTY
                             + "'"));
 
-    return AwsDocumentStoreFactory.create(bucketName, getDefaultTTL(configuration));
+    return AwsDocumentStoreFactory.create(
+        bucketName, getDefaultTTL(configuration), getBucketPath(configuration));
   }
 
   private static Long getDefaultTTL(final DocumentStoreConfigurationRecord configuration) {
     final String bucketTTL = configuration.properties().get(BUCKET_TTL);
 
     if (bucketTTL == null) {
-      log.warn("AWS {} property is not set", BUCKET_TTL);
+      LOG.warn("AWS {} property is not set", BUCKET_TTL);
       return null;
     }
 
@@ -54,5 +60,24 @@ public class AwsDocumentStoreProvider implements DocumentStoreProvider {
               + BUCKET_TTL
               + " must be a number'");
     }
+  }
+
+  private static String getBucketPath(final DocumentStoreConfigurationRecord configuration) {
+    String bucketPath = Objects.requireNonNullElse(configuration.properties().get(BUCKET_PATH), "");
+
+    if (INVALID_CHARACTERS.matcher(bucketPath).find()) {
+      throw new IllegalArgumentException(
+          "Failed to configure document store with id '"
+              + configuration.id()
+              + "': '"
+              + BUCKET_PATH
+              + " is invalid. Must not contain \\ character'");
+    }
+
+    if (!bucketPath.isEmpty() && !bucketPath.endsWith("/")) {
+      bucketPath = bucketPath + "/";
+    }
+
+    return bucketPath;
   }
 }

--- a/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
+++ b/document/store/src/main/resources/META-INF/services/io.camunda.document.api.DocumentStoreProvider
@@ -7,3 +7,4 @@
 #
 io.camunda.document.store.inmemory.InMemoryDocumentStoreProvider
 io.camunda.document.store.gcp.GcpDocumentStoreProvider
+io.camunda.document.store.aws.AwsDocumentStoreProvider

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -30,7 +30,7 @@ public class AwsDocumentStoreProviderTest {
 
       // this mock is used to bypass the auto config of S3Client.create()
       mockedFactory
-          .when(() -> AwsDocumentStoreFactory.create(bucketName, bucketTtl))
+          .when(() -> AwsDocumentStoreFactory.create(bucketName, bucketTtl, ""))
           .thenReturn(mockDocumentStore);
 
       final DocumentStoreConfigurationRecord configuration =
@@ -84,5 +84,27 @@ public class AwsDocumentStoreProviderTest {
     assertThat(ex.getMessage())
         .isEqualTo(
             "Failed to configure document store with id 'aws': 'BUCKET_TTL must be a number'");
+  }
+
+  @Test
+  public void shouldThrowIfBucketPathIsInvalid() {
+    // given
+
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    configuration.properties().put("BUCKET", "bucketName");
+    configuration.properties().put("BUCKET_TTL", "30");
+    configuration.properties().put("BUCKET_PATH", "test\\path");
+
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> provider.createDocumentStore(configuration));
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'aws': 'BUCKET_PATH is invalid. Must not contain \\ character'");
   }
 }

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreProviderTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+import io.camunda.document.api.DocumentStore;
+import io.camunda.document.api.DocumentStoreConfiguration.DocumentStoreConfigurationRecord;
+import java.util.HashMap;
+import org.junit.jupiter.api.Test;
+
+public class AwsDocumentStoreProviderTest {
+
+  @Test
+  public void shouldCreateDocumentStore() {
+    try (final var mockedFactory = mockStatic(AwsDocumentStoreFactory.class)) {
+      // given
+      final String bucketName = "bucketName";
+      final AwsDocumentStore mockDocumentStore = mock(AwsDocumentStore.class);
+
+      // this mock is used to bypass the auto config of S3Client.create()
+      mockedFactory
+          .when(() -> AwsDocumentStoreFactory.create(bucketName))
+          .thenReturn(mockDocumentStore);
+
+      final DocumentStoreConfigurationRecord configuration =
+          new DocumentStoreConfigurationRecord(
+              "aws", AwsDocumentStoreProvider.class, new HashMap<>());
+      configuration.properties().put("BUCKET", bucketName);
+      final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+      // when
+      final DocumentStore documentStore = provider.createDocumentStore(configuration);
+
+      // then
+      assertNotNull(documentStore);
+    }
+  }
+
+  @Test
+  public void shouldThrowIfBucketNameIsMissing() {
+    // given
+    final DocumentStoreConfigurationRecord configuration =
+        new DocumentStoreConfigurationRecord(
+            "my-aws", AwsDocumentStoreProvider.class, new HashMap<>());
+    final AwsDocumentStoreProvider provider = new AwsDocumentStoreProvider();
+
+    // when / then
+    final var ex =
+        assertThrows(
+            IllegalArgumentException.class, () -> provider.createDocumentStore(configuration));
+    assertThat(ex.getMessage())
+        .isEqualTo(
+            "Failed to configure document store with id 'my-aws': missing required property 'BUCKET'");
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.document.store.aws;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.camunda.document.api.*;
+import io.camunda.document.api.DocumentError.DocumentAlreadyExists;
+import io.camunda.document.api.DocumentError.DocumentNotFound;
+import io.camunda.document.api.DocumentError.InvalidInput;
+import io.camunda.document.api.DocumentError.UnknownDocumentError;
+import java.io.ByteArrayInputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.HttpStatusCode;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+@ExtendWith(MockitoExtension.class)
+class AwsDocumentStoreTest {
+
+  public static final String BUCKET_NAME = "test-bucket";
+
+  @Mock private S3Client s3Client;
+  @Mock private S3Presigner preSigner;
+  private AwsDocumentStore documentStore;
+
+  @BeforeEach
+  void setUp() {
+    documentStore =
+        new AwsDocumentStore(BUCKET_NAME, s3Client, Executors.newSingleThreadExecutor(), preSigner);
+  }
+
+  @Test
+  void createDocumentShouldSucceed() {
+    // given
+    final var documentId = "test-document-id";
+    final var content = "test-content".getBytes();
+    final var inputStream = new ByteArrayInputStream(content);
+
+    final var metadata =
+        new DocumentMetadataModel(
+            "text/plain", "test-file.txt", null, (long) content.length, Collections.emptyMap());
+
+    final var request = new DocumentCreationRequest(documentId, inputStream, metadata);
+
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(HttpStatusCode.NOT_FOUND).build());
+    final var mockPutResponse = mock(PutObjectResponse.class);
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(mockPutResponse);
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertTrue(result.isRight());
+    assertEquals(documentId, result.get().documentId());
+    verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+  }
+
+  @Test
+  void createDocumentShouldFailIfDocumentAlreadyExists() {
+    // given
+    final var documentId = "existing-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final var request = new DocumentCreationRequest(documentId, inputStream, null);
+
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().build());
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(DocumentAlreadyExists.class, result.getLeft());
+  }
+
+  @Test
+  void createDocumentShouldFailForGeneralException() {
+    // given
+    final var documentId = "existing-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final var request = new DocumentCreationRequest(documentId, inputStream, null);
+
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(new RuntimeException("Something went wrong"));
+
+    // when
+    final var result = documentStore.createDocument(request).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+  }
+
+  @Test
+  void getDocumentShouldSucceed() {
+    // given
+    final var documentId = "test-document-id";
+    final var inputStream = new ByteArrayInputStream(new byte[0]);
+    final var responseInputStream =
+        new ResponseInputStream<>(GetObjectResponse.builder().build(), inputStream);
+
+    when(s3Client.getObject(any(GetObjectRequest.class))).thenReturn(responseInputStream);
+
+    // when
+    final var result = documentStore.getDocument(documentId).join();
+
+    // then
+    assertTrue(result.isRight());
+    assertEquals(responseInputStream, result.get());
+  }
+
+  @Test
+  void getDocumentShouldFailIfDocumentNotFound() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(s3Client.getObject(any(GetObjectRequest.class)))
+        .thenThrow(S3Exception.builder().statusCode(HttpStatusCode.NOT_FOUND).build());
+
+    // when
+    final var result = documentStore.getDocument(documentId).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(DocumentNotFound.class, result.getLeft());
+    verify(s3Client).getObject(any(GetObjectRequest.class));
+  }
+
+  @Test
+  void deleteDocumentShouldSucceed() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenReturn(mock(DeleteObjectResponse.class));
+
+    // when
+    final var result = documentStore.deleteDocument(documentId).join();
+
+    // then
+    assertFalse(result.isLeft());
+  }
+
+  @Test
+  void deleteDocumentShouldFailForException() {
+    // given
+    final var documentId = "test-document-id";
+
+    when(s3Client.deleteObject(any(DeleteObjectRequest.class)))
+        .thenThrow(new RuntimeException("Something went wrong"));
+
+    // when
+    final var result = documentStore.deleteDocument(documentId).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+  }
+
+  @Test
+  void createDocumentLinkShouldSucceed() throws MalformedURLException {
+    // given
+    final var documentId = "test-document-id";
+    final var linkUrl = URI.create("http://awsurl/" + documentId).toURL();
+
+    final var objectRequestMock = mock(PresignedGetObjectRequest.class);
+    when(preSigner.presignGetObject(any(GetObjectPresignRequest.class)))
+        .thenReturn(objectRequestMock);
+    when(objectRequestMock.url()).thenReturn(linkUrl);
+
+    // when
+    final var result = documentStore.createLink(documentId, 10000).join();
+
+    // then
+    assertFalse(result.isLeft());
+    assertEquals(linkUrl.toString(), result.get().link());
+  }
+
+  @Test
+  void createDocumentLinkShouldFailForInvalidDuration() {
+    // given
+    final var documentId = "test-document-id";
+
+    // when
+    final var result = documentStore.createLink(documentId, -1).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(InvalidInput.class, result.getLeft());
+  }
+
+  @Test
+  void createDocumentLinkShouldFailForException() {
+    // given
+    final var documentId = "test-document-id";
+    when(preSigner.presignGetObject(any(GetObjectPresignRequest.class)))
+        .thenThrow(new RuntimeException("Something went wrong"));
+
+    // when
+    final var result = documentStore.createLink(documentId, 10000).join();
+
+    // then
+    assertTrue(result.isLeft());
+    assertInstanceOf(UnknownDocumentError.class, result.getLeft());
+  }
+}

--- a/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
+++ b/document/store/src/test/java/io/camunda/document/store/aws/AwsDocumentStoreTest.java
@@ -43,6 +43,7 @@ class AwsDocumentStoreTest {
 
   public static final String BUCKET_NAME = "test-bucket";
   public static final Long BUCKET_TTL = 30L;
+  public static final String BUCKET_PATH = "/test/";
 
   @Mock private S3Client s3Client;
   @Mock private S3Presigner preSigner;
@@ -52,7 +53,12 @@ class AwsDocumentStoreTest {
   void setUp() {
     documentStore =
         new AwsDocumentStore(
-            BUCKET_NAME, BUCKET_TTL, s3Client, Executors.newSingleThreadExecutor(), preSigner);
+            BUCKET_NAME,
+            BUCKET_TTL,
+            BUCKET_PATH,
+            s3Client,
+            Executors.newSingleThreadExecutor(),
+            preSigner);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This update introduces the ability to use AWS S3 as the storage platform for documents managed through the Documents API.

#### Environment variables
`DOCUMENT_STORE_AWS_BUCKET_NAME`      => The name of the AWS S3 bucket used for document storage.

`DOCUMENT_STORE_AWS_BUCKET_PATH`      => The path within the S3 bucket for storing documents (e.g., `test/bucket/path/`).

`DOCUMENT_STORE_AWS_BUCKET_TTL`       => The time-to-live (TTL) for document objects in the AWS S3 bucket. This value is specified in days and defines when the objects will be automatically deleted. Do not set to disable TTL.


#### Features covered
- Uploading documents to S3
- Fetching documents from S3
- Deleting documents from S3
- Generating pre-signed URL for documents
- Expired documents return document not found

#### Features not covered
- Hash Verification

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24541
