### PR TITLE
fix: do not apply Tasklist and Operate security filters on v2 endpoints

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
@@ -13,7 +13,7 @@ public final class OperateURIs {
   public static final String X_CSRF_TOKEN = "X-CSRF-TOKEN";
   public static final String ROOT = "/operate";
   public static final String API = "/api/**";
-  public static final String PUBLIC_API = "/v*/**";
+  public static final String PUBLIC_API = "/v1/**";
   public static final String LOGIN_RESOURCE = "/api/login";
   public static final String LOGOUT_RESOURCE = "/api/logout";
   public static final String COOKIE_JSESSIONID = "OPERATE-SESSION";

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
@@ -23,7 +23,7 @@ public final class TasklistURIs {
   public static final String REST_V1_API = "/v1/";
   public static final String REST_V1_EXTERNAL_API = "/v1/external/**";
   public static final String NEW_FORM = "/new/**";
-  public static final String ALL_REST_VERSION_API = "/v*/**";
+  public static final String ALL_REST_VERSION_API = "/v1/**";
   public static final String TASKS_URL_V1 = "/v1/tasks";
   public static final String VARIABLES_URL_V1 = "/v1/variables";
   public static final String FORMS_URL_V1 = "/v1/forms";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Until they get removed, Operate and Tasklist security filters should not be applied on `/v2` endpoints.
In #21818 , we got as a side effect, in the single app, Zeebe user tasks cannot be assigned or completed from Tasklist as the security filters were applied to `/v2` endpoints exposed in the rest gateway.
The flow is: 
```Tasklist UI -/v1-> Tasklist webapp -/v2-> Zeebe REST gateway```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21818 
