### PR TITLE
Initialize identity on startup

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.it.utils;
 
-import static io.camunda.zeebe.engine.processing.user.DefaultUserCreator.DEFAULT_USER_PASSWORD;
-import static io.camunda.zeebe.engine.processing.user.DefaultUserCreator.DEFAULT_USER_USERNAME;
+import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_PASSWORD;
+import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_USERNAME;
 
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor
 import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.identity.AuthorizationProcessors;
 import io.camunda.zeebe.engine.processing.identity.GroupProcessors;
+import io.camunda.zeebe.engine.processing.identity.IdentitySetupProcessors;
 import io.camunda.zeebe.engine.processing.identity.MappingProcessors;
 import io.camunda.zeebe.engine.processing.identity.RoleProcessors;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;
@@ -233,7 +234,6 @@ public final class EngineProcessors {
         processingState,
         writers,
         commandDistributionBehavior,
-        config,
         authCheckBehavior);
 
     ClockProcessors.addClockProcessors(
@@ -288,6 +288,14 @@ public final class EngineProcessors {
         keyGenerator,
         writers,
         commandDistributionBehavior);
+
+    IdentitySetupProcessors.addIdentitySetupProcessors(
+        keyGenerator,
+        typedRecordProcessors,
+        processingState,
+        writers,
+        commandDistributionBehavior,
+        config);
 
     return typedRecordProcessors;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.HashSet;
 import java.util.List;
@@ -120,13 +119,8 @@ public final class AuthorizationCheckBehavior {
     if (userOptional.isEmpty()) {
       return new HashSet<>();
     }
-    final var user = userOptional.get();
 
-    // The default user has all permissions
-    if (user.getUserType().equals(UserType.DEFAULT)) {
-      // TODO this should change when we introduce a default "admin" role to the default user
-      return new HashSet<>(Set.of(WILDCARD_PERMISSION));
-    }
+    final var user = userOptional.get();
 
     // Get resource identifiers for this user
     final var userAuthorizedResourceIdentifiers =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.identity;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
+
+import io.camunda.zeebe.engine.processing.ExcludeAuthorizationCheck;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.UserState;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+@ExcludeAuthorizationCheck
+public final class IdentitySetupInitializeProcessor
+    implements DistributedTypedRecordProcessor<IdentitySetupRecord> {
+  private final RoleState roleState;
+  private final UserState userState;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+
+  public IdentitySetupInitializeProcessor(
+      final ProcessingState processingState,
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    roleState = processingState.getRoleState();
+    userState = processingState.getUserState();
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<IdentitySetupRecord> command) {
+    final var key = keyGenerator.nextKey();
+    initializeDefaultEntities(key, command);
+    commandDistributionBehavior
+        .withKey(key)
+        .inQueue(DistributionQueue.IDENTITY)
+        .distribute(command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<IdentitySetupRecord> command) {
+    initializeDefaultEntities(command.getKey(), command);
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void initializeDefaultEntities(
+      final long commandKey, final TypedRecord<IdentitySetupRecord> command) {
+    final var roleRecord = command.getValue().getDefaultRole();
+    final var userRecord = command.getValue().getDefaultUser();
+
+    final var roleExists = roleState.getRoleKeyByName(roleRecord.getName()).isPresent();
+    final var userExists = userState.getUser(userRecord.getUsername()).isPresent();
+
+    if (!roleExists) {
+      stateWriter.appendFollowUpEvent(commandKey, RoleIntent.CREATED, roleRecord);
+      addAllPermissions(roleRecord.getRoleKey());
+    }
+    if (!userExists) {
+      stateWriter.appendFollowUpEvent(commandKey, UserIntent.CREATED, userRecord);
+    }
+    if (!roleExists || !userExists) {
+      assignUserToRole(commandKey, roleRecord, userRecord);
+    }
+
+    stateWriter.appendFollowUpEvent(
+        commandKey, IdentitySetupIntent.INITIALIZED, command.getValue());
+  }
+
+  private void assignUserToRole(
+      final long commandKey, final RoleRecordValue roleRecord, final UserRecordValue userRecord) {
+    final var record =
+        new RoleRecord()
+            .setRoleKey(roleRecord.getRoleKey())
+            .setEntityKey(userRecord.getUserKey())
+            .setEntityType(EntityType.USER);
+    stateWriter.appendFollowUpEvent(commandKey, RoleIntent.ENTITY_ADDED, record);
+  }
+
+  private void addAllPermissions(final long roleKey) {
+
+    for (final AuthorizationResourceType resourceType : AuthorizationResourceType.values()) {
+      final var record =
+          new AuthorizationRecord().setOwnerKey(roleKey).setOwnerType(AuthorizationOwnerType.ROLE);
+      record.setResourceType(resourceType);
+
+      for (final PermissionType permissionType : PermissionType.values()) {
+        final var permission =
+            new Permission().setPermissionType(permissionType).addResourceId(WILDCARD_PERMISSION);
+        record.addPermission(permission);
+      }
+
+      stateWriter.appendFollowUpEvent(roleKey, AuthorizationIntent.PERMISSION_ADDED, record);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -5,40 +5,32 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.processing.user;
+package io.camunda.zeebe.engine.processing.identity;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
-import io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
-public class UserProcessors {
-  public static void addUserProcessors(
+public final class IdentitySetupProcessors {
+  public static void addIdentitySetupProcessors(
       final KeyGenerator keyGenerator,
       final TypedRecordProcessors typedRecordProcessors,
       final MutableProcessingState processingState,
       final Writers writers,
       final CommandDistributionBehavior distributionBehavior,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final EngineConfiguration config) {
     typedRecordProcessors
         .onCommand(
-            ValueType.USER,
-            UserIntent.CREATE,
-            new UserCreateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
-        .onCommand(
-            ValueType.USER,
-            UserIntent.UPDATE,
-            new UserUpdateProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior))
-        .onCommand(
-            ValueType.USER,
-            UserIntent.DELETE,
-            new UserDeleteProcessor(
-                keyGenerator, processingState, writers, distributionBehavior, authCheckBehavior));
+            ValueType.IDENTITY_SETUP,
+            IdentitySetupIntent.INITIALIZE,
+            new IdentitySetupInitializeProcessor(
+                processingState, writers, keyGenerator, distributionBehavior))
+        .withListener(new IdentitySetupInitializer(keyGenerator, config, processingState));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IdentitySetupInitializeMultiPartitionTest {
+
+  private static final int PARTITION_COUNT = 3;
+
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(PARTITION_COUNT);
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldTestLifecycle() {
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .withPartitionId(1)
+                .limit(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED)))
+        .extracting(
+            Record::getIntent,
+            Record::getRecordType,
+            r ->
+                // We want to verify the partition id where the deletion was distributing to and
+                // where it was completed. Since only the CommandDistribution records have a
+                // value that contains the partition id, we use the partition id the record was
+                // written on for the other records.
+                r.getValue() instanceof CommandDistributionRecordValue
+                    ? ((CommandDistributionRecordValue) r.getValue()).getPartitionId()
+                    : r.getPartitionId())
+        .containsSubsequence(
+            tuple(IdentitySetupIntent.INITIALIZE, RecordType.COMMAND, 1),
+            tuple(IdentitySetupIntent.INITIALIZED, RecordType.EVENT, 1),
+            tuple(CommandDistributionIntent.STARTED, RecordType.EVENT, 1))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 2),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 2))
+        .containsSubsequence(
+            tuple(CommandDistributionIntent.DISTRIBUTING, RecordType.EVENT, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGE, RecordType.COMMAND, 3),
+            tuple(CommandDistributionIntent.ACKNOWLEDGED, RecordType.EVENT, 3))
+        .endsWith(tuple(CommandDistributionIntent.FINISHED, RecordType.EVENT, 1));
+
+    for (int partitionId = 2; partitionId < PARTITION_COUNT; partitionId++) {
+      assertThat(
+              RecordingExporter.records()
+                  .withPartitionId(partitionId)
+                  .limit(r -> r.getIntent().equals(IdentitySetupIntent.INITIALIZED))
+                  .collect(Collectors.toList()))
+          .extracting(Record::getIntent)
+          .containsSubsequence(IdentitySetupIntent.INITIALIZE, IdentitySetupIntent.INITIALIZED);
+    }
+  }
+
+  @Test
+  public void shouldDistributeInIdentityQueue() {
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords()
+                .limitByCount(r -> r.getIntent().equals(CommandDistributionIntent.FINISHED), 3)
+                .withIntent(CommandDistributionIntent.ENQUEUED))
+        .extracting(r -> r.getValue().getQueueId())
+        .containsOnly(DistributionQueue.IDENTITY.getQueueId());
+  }
+
+  @Test
+  public void distributionShouldNotOvertakeOtherCommandsInSameQueue() {
+    // given the role creation distribution is intercepted
+    for (int partitionId = 2; partitionId <= PARTITION_COUNT; partitionId++) {
+      interceptRoleCreateForPartition(partitionId);
+    }
+
+    engine.role().newRole("foo").create();
+
+    // when
+    final var role = new RoleRecord().setRoleKey(1).setName("roleName");
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername("username")
+            .setName("name")
+            .setPassword("password")
+            .setEmail("email");
+
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // Increase time to trigger a redistribution
+    engine.increaseTime(Duration.ofMinutes(1));
+
+    // then
+    assertThat(
+            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.FINISHED)
+                .limit(2))
+        .extracting(r -> r.getValue().getValueType(), r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(ValueType.ROLE, RoleIntent.CREATE),
+            tuple(ValueType.IDENTITY_SETUP, IdentitySetupIntent.INITIALIZE));
+  }
+
+  private void interceptRoleCreateForPartition(final int partitionId) {
+    final var hasInterceptedPartition = new AtomicBoolean(false);
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) -> {
+          if (hasInterceptedPartition.get()) {
+            return true;
+          }
+          hasInterceptedPartition.set(true);
+          return !(receiverPartitionId == partitionId && intent == RoleIntent.CREATE);
+        });
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.authorization;
+
+import static io.camunda.zeebe.engine.processing.identity.AuthorizationCheckBehavior.WILDCARD_PERMISSION;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.UserIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.groups.Tuple;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class IdentitySetupInitializeTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+  @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCreateRoleAndUser() {
+    // given
+    final var roleKey = 1;
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var userKey = 2L;
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+
+    // when
+    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue())
+        .hasRoleKey(roleKey)
+        .hasName(roleName);
+    assertThat(RecordingExporter.userRecords(UserIntent.CREATED).getFirst().getValue())
+        .hasUserKey(userKey)
+        .hasUsername(username)
+        .hasName(userName)
+        .hasPassword(password)
+        .hasEmail(mail);
+    assertUserIsAssignedToRole(roleKey, userKey);
+    assertThatAllPermissionsAreAddedToRole(roleKey);
+  }
+
+  @Test
+  public void shouldNotCreateUserIfAlreadyExists() {
+    // given
+    final var roleKey = 1;
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+  }
+
+  @Test
+  public void shouldNotCreateRoleIfAlreadyExists() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var userKey = 2;
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(userKey)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .authorizationRecords()
+                .asList())
+        .describedAs("No permissions should be added. The role should not be modified.")
+        .isEmpty();
+  }
+
+  @Test
+  public void shouldAssignUserToRoleIfBothAlreadyExist() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsAssignedToRole(roleKey, userKey);
+  }
+
+  private static void assertUserIsAssignedToRole(final long roleKey, final long userKey) {
+    assertThat(RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).getFirst().getValue())
+        .hasRoleKey(roleKey)
+        .hasEntityKey(userKey);
+  }
+
+  @Test
+  public void shouldNotAssignUserToRoleIfAlreadyAssigned() {
+    // given
+    final var roleName = "roleName";
+    final var role = new RoleRecord().setRoleKey(1).setName(roleName);
+    final var username = "username";
+    final var userName = "userName";
+    final var password = "password";
+    final var mail = "e@mail.com";
+    final var user =
+        new UserRecord()
+            .setUserKey(2)
+            .setUsername(username)
+            .setName(userName)
+            .setPassword(password)
+            .setEmail(mail);
+    final var roleKey = engine.role().newRole(roleName).create().getKey();
+    final var userKey =
+        engine
+            .user()
+            .newUser(username)
+            .withName(userName)
+            .withPassword(password)
+            .withEmail(mail)
+            .create()
+            .getKey();
+    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+
+    // then
+    assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
+    assertNoAssignmentIsCreated(initializeRecord.getSourceRecordPosition());
+  }
+
+  private static void assertThatAllPermissionsAreAddedToRole(final long roleKey) {
+    final var addedPermissions =
+        RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)
+            .withOwnerKey(roleKey)
+            .limit(AuthorizationResourceType.values().length)
+            .map(Record::getValue)
+            .toList();
+    Assertions.assertThat(addedPermissions)
+        .describedAs("Added permissions for all resource types")
+        .extracting(AuthorizationRecordValue::getResourceType)
+        .containsExactly(AuthorizationResourceType.values());
+
+    final List<Tuple> expectedPermissions = new ArrayList<>();
+    for (final PermissionType value : PermissionType.values()) {
+      expectedPermissions.add(Tuple.tuple(value, Set.of(WILDCARD_PERMISSION)));
+    }
+
+    Assertions.assertThat(addedPermissions)
+        .describedAs("Added permissions for all resource types")
+        .flatMap(AuthorizationRecordValue::getPermissions)
+        .extracting(PermissionValue::getPermissionType, PermissionValue::getResourceIds)
+        .containsOnly(expectedPermissions.toArray(new Tuple[0]));
+  }
+
+  private static void assertUserIsNotCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .userRecords()
+                .withIntent(UserIntent.CREATED)
+                .toList())
+        .isEmpty();
+  }
+
+  private static void assertRoleIsNotCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .roleRecords()
+                .withIntent(RoleIntent.CREATED)
+                .toList())
+        .isEmpty();
+  }
+
+  private static void assertNoAssignmentIsCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .roleRecords()
+                .withIntent(RoleIntent.ENTITY_ADDED)
+                .toList())
+        .isEmpty();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.GroupClient;
+import io.camunda.zeebe.engine.util.client.IdentitySetupClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.JobClient;
@@ -344,6 +345,10 @@ public final class EngineRule extends ExternalResource {
 
   public UserClient user() {
     return new UserClient(environmentRule);
+  }
+
+  public IdentitySetupClient identitySetup() {
+    return new IdentitySetupClient(environmentRule);
   }
 
   public AuthorizationClient authorization() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Function;
+
+public final class IdentitySetupClient {
+
+  private final CommandWriter writer;
+
+  public IdentitySetupClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public IdentitySetupInitializeClient initialize() {
+    return new IdentitySetupInitializeClient(writer);
+  }
+
+  public static class IdentitySetupInitializeClient {
+    private static final Function<Long, Record<IdentitySetupRecordValue>> SUCCESS_SUPPLIER =
+        (position) ->
+            RecordingExporter.identitySetupRecords()
+                .withIntent(IdentitySetupIntent.INITIALIZED)
+                .withSourceRecordPosition(position)
+                .getFirst();
+    private static final Function<Long, Record<IdentitySetupRecordValue>> REJECTION_SUPPLIER =
+        (position) ->
+            RecordingExporter.identitySetupRecords()
+                .onlyCommandRejections()
+                .withIntent(IdentitySetupIntent.INITIALIZE)
+                .withSourceRecordPosition(position)
+                .getFirst();
+
+    private final CommandWriter writer;
+    private final IdentitySetupRecord record;
+    private Function<Long, Record<IdentitySetupRecordValue>> expectation = SUCCESS_SUPPLIER;
+
+    public IdentitySetupInitializeClient(final CommandWriter writer) {
+      this.writer = writer;
+      record = new IdentitySetupRecord();
+    }
+
+    public IdentitySetupInitializeClient withRole(final RoleRecord role) {
+      record.setDefaultRole(role);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withUser(final UserRecord user) {
+      record.setDefaultUser(user);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient expectRejection() {
+      expectation = REJECTION_SUPPLIER;
+      return this;
+    }
+
+    public Record<IdentitySetupRecordValue> initialize() {
+      final long position = writer.writeCommand(IdentitySetupIntent.INITIALIZE, record);
+      return expectation.apply(position);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/RoleClient.java
@@ -31,8 +31,8 @@ public class RoleClient {
     return new RoleUpdateClient(writer, roleKey);
   }
 
-  public RoleAddEntityClient addEntity(final long key) {
-    return new RoleAddEntityClient(writer, key);
+  public RoleAddEntityClient addEntity(final long roleKey) {
+    return new RoleAddEntityClient(writer, roleKey);
   }
 
   public RoleRemoveEntityClient removeEntity(final long key) {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -51,7 +51,7 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
     return userKeyProp.getValue();
   }
 
-  public UserRecord setUserKey(final Long userKey) {
+  public UserRecord setUserKey(final long userKey) {
     userKeyProp.setValue(userKey);
     return this;
   }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/IdentitySetupRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/IdentitySetupRecordStream.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import java.util.stream.Stream;
+
+public class IdentitySetupRecordStream
+    extends ExporterRecordStream<IdentitySetupRecordValue, IdentitySetupRecordStream> {
+
+  public IdentitySetupRecordStream(final Stream<Record<IdentitySetupRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected IdentitySetupRecordStream supply(
+      final Stream<Record<IdentitySetupRecordValue>> wrappedStream) {
+    return new IdentitySetupRecordStream(wrappedStream);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -132,4 +132,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new UserRecordStream(
         filter(r -> r.getValueType() == ValueType.USER).map(Record.class::cast));
   }
+
+  public IdentitySetupRecordStream identitySetupRecords() {
+    return new IdentitySetupRecordStream(
+        filter(r -> r.getValueType() == ValueType.IDENTITY_SETUP).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -137,4 +137,14 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new IdentitySetupRecordStream(
         filter(r -> r.getValueType() == ValueType.IDENTITY_SETUP).map(Record.class::cast));
   }
+
+  public RoleRecordStream roleRecords() {
+    return new RoleRecordStream(
+        filter(r -> r.getValueType() == ValueType.ROLE).map(Record.class::cast));
+  }
+
+  public AuthorizationRecordStream authorizationRecords() {
+    return new AuthorizationRecordStream(
+        filter(r -> r.getValueType() == ValueType.AUTHORIZATION).map(Record.class::cast));
+  }
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorRecordValue;
 import io.camunda.zeebe.protocol.record.value.EscalationRecordValue;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
@@ -498,6 +500,15 @@ public final class RecordingExporter implements Exporter {
 
   public static GroupRecordStream groupRecords(final GroupIntent intent) {
     return groupRecords().withIntent(intent);
+  }
+
+  public static IdentitySetupRecordStream identitySetupRecords() {
+    return new IdentitySetupRecordStream(
+        records(ValueType.IDENTITY_SETUP, IdentitySetupRecordValue.class));
+  }
+
+  public static IdentitySetupRecordStream identitySetupRecords(final IdentitySetupIntent intent) {
+    return identitySetupRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Before we had a `DefaultUserCreator`. This was responsible to create a default user with all permissions. With this PR this is slightly changed. Instead of just a user we create an Admin role. This role will get all permissions. Finally we assign the default user to this role. By doing this we don't need to have any exceptional cases to check permissions for the default user. It'll get assigned permissions just like any other user would.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24594
