### PR TITLE
Output mappings applied before updating multi instance body output collection

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBeh
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.MultiInstanceOutputCollectionBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -65,6 +66,7 @@ public final class MultiInstanceBodyProcessor
   private final BpmnIncidentBehavior incidentBehavior;
   private final MultiInstanceOutputCollectionBehavior multiInstanceOutputCollectionBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
+  private final BpmnVariableMappingBehavior variableMappingBehavior;
 
   public MultiInstanceBodyProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -76,6 +78,7 @@ public final class MultiInstanceBodyProcessor
     incidentBehavior = bpmnBehaviors.incidentBehavior();
     multiInstanceOutputCollectionBehavior = bpmnBehaviors.outputCollectionBehavior();
     compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
+    variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
   }
 
   @Override
@@ -175,6 +178,10 @@ public final class MultiInstanceBodyProcessor
     if (updatedOrFailure.isLeft()) {
       return updatedOrFailure;
     }
+
+    // we modify the output collection variable above
+    // if there is a mapping using this, it should get updated as well
+    variableMappingBehavior.applyOutputMappings(childContext, element.getInnerActivity());
 
     // test that completion condition can be evaluated correctly
     final Either<Failure, Boolean> satisfiesCompletionConditionOrFailure =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As an alternative approach, I tried to update output mapping collection inside `onChildCompleting()` which I called right before `onComplete()` in `BpmnStreamProcessor` as such:

```java
      case COMPLETE_ELEMENT:
        final var completingContext = stateTransitionBehavior.transitionToCompleting(context);
        stateTransitionBehavior
            .onElementCompleting(element, completingContext)
            .flatMap(ok -> processor.onComplete(element, completingContext))
            .flatMap(ok -> afterCompleting(element, processor, completingContext))
            .ifLeft(failure -> incidentBehavior.createIncident(failure, completingContext));
```

But it did not work because the output element variable of the multi instance body is updated in `onComplete()` called after `onElementCompleting()`. That causes the output element variable to be not updated while updating the output mapping collection and results in output element as `null` all the time.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23658 
