### PR TITLE
feat: return name for flownode-instances & user-tasks

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/FlowNodeInstance.java
@@ -29,6 +29,9 @@ public interface FlowNodeInstance {
   /** flow node id for flow node instance */
   String getFlowNodeId();
 
+  /** flow node name for flow node instance */
+  String getFlowNodeName();
+
   /** start date of flow node instance */
   String getStartDate();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/UserTask.java
@@ -22,6 +22,9 @@ public interface UserTask {
 
   Long getUserTaskKey();
 
+  /** Name of the task */
+  String getName();
+
   /** State of the task */
   String getState();
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/FlowNodeInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/FlowNodeInstanceImpl.java
@@ -25,6 +25,7 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
   private final Long processDefinitionKey;
   private final Long processInstanceKey;
   private final String flowNodeId;
+  private final String flowNodeName;
   private final String startDate;
   private final String endDate;
   private final Boolean incident;
@@ -39,6 +40,7 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
     processDefinitionKey = item.getProcessDefinitionKey();
     processInstanceKey = item.getProcessInstanceKey();
     flowNodeId = item.getFlowNodeId();
+    flowNodeName = item.getFlowNodeName();
     startDate = item.getStartDate();
     endDate = item.getEndDate();
     incident = item.getHasIncident();
@@ -67,6 +69,11 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
   @Override
   public String getFlowNodeId() {
     return flowNodeId;
+  }
+
+  @Override
+  public String getFlowNodeName() {
+    return flowNodeName;
   }
 
   @Override
@@ -139,6 +146,7 @@ public final class FlowNodeInstanceImpl implements FlowNodeInstance {
         && Objects.equals(processDefinitionKey, that.processDefinitionKey)
         && Objects.equals(processInstanceKey, that.processInstanceKey)
         && Objects.equals(flowNodeId, that.flowNodeId)
+        && Objects.equals(flowNodeName, that.flowNodeName)
         && Objects.equals(startDate, that.startDate)
         && Objects.equals(endDate, that.endDate)
         && Objects.equals(incident, that.incident)

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
@@ -23,6 +23,7 @@ import java.util.Map;
 public class UserTaskImpl implements UserTask {
 
   private final Long userTaskKey;
+  private final String name;
   private final String state;
   private final String assignee;
   private final String elementId;
@@ -45,6 +46,7 @@ public class UserTaskImpl implements UserTask {
 
   public UserTaskImpl(final UserTaskItem item) {
     userTaskKey = item.getUserTaskKey();
+    name = item.getName();
     state = item.getState().getValue();
     assignee = item.getAssignee();
     elementId = item.getElementId();
@@ -69,6 +71,11 @@ public class UserTaskImpl implements UserTask {
   @Override
   public Long getUserTaskKey() {
     return userTaskKey;
+  }
+
+  @Override
+  public String getName() {
+    return name;
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/rest/RestApiConfiguration.java
@@ -7,11 +7,20 @@
  */
 package io.camunda.application.commons.rest;
 
+import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
+import io.camunda.zeebe.gateway.rest.util.XmlUtil;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = "io.camunda.zeebe.gateway.rest")
 @ConditionalOnRestGatewayEnabled
-public class RestApiConfiguration {}
+public class RestApiConfiguration {
+
+  @Bean
+  public XmlUtil xmlUtil(final ProcessDefinitionServices processDefinitionServices) {
+    return new XmlUtil(processDefinitionServices);
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -799,6 +799,20 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
   }
 
   @Test
+  void shouldUseFlowNodeInstanceFlowNodeIdIfNameNotSet() {
+    // when
+    final var result =
+        zeebeClient
+            .newFlownodeInstanceQuery()
+            .filter(f -> f.flowNodeId("Event_1p0nsc7"))
+            .send()
+            .join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getFlowNodeName()).isEqualTo("Event_1p0nsc7");
+  }
+
+  @Test
   void shouldQueryFlowNodeInstanceByProcessDefinitionKey() {
     // given
     final var processDefinitionKey = flowNodeInstance.getProcessDefinitionKey();

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -789,6 +789,16 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
   }
 
   @Test
+  void shouldHaveCorrectFlowNodeInstanceFlowNodeName() {
+    // when
+    final var result =
+        zeebeClient.newFlownodeInstanceQuery().filter(f -> f.flowNodeId("noOpTask")).send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getFlowNodeName()).isEqualTo("No Op");
+  }
+
+  @Test
   void shouldQueryFlowNodeInstanceByProcessDefinitionKey() {
     // given
     final var processDefinitionKey = flowNodeInstance.getProcessDefinitionKey();

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -91,6 +91,16 @@ class UserTaskQueryTest {
   }
 
   @Test
+  public void shouldUseUserTaskElementIdIfNameNotSet() {
+    // when
+    final var result =
+        camundaClient.newUserTaskQuery().filter(f -> f.elementId("test-2")).send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getName()).isEqualTo("test-2");
+  }
+
+  @Test
   public void shouldRetrieveVariablesFromUserTask() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("task02").value("1");

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -81,6 +81,16 @@ class UserTaskQueryTest {
   }
 
   @Test
+  public void shouldHaveCorrectUserTaskName() {
+    // when
+    final var result =
+        camundaClient.newUserTaskQuery().filter(f -> f.elementId("form_process")).send().join();
+    // then
+    assertThat(result.items()).hasSize(1);
+    assertThat(result.items().getFirst().getName()).isEqualTo("Form");
+  }
+
+  @Test
   public void shouldRetrieveVariablesFromUserTask() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("task02").value("1");

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3267,6 +3267,9 @@ components:
           description: The key of the user task.
           type: integer
           format: int64
+        name:
+          type: string
+          description: The name for this user task.
         state:
           type: string
           description: The state of the user task.
@@ -3990,6 +3993,9 @@ components:
           format: date-time
         flowNodeId:
           description: The flow node ID for this flow node instance.
+          type: string
+        flowNodeName:
+          description: The flow node name for this flow node instance.
           type: string
         treePath:
           description: The path from process instance leading to this flow node instance.

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -70,7 +70,6 @@ import io.camunda.zeebe.gateway.protocol.rest.VariableItem;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResponse;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -145,7 +144,7 @@ public final class SearchQueryResponseMapper {
 
   public static FlowNodeInstanceSearchQueryResponse toFlowNodeInstanceSearchQueryResponse(
       final SearchQueryResult<FlowNodeInstanceEntity> result,
-      final Map<Long, Map<Long, String>> nameMap) {
+      final Map<Long, Map<String, String>> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new FlowNodeInstanceSearchQueryResponse()
         .page(page)
@@ -168,7 +167,7 @@ public final class SearchQueryResponseMapper {
 
   public static UserTaskSearchQueryResponse toUserTaskSearchQueryResponse(
       final SearchQueryResult<UserTaskEntity> result,
-      final HashMap<Long, Map<Long, String>> nameMap) {
+      final Map<Long, Map<String, String>> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new UserTaskSearchQueryResponse()
         .page(page)
@@ -292,15 +291,13 @@ public final class SearchQueryResponseMapper {
   }
 
   private static List<FlowNodeInstanceItem> toFlowNodeInstance(
-      final List<FlowNodeInstanceEntity> instances, final Map<Long, Map<Long, String>> nameMap) {
+      final List<FlowNodeInstanceEntity> instances, final Map<Long, Map<String, String>> nameMap) {
     return instances.stream()
         .map(
             instance ->
                 toFlowNodeInstance(
                     instance,
-                    nameMap
-                        .get(instance.processDefinitionKey())
-                        .get(instance.flowNodeInstanceKey())))
+                    nameMap.get(instance.processDefinitionKey()).get(instance.flowNodeId())))
         .toList();
   }
 
@@ -346,11 +343,11 @@ public final class SearchQueryResponseMapper {
   }
 
   private static List<UserTaskItem> toUserTasks(
-      final List<UserTaskEntity> tasks, final HashMap<Long, Map<Long, String>> nameMap) {
+      final List<UserTaskEntity> tasks, final Map<Long, Map<String, String>> nameMap) {
     return tasks.stream()
         .map(
             (UserTaskEntity t) ->
-                toUserTask(t, nameMap.get(t.processDefinitionKey()).get(t.userTaskKey())))
+                toUserTask(t, nameMap.get(t.processDefinitionKey()).get(t.elementId())))
         .toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -144,7 +144,8 @@ public final class SearchQueryResponseMapper {
   }
 
   public static FlowNodeInstanceSearchQueryResponse toFlowNodeInstanceSearchQueryResponse(
-      final SearchQueryResult<FlowNodeInstanceEntity> result, final HashMap<Long, String> nameMap) {
+      final SearchQueryResult<FlowNodeInstanceEntity> result,
+      final Map<Long, Map<Long, String>> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new FlowNodeInstanceSearchQueryResponse()
         .page(page)
@@ -166,7 +167,8 @@ public final class SearchQueryResponseMapper {
   }
 
   public static UserTaskSearchQueryResponse toUserTaskSearchQueryResponse(
-      final SearchQueryResult<UserTaskEntity> result, final Map<Long, String> nameMap) {
+      final SearchQueryResult<UserTaskEntity> result,
+      final HashMap<Long, Map<Long, String>> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new UserTaskSearchQueryResponse()
         .page(page)
@@ -290,9 +292,15 @@ public final class SearchQueryResponseMapper {
   }
 
   private static List<FlowNodeInstanceItem> toFlowNodeInstance(
-      final List<FlowNodeInstanceEntity> instances, final HashMap<Long, String> nameMap) {
+      final List<FlowNodeInstanceEntity> instances, final Map<Long, Map<Long, String>> nameMap) {
     return instances.stream()
-        .map(instance -> toFlowNodeInstance(instance, nameMap.get(instance.flowNodeInstanceKey())))
+        .map(
+            instance ->
+                toFlowNodeInstance(
+                    instance,
+                    nameMap
+                        .get(instance.processDefinitionKey())
+                        .get(instance.flowNodeInstanceKey())))
         .toList();
   }
 
@@ -338,9 +346,11 @@ public final class SearchQueryResponseMapper {
   }
 
   private static List<UserTaskItem> toUserTasks(
-      final List<UserTaskEntity> tasks, final Map<Long, String> nameMap) {
+      final List<UserTaskEntity> tasks, final HashMap<Long, Map<Long, String>> nameMap) {
     return tasks.stream()
-        .map((UserTaskEntity t) -> toUserTask(t, nameMap.get(t.userTaskKey())))
+        .map(
+            (UserTaskEntity t) ->
+                toUserTask(t, nameMap.get(t.processDefinitionKey()).get(t.userTaskKey())))
         .toList();
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -70,7 +70,9 @@ import io.camunda.zeebe.gateway.protocol.rest.VariableItem;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResponse;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public final class SearchQueryResponseMapper {
@@ -141,14 +143,14 @@ public final class SearchQueryResponseMapper {
                 .orElseGet(Collections::emptyList));
   }
 
-  public static FlowNodeInstanceSearchQueryResponse toFlownodeInstanceSearchQueryResponse(
-      final SearchQueryResult<FlowNodeInstanceEntity> result) {
+  public static FlowNodeInstanceSearchQueryResponse toFlowNodeInstanceSearchQueryResponse(
+      final SearchQueryResult<FlowNodeInstanceEntity> result, final HashMap<Long, String> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new FlowNodeInstanceSearchQueryResponse()
         .page(page)
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toFlownodeInstance)
+                .map(instances -> toFlowNodeInstance(instances, nameMap))
                 .orElseGet(Collections::emptyList));
   }
 
@@ -164,13 +166,13 @@ public final class SearchQueryResponseMapper {
   }
 
   public static UserTaskSearchQueryResponse toUserTaskSearchQueryResponse(
-      final SearchQueryResult<UserTaskEntity> result) {
+      final SearchQueryResult<UserTaskEntity> result, final Map<Long, String> nameMap) {
     final var page = toSearchQueryPageResponse(result);
     return new UserTaskSearchQueryResponse()
         .page(page)
         .items(
             ofNullable(result.items())
-                .map(SearchQueryResponseMapper::toUserTasks)
+                .map(tasks -> toUserTasks(tasks, nameMap))
                 .orElseGet(Collections::emptyList));
   }
 
@@ -287,15 +289,19 @@ public final class SearchQueryResponseMapper {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionRequirements).toList();
   }
 
-  private static List<FlowNodeInstanceItem> toFlownodeInstance(
-      final List<FlowNodeInstanceEntity> instances) {
-    return instances.stream().map(SearchQueryResponseMapper::toFlowNodeInstance).toList();
+  private static List<FlowNodeInstanceItem> toFlowNodeInstance(
+      final List<FlowNodeInstanceEntity> instances, final HashMap<Long, String> nameMap) {
+    return instances.stream()
+        .map(instance -> toFlowNodeInstance(instance, nameMap.get(instance.flowNodeInstanceKey())))
+        .toList();
   }
 
-  public static FlowNodeInstanceItem toFlowNodeInstance(final FlowNodeInstanceEntity instance) {
+  public static FlowNodeInstanceItem toFlowNodeInstance(
+      final FlowNodeInstanceEntity instance, final String name) {
     return new FlowNodeInstanceItem()
         .flowNodeInstanceKey(instance.flowNodeInstanceKey())
         .flowNodeId(instance.flowNodeId())
+        .flowNodeName(name)
         .processDefinitionKey(instance.processDefinitionKey())
         .processDefinitionId(instance.processDefinitionId())
         .processInstanceKey(instance.processInstanceKey())
@@ -331,8 +337,11 @@ public final class SearchQueryResponseMapper {
         .decisionRequirementsId(d.decisionRequirementsId());
   }
 
-  private static List<UserTaskItem> toUserTasks(final List<UserTaskEntity> tasks) {
-    return tasks.stream().map(SearchQueryResponseMapper::toUserTask).toList();
+  private static List<UserTaskItem> toUserTasks(
+      final List<UserTaskEntity> tasks, final Map<Long, String> nameMap) {
+    return tasks.stream()
+        .map((UserTaskEntity t) -> toUserTask(t, nameMap.get(t.userTaskKey())))
+        .toList();
   }
 
   private static List<IncidentItem> toIncidents(final List<IncidentEntity> incidents) {
@@ -356,10 +365,11 @@ public final class SearchQueryResponseMapper {
         .tenantId(t.tenantId());
   }
 
-  public static UserTaskItem toUserTask(final UserTaskEntity t) {
+  public static UserTaskItem toUserTask(final UserTaskEntity t, final String name) {
     return new UserTaskItem()
         .tenantId(t.tenantId())
         .userTaskKey(t.userTaskKey())
+        .name(name)
         .processInstanceKey(t.processInstanceKey())
         .processDefinitionKey(t.processDefinitionKey())
         .elementInstanceKey(t.elementInstanceKey())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryController.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.util.XmlUtil;
-import java.util.HashMap;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -76,8 +75,7 @@ public class FlowNodeInstanceQueryController {
           flownodeInstanceServices
               .withAuthentication(RequestMapper.getAuthentication())
               .search(query);
-      final var nameMap = new HashMap<Long, String>();
-      result.items().forEach(f -> nameMap.put(f.flowNodeInstanceKey(), xmlUtil.getFlowNodeName(f)));
+      final var nameMap = xmlUtil.getFlowNodesNames(result.items());
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toFlowNodeInstanceSearchQueryResponse(result, nameMap));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import io.camunda.zeebe.gateway.rest.util.XmlUtil;
-import java.util.HashMap;
 import java.util.Optional;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -60,8 +59,7 @@ public class UserTaskQueryController {
     try {
       final var result =
           userTaskServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
-      final var nameMap = new HashMap<Long, String>();
-      result.items().forEach(u -> nameMap.put(u.userTaskKey(), xmlUtil.getUserTaskName(u)));
+      final var nameMap = xmlUtil.getUserTasksNames(result.items());
       return ResponseEntity.ok(
           SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result, nameMap));
     } catch (final Exception e) {
@@ -79,7 +77,7 @@ public class UserTaskQueryController {
           userTaskServices
               .withAuthentication(RequestMapper.getAuthentication())
               .getByKey(userTaskKey);
-      final String name = xmlUtil.getUserTaskName(userTask);
+      final var name = xmlUtil.getUserTaskName(userTask);
       return ResponseEntity.ok().body(SearchQueryResponseMapper.toUserTask(userTask, name));
     } catch (final Exception e) {
       return mapErrorToResponse(e);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
@@ -16,12 +16,15 @@ import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.protocol.rest.FormItem;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskVariableSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.util.XmlUtil;
+import java.util.HashMap;
 import java.util.Optional;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -36,26 +39,31 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class UserTaskQueryController {
 
   private final UserTaskServices userTaskServices;
+  private final XmlUtil xmlUtil;
 
-  public UserTaskQueryController(final UserTaskServices userTaskServices) {
+  public UserTaskQueryController(final UserTaskServices userTaskServices, final XmlUtil xmlUtil) {
     this.userTaskServices = userTaskServices;
+    this.xmlUtil = xmlUtil;
   }
 
   @PostMapping(
       path = "/search",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<Object> searchUserTasks(
+  public ResponseEntity<UserTaskSearchQueryResponse> searchUserTasks(
       @RequestBody(required = false) final UserTaskSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserTaskQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
-  private ResponseEntity<Object> search(final UserTaskQuery query) {
+  private ResponseEntity<UserTaskSearchQueryResponse> search(final UserTaskQuery query) {
     try {
       final var result =
           userTaskServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result));
+      final var nameMap = new HashMap<Long, String>();
+      result.items().forEach(u -> nameMap.put(u.userTaskKey(), xmlUtil.getUserTaskName(u)));
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toUserTaskSearchQueryResponse(result, nameMap));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }
@@ -67,12 +75,12 @@ public class UserTaskQueryController {
   public ResponseEntity<UserTaskItem> getByKey(
       @PathVariable("userTaskKey") final Long userTaskKey) {
     try {
-      return ResponseEntity.ok()
-          .body(
-              SearchQueryResponseMapper.toUserTask(
-                  userTaskServices
-                      .withAuthentication(RequestMapper.getAuthentication())
-                      .getByKey(userTaskKey)));
+      final var userTask =
+          userTaskServices
+              .withAuthentication(RequestMapper.getAuthentication())
+              .getByKey(userTaskKey);
+      final String name = xmlUtil.getUserTaskName(userTask);
+      return ResponseEntity.ok().body(SearchQueryResponseMapper.toUserTask(userTask, name));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/XmlUtil.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/XmlUtil.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.util;
+
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.xml.sax.SAXException;
+
+@Component
+public class XmlUtil {
+
+  public static final String XPATH_NODE_NAME = "//process[@id='%s']/%s[@id='%s']/@name";
+  private static final Logger LOG = LoggerFactory.getLogger(XmlUtil.class);
+
+  private final ProcessDefinitionServices processDefinitionServices;
+
+  public XmlUtil(final ProcessDefinitionServices processDefinitionServices) {
+    this.processDefinitionServices = processDefinitionServices;
+  }
+
+  public String getFlowNodeName(final FlowNodeInstanceEntity flowNode) {
+    final var processDefinition =
+        processDefinitionServices.getByKey(flowNode.processDefinitionKey());
+    final var type = BpmnElementType.valueOf(flowNode.type().name());
+    if (type.getElementTypeName().isEmpty()) {
+      return flowNode.flowNodeId();
+    }
+    return extractFlowNodeName(
+        processDefinition.bpmnXml(),
+        processDefinition.processDefinitionId(),
+        type.getElementTypeName().get(),
+        flowNode.flowNodeId());
+  }
+
+  public String getUserTaskName(final UserTaskEntity userTask) {
+    final var processDefinition =
+        processDefinitionServices.getByKey(userTask.processDefinitionKey());
+    return extractFlowNodeName(
+        processDefinition.bpmnXml(),
+        processDefinition.processDefinitionId(),
+        "userTask",
+        userTask.elementId());
+  }
+
+  public String extractFlowNodeName(
+      final String xml,
+      final String processDefinitionId,
+      final String flowNodeType,
+      final String flowNodeId) {
+    try {
+      final var documentBuilder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+      final var xmlStream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8));
+      final var document = documentBuilder.parse(xmlStream);
+      final var expression =
+          XPATH_NODE_NAME.formatted(processDefinitionId, flowNodeType, flowNodeId);
+      final var xPath = XPathFactory.newInstance().newXPath();
+      final var name = (String) xPath.compile(expression).evaluate(document, XPathConstants.STRING);
+      LOG.debug("XPath expression {}, result {}", expression, name);
+      return StringUtils.isNotBlank(name) ? name : flowNodeId;
+    } catch (final SAXException
+        | IOException
+        | XPathExpressionException
+        | ParserConfigurationException e) {
+      LOG.error(e.getMessage(), e);
+    }
+    return flowNodeId;
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/XmlUtil.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/util/XmlUtil.java
@@ -43,12 +43,12 @@ public class XmlUtil {
     this.processDefinitionServices = processDefinitionServices;
   }
 
-  public Map<Long, Map<Long, String>> getFlowNodesNames(
+  public Map<Long, Map<String, String>> getFlowNodesNames(
       final List<FlowNodeInstanceEntity> flowNodes) {
     return getNamesForEntities(
         flowNodes,
         FlowNodeInstanceEntity::processDefinitionKey,
-        FlowNodeInstanceEntity::flowNodeInstanceKey,
+        FlowNodeInstanceEntity::flowNodeId,
         this::getFlowNodeName);
   }
 
@@ -58,7 +58,7 @@ public class XmlUtil {
     return getFlowNodeName(processDefinition, flowNode);
   }
 
-  protected String getFlowNodeName(
+  private String getFlowNodeName(
       final ProcessDefinitionEntity processDefinition, final FlowNodeInstanceEntity flowNode) {
     final var type = BpmnElementType.valueOf(flowNode.type().name());
     if (type.getElementTypeName().isEmpty()) {
@@ -71,11 +71,11 @@ public class XmlUtil {
         flowNode.flowNodeId());
   }
 
-  public HashMap<Long, Map<Long, String>> getUserTasksNames(final List<UserTaskEntity> userTasks) {
+  public Map<Long, Map<String, String>> getUserTasksNames(final List<UserTaskEntity> userTasks) {
     return getNamesForEntities(
         userTasks,
         UserTaskEntity::processDefinitionKey,
-        UserTaskEntity::userTaskKey,
+        UserTaskEntity::elementId,
         this::getUserTaskName);
   }
 
@@ -85,7 +85,7 @@ public class XmlUtil {
     return getUserTaskName(processDefinition, userTask);
   }
 
-  protected String getUserTaskName(
+  private String getUserTaskName(
       final ProcessDefinitionEntity processDefinition, final UserTaskEntity userTask) {
     return extractFlowNodeName(
         processDefinition.bpmnXml(),
@@ -94,13 +94,13 @@ public class XmlUtil {
         userTask.elementId());
   }
 
-  protected <T> HashMap<Long, Map<Long, String>> getNamesForEntities(
+  private <T> Map<Long, Map<String, String>> getNamesForEntities(
       final List<T> items,
       final Function<T, Long> fnProcessDefinitionKey,
-      final Function<T, Long> fnEntityKey,
+      final Function<T, String> fnEntityKey,
       final BiFunction<ProcessDefinitionEntity, T, String> fnGetFlowNodeName) {
 
-    final var processDefinitionFlowNodesMap = new HashMap<Long, Map<Long, String>>();
+    final var processDefinitionFlowNodesMap = new HashMap<Long, Map<String, String>>();
     if (items.isEmpty()) {
       return processDefinitionFlowNodesMap;
     }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,6 +27,7 @@ import io.camunda.service.FlowNodeInstanceServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.util.XmlUtil;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -135,6 +137,11 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
     when(flowNodeInstanceServices.withAuthentication(any(Authentication.class)))
         .thenReturn(flowNodeInstanceServices);
     when(xmlUtil.getFlowNodeName(any())).thenReturn("flowNodeName");
+    final var processDefinitionMap = mock(HashMap.class);
+    final var userTaskNamesMap = mock(HashMap.class);
+    when(userTaskNamesMap.get(any())).thenReturn("flowNodeName");
+    when(processDefinitionMap.get(any())).thenReturn(userTaskNamesMap);
+    when(xmlUtil.getFlowNodesNames(any())).thenReturn(processDefinitionMap);
   }
 
   @Test
@@ -155,7 +162,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(flowNodeInstanceServices).search(new FlowNodeInstanceQuery.Builder().build());
-    verify(xmlUtil).getFlowNodeName(any());
+    verify(xmlUtil).getFlowNodesNames(any());
   }
 
   @Test
@@ -180,7 +187,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(flowNodeInstanceServices).search(new FlowNodeInstanceQuery.Builder().build());
-    verify(xmlUtil).getFlowNodeName(any());
+    verify(xmlUtil).getFlowNodesNames(any());
   }
 
   @Test
@@ -308,7 +315,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                         .asc()
                         .build())
                 .build());
-    verify(xmlUtil).getFlowNodeName(any());
+    verify(xmlUtil).getFlowNodesNames(any());
   }
 
   @Test

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -237,6 +238,11 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 String.format("User Task with key %d not found", INVALID_USER_TASK_KEY)));
     final ProcessDefinitionEntity processDefinition = mock(ProcessDefinitionEntity.class);
     when(xmlUtil.getUserTaskName(any())).thenReturn("name");
+    final var processDefinitionMap = mock(HashMap.class);
+    final var userTaskNamesMap = mock(HashMap.class);
+    when(userTaskNamesMap.get(any())).thenReturn("name");
+    when(processDefinitionMap.get(any())).thenReturn(userTaskNamesMap);
+    when(xmlUtil.getUserTasksNames(any())).thenReturn(processDefinitionMap);
   }
 
   @Test
@@ -256,7 +262,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
-    verify(xmlUtil).getUserTaskName(any());
+    verify(xmlUtil).getUserTasksNames(any());
   }
 
   @Test
@@ -280,7 +286,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
-    verify(xmlUtil).getUserTaskName(any());
+    verify(xmlUtil).getUserTasksNames(any());
   }
 
   @Test
@@ -322,7 +328,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 .sort(
                     new UserTaskSort.Builder().creationDate().desc().completionDate().asc().build())
                 .build());
-    verify(xmlUtil).getUserTaskName(any());
+    verify(xmlUtil).getUserTasksNames(any());
   }
 
   @Test
@@ -677,6 +683,6 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().filter(filter).build());
-    verify(xmlUtil).getUserTaskName(any());
+    verify(xmlUtil).getUserTasksNames(any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -9,12 +9,14 @@ package io.camunda.zeebe.gateway.rest.controller;
 
 import static io.camunda.search.query.SearchQueryBuilders.variableSearchQuery;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import io.camunda.search.entities.FormEntity;
+import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.UserTaskEntity.UserTaskState;
 import io.camunda.search.entities.VariableEntity;
@@ -28,6 +30,8 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.rest.JacksonConfig;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import io.camunda.zeebe.gateway.rest.util.XmlUtil;
+import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,6 +73,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "candidateGroups": [],
                       "formKey": 0,
                       "elementId": "e",
+                      "name": "name",
                       "creationDate": "2020-11-11T00:00:00.000Z",
                       "completionDate": "2020-11-11T00:00:00.000Z",
                       "dueDate": "2020-11-11T00:00:00.000Z",
@@ -128,6 +133,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "candidateGroups": [],
                       "formKey": 0,
                       "elementId": "e",
+                      "name": "name",
                       "creationDate": "2020-11-11T00:00:00.000Z",
                       "completionDate": "2020-11-11T00:00:00.000Z",
                       "dueDate": "2020-11-11T00:00:00.000Z",
@@ -193,9 +199,10 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
           .build();
 
   @MockBean UserTaskServices userTaskServices;
+  @MockBean XmlUtil xmlUtil;
 
   @BeforeEach
-  void setupServices() {
+  void setupServices() throws IOException {
     when(userTaskServices.withAuthentication(any(Authentication.class)))
         .thenReturn(userTaskServices);
 
@@ -228,6 +235,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .thenThrow(
             new NotFoundException(
                 String.format("User Task with key %d not found", INVALID_USER_TASK_KEY)));
+    final ProcessDefinitionEntity processDefinition = mock(ProcessDefinitionEntity.class);
+    when(xmlUtil.getUserTaskName(any())).thenReturn("name");
   }
 
   @Test
@@ -247,6 +256,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
+    verify(xmlUtil).getUserTaskName(any());
   }
 
   @Test
@@ -270,6 +280,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
+    verify(xmlUtil).getUserTaskName(any());
   }
 
   @Test
@@ -311,6 +322,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                 .sort(
                     new UserTaskSort.Builder().creationDate().desc().completionDate().asc().build())
                 .build());
+    verify(xmlUtil).getUserTaskName(any());
   }
 
   @Test
@@ -353,6 +365,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(expectedResponse);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
+    verify(xmlUtil, never()).getUserTaskName(any());
   }
 
   @Test
@@ -395,6 +408,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(expectedResponse);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
+    verify(xmlUtil, never()).getUserTaskName(any());
   }
 
   @Test
@@ -436,6 +450,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(expectedResponse);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
+    verify(xmlUtil, never()).getUserTaskName(any());
   }
 
   @Test
@@ -476,6 +491,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(expectedResponse);
 
     verify(userTaskServices, never()).search(any(UserTaskQuery.class));
+    verify(xmlUtil, never()).getUserTaskName(any());
   }
 
   @Test
@@ -493,6 +509,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the invalid userTaskKey
     verify(userTaskServices).getByKey(VALID_USER_TASK_KEY);
+    verify(xmlUtil).getUserTaskName(any());
   }
 
   @Test
@@ -518,6 +535,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
 
     // Verify that the service was called with the invalid userTaskKey
     verify(userTaskServices).getByKey(INVALID_USER_TASK_KEY);
+    verify(xmlUtil, never()).getUserTaskName(any());
   }
 
   @Test
@@ -659,5 +677,6 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .json(EXPECTED_SEARCH_RESPONSE);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().filter(filter).build());
+    verify(xmlUtil).getUserTaskName(any());
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/XmlUtilTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/XmlUtilTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.FlowNodeInstanceEntity;
+import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
+import io.camunda.search.entities.ProcessDefinitionEntity;
+import io.camunda.search.entities.UserTaskEntity;
+import io.camunda.service.ProcessDefinitionServices;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {XmlUtil.class})
+class XmlUtilTest {
+
+  public static final String PROCESS_DEFINITION_ID = "testProcess";
+  @Autowired XmlUtil xmlUtil;
+  @MockBean ProcessDefinitionServices processDefinitionServices;
+  @Mock ProcessDefinitionEntity processDefinition;
+  @Mock UserTaskEntity userTaskEntity;
+  @Mock FlowNodeInstanceEntity flowNodeInstanceEntity;
+  private String bpmn;
+
+  @BeforeEach
+  void setupServices() throws Exception {
+    bpmn =
+        new String(
+            getClass().getClassLoader().getResourceAsStream("./user-task.bpmn").readAllBytes(),
+            StandardCharsets.UTF_8);
+    when(processDefinition.bpmnXml()).thenReturn(bpmn);
+    when(processDefinition.processDefinitionId()).thenReturn(PROCESS_DEFINITION_ID);
+    when(processDefinitionServices.getByKey(eq(1L))).thenReturn(processDefinition);
+    when(userTaskEntity.processDefinitionKey()).thenReturn(1L);
+    when(flowNodeInstanceEntity.processDefinitionKey()).thenReturn(1L);
+    when(flowNodeInstanceEntity.type()).thenReturn(FlowNodeType.START_EVENT);
+  }
+
+  @Test
+  void shouldReturnFlowNodeName() {
+    // given
+    when(flowNodeInstanceEntity.flowNodeId()).thenReturn("StartEvent_1");
+    // when
+    final var actual = xmlUtil.getFlowNodeName(flowNodeInstanceEntity);
+    // then
+    verify(processDefinitionServices).getByKey(eq(1L));
+    assertThat(actual).isEqualTo("Start");
+  }
+
+  @Test
+  void shouldReturnUserTaskName() {
+    // given
+    when(userTaskEntity.elementId()).thenReturn("taskB");
+    // when
+    final var actual = xmlUtil.getUserTaskName(userTaskEntity);
+    // then
+    verify(processDefinitionServices).getByKey(eq(1L));
+    assertThat(actual).isEqualTo("Task B");
+  }
+
+  @Test
+  void shouldReturnNameForStartEvent() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn,
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.START_EVENT.getElementTypeName().get(),
+            "StartEvent_1");
+    // then
+    assertThat(actual).isEqualTo("Start");
+  }
+
+  @Test
+  void shouldReturnNameForUserTaskEvent() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn,
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.USER_TASK.getElementTypeName().get(),
+            "taskB");
+    // then
+    assertThat(actual).isEqualTo("Task B");
+  }
+
+  @Test
+  void shouldReturnNameForEndEvent() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn,
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.END_EVENT.getElementTypeName().get(),
+            "Event_0692jdh");
+    // then
+    assertThat(actual).isEqualTo("End");
+  }
+
+  @Test
+  void shouldReturnNodeIdWhenNameNotDefined() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn,
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.USER_TASK.getElementTypeName().get(),
+            "taskA");
+    // then
+    assertThat(actual).isEqualTo("taskA");
+  }
+
+  @Test
+  void shouldReturnNodeIdWhenNodeMissing() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn,
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.USER_TASK.getElementTypeName().get(),
+            "taskC");
+    // then
+    assertThat(actual).isEqualTo("taskC");
+  }
+
+  @Test
+  void shouldReturnNodeIdWhenProcessDefinitionIdMissing() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            bpmn, "not-found", BpmnElementType.USER_TASK.getElementTypeName().get(), "taskD");
+    // then
+    assertThat(actual).isEqualTo("taskD");
+  }
+
+  @Test
+  void shouldReturnNodeIdWhenXmlInvalid() {
+    // when
+    final var actual =
+        xmlUtil.extractFlowNodeName(
+            "not-xml",
+            PROCESS_DEFINITION_ID,
+            BpmnElementType.USER_TASK.getElementTypeName().get(),
+            "taskE");
+    // then
+    assertThat(actual).isEqualTo("taskE");
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/XmlUtilTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/util/XmlUtilTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.gateway.rest.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +23,6 @@ import io.camunda.service.ProcessDefinitionServices;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.function.BiFunction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -176,30 +174,21 @@ class XmlUtilTest {
   @Test
   void shouldSearchProcessDefinitionsAndResolveNames() {
     // given
-    when(userTaskEntity.userTaskKey()).thenReturn(10L);
-    final BiFunction<ProcessDefinitionEntity, UserTaskEntity, String> fnGetFlowNodeName =
-        mock(BiFunction.class);
-    when(fnGetFlowNodeName.apply(any(), any())).thenReturn("userTaskName");
+    when(userTaskEntity.elementId()).thenReturn("taskB");
     when(processDefinitionServices.search(any()))
         .thenReturn(
             new SearchQueryResult.Builder<ProcessDefinitionEntity>()
                 .items(List.of(processDefinition))
                 .build());
     // when
-    final var actual =
-        xmlUtil.getNamesForEntities(
-            List.of(userTaskEntity),
-            UserTaskEntity::processDefinitionKey,
-            UserTaskEntity::userTaskKey,
-            fnGetFlowNodeName);
+    final var actual = xmlUtil.getUserTasksNames(List.of(userTaskEntity));
     // then
     verify(processDefinitionServices)
         .search(
             ProcessDefinitionQuery.of(
                 q -> q.filter(f -> f.processDefinitionKeys(List.of(PROCESS_DEFINITION_KEY)))));
-    verify(fnGetFlowNodeName).apply(processDefinition, userTaskEntity);
     assertThat(actual).hasSize(1);
     assertThat(actual.get(PROCESS_DEFINITION_KEY)).hasSize(1);
-    assertThat(actual.get(PROCESS_DEFINITION_KEY).get(10L)).isEqualTo("userTaskName");
+    assertThat(actual.get(PROCESS_DEFINITION_KEY).get("taskB")).isEqualTo("Task B");
   }
 }

--- a/zeebe/gateway-rest/src/test/resources/user-task.bpmn
+++ b/zeebe/gateway-rest/src/test/resources/user-task.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_09jlb3q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.9.1">
+  <bpmn:process id="testProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_007nkah</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_007nkah" sourceRef="StartEvent_1" targetRef="taskA" />
+    <bpmn:sequenceFlow id="Flow_0qc07xr" sourceRef="taskA" targetRef="taskB" />
+    <bpmn:endEvent id="Event_0692jdh" name="End">
+      <bpmn:incoming>Flow_0lsd3t8</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0lsd3t8" sourceRef="taskB" targetRef="Event_0692jdh" />
+    <bpmn:userTask id="taskA">
+      <bpmn:incoming>Flow_007nkah</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qc07xr</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="taskB" name="Task B">
+      <bpmn:incoming>Flow_0qc07xr</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lsd3t8</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

- Adds `XmlUtil` in gateway-rest to hold methods to parse xml attributes
- Adds `name` field for user-tasks search & get APIs
- Adds `flowNodeName` field for flownode-instances search & get APIs
- Adds java client properties
- Tests for QA & gateway-rest

## Related issues

closes https://github.com/camunda/camunda/issues/24893
