### PR TITLE
feat: enable identity in c8run

### DIFF
--- a/c8run/main.go
+++ b/c8run/main.go
@@ -162,6 +162,7 @@ func main() {
 	os.Setenv("CAMUNDA_OPERATE_IMPORTER_READERBACKOFF", "1000")
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
+	os.Setenv("SPRING_PROFILES_ACTIVE", "operate,tasklist,broker,identity")
 
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 


### PR DESCRIPTION
## Description

Identity is currently not viewable in c8run under the `/identity` endpoint, due to the identity spring profile not being active. This spring profile is not active by default in StandaloneCamunda because identity currently has backend functionality that is dysfunctional. However, in the scope of c8run, it makes sense to make this page viewable because as developers, we want to be able to see how much of identity is working or not working.

The screenshot below is what a user sees underneath the 
http://localhost:8080/identity/roles
url.

![2024-11-22-114237_grim](https://github.com/user-attachments/assets/c508bd37-ba54-4389-9d36-b8e9c49678c5)


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25079 
