### PR TITLE
Reject operation from task listener - java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -68,4 +68,22 @@ public interface CompleteJobCommandStep1
    *     to the broker.
    */
   CompleteJobCommandStep1 variable(String key, Object value);
+
+  /**
+   * Set the result of the job.
+   *
+   * @return the builder for this command.
+   */
+  CompleteJobCommandStep2 result();
+
+  interface CompleteJobCommandStep2 extends FinalCommandStep<CompleteJobResponse> {
+
+    /**
+     * Set if the job was denied by the worker.
+     *
+     * @param denied indicates if the worker has denied the reason for the job
+     * @return the builder for this command.
+     */
+    CompleteJobCommandStep2 denied(boolean denied);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteJobCommandStep1.java
@@ -70,7 +70,7 @@ public interface CompleteJobCommandStep1
   CompleteJobCommandStep1 variable(String key, Object value);
 
   /**
-   * Set the result of the job.
+   * The result of the completed job as determined by the worker.
    *
    * @return the builder for this command.
    */
@@ -79,7 +79,11 @@ public interface CompleteJobCommandStep1
   interface CompleteJobCommandStep2 extends FinalCommandStep<CompleteJobResponse> {
 
     /**
-     * Set if the job was denied by the worker.
+     * Indicates whether the worker denies the work, i.e. explicitly doesn't approve it. For
+     * example, a Task Listener can deny the completion of a task by setting this flag to true. In
+     * this example, the completion of a task is represented by a job that the worker can complete
+     * as denied. As a result, the completion request is rejected and the task remains active.
+     * Defaults to false.
      *
      * @param denied indicates if the worker has denied the reason for the job
      * @return the builder for this command.

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/CompleteJobTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/CompleteJobTest.java
@@ -62,6 +62,8 @@ public final class CompleteJobTest extends ClientTest {
     final CompleteJobRequest request = gatewayService.getLastRequest();
     assertThat(request.getJobKey()).isEqualTo(job.getKey());
     assertThat(request.getVariables()).isEmpty();
+    // gRPC provides the result with default value, so checking for default property value here.
+    assertThat(request.getResult().getDenied()).isFalse();
 
     rule.verifyDefaultRequestTimeout();
   }
@@ -177,6 +179,57 @@ public final class CompleteJobTest extends ClientTest {
 
     // then
     assertThat(response).isNotNull();
+  }
+
+  @Test
+  public void shouldCompleteJobWithEmptyResult() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client.newCompleteCommand(job).result().send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getResult().getDenied()).isFalse();
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultDeniedFalse() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client.newCompleteCommand(job).result().denied(false).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getResult().getDenied()).isFalse();
+
+    rule.verifyDefaultRequestTimeout();
+  }
+
+  @Test
+  public void shouldCompleteJobWithResultDeniedTrue() {
+    // given
+    final ActivatedJob job = Mockito.mock(ActivatedJob.class);
+    Mockito.when(job.getKey()).thenReturn(12L);
+
+    // when
+    client.newCompleteCommand(job).result().denied(true).send().join();
+
+    // then
+    final CompleteJobRequest request = gatewayService.getLastRequest();
+    assertThat(request.getJobKey()).isEqualTo(job.getKey());
+    assertThat(request.getResult().getDenied()).isTrue();
+
+    rule.verifyDefaultRequestTimeout();
   }
 
   public static class POJO {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -157,6 +157,51 @@ public final class CompleteJobTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
+  public void shouldCompleteJobWithResultDeniedTrue(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var jobKey = resourcesHelper.createSingleJob(jobType);
+    // when
+    getCommand(client, useRest, jobKey).result().denied(true).send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(
+        jobType, (job) -> assertThat(job.getResult().isDenied()).isTrue());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCompleteJobWithResultDeniedNotSet(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var jobKey = resourcesHelper.createSingleJob(jobType);
+    // when
+    getCommand(client, useRest, jobKey).result().send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(
+        jobType, (job) -> assertThat(job.getResult().isDenied()).isFalse());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldCompleteJobWithResultDeniedFalse(
+      final boolean useRest, final TestInfo testInfo) {
+    // given
+    final String jobType = "job-" + testInfo.getDisplayName();
+    final var jobKey = resourcesHelper.createSingleJob(jobType);
+    // when
+    getCommand(client, useRest, jobKey).result().denied(false).send().join();
+
+    // then
+    ZeebeAssertHelper.assertJobCompleted(
+        jobType, (job) -> assertThat(job.getResult().isDenied()).isFalse());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
   public void shouldThrowErrorWhenTryToCompleteJobWithNullVariable(
       final boolean useRest, final TestInfo testInfo) {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CompleteJobTest.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 @ZeebeIntegration
@@ -156,18 +157,18 @@ public final class CompleteJobTest {
   }
 
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void shouldCompleteJobWithResultDeniedTrue(
-      final boolean useRest, final TestInfo testInfo) {
+  @CsvSource({"true, true", "true, false", "false, true", "false, false"})
+  public void shouldCompleteJobWhenResultDeniedIsSet(
+      final boolean useRest, final boolean denied, final TestInfo testInfo) {
     // given
     final String jobType = "job-" + testInfo.getDisplayName();
     final var jobKey = resourcesHelper.createSingleJob(jobType);
     // when
-    getCommand(client, useRest, jobKey).result().denied(true).send().join();
+    getCommand(client, useRest, jobKey).result().denied(denied).send().join();
 
     // then
     ZeebeAssertHelper.assertJobCompleted(
-        jobType, (job) -> assertThat(job.getResult().isDenied()).isTrue());
+        jobType, (job) -> assertThat(job.getResult().isDenied()).isEqualTo(denied));
   }
 
   @ParameterizedTest
@@ -179,21 +180,6 @@ public final class CompleteJobTest {
     final var jobKey = resourcesHelper.createSingleJob(jobType);
     // when
     getCommand(client, useRest, jobKey).result().send().join();
-
-    // then
-    ZeebeAssertHelper.assertJobCompleted(
-        jobType, (job) -> assertThat(job.getResult().isDenied()).isFalse());
-  }
-
-  @ParameterizedTest
-  @ValueSource(booleans = {true, false})
-  public void shouldCompleteJobWithResultDeniedFalse(
-      final boolean useRest, final TestInfo testInfo) {
-    // given
-    final String jobType = "job-" + testInfo.getDisplayName();
-    final var jobKey = resourcesHelper.createSingleJob(jobType);
-    // when
-    getCommand(client, useRest, jobKey).result().denied(false).send().join();
 
     // then
     ZeebeAssertHelper.assertJobCompleted(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.Test;
 public class UserTaskListenersTest {
 
   @TestZeebe
-  private static final TestStandaloneBroker zeebe =
+  private static final TestStandaloneBroker ZEEBE =
       new TestStandaloneBroker().withRecordingExporter(true);
 
   @AutoCloseResource private ZeebeClient client;
@@ -58,7 +58,7 @@ public class UserTaskListenersTest {
 
   @BeforeEach
   void init() {
-    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(5)).build();
+    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(5)).build();
     resourcesHelper = new ZeebeResourcesHelper(client);
   }
 


### PR DESCRIPTION
## Description
Support operation rejection from Task Listener: Java Client side.

- Adding `CompleteJobCommandStep2` that would allow to set the `result` and `denied` field
- Adding corresponding implementation (setting the `result` and the value of `denied` field) for both REST and gRPC
- Adding tests to verify that the result is set correctly for both REST and gRPC
- Add IT tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24556
