### PR TITLE
Add Errors to backup openapi responses and fix the return type of `GET /backup-history`

### DIFF
--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -161,7 +161,7 @@ paths:
       responses:
         '200':
           description: OK
-          $ref: '#/components/responses/HistoryBackupDetail'
+          $ref: '#/components/responses/HistoryBackupInfo'
         '404':
           description: Backup with given ID does not exist.
           $ref: '#/components/responses/Error'
@@ -477,7 +477,7 @@ components:
         - startTime
         - failures
 
-    HistoryBackupList:
+    HistoryBackupInfo:
       type: object
       properties:
         backupId:
@@ -496,3 +496,7 @@ components:
         - state
         - details
 
+    HistoryBackupList:
+      type: array
+      items:
+        $ref: '#/components/schemas/HistoryBackupInfo'

--- a/dist/src/main/resources/api/backup-management-api.yaml
+++ b/dist/src/main/resources/api/backup-management-api.yaml
@@ -127,10 +127,13 @@ paths:
           $ref: '#/components/responses/TakeBackupHistoryResponse'
         '400':
           description: In case something is wrong with backupId, e.g. the same backup ID already exists.
+          $ref: '#/components/responses/Error'
         '500':
           description: All other errors, e.g. ES returned error response when attempting to create a snapshot.
+          $ref: '#/components/responses/Error'
         '502':
           description: Elasticsearch is not accessible, the request can be retried when it is back.
+          $ref: '#/components/responses/Error'
     get:
       summary: Lists all available historic backups
       description: |
@@ -142,10 +145,13 @@ paths:
           $ref: '#/components/responses/HistoryBackupList'
         '404':
           description: Backup repository is not configured.
+          $ref: '#/components/responses/Error'
         '500':
           description: Elasticsearch is not accessible, the request can be retried when it is back.
+          $ref: '#/components/responses/Error'
         '502':
           description: Elasticsearch is not accessible, the request can be retried when it is back.
+          $ref: '#/components/responses/Error'
   /backup-history/{backupId}:
     get:
       summary: Get information of a historic backup
@@ -158,10 +164,13 @@ paths:
           $ref: '#/components/responses/HistoryBackupDetail'
         '404':
           description: Backup with given ID does not exist.
+          $ref: '#/components/responses/Error'
         '500':
           description: All other errors, e.g. ES returned error response when attempting to create a snapshot.
+          $ref: '#/components/responses/Error'
         '502':
           description: Elasticsearch is not accessible, the request can be retried when it is back.
+          $ref: '#/components/responses/Error'
     delete:
       summary: Delete a historic backup
       description: Delete a backup with the given id
@@ -172,10 +181,13 @@ paths:
           description: Backup is deleted
         '404':
           description: Not a single snapshot corresponding to given ID exist.
+          $ref: '#/components/responses/Error'
         '500':
           description: All other errors, e.g. ES returned error response when attempting to create a snapshot.
+          $ref: '#/components/responses/Error'
         '502':
           description: Elasticsearch is not accessible, the request can be retried when it is back.
+          $ref: '#/components/responses/Error'
 
 components:
   parameters:


### PR DESCRIPTION
## Description
Better align the openapi spec schema with the documentation, by adding errors and fix the schema for 
`GET /backup-history` as it was different than the current docs.

> It's based on #25211


## Related issues

relates #24465 
