### PR TITLE
Setup default Identity entities

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.utils;
 
-import static io.camunda.zeebe.engine.processing.user.DefaultUserCreator.DEFAULT_USER_PASSWORD;
-import static io.camunda.zeebe.engine.processing.user.DefaultUserCreator.DEFAULT_USER_USERNAME;
+import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_PASSWORD;
+import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_USERNAME;
 
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
@@ -82,6 +83,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.SCALE, ScaleRecord::new);
     RECORDS_BY_TYPE.put(ValueType.GROUP, GroupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MAPPING, MappingRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
+import io.camunda.zeebe.engine.processing.identity.IdentitySetupProcessors;
 import io.camunda.zeebe.engine.processing.identity.MappingProcessors;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
@@ -233,7 +234,6 @@ public final class EngineProcessors {
         processingState,
         writers,
         commandDistributionBehavior,
-        config,
         authCheckBehavior);
 
     ClockProcessors.addClockProcessors(
@@ -288,6 +288,14 @@ public final class EngineProcessors {
         keyGenerator,
         writers,
         commandDistributionBehavior);
+
+    IdentitySetupProcessors.addIdentitySetupProcessors(
+        keyGenerator,
+        typedRecordProcessors,
+        processingState,
+        writers,
+        commandDistributionBehavior,
+        config);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+@ExcludeAuthorizationCheck
+public final class IdentitySetupInitializeProcessor
+    implements DistributedTypedRecordProcessor<IdentitySetupRecord> {
+  private final RoleState roleState;
+  private final UserState userState;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+
+  public IdentitySetupInitializeProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    roleState = processingState.getRoleState();
+    userState = processingState.getUserState();
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<IdentitySetupRecord> command) {
+    final var key = keyGenerator.nextKey();
+    initializeDefaultEntities(key, command);
+    commandDistributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.IDENTITY)
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<IdentitySetupRecord> command) {
+    initializeDefaultEntities(command.getKey(), command);
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void initializeDefaultEntities(
+      final long commandKey, final TypedRecord<IdentitySetupRecord> command) {
+    final var roleRecord = command.getValue().getDefaultRole();
+    final var userRecord = command.getValue().getDefaultUser();
+
+    final var roleExists = roleState.getRoleKeyByName(roleRecord.getName()).isPresent();
+    final var userExists = userState.getUser(userRecord.getUsername()).isPresent();
+
+    if (!roleExists) {
+      stateWriter.appendFollowUpEvent(commandKey, RoleIntent.CREATED, roleRecord);
+      addAllPermissions(roleRecord.getRoleKey());
+    }
+    if (!userExists) {
+      stateWriter.appendFollowUpEvent(commandKey, UserIntent.CREATED, userRecord);
+    }
+    if (!roleExists || !userExists) {
+      assignUserToRole(commandKey, roleRecord, userRecord);
+    }
+
+    stateWriter.appendFollowUpEvent(
+        commandKey, IdentitySetupIntent.INITIALIZED, command.getValue());
+  }
+
+  private void assignUserToRole(
+      final long commandKey, final RoleRecordValue roleRecord, final UserRecordValue userRecord) {
+    final var record =
+        new RoleRecord()
+            .setRoleKey(roleRecord.getRoleKey())
+            .setEntityKey(userRecord.getUserKey())
+            .setEntityType(EntityType.USER);
+    stateWriter.appendFollowUpEvent(commandKey, RoleIntent.ENTITY_ADDED, record);
+  }
+
+  private void addAllPermissions(final long roleKey) {
+
+    for (final AuthorizationResourceType resourceType : AuthorizationResourceType.values()) {
+      final var record =
+          new AuthorizationRecord().setOwnerKey(roleKey).setOwnerType(AuthorizationOwnerType.ROLE);
+      record.setResourceType(resourceType);
+
+      for (final PermissionType permissionType : PermissionType.values()) {
+        final var permission =
+            new Permission().setPermissionType(permissionType).addResourceId(WILDCARD_PERMISSION);
+        record.addPermission(permission);
+      }
+
+      stateWriter.appendFollowUpEvent(roleKey, AuthorizationIntent.PERMISSION_ADDED, record);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -5,40 +5,32 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.processing.user;
+package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
-public class UserProcessors {
-  public static void addUserProcessors(
+public final class IdentitySetupProcessors {
+  public static void addIdentitySetupProcessors(
       final KeyGenerator keyGenerator,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final EngineConfiguration config) {
     typedRecordProcessors
         .onCommand(
-            ValueType.USER,
-            UserIntent.CREATE,
-            new UserCreateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
-        .onCommand(
-            ValueType.USER,
-            UserIntent.UPDATE,
-            new UserUpdateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
-        .onCommand(
-            ValueType.USER,
-            UserIntent.DELETE,
-            new UserDeleteProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior));
+            ValueType.IDENTITY_SETUP,
+            IdentitySetupIntent.INITIALIZE,
+            new IdentitySetupInitializeProcessor(
+                processingState, writers, keyGenerator, distributionBehavior))
+        .withListener(new IdentitySetupInitializer(keyGenerator, config, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -127,6 +128,7 @@ public final class EventAppliers implements EventApplier {
     registerScalingAppliers(state);
     registerTenantAppliers(state);
     registerMappingAppliers(state);
+    registerIdentitySetupAppliers();
 
     return this;
   }
@@ -537,6 +539,10 @@ public final class EventAppliers implements EventApplier {
         MappingIntent.CREATED,
         new MappingCreatedApplier(state.getMappingState(), state.getAuthorizationState()));
     register(MappingIntent.DELETED, new MappingDeletedApplier(state));
+  }
+
+  private void registerIdentitySetupAppliers() {
+    register(IdentitySetupIntent.INITIALIZED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IdentitySetupInitializeMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTestLifecycle() {
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED)))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the deletion was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(IdentitySetupIntent.INITIALIZE, RecordType.COMMAND, 1),
+            tuple(IdentitySetupIntent.INITIALIZED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(r -> r.getIntent().equals(IdentitySetupIntent.INITIALIZED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(IdentitySetupIntent.INITIALIZE, IdentitySetupIntent.INITIALIZED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+
+  @Test
+  public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
+    // given the role creation distribution is intercepted
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      interceptRoleCreateForPartition(partitionId);
+    }
+
+    engine.role().newRole("foo").create();
+
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // Increase time to trigger a redistribution
+    engine.increaseTime(Duration.ofMinutes(1));
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .limit(2))
+        .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(ValueType.ROLE, RoleIntent.CREATE),
+            tuple(ValueType.IDENTITY_SETUP, IdentitySetupIntent.INITIALIZE));
+  }
+
+  private void interceptRoleCreateForPartition(final int partitionId) {
+    final var hasInterceptedPartition = new AtomicBoolean(false);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (hasInterceptedPartition.get()) {
+            return true;
+          }
+          hasInterceptedPartition.set(true);
+          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
+        });
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IdentitySetupInitializeTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateRoleAndUser() {
+    // given
+    final var roleKey = 1;
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var userKey = 2;
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+
+    // when
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue())
+        .hasRoleKey(roleKey)
+        .hasName(roleName);
+    assertThat(RecordingExporter.userRecords(UserIntent.CREATED).getFirst().getValue())
+        .hasUserKey(userKey)
+        .hasUsername(username)
+        .hasName(userName)
+        .hasPassword(password)
+        .hasEmail(mail);
+    assertUserIsAssignedToRole(roleKey, userKey);
+    assertThatAllPermissionsAreAddedToRole(roleKey);
+  }
+
+  @Test
+  public void shouldNotCreateUserIfAlreadyExists() {
+    // given
+    final var roleKey = 1;
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+  }
+
+  @Test
+  public void shouldNotCreateRoleIfAlreadyExists() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var userKey = 2;
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .asList())
+        .describedAs("No permissions should be added. The role should not be modified.")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldAssignUserToRoleIfBothAlreadyExist() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+  }
+
+  private static void assertUserIsAssignedToRole(final long roleKey, final long userKey) {
+    assertThat(RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).getFirst().getValue())
+        .hasRoleKey(roleKey)
+        .hasEntityKey(userKey);
+  }
+
+  @Test
+  public void shouldNotAssignUserToRoleIfAlreadyAssigned() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertNoAssignmentIsCreated(initializeRecord.getSourceRecordPosition());
+  }
+
+  private static void assertThatAllPermissionsAreAddedToRole(final long roleKey) {
+    final var addedPermissions =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)
+            .withOwnerKey(roleKey)
+            .limit(AuthorizationResourceType.values().length)
+            .map(Record::getValue)
+            .toList();
+    Assertions.assertThat(addedPermissions)
+        .describedAs("Added permissions for all resource types")
+        .extracting(AuthorizationRecordValue::getResourceType)
+        .containsExactly(AuthorizationResourceType.values());
+
+    final List<Tuple> expectedPermissions = new ArrayList<>();
+    for (final PermissionType value : PermissionType.values()) {
+      expectedPermissions.add(Tuple.tuple(value, Set.of(WILDCARD_PERMISSION)));
+    }
+
+    Assertions.assertThat(addedPermissions)
+        .describedAs("Added permissions for all resource types")
+        .flatMap(AuthorizationRecordValue::getPermissions)
+        .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
+        .containsOnly(expectedPermissions.toArray(new Tuple[0]));
+  }
+
+  private static void assertUserIsNotCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .userRecords()
+                .withIntent(UserIntent.CREATED)
+                .toList())
+        .isEmpty();
+  }
+
+  private static void assertRoleIsNotCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .roleRecords()
+                .withIntent(RoleIntent.CREATED)
+                .toList())
+        .isEmpty();
+  }
+
+  private static void assertNoAssignmentIsCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .roleRecords()
+                .withIntent(RoleIntent.ENTITY_ADDED)
+                .toList())
+        .isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
+import io.camunda.zeebe.engine.util.client.IdentitySetupClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.JobClient;
@@ -344,6 +345,10 @@ public final class EngineRule extends ExternalResource {
 
   public UserClient user() {
     return new UserClient(environmentRule);
+  }
+
+  public IdentitySetupClient identitySetup() {
+    return new IdentitySetupClient(environmentRule);
   }
 
   public AuthorizationClient authorization() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Function;
+
+public final class IdentitySetupClient {
+
+  private final CommandWriter writer;
+
+  public IdentitySetupClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public IdentitySetupInitializeClient initialize() {
+    return new IdentitySetupInitializeClient(writer);
+  }
+
+  public static class IdentitySetupInitializeClient {
+    private static final Function<Long, Record<IdentitySetupRecordValue>> SUCCESS_SUPPLIER =
+        (position) ->
+            RecordingExporter.identitySetupRecords()
+                .withIntent(IdentitySetupIntent.INITIALIZED)
+                .withSourceRecordPosition(position)
+                .getFirst();
+    private static final Function<Long, Record<IdentitySetupRecordValue>> REJECTION_SUPPLIER =
+        (position) ->
+            RecordingExporter.identitySetupRecords()
+                .onlyCommandRejections()
+                .withIntent(IdentitySetupIntent.INITIALIZE)
+                .withSourceRecordPosition(position)
+                .getFirst();
+
+    private final CommandWriter writer;
+    private final IdentitySetupRecord record;
+    private Function<Long, Record<IdentitySetupRecordValue>> expectation = SUCCESS_SUPPLIER;
+
+    public IdentitySetupInitializeClient(final CommandWriter writer) {
+      this.writer = writer;
+      record = new IdentitySetupRecord();
+    }
+
+    public IdentitySetupInitializeClient withRole(final RoleRecord role) {
+      record.setDefaultRole(role);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withUser(final UserRecord user) {
+      record.setDefaultUser(user);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient expectRejection() {
+      expectation = REJECTION_SUPPLIER;
+      return this;
+    }
+
+    public Record<IdentitySetupRecordValue> initialize() {
+      final long position = writer.writeCommand(IdentitySetupIntent.INITIALIZE, record);
+      return expectation.apply(position);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -31,8 +31,8 @@ public class RoleClient {
     return new RoleUpdateClient(writer, roleKey);
   }
 
-  public RoleAddEntityClient addEntity(final long key) {
-    return new RoleAddEntityClient(writer, key);
+  public RoleAddEntityClient addEntity(final long roleKey) {
+    return new RoleAddEntityClient(writer, roleKey);
   }
 
   public RoleRemoveEntityClient removeEntity(final long key) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.authorization;
+
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+
+public class IdentitySetupRecord extends UnifiedRecordValue implements IdentitySetupRecordValue {
+
+  private final ObjectProperty<RoleRecord> defaultRoleProp =
+      new ObjectProperty<>("defaultRole", new RoleRecord());
+  private final ObjectProperty<UserRecord> defaultUserProp =
+      new ObjectProperty<>("defaultUser", new UserRecord());
+
+  public IdentitySetupRecord() {
+    super(2);
+    declareProperty(defaultRoleProp).declareProperty(defaultUserProp);
+  }
+
+  @Override
+  public RoleRecordValue getDefaultRole() {
+    return defaultRoleProp.getValue();
+  }
+
+  public IdentitySetupRecord setDefaultRole(final RoleRecord role) {
+    defaultRoleProp.getValue().wrap(role);
+    return this;
+  }
+
+  @Override
+  public UserRecordValue getDefaultUser() {
+    return defaultUserProp.getValue();
+  }
+
+  public IdentitySetupRecord setDefaultUser(final UserRecord user) {
+    defaultUserProp.getValue().wrap(user);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
@@ -55,6 +56,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.MAPPING, MappingRecord::new);
     RECORDS_BY_TYPE.put(ValueType.GROUP, GroupRecord::new);
     RECORDS_BY_TYPE.put(ValueType.REDISTRIBUTION, RedistributionRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord::new);
   }
 
   /*

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -20,7 +20,7 @@ import org.agrona.DirectBuffer;
 
 public final class UserRecord extends UnifiedRecordValue implements UserRecordValue {
   private final LongProperty userKeyProp = new LongProperty("userKey", -1L);
-  private final StringProperty usernameProp = new StringProperty("username");
+  private final StringProperty usernameProp = new StringProperty("username", "");
   private final StringProperty nameProp = new StringProperty("name", "");
   private final StringProperty emailProp = new StringProperty("email", "");
   private final StringProperty passwordProp = new StringProperty("password", "");

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -51,7 +51,7 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
     return userKeyProp.getValue();
   }
 
-  public UserRecord setUserKey(final Long userKey) {
+  public UserRecord setUserKey(final long userKey) {
     userKeyProp.setValue(userKey);
     return this;
   }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -2970,6 +2971,72 @@ final class JsonSerializableToJsonTest {
         "mappingKey": -1,
         "claimName": "",
         "claimValue": ""
+      }
+      """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ///////////////////////////////// IdentitySetupRecord ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "IdentitySetup record",
+        (Supplier<IdentitySetupRecord>)
+            () ->
+                new IdentitySetupRecord()
+                    .setDefaultRole(
+                        new RoleRecord()
+                            .setRoleKey(1)
+                            .setName("roleName")
+                            .setEntityKey(2)
+                            .setEntityType(EntityType.USER))
+                    .setDefaultUser(
+                        new UserRecord()
+                            .setUserKey(3L)
+                            .setUsername("username")
+                            .setName("name")
+                            .setEmail("email")
+                            .setPassword("password")
+                            .setUserType(UserType.REGULAR)),
+        """
+      {
+        "defaultRole": {
+          "roleKey": 1,
+          "name": "roleName",
+          "entityKey": 2,
+          "entityType": "USER"
+        },
+        "defaultUser": {
+          "userKey": 3,
+          "username": "username",
+          "name": "name",
+          "email": "email",
+          "password": "password",
+          "userType": "REGULAR"
+        }
+      }
+      """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      ////////////////////////////// Empty IdentitySetupRecord ////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty IdentitySetupRecord",
+        (Supplier<IdentitySetupRecord>) IdentitySetupRecord::new,
+        """
+      {
+          "defaultRole": {
+              "roleKey": -1,
+              "name": "",
+              "entityKey": -1,
+              "entityType": "UNSPECIFIED"
+          },
+          "defaultUser": {
+              "userKey": -1,
+              "name": "",
+              "username": "",
+              "password": "",
+              "email": "",
+              "userType": "REGULAR"
+          }
       }
       """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -70,6 +71,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -259,6 +261,9 @@ public final class ValueTypeMapping {
         new Mapping<>(RedistributionRecordValue.class, RedistributionIntent.class));
     mapping.put(ValueType.GROUP, new Mapping<>(GroupRecordValue.class, GroupIntent.class));
     mapping.put(ValueType.MAPPING, new Mapping<>(MappingRecordValue.class, MappingIntent.class));
+    mapping.put(
+        ValueType.IDENTITY_SETUP,
+        new Mapping<>(IdentitySetupRecordValue.class, IdentitySetupIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IdentitySetupIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IdentitySetupIntent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum IdentitySetupIntent implements Intent {
+  INITIALIZE(0),
+  INITIALIZED(1);
+
+  private final short value;
+
+  IdentitySetupIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case INITIALIZED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return INITIALIZE;
+      case 1:
+        return INITIALIZED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -70,7 +70,8 @@ public interface Intent {
           ScaleIntent.class,
           RedistributionIntent.class,
           GroupIntent.class,
-          MappingIntent.class);
+          MappingIntent.class,
+          IdentitySetupIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -174,6 +175,8 @@ public interface Intent {
         return GroupIntent.from(intent);
       case MAPPING:
         return MappingIntent.from(intent);
+      case IDENTITY_SETUP:
+        return IdentitySetupIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -267,6 +270,8 @@ public interface Intent {
         return GroupIntent.valueOf(intent);
       case MAPPING:
         return MappingIntent.valueOf(intent);
+      case IDENTITY_SETUP:
+        return IdentitySetupIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableIdentitySetupRecordValue.Builder.class)
+public interface IdentitySetupRecordValue extends RecordValue {
+
+  RoleRecordValue getDefaultRole();
+
+  UserRecordValue getDefaultUser();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -63,7 +63,7 @@
       <validValue name="TENANT">45</validValue>
       <validValue name="GROUP">46</validValue>
       <validValue name="MAPPING">47</validValue>
-      <validValue name="IDENTITY_SETUP">47</validValue>
+      <validValue name="IDENTITY_SETUP">48</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -63,6 +63,7 @@
       <validValue name="TENANT">45</validValue>
       <validValue name="GROUP">46</validValue>
       <validValue name="MAPPING">47</validValue>
+      <validValue name="IDENTITY_SETUP">47</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="REDISTRIBUTION">252</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
@@ -112,6 +113,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.MAPPING, MappingRecord.class);
     registry.put(ValueType.GROUP, GroupRecord.class);
     registry.put(ValueType.REDISTRIBUTION, RedistributionRecord.class);
+    registry.put(ValueType.IDENTITY_SETUP, IdentitySetupRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/IdentitySetupRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/IdentitySetupRecordStream.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import java.util.stream.Stream;
+
+public class IdentitySetupRecordStream
+    extends ExporterRecordStream<IdentitySetupRecordValue, IdentitySetupRecordStream> {
+
+  public IdentitySetupRecordStream(final Stream<Record<IdentitySetupRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected IdentitySetupRecordStream supply(
+      final Stream<Record<IdentitySetupRecordValue>> wrappedStream) {
+    return new IdentitySetupRecordStream(wrappedStream);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -132,4 +132,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new UserRecordStream(
         filter(r -> r.getValueType() == ValueType.USER).map(Record.class::cast));
   }
+
+  public IdentitySetupRecordStream identitySetupRecords() {
+    return new IdentitySetupRecordStream(
+        filter(r -> r.getValueType() == ValueType.IDENTITY_SETUP).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -137,4 +137,14 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new IdentitySetupRecordStream(
         filter(r -> r.getValueType() == ValueType.IDENTITY_SETUP).map(Record.class::cast));
   }
+
+  public RoleRecordStream roleRecords() {
+    return new RoleRecordStream(
+        filter(r -> r.getValueType() == ValueType.ROLE).map(Record.class::cast));
+  }
+
+  public AuthorizationRecordStream authorizationRecords() {
+    return new AuthorizationRecordStream(
+        filter(r -> r.getValueType() == ValueType.AUTHORIZATION).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -498,6 +500,15 @@ public final class RecordingExporter implements Exporter {
 
   public static GroupRecordStream groupRecords(final GroupIntent intent) {
     return groupRecords().withIntent(intent);
+  }
+
+  public static IdentitySetupRecordStream identitySetupRecords() {
+    return new IdentitySetupRecordStream(
+        records(ValueType.IDENTITY_SETUP, IdentitySetupRecordValue.class));
+  }
+
+  public static IdentitySetupRecordStream identitySetupRecords(final IdentitySetupIntent intent) {
+    return identitySetupRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Before we had a `DefaultUserCreator`. This was responsible to create a default user with all permissions. With this PR this is slightly changed. Instead of just a user we create an Admin role. This role will get all permissions. Finally we assign the default user to this role. By doing this we don't need to have any exceptional cases to check permissions for the default user. It'll get assigned permissions just like any other user would.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24594 
