### PR TITLE
fix: Remove Elasticsearch deprecation warning logs: about ignore_throttled

### DIFF
--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.data.es;
 
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
 import static java.util.Arrays.asList;
 
 import io.camunda.tasklist.data.DataGenerator;
@@ -16,7 +17,6 @@ import io.camunda.tasklist.entities.UserEntity;
 import java.io.IOException;
 import java.util.List;
 import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.indices.GetIndexRequest;
@@ -70,7 +70,7 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
     try {
       final GetIndexRequest request =
           new GetIndexRequest(tasklistProperties.getZeebeElasticsearch().getPrefix() + "*");
-      request.indicesOptions(IndicesOptions.fromOptions(true, false, true, false));
+      request.indicesOptions(LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED);
       final boolean exists = zeebeEsClient.indices().exists(request, RequestOptions.DEFAULT);
       if (exists) {
         // data already exists

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.es;
 
 import static io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty.createIndexMappingProperty;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultForNullValue;
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -54,7 +55,6 @@ import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.GetAliasesResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -405,7 +405,7 @@ public class RetryElasticsearchClient {
         .indices()
         .exists(
             new GetIndexRequest(indexPattern)
-                .indicesOptions(IndicesOptions.fromOptions(true, false, true, false)),
+                .indicesOptions(LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED),
             requestOptions);
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.store.elasticsearch;
 
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_IGNORE_THROTTLED;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.EVENT;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.EVENT_TIME;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.VALUE;
@@ -26,7 +27,6 @@ import java.util.stream.Collectors;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -104,7 +104,7 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
         SearchSourceBuilder.searchSource().query(rangeQuery).aggregation(aggregation);
     final SearchRequest searchRequest =
         new SearchRequest(index.getFullQualifiedName())
-            .indicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(LENIENT_EXPAND_OPEN_IGNORE_THROTTLED)
             .source(source);
     try {
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/ElasticsearchUtil.java
@@ -9,6 +9,11 @@ package io.camunda.tasklist.util;
 
 import static io.camunda.tasklist.util.CollectionUtil.map;
 import static io.camunda.tasklist.util.CollectionUtil.throwAwayNullElements;
+import static org.elasticsearch.action.support.IndicesOptions.Option.ALLOW_NO_INDICES;
+import static org.elasticsearch.action.support.IndicesOptions.Option.IGNORE_THROTTLED;
+import static org.elasticsearch.action.support.IndicesOptions.Option.IGNORE_UNAVAILABLE;
+import static org.elasticsearch.action.support.IndicesOptions.WildcardStates.CLOSED;
+import static org.elasticsearch.action.support.IndicesOptions.WildcardStates.OPEN;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.idsQuery;
@@ -24,6 +29,7 @@ import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -46,6 +52,7 @@ import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy;
 import org.elasticsearch.action.update.UpdateRequest;
 import org.elasticsearch.client.RequestOptions;
@@ -75,9 +82,20 @@ public abstract class ElasticsearchUtil {
   public static final Function<SearchHit, Long> SEARCH_HIT_ID_TO_LONG =
       (hit) -> Long.valueOf(hit.getId());
   public static final Function<SearchHit, String> SEARCH_HIT_ID_TO_STRING = SearchHit::getId;
+
+  /** IndicesOptions */
+  public static final IndicesOptions LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED =
+      new IndicesOptions(EnumSet.of(IGNORE_UNAVAILABLE, IGNORE_THROTTLED), EnumSet.of(OPEN));
+
+  public static final IndicesOptions LENIENT_EXPAND_OPEN_IGNORE_THROTTLED =
+      new IndicesOptions(
+          EnumSet.of(ALLOW_NO_INDICES, IGNORE_UNAVAILABLE, IGNORE_THROTTLED), EnumSet.of(OPEN));
+  public static final IndicesOptions STRICT_EXPAND_OPEN_CLOSED_IGNORE_THROTTLED =
+      new IndicesOptions(EnumSet.of(ALLOW_NO_INDICES, IGNORE_THROTTLED), EnumSet.of(OPEN, CLOSED));
+
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchUtil.class);
 
-  public static SearchRequest createSearchRequest(TemplateDescriptor template) {
+  public static SearchRequest createSearchRequest(final TemplateDescriptor template) {
     return createSearchRequest(template, QueryType.ALL);
   }
 
@@ -262,7 +280,9 @@ public abstract class ElasticsearchUtil {
   /* EXECUTE QUERY */
 
   public static void processBulkRequest(
-      RestHighLevelClient esClient, BulkRequest bulkRequest, RefreshPolicy refreshPolicy)
+      final RestHighLevelClient esClient,
+      BulkRequest bulkRequest,
+      final RefreshPolicy refreshPolicy)
       throws PersistenceException {
     if (bulkRequest.requests().size() > 0) {
       try {
@@ -526,8 +546,8 @@ public abstract class ElasticsearchUtil {
     return result;
   }
 
-  public static Set<Long> scrollKeysToSet(SearchRequest request, RestHighLevelClient esClient)
-      throws IOException {
+  public static Set<Long> scrollKeysToSet(
+      final SearchRequest request, final RestHighLevelClient esClient) throws IOException {
     final Set<Long> result = new HashSet<>();
     final Consumer<SearchHits> collectIds =
         (hits) -> result.addAll(map(hits.getHits(), SEARCH_HIT_ID_TO_LONG));

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearchTest.java
@@ -9,6 +9,7 @@ package io.camunda.tasklist.store.elasticsearch;
 
 import static io.camunda.tasklist.store.elasticsearch.TaskMetricsStoreElasticSearch.ASSIGNEE;
 import static io.camunda.tasklist.store.elasticsearch.TaskMetricsStoreElasticSearch.EVENT_TASK_COMPLETED_BY_ASSIGNEE;
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_IGNORE_THROTTLED;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.EVENT;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.EVENT_TIME;
 import static io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex.VALUE;
@@ -36,7 +37,6 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.BoolQueryBuilder;
@@ -162,7 +162,7 @@ public class TaskMetricsStoreElasticSearchTest {
         SearchSourceBuilder.searchSource().query(rangeQuery).aggregation(aggregation);
     final SearchRequest searchRequest =
         new SearchRequest(index.getFullQualifiedName())
-            .indicesOptions(IndicesOptions.lenientExpandOpen())
+            .indicesOptions(LENIENT_EXPAND_OPEN_IGNORE_THROTTLED)
             .source(source);
     return searchRequest;
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.util;
 
+import static io.camunda.tasklist.util.ElasticsearchUtil.LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED;
 import static io.camunda.tasklist.util.ThreadUtil.sleepFor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
@@ -29,7 +30,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
@@ -297,7 +297,7 @@ public class ElasticsearchTestExtension
             .indices()
             .get(
                 new GetIndexRequest(indexPrefix + "*")
-                    .indicesOptions(IndicesOptions.fromOptions(true, false, true, false)),
+                    .indicesOptions(LENIENT_EXPAND_OPEN_FORBID_NO_INDICES_IGNORE_THROTTLED),
                 RequestOptions.DEFAULT);
     final String[] indices = response.getIndices();
     return indices != null && indices.length >= minCountOfIndices;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.webapp.es.backup.es;
 
+import static io.camunda.tasklist.util.ElasticsearchUtil.STRICT_EXPAND_OPEN_CLOSED_IGNORE_THROTTLED;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -51,7 +52,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRes
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
-import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -251,7 +251,7 @@ public class BackupManagerElasticSearch extends BackupManager {
               // ignoreUnavailable = false - indices defined by their exact name MUST be present
               // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE
               // absent
-              .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
+              .indicesOptions(STRICT_EXPAND_OPEN_CLOSED_IGNORE_THROTTLED)
               .includeGlobalState(true)
               .userMetadata(objectMapper.convertValue(metadata, new TypeReference<>() {}))
               .featureStates(new String[] {"none"})


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Elasticsearch issues a warning when the `ignore_throttled=false` parameter is included in the `indicesOptions` settings sent with a query. 
This warning is resolved by explicitly enabling the `IGNORE_THROTTLED` option. This behavior occurs when using the Elasticsearch client version 7 with explicitly configured indicesOptions.

Frozen indices have been deprecated since ES 7.16 , `ignore_throttled=false` was used to explicitly include frozen indices in the search query.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24801 
