### PR TITLE
Only set routing on list view updates and use the FNI's parent PI ID for it

### DIFF
--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -24,5 +24,17 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/webapps-common/src/main/java/io/camunda/webapps/operate/TreePath.java
+++ b/webapps-common/src/main/java/io/camunda/webapps/operate/TreePath.java
@@ -170,7 +170,7 @@ public class TreePath {
   public Optional<String> processInstanceForFni(final String fniId) {
     final var compiled = treePath.toString();
     final var pathSegments = compiled.split("/");
-    final var fniIndex = Arrays.binarySearch(pathSegments, "FNI_" + fniId);
+    final var fniIndex = Arrays.asList(pathSegments).indexOf("FNI_" + fniId);
     for (int index = fniIndex; index >= 0; index--) {
       final var pathSegment = pathSegments[index];
       if (pathSegment.startsWith("PI_")) {

--- a/webapps-common/src/main/java/io/camunda/webapps/operate/TreePath.java
+++ b/webapps-common/src/main/java/io/camunda/webapps/operate/TreePath.java
@@ -167,6 +167,20 @@ public class TreePath {
     return this;
   }
 
+  public Optional<String> processInstanceForFni(final String fniId) {
+    final var compiled = treePath.toString();
+    final var pathSegments = compiled.split("/");
+    final var fniIndex = Arrays.binarySearch(pathSegments, "FNI_" + fniId);
+    for (int index = fniIndex; index >= 0; index--) {
+      final var pathSegment = pathSegments[index];
+      if (pathSegment.startsWith("PI_")) {
+        return Optional.of(pathSegment.replaceAll("PI_", ""));
+      }
+    }
+
+    return Optional.empty();
+  }
+
   public enum TreePathEntryType {
     /** Process instance. */
     PI,

--- a/webapps-common/src/test/java/io/camunda/webapps/operate/TreePathTest.java
+++ b/webapps-common/src/test/java/io/camunda/webapps/operate/TreePathTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.operate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class TreePathTest {
+  @Nested
+  final class ProcessInstanceIdForFniIdTest {
+    @Test
+    void shouldFindPidForFniId() {
+      // given
+      final var treePath = new TreePath("PI_1/FN_1/FNI_1/PI_2/FN_3/FNI_3");
+
+      // when
+      final var piId = treePath.processInstanceForFni("3");
+
+      // then
+      assertThat(piId).hasValue("2");
+    }
+
+    @Test
+    void shouldNotFindPidForNonExistentFni() {
+      // given
+      final var treePath = new TreePath("PI_1/FN_1/FNI_1");
+
+      // when
+      final var piId = treePath.processInstanceForFni("2");
+
+      // then
+      assertThat(piId).isEmpty();
+    }
+
+    @Test
+    void shouldNotFailOnEmptyPath() {
+      // given
+      final var treePath = new TreePath("");
+
+      // when
+      final var piId = treePath.processInstanceForFni("2");
+
+      // then
+      assertThat(piId).isEmpty();
+    }
+
+    @Test
+    void shouldFindPiStartingFromMiddle() {
+      // given
+      final var treePath = new TreePath("PI_1/FN_1/FNI_1/PI_2/FN_3/FNI_3");
+
+      // when
+      final var piId = treePath.processInstanceForFni("1");
+
+      // then
+      assertThat(piId).hasValue("1");
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.tasks.incident;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.ExporterMetadata;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ActiveIncident;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.Document;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.IncidentDocument;
@@ -17,6 +18,7 @@ import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentU
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.ProcessInstanceDocument;
 import io.camunda.webapps.operate.TreePath;
+import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
@@ -162,30 +164,53 @@ final class IncidentUpdateTaskTest {
   /**
    * All tests in this class have the following set up:
    *
-   * <p>A single incident (3), a single process instance (1), and a single flow node (2). The
-   * incident was pending, and now has a single update to set it active.
+   * <p>We deployed a process consisting of a call activity, which calls a process with a single
+   * task.
+   *
+   * <p>An instance of that parent process instance (1) has a call activity instance flow node (2)
+   * with a child process instance (3), with a task flow node (4).
+   *
+   * <p>There is a single incident update by default (5) which is being created.
    *
    * <p>The pending update has a position of 10.
    */
   @Nested
-  final class SingleIncidentTest {
+  final class IncidentTreePathTest {
     private final int highestPosition = 10;
 
-    private final ProcessInstanceDocument processInstance =
+    private final ProcessInstanceDocument parentProcessInstance =
         new ProcessInstanceDocument(
             "1", "list-view", 1, new TreePath().startTreePath(1).toString());
-    private final Document flowNodeInstance = new Document("2", "flow-nodes");
-    private final Document flowNodeInstanceInListView = new Document("2", "list-view");
+    private final ProcessInstanceDocument childProcessInstance =
+        new ProcessInstanceDocument(
+            "3",
+            "list-view",
+            3,
+            new TreePath()
+                .startTreePath(1)
+                .appendFlowNodeInstance(2)
+                .appendProcessInstance(3)
+                .toString());
+    private final Document callActivityFlowNode = new Document("2", "flow-nodes");
+    private final Document callActivityFlowNodeInListView = new Document("2", "list-view");
+    private final Document taskFlowNode = new Document("4", "flow-nodes");
+    private final Document taskFlowNodeInListView = new Document("4", "list-view");
     private final IncidentEntity incidentEntity =
         new IncidentEntity()
-            .setKey(3L)
-            .setId("3")
+            .setKey(5L)
+            .setId("5")
             .setState(IncidentState.PENDING)
-            .setProcessInstanceKey(1L)
-            .setFlowNodeInstanceKey(2L)
-            .setTreePath(new TreePath().startTreePath(1).appendFlowNodeInstance(2).toString());
+            .setProcessInstanceKey(3L)
+            .setFlowNodeInstanceKey(4L)
+            .setTreePath(
+                new TreePath()
+                    .startTreePath(1)
+                    .appendFlowNodeInstance(2)
+                    .appendProcessInstance(3)
+                    .appendFlowNodeInstance(4)
+                    .toString());
     private final IncidentDocument incident =
-        new IncidentDocument("3", "incidents", incidentEntity);
+        new IncidentDocument("5", "incidents", incidentEntity);
 
     @BeforeEach
     void beforeEach() {
@@ -195,9 +220,12 @@ final class IncidentUpdateTaskTest {
                   highestPosition, Map.of(incident.incident().getKey(), IncidentState.ACTIVE)));
       repository.incidents = CompletableFuture.completedFuture(Map.of(incident.id(), incident));
       repository.flowNodesInListView =
-          CompletableFuture.completedFuture(List.of(flowNodeInstanceInListView));
-      repository.flowNodeInstances = CompletableFuture.completedFuture(List.of(flowNodeInstance));
-      repository.processInstances = CompletableFuture.completedFuture(List.of(processInstance));
+          CompletableFuture.completedFuture(
+              List.of(callActivityFlowNodeInListView, taskFlowNodeInListView));
+      repository.flowNodeInstances =
+          CompletableFuture.completedFuture(List.of(callActivityFlowNode, taskFlowNode));
+      repository.processInstances =
+          CompletableFuture.completedFuture(List.of(parentProcessInstance, childProcessInstance));
     }
 
     @Test
@@ -224,7 +252,7 @@ final class IncidentUpdateTaskTest {
       assertThat(result)
           .succeedsWithin(Duration.ZERO)
           .asInstanceOf(InstanceOfAssertFactories.INTEGER)
-          .isEqualTo(4);
+          .isEqualTo(7);
     }
 
     @Test
@@ -260,7 +288,7 @@ final class IncidentUpdateTaskTest {
           .failsWithin(Duration.ZERO)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
-          .withMessageContaining("Process instance 1 is not yet imported for incident 3");
+          .withMessageContaining("Process instance 3 is not yet imported for incident 5");
     }
 
     @Test
@@ -278,7 +306,7 @@ final class IncidentUpdateTaskTest {
           .failsWithin(Duration.ZERO)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
-          .withMessageContaining("Flow node instance 2 affected by incident 3");
+          .withMessageContaining("Flow node instance 2 affected by incident 5");
     }
 
     @Test
@@ -296,7 +324,7 @@ final class IncidentUpdateTaskTest {
           .failsWithin(Duration.ZERO)
           .withThrowableThat()
           .withRootCauseExactlyInstanceOf(ExporterException.class)
-          .withMessageContaining("Flow node instance 2 affected by incident 3");
+          .withMessageContaining("Flow node instance 2 affected by incident 5");
     }
 
     @Test
@@ -313,16 +341,16 @@ final class IncidentUpdateTaskTest {
       assertThat(repository.updated.incidentRequests())
           .hasSize(1)
           .containsEntry(
-              "3",
+              "5",
               new DocumentUpdate(
-                  "3",
+                  "5",
                   "incidents",
                   Map.of(
                       IncidentTemplate.STATE,
                       IncidentState.ACTIVE,
                       IncidentTemplate.TREE_PATH,
-                      "PI_1/FNI_2"),
-                  "1"));
+                      "PI_1/FNI_2/PI_3/FNI_4"),
+                  null));
     }
 
     @Test
@@ -337,13 +365,19 @@ final class IncidentUpdateTaskTest {
       // then
       assertThat(result).succeedsWithin(Duration.ZERO);
       assertThat(repository.updated.listViewRequests())
-          .hasSize(2)
+          .hasSize(4)
           .containsEntry(
               "1",
               new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"))
           .containsEntry(
               "2",
-              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"));
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "1"))
+          .containsEntry(
+              "3",
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"))
+          .containsEntry(
+              "4",
+              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, true), "3"));
     }
 
     @Test
@@ -358,10 +392,118 @@ final class IncidentUpdateTaskTest {
       // then
       assertThat(result).succeedsWithin(Duration.ZERO);
       assertThat(repository.updated.flowNodeInstanceRequests())
-          .hasSize(1)
+          .hasSize(2)
           .containsEntry(
               "2",
-              new DocumentUpdate("2", "flow-nodes", Map.of(ListViewTemplate.INCIDENT, true), "1"));
+              new DocumentUpdate(
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null))
+          .containsEntry(
+              "4",
+              new DocumentUpdate(
+                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, true), null));
+    }
+
+    @Test
+    void shouldResolveIncident() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      incidentEntity.setState(IncidentState.ACTIVE);
+      repository.activeIncidentsByTreePaths =
+          CompletableFuture.completedFuture(
+              List.of(new ActiveIncident(incident.id(), incidentEntity.getTreePath())));
+      repository.batch =
+          CompletableFuture.completedFuture(
+              new PendingIncidentUpdateBatch(
+                  highestPosition, Map.of(incident.incident().getKey(), IncidentState.RESOLVED)));
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.incidentRequests())
+          .hasSize(1)
+          .containsEntry(
+              "5",
+              new DocumentUpdate(
+                  "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
+      assertThat(repository.updated.flowNodeInstanceRequests())
+          .hasSize(2)
+          .containsEntry(
+              "2",
+              new DocumentUpdate(
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null))
+          .containsEntry(
+              "4",
+              new DocumentUpdate(
+                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
+      assertThat(repository.updated.listViewRequests())
+          .hasSize(4)
+          .containsEntry(
+              "1",
+              new DocumentUpdate("1", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
+          .containsEntry(
+              "2",
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
+          .containsEntry(
+              "3",
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"))
+          .containsEntry(
+              "4",
+              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
+    }
+
+    @Test
+    void shouldNotMarkIncidentFalseIfMoreActiveIncidents() {
+      // given - we have another active incident with an overlapping tree path, but only covering
+      // process instance
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      incidentEntity.setState(IncidentState.ACTIVE);
+      repository.activeIncidentsByTreePaths =
+          CompletableFuture.completedFuture(
+              List.of(
+                  new ActiveIncident("30", new TreePath().startTreePath("1").toString()),
+                  new ActiveIncident(incident.id(), incidentEntity.getTreePath())));
+      repository.batch =
+          CompletableFuture.completedFuture(
+              new PendingIncidentUpdateBatch(
+                  highestPosition, Map.of(incident.incident().getKey(), IncidentState.RESOLVED)));
+
+      // when
+      final var result = task.execute();
+
+      // then - we should mark the child process instance, the call activity, and the task as
+      // incident free, but NOT the parent process instance as it still has an active incident
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.incidentRequests())
+          .hasSize(1)
+          .containsEntry(
+              "5",
+              new DocumentUpdate(
+                  "5", "incidents", Map.of(IncidentTemplate.STATE, IncidentState.RESOLVED), null));
+      assertThat(repository.updated.flowNodeInstanceRequests())
+          .hasSize(2)
+          .containsEntry(
+              "2",
+              new DocumentUpdate(
+                  "2", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null))
+          .containsEntry(
+              "4",
+              new DocumentUpdate(
+                  "4", "flow-nodes", Map.of(FlowNodeInstanceTemplate.INCIDENT, false), null));
+      assertThat(repository.updated.listViewRequests())
+          .hasSize(3)
+          .containsEntry(
+              "2",
+              new DocumentUpdate("2", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "1"))
+          .containsEntry(
+              "3",
+              new DocumentUpdate("3", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"))
+          .containsEntry(
+              "4",
+              new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -505,5 +505,24 @@ final class IncidentUpdateTaskTest {
               "4",
               new DocumentUpdate("4", "list-view", Map.of(ListViewTemplate.INCIDENT, false), "3"));
     }
+
+    @Test
+    void shouldIgnoreDeletedProcessInstance() {
+      // given
+      final var task =
+          new IncidentUpdateTask(metadata, repository, false, 10, LOGGER, Duration.ZERO);
+      repository.processInstances =
+          CompletableFuture.completedFuture(List.of(parentProcessInstance));
+      repository.wasProcessInstanceDeleted = CompletableFuture.completedFuture(true);
+
+      // when
+      final var result = task.execute();
+
+      // then
+      assertThat(result).succeedsWithin(Duration.ZERO);
+      assertThat(repository.updated.listViewRequests()).isEmpty();
+      assertThat(repository.updated.incidentRequests()).isEmpty();
+      assertThat(repository.updated.flowNodeInstanceRequests()).isEmpty();
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR improves the test coverage for the `IncidentUpdateTask`, which surfaced two bugs, which are both fixed here as well:

- The routing property of the document should be set _only_ for the list view indices updates.
- The routing property of an FNI document in the list view should be its parent process instance key, and not just the incident's process instance key (which could be of a child process instance not associated with the FNI). We use the tree path to find the right routing for the FNI.

[See this Slack thread for more](https://camunda.slack.com/archives/C06F0GLJNFM/p1732281258373749)

## Related issues

related to #24929 
