### PR TITLE
Implement bulkUpdate for the ElasticsearchIncidentUpdateRepository

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Stream;
 
 /**
  * Encapsulates all accesses to the underlying storage for the {@link IncidentUpdateTask}, allowing
@@ -151,6 +152,13 @@ public interface IncidentUpdateRepository {
       Map<String, DocumentUpdate> incidentRequests) {
     public IncidentBulkUpdate() {
       this(new HashMap<>(), new HashMap<>(), new HashMap<>());
+    }
+
+    public Stream<DocumentUpdate> stream() {
+      return Stream.concat(
+          Stream.concat(
+              listViewRequests.values().stream(), flowNodeInstanceRequests.values().stream()),
+          incidentRequests.values().stream());
     }
   }
 


### PR DESCRIPTION
## Description

Implements the `bulkUpdate` method for the `ElasticsearchIncidentUpdateRepository`. 

For tests, I opted against using our common search clients from the search modules, specifically because they abstract away where or how we find these entities, and here we want to specifically see that we've updated X field for document Y in index Z. Since it's not so much to implement a really basic abstract search, I figured that's a better compromise.

## Related issues

related to #24930 
