### PR TITLE
feat: c8run customize server port

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -1,8 +1,8 @@
 -------------------------------------------
 Access each component at the following urls:
 
-Operate:                     http://localhost:8080/operate
-Tasklist:                    http://localhost:8080/tasklist
+Operate:                     http://localhost:{{.ServerPort}}/operate
+Tasklist:                    http://localhost:{{.ServerPort}}/tasklist
 Zeebe Cluster Endpoint:      http://localhost:26500
 Inbound Connectors Endpoint: http://localhost:8085
 

--- a/c8run/internal/unix/stub.go
+++ b/c8run/internal/unix/stub.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-func (w *UnixC8Run) OpenBrowser(protocol string) error {
+func (w *UnixC8Run) OpenBrowser(protocol string, port int) error {
 	panic("Platform was not built for unix")
 }
 

--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -9,11 +9,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"syscall"
 )
 
-func (w *UnixC8Run) OpenBrowser(protocol string) error {
-	operateUrl := protocol + "://localhost:8080/operate/login"
+func (w *UnixC8Run) OpenBrowser(protocol string, port int) error {
+	operateUrl := protocol + "://localhost:" + strconv.Itoa(port) + "/operate/login"
 	var openBrowserCmdString string
 	if runtime.GOOS == "darwin" {
 		openBrowserCmdString = "open"

--- a/c8run/internal/windows/stub.go
+++ b/c8run/internal/windows/stub.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 )
 
-func (w *WindowsC8Run) OpenBrowser(protocol string) error {
+func (w *WindowsC8Run) OpenBrowser(protocol string, port int) error {
 	panic("Platform was not built for windows")
 }
 

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -8,11 +8,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 	"syscall"
 )
 
-func (w *WindowsC8Run) OpenBrowser(protocol string) error {
-	operateUrl := protocol + "://localhost:8080/operate/login"
+func (w *WindowsC8Run) OpenBrowser(protocol string, port int) error {
+	operateUrl := protocol + "://localhost:" + strconv.Itoa(port) + "/operate/login"
 	openBrowserCmdString := "start " + operateUrl
 	openBrowserCmd := exec.Command("cmd", "/C", openBrowserCmdString)
 	openBrowserCmd.SysProcAttr = &syscall.SysProcAttr{

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -14,12 +14,26 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"text/template"
 	"time"
 )
 
-func printStatus() {
+func printStatus(port int) error {
 	endpoints, _ := os.ReadFile("endpoints.txt")
-	fmt.Println(string(endpoints))
+	t, err := template.New("endpoints").Parse(string(endpoints))
+	if err != nil {
+		return fmt.Errorf("Error: failed to parse endpoints template: %s", err.Error())
+	}
+
+	data := TemplateData{
+		ServerPort: port,
+	}
+
+	err = t.Execute(os.Stdout, data)
+	if err != nil {
+		return fmt.Errorf("Error: failed to fill endpoints template %s", err.Error())
+	}
+	return nil
 }
 
 func queryElasticsearchHealth(name string, url string) {
@@ -51,7 +65,7 @@ func queryCamundaHealth(c8 C8Run, name string, settings C8RunSettings) error {
 	if settings.keystore != "" && settings.keystorePassword != "" {
 		protocol = "https"
 	}
-	url := protocol + "://localhost:8080/operate/login"
+	url := protocol + "://localhost:" + strconv.Itoa(settings.port) + "/operate/login"
 	for retries := 24; retries >= 0; retries-- {
 		fmt.Println("Waiting for " + name + " to start. " + strconv.Itoa(retries) + " retries left")
 		time.Sleep(14 * time.Second)
@@ -68,13 +82,13 @@ func queryCamundaHealth(c8 C8Run, name string, settings C8RunSettings) error {
 		return fmt.Errorf("Error: %s did not start!", name)
 	}
 	fmt.Println(name + " has successfully been started.")
-	err := c8.OpenBrowser(protocol)
+	err := c8.OpenBrowser(protocol, settings.port)
 	if err != nil {
 		// failing to open the browser is not a critical error. It could simply be a sign the script is running in a CI node without a browser installed, or a docker image.
 		fmt.Println("Failed to open browser")
 		return nil
 	}
-	printStatus()
+	printStatus(settings.port)
 	return nil
 }
 
@@ -111,9 +125,15 @@ func getC8RunPlatform() C8Run {
 }
 
 func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
+	protocol := "http"
 	if settings.keystore != "" && settings.keystorePassword != "" {
 		javaOpts = javaOpts + " -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
+		protocol = "https"
 	}
+	if settings.port != 8080 {
+		javaOpts = javaOpts + " -Dserver.port=" + strconv.Itoa(settings.port)
+	}
+	os.Setenv("CAMUNDA_OPERATE_ZEEBE_RESTADDRESS", protocol+"://localhost:"+strconv.Itoa(settings.port))
 	return javaOpts
 }
 
@@ -188,6 +208,7 @@ func main() {
 	startFlagSet := flag.NewFlagSet("start", flag.ExitOnError)
 	startFlagSet.StringVar(&settings.config, "config", "", "Applies the specified configuration file.")
 	startFlagSet.BoolVar(&settings.detached, "detached", false, "Starts Camunda Run as a detached process")
+	startFlagSet.IntVar(&settings.port, "port", 8080, "Port to run Camunda on")
 	startFlagSet.StringVar(&settings.keystore, "keystore", "", "Provide a JKS filepath to enable TLS")
 	startFlagSet.StringVar(&settings.keystorePassword, "keystorePassword", "", "Provide a password to unlock your JKS keystore")
 

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -18,6 +18,7 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 	settings := C8RunSettings{
 		config:           "",
 		detached:         false,
+		port:             8080,
 		keystore:         "/tmp/camundatest/certs/secret.jks",
 		keystorePassword: "changeme",
 	}
@@ -45,6 +46,7 @@ func TestCamundaCmdHasNoJavaOpts(t *testing.T) {
 	settings := C8RunSettings{
 		config:           "",
 		detached:         false,
+		port:             8080,
 		keystore:         "",
 		keystorePassword: "",
 	}
@@ -68,6 +70,7 @@ func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {
 	settings := C8RunSettings{
 		config:           "",
 		detached:         false,
+		port:             8080,
 		keystore:         "/tmp/camundatest/certs/secret.jks",
 		keystorePassword: "",
 	}
@@ -75,4 +78,25 @@ func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {
 
 	assert.NotNil(t, err)
 	assert.Error(t, err, "You must provide a password with --keystorePassword to unlock your keystore.")
+}
+
+func TestCamundaCmdDifferentPort(t *testing.T) {
+
+	settings := C8RunSettings{
+		port: 8087,
+	}
+	javaOpts := adjustJavaOpts("", settings)
+	c8runPlatform := getC8RunPlatform()
+
+	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
+
+	javaOptsEnvVar := ""
+	for _, envVar := range cmd.Env {
+		if strings.Contains(envVar, "JAVA_OPTS") {
+			javaOptsEnvVar = envVar
+			break
+		}
+	}
+	assert.Contains(t, javaOptsEnvVar, "-Dserver.port=8087")
+
 }

--- a/c8run/types.go
+++ b/c8run/types.go
@@ -6,7 +6,7 @@ import (
 )
 
 type C8Run interface {
-	OpenBrowser(protocol string) error
+	OpenBrowser(protocol string, port int) error
 	ProcessTree(commandPid int) []*os.Process
 	VersionCmd(javaBinaryPath string) *exec.Cmd
 	ElasticsearchCmd(elasticsearchVersion string, parentDir string) *exec.Cmd
@@ -17,6 +17,11 @@ type C8Run interface {
 type C8RunSettings struct {
 	config           string
 	detached         bool
+	port             int
 	keystore         string
 	keystorePassword string
+}
+
+type TemplateData struct {
+	ServerPort int
 }


### PR DESCRIPTION
## Description


In c8run, port 8080 is used. When any other port is set via --config, the healthchecks fail because those are hardcoded to listen on port 8080.

This issue is a request to support a --port command line flag to change the default port.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/25086
