### PR TITLE
Implement getPendingIncidentsBatch for Elasticsearch

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.SourceFilter;
+import co.elastic.clients.json.JsonData;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
+import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+
+public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpdateRepository {
+
+  private final int partitionId;
+  private final String pendingUpdateAlias;
+  private final String incidentAlias;
+  private final String listViewAlias;
+  private final String flowNodeAlias;
+  private final ElasticsearchAsyncClient client;
+  private final Executor executor;
+
+  public ElasticsearchIncidentUpdateRepository(
+      final int partitionId,
+      final String pendingUpdateAlias,
+      final String incidentAlias,
+      final String listViewAlias,
+      final String flowNodeAlias,
+      final ElasticsearchAsyncClient client,
+      final Executor executor) {
+    this.partitionId = partitionId;
+    this.pendingUpdateAlias = pendingUpdateAlias;
+    this.incidentAlias = incidentAlias;
+    this.listViewAlias = listViewAlias;
+    this.flowNodeAlias = flowNodeAlias;
+    this.client = client;
+    this.executor = executor;
+  }
+
+  @Override
+  public CompletionStage<PendingIncidentUpdateBatch> getPendingIncidentsBatch(
+      final long fromPosition, final int size) {
+    final var query = createPendingIncidentsBatchQuery(fromPosition);
+    final var request = createPendingIncidentsBatchRequest(size, query);
+
+    return client
+        .search(request, PendingIncidentUpdate.class)
+        .thenApplyAsync(this::createPendingIncidentBatch, executor);
+  }
+
+  private SearchRequest createPendingIncidentsBatchRequest(final int size, final Query query) {
+    final var sourceFilter =
+        new SourceFilter.Builder()
+            .includes(
+                PostImporterQueueTemplate.KEY,
+                PostImporterQueueTemplate.POSITION,
+                PostImporterQueueTemplate.INTENT)
+            .build();
+
+    return new SearchRequest.Builder()
+        .index(pendingUpdateAlias)
+        .query(query)
+        .ignoreUnavailable(true)
+        .allowNoIndices(true)
+        .source(s -> s.filter(sourceFilter))
+        .sort(s -> s.field(f -> f.field(PostImporterQueueTemplate.POSITION).order(SortOrder.Asc)))
+        .size(size)
+        .build();
+  }
+
+  private Query createPendingIncidentsBatchQuery(final long fromPosition) {
+    final var positionQ =
+        QueryBuilders.range()
+            .field(PostImporterQueueTemplate.POSITION)
+            .gt(JsonData.of(fromPosition))
+            .build()
+            ._toQuery();
+    final var typeQ =
+        QueryBuilders.term()
+            .field(PostImporterQueueTemplate.ACTION_TYPE)
+            .value(f -> f.anyValue(JsonData.of(PostImporterActionType.INCIDENT)))
+            .build()
+            ._toQuery();
+    final var partitionQ =
+        QueryBuilders.term()
+            .field(PostImporterQueueTemplate.PARTITION_ID)
+            .value(partitionId)
+            .build()
+            ._toQuery();
+    return QueryBuilders.bool().must(positionQ, typeQ, partitionQ).build()._toQuery();
+  }
+
+  private PendingIncidentUpdateBatch createPendingIncidentBatch(
+      final SearchResponse<PendingIncidentUpdate> response) {
+    final var hits = response.hits().hits();
+    final Map<Long, IncidentState> incidents = new HashMap<>();
+
+    // if there are multiple updates for a given incident, keep the latest one only; assuming no
+    // bugs in the engine, this means it can only be CREATED -> RESOLVED. Since our search results
+    // are sorted by position, we know the latest will necessarily be the actual "latest" (as in,
+    // wall clock) result
+    final var highestPosition = hits.isEmpty() ? -1L : hits.getLast().source().position();
+    for (final var hit : hits) {
+      final var entity = hit.source();
+      final var newState = IncidentState.createFrom(entity.intent());
+      incidents.put(entity.key(), newState);
+    }
+
+    return new PendingIncidentUpdateBatch(highestPosition, incidents);
+  }
+
+  private record PendingIncidentUpdate(long key, long position, String intent) {}
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryIT.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.Refresh;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
+import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.PendingIncidentUpdateBatch;
+import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
+import io.camunda.webapps.schema.entities.operate.IncidentState;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterActionType;
+import io.camunda.webapps.schema.entities.operate.post.PostImporterQueueEntity;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import org.apache.http.HttpHost;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@AutoCloseResources
+final class ElasticsearchIncidentUpdateRepositoryIT {
+
+  @Container
+  private static final ElasticsearchContainer CONTAINER =
+      TestSearchContainers.createDefeaultElasticsearchContainer();
+
+  private static final int PARTITION_ID = 1;
+  private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+  @AutoCloseResource private final RestClientTransport transport = createRestClient();
+  private final String indexPrefix = UUID.randomUUID().toString();
+  private final ElasticsearchClient testClient = new ElasticsearchClient(transport);
+  private final ElasticsearchEngineClient searchClient = new ElasticsearchEngineClient(testClient);
+  private final ElasticsearchAsyncClient client = new ElasticsearchAsyncClient(transport);
+  private final PostImporterQueueTemplate postImporterQueueTemplate =
+      new PostImporterQueueTemplate(indexPrefix, true);
+  private final IncidentTemplate incidentTemplate = new IncidentTemplate(indexPrefix, true);
+  private final ListViewTemplate listViewTemplate = new ListViewTemplate(indexPrefix, true);
+  private final FlowNodeInstanceTemplate flowNodeInstanceTemplate =
+      new FlowNodeInstanceTemplate(indexPrefix, true);
+
+  @BeforeEach
+  void beforeEach() {
+    Stream.of(
+            postImporterQueueTemplate, incidentTemplate, listViewTemplate, flowNodeInstanceTemplate)
+        .forEach(template -> searchClient.createIndexTemplate(template, new IndexSettings(), true));
+  }
+
+  private ElasticsearchIncidentUpdateRepository createRepository() {
+    return new ElasticsearchIncidentUpdateRepository(
+        PARTITION_ID,
+        postImporterQueueTemplate.getAlias(),
+        incidentTemplate.getAlias(),
+        listViewTemplate.getAlias(),
+        flowNodeInstanceTemplate.getAlias(),
+        client,
+        Runnable::run);
+  }
+
+  private RestClientTransport createRestClient() {
+    final var restClient =
+        RestClient.builder(HttpHost.create(CONTAINER.getHttpHostAddress())).build();
+    return new RestClientTransport(restClient, new JacksonJsonpMapper());
+  }
+
+  private PostImporterQueueEntity newPendingUpdate() {
+    return new PostImporterQueueEntity()
+        .setActionType(PostImporterActionType.INCIDENT)
+        .setIntent(IncidentIntent.CREATED.name())
+        .setKey(1L)
+        .setPartitionId(PARTITION_ID)
+        .setProcessInstanceKey(1L)
+        .setPosition(1L);
+  }
+
+  @Nested
+  final class GetPendingIncidentsBatchTest {
+    @Test
+    void shouldGetOnlyNewUpdatesByPosition() throws IOException {
+      // given
+      final var repository = createRepository();
+      final var updates = setupIncidentUpdates(1, 2);
+      testClient.bulk(b -> b.operations(updates).refresh(Refresh.True));
+
+      // when
+      final var batch = repository.getPendingIncidentsBatch(1L, 10);
+
+      // then
+      assertThat(batch)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .extracting(
+              PendingIncidentUpdateBatch::highestPosition,
+              PendingIncidentUpdateBatch::newIncidentStates)
+          .containsExactly(2L, Map.of(2L, IncidentState.ACTIVE));
+    }
+
+    @Test
+    void shouldKeepOnlyLatestUpdatePerKey() throws IOException {
+      // given
+      final var repository = createRepository();
+      final var updates =
+          setupIncidentUpdates(
+              1,
+              2L,
+              e ->
+                  e.setKey(1L)
+                      .setIntent(
+                          e.getPosition() == 2
+                              ? IncidentIntent.RESOLVED.name()
+                              : IncidentIntent.CREATED.name()));
+      testClient.bulk(b -> b.operations(updates).refresh(Refresh.True));
+
+      // when
+      final var batch = repository.getPendingIncidentsBatch(1L, 10);
+
+      // then
+      assertThat(batch)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .returns(2L, PendingIncidentUpdateBatch::highestPosition)
+          .extracting(PendingIncidentUpdateBatch::newIncidentStates)
+          .asInstanceOf(InstanceOfAssertFactories.map(Long.class, IncidentState.class))
+          .hasSize(1)
+          .containsEntry(1L, IncidentState.RESOLVED);
+    }
+
+    @Test
+    void shouldGetUpdates() throws IOException {
+      // given - incident 1 is resolved, incident 2 is created
+      final var repository = createRepository();
+      final var updates =
+          setupIncidentUpdates(
+              1,
+              2,
+              e ->
+                  e.setIntent(
+                      e.getKey() == 1
+                          ? IncidentIntent.RESOLVED.name()
+                          : IncidentIntent.CREATED.name()));
+      testClient.bulk(b -> b.operations(updates).refresh(Refresh.True));
+
+      // when
+      final var batch = repository.getPendingIncidentsBatch(-1L, 10);
+
+      // then
+      assertThat(batch)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .extracting(PendingIncidentUpdateBatch::newIncidentStates)
+          .asInstanceOf(InstanceOfAssertFactories.map(Long.class, IncidentState.class))
+          .hasSize(2)
+          .containsEntry(1L, IncidentState.RESOLVED)
+          .containsEntry(2L, IncidentState.ACTIVE);
+    }
+
+    @Test
+    void shouldGetByPartitionId() throws IOException {
+      // given - incident 1 on partition 1, incident 2 on partition 2
+      final var repository = createRepository();
+      final var updates =
+          setupIncidentUpdates(1, 2, e -> e.setPartitionId(Math.toIntExact(e.getKey())));
+      testClient.bulk(b -> b.operations(updates).refresh(Refresh.True));
+
+      // when
+      final var batch = repository.getPendingIncidentsBatch(-1L, 10);
+
+      // then
+      assertThat(batch)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .extracting(
+              PendingIncidentUpdateBatch::highestPosition,
+              PendingIncidentUpdateBatch::newIncidentStates)
+          .containsExactly(1L, Map.of(1L, IncidentState.ACTIVE));
+    }
+
+    @Test
+    void shouldReturnEmptyBatch() {
+      // given
+      final var repository = createRepository();
+
+      // when
+      final var batch = repository.getPendingIncidentsBatch(-1L, 10);
+
+      // then
+      assertThat(batch)
+          .succeedsWithin(REQUEST_TIMEOUT)
+          .extracting(
+              PendingIncidentUpdateBatch::highestPosition,
+              PendingIncidentUpdateBatch::newIncidentStates)
+          .containsExactly(-1L, Collections.emptyMap());
+    }
+
+    private List<BulkOperation> setupIncidentUpdates(
+        final long fromPosition, final long toPosition) {
+      return setupIncidentUpdates(fromPosition, toPosition, ignored -> {});
+    }
+
+    private List<BulkOperation> setupIncidentUpdates(
+        final long fromPosition,
+        final long toPosition,
+        final Consumer<PostImporterQueueEntity> modifier) {
+      return LongStream.rangeClosed(fromPosition, toPosition)
+          .mapToObj(position -> newPendingUpdate().setPosition(position).setKey(position))
+          .peek(modifier)
+          .map(
+              doc ->
+                  IndexOperation.of(
+                      i -> i.index(postImporterQueueTemplate.getFullQualifiedName()).document(doc)))
+          .map(op -> BulkOperation.of(b -> b.index(op)))
+          .toList();
+    }
+  }
+}


### PR DESCRIPTION
## Description

This PR adds the implementation of `getPendingIncidentsBatch` for Elasticsearch.

## Related issues

related to #24930
