### PR TITLE
fix: hold commang wrong script directory

### DIFF
--- a/.github/workflows/optimize-command-hold.yml
+++ b/.github/workflows/optimize-command-hold.yml
@@ -43,7 +43,7 @@ jobs:
           PROJECT_ID: ${{ steps.vars.outputs.project_id }}
           PROJECT_OWNER: ${{ github.event.client_payload.github.payload.organization.login }}
           GITHUB_TOKEN: ${{ steps.github-token.outputs.token }}
-        run: ./.github/scripts/commands/get-issue-project-data.sh
+        run: ./.github/optimize/scripts/commands/get-issue-project-data.sh
 
       - name: Validate inputs
         run: |


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

In the `/hold` there was a wrong path to the `get-issue-project-data.sh` script

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/camunda-optimize/issues/13328#issuecomment-2498396673