### PR TITLE
fix: eng start commang validation check

### DIFF
--- a/.github/workflows/optimize-command-eng.yml
+++ b/.github/workflows/optimize-command-eng.yml
@@ -126,9 +126,9 @@ jobs:
           # Validate 'start' command
           if [ "${{ steps.parse-args.outputs.arg1 }}" == 'start' ]; then
             # Check if the issue is in the correct status
-            if [ "$project_status" != 'Global Backlog' ] ||
-               [ "$project_status" != 'Ready' ] ||
-               [ "$project_status" != 'On Hold' ] ||
+            if [ "$project_status" != 'Global Backlog' ] &&
+               [ "$project_status" != 'Ready' ] &&
+               [ "$project_status" != 'On Hold' ] &&
                [ "$project_status" != 'Inbox' ]; then
               echo "Issue can be moved to In Progress only from 'Global Backlog', 'Ready', 'On Hold' or 'Inbox' status"
               exit 1


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

There was an issue with `/eng start` command validation which causes it to always fail

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13327#issuecomment-2498381003