### PR TITLE
refactor: minor changes to ElasticSearchRepository after comparing it with tasklist's version

### DIFF
--- a/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
+++ b/operate/qa/backup-restore-tests/src/test/java/io/camunda/operate/qa/backup/BackupRestoreTest.java
@@ -145,7 +145,8 @@ public class BackupRestoreTest {
     createSnapshotRepository(testContext);
 
     String zeebeVersion = ZeebeClient.class.getPackage().getImplementationVersion();
-    if (zeebeVersion.toLowerCase().contains("snapshot")) {
+    // zeebeVersion can be null if tests are launched from the IDE
+    if (zeebeVersion == null || zeebeVersion.toLowerCase().contains("snapshot")) {
       zeebeVersion = "SNAPSHOT";
     }
     testContainerUtil.startZeebe(zeebeVersion, testContext);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupConfig.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupConfig.java
@@ -56,6 +56,12 @@ public class BackupConfig {
       public Long incompleteCheckTimeoutInSeconds() {
         return operateProperties.getIncompleteCheckTimeoutInSeconds();
       }
+
+      @Override
+      public boolean includeGlobalState() {
+        // was not set in operate
+        return false;
+      }
     };
   }
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/BackupRepositoryProps.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/BackupRepositoryProps.java
@@ -21,6 +21,8 @@ public interface BackupRepositoryProps {
 
   Long incompleteCheckTimeoutInSeconds();
 
+  boolean includeGlobalState();
+
   static Integer defaultSnapshotTimeout() {
     return 0;
   }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriority.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriority.java
@@ -5,11 +5,8 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.webapps.backup.repository;
+package io.camunda.webapps.schema.descriptors.backup;
 
-public record BackupRepositoryPropsImpl(
-    String version,
-    String repositoryName,
-    int snapshotTimeout,
-    Long incompleteCheckTimeoutInSeconds)
-    implements BackupRepositoryProps {}
+import io.camunda.webapps.schema.descriptors.IndexDescriptor;
+
+public interface BackupPriority extends IndexDescriptor {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio1Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio1Backup.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
-public interface Prio1Backup {}
+public interface Prio1Backup extends BackupPriority {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio2Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio2Backup.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
-public interface Prio2Backup {}
+public interface Prio2Backup extends BackupPriority {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio3Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio3Backup.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
-public interface Prio3Backup {}
+public interface Prio3Backup extends BackupPriority {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio4Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio4Backup.java
@@ -7,4 +7,4 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
-public interface Prio4Backup {}
+public interface Prio4Backup extends BackupPriority {}


### PR DESCRIPTION

## Description

First minor changes to ElasticSearchRepository after comparing it with tasklist implementation.

Prio{1,2,3,4}Backup interfaces now extend a common interface BackupPriority, which extends IndexRepository.
Thanks to this change, a small refactor in BackupServiceImpl eliminates all unchecked casts.

## Related issues

relates #24869
