### PR TITLE
Add go job timeouts to stable branches

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -444,6 +444,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-lint:
     name: Go linting
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -473,6 +474,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-apidiff:
     name: Go Backward Compatibility
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
       # set the comparison based on the type of workflow trigger:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As a followup to PR #24880, `go-lint`, `go-apidiff` jobs also need timeouts (both are running ~1min, so should be enough to set 5min timeout) to be defined, but they are removed on main. They are needed to be added in 8.5, 8.4, 8.3.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
