### PR TITLE
fix: move the setTimeout inside the drag autoscroll

### DIFF
--- a/optimize/client/e2e/sm-tests/Dashboard.elements.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.elements.js
@@ -54,3 +54,4 @@ export const alertsDropdown = Selector('.AlertsDropdown button');
 export const alertDeleteButton = Selector('.AlertModal .deleteAlertButton');
 export const dashboardsLink = Selector('.NavItem a').withText('Dashboards');
 export const createCopyButton = Selector('.create-copy');
+export const gridItem = Selector('.react-grid-item');

--- a/optimize/client/e2e/sm-tests/Dashboard.js
+++ b/optimize/client/e2e/sm-tests/Dashboard.js
@@ -664,3 +664,27 @@ test('copy dashboard tiles', async (t) => {
   await t.click('.DashboardRenderer');
   await t.expect(e.reportTile.count).eql(10);
 });
+
+test('drag a report in a Dashboard', async (t) => {
+  await u.createNewReport(t);
+  await u.selectReportDefinition(t, 'Order process');
+  await u.selectView(t, 'Raw data');
+  await u.save(t);
+  await u.gotoOverview(t);
+  await u.createNewDashboard(t);
+  await u.addReportToDashboard(t, 'Blank report');
+
+  await t.dispatchEvent(e.gridItem, 'mousedown');
+  const leftOffset = await e.gridItem.getBoundingClientRectProperty('left');
+  const DRAG_AMOUNT = 500;
+  await t.expect(leftOffset).lt(DRAG_AMOUNT);
+  await t.drag(e.gridItem, DRAG_AMOUNT, 0);
+  const newLeftOffset = await e.gridItem.getBoundingClientRectProperty('left');
+
+  await t.expect(newLeftOffset).gt(DRAG_AMOUNT);
+
+  await u.save(t);
+
+  const offsetAfterSave = await e.gridItem.getBoundingClientRectProperty('left');
+  await t.expect(offsetAfterSave).gt(DRAG_AMOUNT);
+});

--- a/optimize/client/src/components/Dashboards/DashboardEdit.js
+++ b/optimize/client/src/components/Dashboards/DashboardEdit.js
@@ -74,10 +74,7 @@ export class DashboardEdit extends React.Component {
     if (this.draggedItem) {
       // We need to prevent the browser scroll that occurs when resizing
       evt.preventDefault();
-
-      // We need to give the library time to process the grab before
-      // artificially generating mousemove events
-      setTimeout(this.autoScroll);
+      this.autoScroll();
     }
   };
 
@@ -94,19 +91,20 @@ export class DashboardEdit extends React.Component {
       } else if (deltaBottom < 30) {
         container.scrollTop += (30 - deltaBottom) / 5;
       }
-      this.draggedItem.dispatchEvent(createEvent('mousemove', this.mousePosition));
+
+      // We need to give the library time to process the grab before
+      // artificially generating mousemove events
+      setTimeout(() => {
+        this.draggedItem.dispatchEvent(createEvent('mousemove', this.mousePosition));
+      });
+
       this.autoScrollHandle = requestAnimationFrame(this.autoScroll);
     }
   };
 
   clearDraggedItem = () => {
     this.draggedItem = null;
-
-    // since we need to timeout the start of the autoscroll, we also need
-    // to timeout the cancel to prevent a "cancel before start" bug
-    setTimeout(() => {
-      cancelAnimationFrame(this.autoScrollHandle);
-    });
+    cancelAnimationFrame(this.autoScrollHandle);
   };
 
   updateLayout = (layout) => {


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
After the React 18 update, the drag stopped working because the artificial mousedown events we trigger started to interfere with the mousedown of the react-grid library. I had to add a setimeout over the dispatch function to ensure our mousedown event get delayed correctly.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #25176
