### PR TITLE
fix: makes metrics endpoint more clear in c8run

### DIFF
--- a/c8run/endpoints.txt
+++ b/c8run/endpoints.txt
@@ -6,6 +6,8 @@ Tasklist:                    http://localhost:8080/tasklist
 Zeebe Cluster Endpoint:      http://localhost:26500
 Inbound Connectors Endpoint: http://localhost:8085
 
+Camunda metrics endpoint:    http://localhost:9600/actuator/prometheus
+
 When using the Desktop Modeler, Authentication may be set to None.
 
 Refer to https://docs.camunda.io/docs/guides/getting-started-java-spring/ for help getting started with Camunda


### PR DESCRIPTION
## Description

The prometheus endpoint isn't obvious since it's on the 9600 port when I expected it to be on 8080. This commit will show on startup what the url is for prometheus metrics.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
