### PR TITLE
fix: update user task when formId is not set during importing

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/FormStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/FormStore.java
@@ -17,7 +17,7 @@ public interface FormStore {
 
   List<String> getFormIdsByProcessDefinitionId(String processDefinitionId);
 
-  Optional<FormIdView> getHighestVersionFormByKey(String formKey);
+  Optional<FormIdView> getFormByKey(String formKey);
 
   record FormIdView(String id, String bpmnId, Long version) {}
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/TaskStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/TaskStore.java
@@ -44,6 +44,8 @@ public interface TaskStore {
 
   List<TaskEntity> getTasksById(List<String> ids);
 
+  void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId);
+
   default TaskEntity makeCopyOf(final TaskEntity taskBefore) {
     return new TaskEntity()
         .setId(taskBefore.getId())

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/TaskStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/TaskStore.java
@@ -44,7 +44,7 @@ public interface TaskStore {
 
   List<TaskEntity> getTasksById(List<String> ids);
 
-  void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId);
+  void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId, final long formVersion);
 
   default TaskEntity makeCopyOf(final TaskEntity taskBefore) {
     return new TaskEntity()

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RequestOptions;
@@ -63,6 +65,7 @@ public class FormStoreElasticSearch implements FormStore {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
+  @Override
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {
     final FormEntity formEmbedded =
         version == null ? getFormEmbedded(id, processDefinitionId) : null;
@@ -83,7 +86,7 @@ public class FormStoreElasticSearch implements FormStore {
   }
 
   @Override
-  public List<String> getFormIdsByProcessDefinitionId(String processDefinitionId) {
+  public List<String> getFormIdsByProcessDefinitionId(final String processDefinitionId) {
     final SearchRequest searchRequest =
         new SearchRequest(formIndex.getFullQualifiedName())
             .source(
@@ -92,38 +95,26 @@ public class FormStoreElasticSearch implements FormStore {
                     .fetchField(FormIndex.ID));
     try {
       return ElasticsearchUtil.scrollIdsToList(searchRequest, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }
 
   @Override
-  public Optional<FormIdView> getHighestVersionFormByKey(String formKey) {
-
-    final SearchSourceBuilder searchSourceBuilder =
-        new SearchSourceBuilder()
-            .query(QueryBuilders.termQuery(FormIndex.ID, formKey))
-            .sort(FormIndex.VERSION, SortOrder.DESC)
-            .size(1)
-            .fetchSource(new String[] {FormIndex.ID, FormIndex.BPMN_ID, FormIndex.VERSION}, null);
-
-    final SearchRequest searchRequest =
-        new SearchRequest(formIndex.getFullQualifiedName()).source(searchSourceBuilder);
+  public Optional<FormIdView> getFormByKey(final String formKey) {
+    final GetRequest getRequest = new GetRequest(formIndex.getFullQualifiedName(), formKey);
 
     try {
-      final SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
-
-      if (searchResponse.getHits().getHits().length > 0) {
-        // Extract the source and map it to your FormEntity object
-        final Map<String, Object> sourceAsMap =
-            searchResponse.getHits().getHits()[0].getSourceAsMap();
+      final GetResponse response = esClient.get(getRequest, RequestOptions.DEFAULT);
+      if (response.isExists()) {
+        final Map<String, Object> sourceAsMap = response.getSourceAsMap();
         return Optional.of(
             new FormIdView(
                 (String) sourceAsMap.get(FormIndex.ID),
                 (String) sourceAsMap.get(FormIndex.BPMN_ID),
                 ((Number) sourceAsMap.get(FormIndex.VERSION)).longValue()));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(
           String.format("Error retrieving the last version for the formKey: %s", formKey), e);
     }
@@ -140,9 +131,9 @@ public class FormStoreElasticSearch implements FormStore {
               formIndex.getIndexName(),
               tenantAwareClient);
       return fromSearchHit(formSearchHit.getSourceAsString(), objectMapper, FormEntity.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
-    } catch (NotFoundException e) {
+    } catch (final NotFoundException e) {
       return null;
     }
   }
@@ -185,7 +176,7 @@ public class FormStoreElasticSearch implements FormStore {
         formEntity.setIsDeleted((Boolean) sourceAsMap.get(FormIndex.IS_DELETED));
         return formEntity;
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
       throw new TasklistRuntimeException(formIdNotFoundMessage);
@@ -216,7 +207,7 @@ public class FormStoreElasticSearch implements FormStore {
       final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
 
       return searchResponse.getHits().getTotalHits().value > 0;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
       throw new TasklistRuntimeException(formIdNotFoundMessage);
@@ -240,7 +231,7 @@ public class FormStoreElasticSearch implements FormStore {
       final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
 
       return searchResponse.getHits().getTotalHits().value > 0;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
       throw new TasklistRuntimeException(formIdNotFoundMessage);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -169,6 +169,16 @@ public class TaskStoreElasticSearch implements TaskStore {
     return response;
   }
 
+  @Override
+  public List<TaskEntity> getTasksById(final List<String> ids) {
+    try {
+      final SearchHit[] response = getTasksRawResponse(ids);
+      return mapSearchHits(response, objectMapper, TaskEntity.class);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Persist that task is completed even before the corresponding events are imported from Zeebe.
    */
@@ -271,13 +281,8 @@ public class TaskStoreElasticSearch implements TaskStore {
   }
 
   @Override
-  public List<TaskEntity> getTasksById(final List<String> ids) {
-    try {
-      final SearchHit[] response = getTasksRawResponse(ids);
-      return mapSearchHits(response, objectMapper, TaskEntity.class);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
+  public void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId) {
+    updateTask(task.getId(), asMap(TaskTemplate.FORM_ID, formBpmnId));
   }
 
   private SearchHit[] getTasksRawResponse(final List<String> ids) throws IOException {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -169,16 +169,6 @@ public class TaskStoreElasticSearch implements TaskStore {
     return response;
   }
 
-  @Override
-  public List<TaskEntity> getTasksById(final List<String> ids) {
-    try {
-      final SearchHit[] response = getTasksRawResponse(ids);
-      return mapSearchHits(response, objectMapper, TaskEntity.class);
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   /**
    * Persist that task is completed even before the corresponding events are imported from Zeebe.
    */
@@ -281,8 +271,21 @@ public class TaskStoreElasticSearch implements TaskStore {
   }
 
   @Override
-  public void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId) {
-    updateTask(task.getId(), asMap(TaskTemplate.FORM_ID, formBpmnId));
+  public List<TaskEntity> getTasksById(final List<String> ids) {
+    try {
+      final SearchHit[] response = getTasksRawResponse(ids);
+      return mapSearchHits(response, objectMapper, TaskEntity.class);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void updateTaskLinkedForm(
+      final TaskEntity task, final String formBpmnId, final long formVersion) {
+    updateTask(
+        task.getId(),
+        asMap(TaskTemplate.FORM_ID, formBpmnId, TaskTemplate.FORM_VERSION, formVersion));
   }
 
   private SearchHit[] getTasksRawResponse(final List<String> ids) throws IOException {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -28,6 +28,8 @@ import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.GetRequest;
+import org.opensearch.client.opensearch.core.GetResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -50,6 +52,7 @@ public class FormStoreOpenSearch implements FormStore {
   @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
+  @Override
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {
     final FormEntity formEmbedded =
         version == null ? getFormEmbedded(id, processDefinitionId) : null;
@@ -67,6 +70,40 @@ public class FormStoreOpenSearch implements FormStore {
       }
     }
     throw new NotFoundException(String.format("form with id %s was not found", id));
+  }
+
+  @Override
+  public List<String> getFormIdsByProcessDefinitionId(final String processDefinitionId) {
+    final SearchRequest.Builder searchRequest =
+        OpenSearchUtil.createSearchRequest(formIndex.getFullQualifiedName())
+            .query(
+                q ->
+                    q.term(
+                        term ->
+                            term.field(FormIndex.PROCESS_DEFINITION_ID)
+                                .value(FieldValue.of(processDefinitionId))))
+            .fields(f -> f.field(TaskTemplate.ID));
+    try {
+      return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException(e.getMessage(), e);
+    }
+  }
+
+  @Override
+  public Optional<FormIdView> getFormByKey(final String formKey) {
+    final GetRequest request =
+        new GetRequest.Builder().index(formIndex.getFullQualifiedName()).id(formKey).build();
+    try {
+      final GetResponse<FormIdView> response = osClient.get(request, FormIdView.class);
+      if (response.found() && response.source() != null) {
+        return Optional.of(response.source());
+      } else {
+        return Optional.empty();
+      }
+    } catch (final IOException e) {
+      throw new TasklistRuntimeException(e);
+    }
   }
 
   private Boolean isFormAssociatedToTask(final String formId, final String processDefinitionId) {
@@ -111,7 +148,7 @@ public class FormStoreOpenSearch implements FormStore {
       final var searchResponse = tenantAwareClient.search(searchRequest, TaskTemplate.class);
 
       return searchResponse.hits().total().value() > 0;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format(
               "Error retrieving the association for the formId: [%s] and processDefinitionId: [%s]",
@@ -146,7 +183,7 @@ public class FormStoreOpenSearch implements FormStore {
       final var searchResponse = tenantAwareClient.search(searchRequest, ProcessIndex.class);
 
       return searchResponse.hits().total().value() > 0;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format(
               "Error retrieving the association for the formId: [%s] and processDefinitionId: [%s]",
@@ -222,7 +259,7 @@ public class FormStoreOpenSearch implements FormStore {
       } else {
         return null;
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String formIdNotFoundMessage =
           String.format("Error retrieving the version for the formId: [%s]", formId);
       throw new TasklistRuntimeException(formIdNotFoundMessage);
@@ -238,58 +275,10 @@ public class FormStoreOpenSearch implements FormStore {
           formIndex.getIndexName(),
           tenantAwareClient,
           FormEntity.class);
-    } catch (IOException | OpenSearchException e) {
+    } catch (final IOException | OpenSearchException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
-    } catch (NotFoundException e) {
+    } catch (final NotFoundException e) {
       return null;
-    }
-  }
-
-  @Override
-  public List<String> getFormIdsByProcessDefinitionId(String processDefinitionId) {
-    final SearchRequest.Builder searchRequest =
-        OpenSearchUtil.createSearchRequest(formIndex.getFullQualifiedName())
-            .query(
-                q ->
-                    q.term(
-                        term ->
-                            term.field(FormIndex.PROCESS_DEFINITION_ID)
-                                .value(FieldValue.of(processDefinitionId))))
-            .fields(f -> f.field(TaskTemplate.ID));
-    try {
-      return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
-    } catch (IOException e) {
-      throw new TasklistRuntimeException(e.getMessage(), e);
-    }
-  }
-
-  @Override
-  public Optional<FormIdView> getHighestVersionFormByKey(String formKey) {
-    try {
-      final var formEntityResponse =
-          osClient.search(
-              b ->
-                  b.index(formIndex.getFullQualifiedName())
-                      .query(q -> q.term(t -> t.field(FormIndex.ID).value(FieldValue.of(formKey))))
-                      .sort(s -> s.field(f -> f.field(FormIndex.VERSION).order(SortOrder.Desc)))
-                      .source(
-                          s ->
-                              s.filter(
-                                  f ->
-                                      f.includes(
-                                          List.of(
-                                              FormIndex.ID, FormIndex.BPMN_ID, FormIndex.VERSION))))
-                      .size(1),
-              FormEntity.class);
-      if (formEntityResponse.hits().total().value() == 1L) {
-        final FormEntity formEntity = formEntityResponse.hits().hits().get(0).source();
-        return Optional.of(
-            new FormIdView(formEntity.getId(), formEntity.getFormId(), formEntity.getVersion()));
-      } else {
-        return Optional.empty();
-      }
-    } catch (IOException e) {
-      throw new TasklistRuntimeException(e);
     }
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -173,6 +173,16 @@ public class TaskStoreOpenSearch implements TaskStore {
     return response;
   }
 
+  @Override
+  public List<TaskEntity> getTasksById(final List<String> ids) {
+    try {
+      final List<Hit<TaskEntity>> response = getTasksRawResponse(ids);
+      return response.stream().map(Hit::source).collect(Collectors.toList());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   /**
    * Persist that task is completed even before the corresponding events are imported from Zeebe.
    */
@@ -266,13 +276,8 @@ public class TaskStoreOpenSearch implements TaskStore {
   }
 
   @Override
-  public List<TaskEntity> getTasksById(final List<String> ids) {
-    try {
-      final List<Hit<TaskEntity>> response = getTasksRawResponse(ids);
-      return response.stream().map(Hit::source).collect(Collectors.toList());
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
+  public void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId) {
+    updateTask(task.getId(), asMap(TaskTemplate.FORM_ID, formBpmnId));
   }
 
   /**

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -173,16 +173,6 @@ public class TaskStoreOpenSearch implements TaskStore {
     return response;
   }
 
-  @Override
-  public List<TaskEntity> getTasksById(final List<String> ids) {
-    try {
-      final List<Hit<TaskEntity>> response = getTasksRawResponse(ids);
-      return response.stream().map(Hit::source).collect(Collectors.toList());
-    } catch (final IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   /**
    * Persist that task is completed even before the corresponding events are imported from Zeebe.
    */
@@ -276,8 +266,21 @@ public class TaskStoreOpenSearch implements TaskStore {
   }
 
   @Override
-  public void updateTaskLinkedForm(final TaskEntity task, final String formBpmnId) {
-    updateTask(task.getId(), asMap(TaskTemplate.FORM_ID, formBpmnId));
+  public List<TaskEntity> getTasksById(final List<String> ids) {
+    try {
+      final List<Hit<TaskEntity>> response = getTasksRawResponse(ids);
+      return response.stream().map(Hit::source).collect(Collectors.toList());
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void updateTaskLinkedForm(
+      final TaskEntity task, final String formBpmnId, final long formVersion) {
+    updateTask(
+        task.getId(),
+        asMap(TaskTemplate.FORM_ID, formBpmnId, TaskTemplate.FORM_VERSION, formVersion));
   }
 
   /**

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToTaskEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToTaskEntityMapper.java
@@ -129,15 +129,13 @@ public class UserTaskRecordToTaskEntityMapper {
       final String strFromKey = String.valueOf(formKey);
       entity.setFormKey(strFromKey).setIsFormEmbedded(false);
       formStore
-          .getHighestVersionFormByKey(strFromKey)
+          .getFormByKey(strFromKey)
           .ifPresentOrElse(
               linkedForm -> {
                 entity.setFormVersion(linkedForm.version());
                 entity.setFormId(linkedForm.bpmnId());
               },
-              () -> {
-                LOGGER.warn("Form with key={} cannot be found", strFromKey);
-              });
+              () -> LOGGER.warn("Form with key={} cannot be found", strFromKey));
     }
 
     // TODO handle removal of attributes in Zeebe https://github.com/camunda/tasklist/issues/4306

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -112,7 +112,7 @@ public class JobZeebeRecordProcessorElasticSearch {
     entity.setFormKey(formKey);
 
     Optional.ofNullable(formKey)
-        .flatMap(formStore::getHighestVersionFormByKey)
+        .flatMap(formStore::getFormByKey)
         .ifPresentOrElse(
             linkedForm -> {
               entity.setFormVersion(linkedForm.version());

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -106,7 +106,7 @@ public class JobZeebeRecordProcessorOpenSearch {
     entity.setFormKey(formKey);
 
     Optional.ofNullable(formKey)
-        .flatMap(formStore::getHighestVersionFormByKey)
+        .flatMap(formStore::getFormByKey)
         .ifPresentOrElse(
             linkedForm -> {
               entity.setFormVersion(linkedForm.version());

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/common/UserTaskRecordToTaskEntityMapper.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/common/UserTaskRecordToTaskEntityMapper.java
@@ -129,15 +129,13 @@ public class UserTaskRecordToTaskEntityMapper {
       final String strFromKey = String.valueOf(formKey);
       entity.setFormKey(strFromKey).setIsFormEmbedded(false);
       formStore
-          .getHighestVersionFormByKey(strFromKey)
+          .getFormByKey(strFromKey)
           .ifPresentOrElse(
               linkedForm -> {
                 entity.setFormVersion(linkedForm.version());
                 entity.setFormId(linkedForm.bpmnId());
               },
-              () -> {
-                LOGGER.warn("Form with key={} cannot be found", strFromKey);
-              });
+              () -> LOGGER.warn("Form with key={} cannot be found", strFromKey));
     }
 
     // TODO handle removal of attributes in Zeebe https://github.com/camunda/tasklist/issues/4306

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -112,7 +112,7 @@ public class JobZeebeRecordProcessorElasticSearch {
     entity.setFormKey(formKey);
 
     Optional.ofNullable(formKey)
-        .flatMap(formStore::getHighestVersionFormByKey)
+        .flatMap(formStore::getFormByKey)
         .ifPresentOrElse(
             linkedForm -> {
               entity.setFormVersion(linkedForm.version());

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -106,7 +106,7 @@ public class JobZeebeRecordProcessorOpenSearch {
     entity.setFormKey(formKey);
 
     Optional.ofNullable(formKey)
-        .flatMap(formStore::getHighestVersionFormByKey)
+        .flatMap(formStore::getFormByKey)
         .ifPresentOrElse(
             linkedForm -> {
               entity.setFormVersion(linkedForm.version());

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -137,8 +137,7 @@ public class TaskService {
           taskId,
           task.getFormKey());
 
-      final Optional<FormIdView> linkedForm =
-          formStore.getHighestVersionFormByKey(task.getFormKey());
+      final Optional<FormIdView> linkedForm = formStore.getFormByKey(task.getFormKey());
 
       linkedForm.ifPresent(
           form -> {

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -38,6 +38,7 @@ public class TaskTemplate extends TasklistTemplateDescriptor
 
   public static final String FORM_ID = "formId";
   public static final String FORM_KEY = "formKey";
+  public static final String FORM_VERSION = "formVersion";
   public static final String EXTERNAL_FORM_REFERENCE = "externalFormReference";
 
   public static final String TENANT_ID = "tenantId";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix the issue that occurs when a Form is not present/indexed yet when a User Task is created.

When the UserTask is queried check if it's `formId` field is not set and if other conditions apply and perform an update on the UserTask setting the `formId`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24771 
