### PR TITLE
fix: remove formatting for job types in listeners table

### DIFF
--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/Listeners/index.tsx
@@ -88,9 +88,7 @@ const Listeners: React.FC<Props> = observer(({listeners}) => {
                   ),
                 },
                 {
-                  cellContent: (
-                    <CellContainer>{spaceAndCapitalize(jobType)}</CellContainer>
-                  ),
+                  cellContent: <CellContainer>{jobType}</CellContainer>,
                 },
                 {
                   cellContent: (


### PR DESCRIPTION
## Description

- Remove capitalization for job types on the listeners table (thus keeping the original capitalization that comes from the backend)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25060
