### PR TITLE
feat: Trigger assignment listeners after UserTask creation with defined `assignee`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -230,6 +230,17 @@ public final class BpmnJobBehavior {
         taskHeaders);
   }
 
+  public void createTaskListenerJob(
+      final TaskListener listener,
+      final BpmnElementContext context,
+      final UserTaskRecord taskRecordValue) {
+    evaluateTaskListenerJobExpressions(listener.getJobWorkerProperties(), context, taskRecordValue)
+        .thenDo(
+            listenerJobProperties ->
+                createNewTaskListenerJob(context, listenerJobProperties, listener, taskRecordValue))
+        .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+  }
+
   private static JobListenerEventType fromExecutionListenerEventType(
       final ZeebeExecutionListenerEventType eventType) {
     return switch (eventType) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -88,43 +88,6 @@ public final class BpmnJobBehavior {
     this.userTaskBehavior = userTaskBehavior;
   }
 
-  public Either<Failure, JobProperties> evaluateTaskListenerJobExpressions(
-      final JobWorkerProperties jobWorkerProps,
-      final BpmnElementContext context,
-      final UserTaskRecord taskRecordValue) {
-    return evaluateJobExpressions(jobWorkerProps, context)
-        .map(
-            p ->
-                Optional.of(taskRecordValue.getAssignee())
-                    .map(BpmnJobBehavior::notBlankOrNull)
-                    .map(p::assignee)
-                    .orElse(p))
-        .map(
-            p ->
-                Optional.ofNullable(taskRecordValue.getCandidateGroupsList())
-                    .map(BpmnJobBehavior::asNotEmptyListLiteralOrNull)
-                    .map(p::candidateGroups)
-                    .orElse(p))
-        .map(
-            p ->
-                Optional.ofNullable(taskRecordValue.getCandidateUsersList())
-                    .map(BpmnJobBehavior::asNotEmptyListLiteralOrNull)
-                    .map(p::candidateUsers)
-                    .orElse(p))
-        .map(
-            p ->
-                Optional.of(taskRecordValue.getDueDate())
-                    .map(BpmnJobBehavior::notBlankOrNull)
-                    .map(p::dueDate)
-                    .orElse(p))
-        .map(
-            p ->
-                Optional.of(taskRecordValue.getFollowUpDate())
-                    .map(BpmnJobBehavior::notBlankOrNull)
-                    .map(p::followUpDate)
-                    .orElse(p));
-  }
-
   public Either<Failure, JobProperties> evaluateJobExpressions(
       final JobWorkerProperties jobWorkerProps, final BpmnElementContext context) {
     final var scopeKey = context.getElementInstanceKey();
@@ -214,31 +177,60 @@ public final class BpmnJobBehavior {
 
   public void createNewTaskListenerJob(
       final BpmnElementContext context,
-      final JobProperties jobProperties,
-      final TaskListener taskListener,
-      final UserTaskRecord taskRecordValue) {
-
-    final var taskHeaders =
-        Collections.singletonMap(
-            Protocol.RESERVED_HEADER_NAME_PREFIX + "userTaskKey",
-            Objects.toString(taskRecordValue.getUserTaskKey()));
-    writeJobCreatedEvent(
-        context,
-        jobProperties,
-        JobKind.TASK_LISTENER,
-        fromTaskListenerEventType(taskListener.getEventType()),
-        taskHeaders);
-  }
-
-  public void createTaskListenerJob(
-      final TaskListener listener,
-      final BpmnElementContext context,
-      final UserTaskRecord taskRecordValue) {
+      final UserTaskRecord taskRecordValue,
+      final TaskListener listener) {
     evaluateTaskListenerJobExpressions(listener.getJobWorkerProperties(), context, taskRecordValue)
         .thenDo(
-            listenerJobProperties ->
-                createNewTaskListenerJob(context, listenerJobProperties, listener, taskRecordValue))
+            listenerJobProperties -> {
+              final var taskHeaders =
+                  Collections.singletonMap(
+                      Protocol.RESERVED_HEADER_NAME_PREFIX + "userTaskKey",
+                      Objects.toString(taskRecordValue.getUserTaskKey()));
+              writeJobCreatedEvent(
+                  context,
+                  listenerJobProperties,
+                  JobKind.TASK_LISTENER,
+                  fromTaskListenerEventType(listener.getEventType()),
+                  taskHeaders);
+            })
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+  }
+
+  private Either<Failure, JobProperties> evaluateTaskListenerJobExpressions(
+      final JobWorkerProperties jobWorkerProps,
+      final BpmnElementContext context,
+      final UserTaskRecord taskRecordValue) {
+    return evaluateJobExpressions(jobWorkerProps, context)
+        .map(
+            p ->
+                Optional.of(taskRecordValue.getAssignee())
+                    .map(BpmnJobBehavior::notBlankOrNull)
+                    .map(p::assignee)
+                    .orElse(p))
+        .map(
+            p ->
+                Optional.ofNullable(taskRecordValue.getCandidateGroupsList())
+                    .map(BpmnJobBehavior::asNotEmptyListLiteralOrNull)
+                    .map(p::candidateGroups)
+                    .orElse(p))
+        .map(
+            p ->
+                Optional.ofNullable(taskRecordValue.getCandidateUsersList())
+                    .map(BpmnJobBehavior::asNotEmptyListLiteralOrNull)
+                    .map(p::candidateUsers)
+                    .orElse(p))
+        .map(
+            p ->
+                Optional.of(taskRecordValue.getDueDate())
+                    .map(BpmnJobBehavior::notBlankOrNull)
+                    .map(p::dueDate)
+                    .orElse(p))
+        .map(
+            p ->
+                Optional.of(taskRecordValue.getFollowUpDate())
+                    .map(BpmnJobBehavior::notBlankOrNull)
+                    .map(p::followUpDate)
+                    .orElse(p));
   }
 
   private static JobListenerEventType fromExecutionListenerEventType(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -46,8 +46,6 @@ public final class BpmnUserTaskBehavior {
       LoggerFactory.getLogger(BpmnUserTaskBehavior.class.getPackageName());
   private static final Set<LifecycleState> CANCELABLE_LIFECYCLE_STATES =
       EnumSet.complementOf(EnumSet.of(LifecycleState.NOT_FOUND, LifecycleState.CANCELING));
-  private final UserTaskRecord userTaskRecord =
-      new UserTaskRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
 
   private final HeaderEncoder headerEncoder = new HeaderEncoder(LOGGER);
   private final KeyGenerator keyGenerator;
@@ -123,25 +121,27 @@ public final class BpmnUserTaskBehavior {
     final var encodedHeaders =
         headerEncoder.encode(element.getUserTaskProperties().getTaskHeaders());
 
-    userTaskRecord
-        .setUserTaskKey(userTaskKey)
-        .setAssignee(userTaskProperties.getAssignee())
-        .setCandidateGroupsList(userTaskProperties.getCandidateGroups())
-        .setCandidateUsersList(userTaskProperties.getCandidateUsers())
-        .setDueDate(userTaskProperties.getDueDate())
-        .setFollowUpDate(userTaskProperties.getFollowUpDate())
-        .setFormKey(userTaskProperties.getFormKey())
-        .setExternalFormReference(userTaskProperties.getExternalFormReference())
-        .setCustomHeaders(encodedHeaders)
-        .setBpmnProcessId(context.getBpmnProcessId())
-        .setProcessDefinitionVersion(context.getProcessVersion())
-        .setProcessDefinitionKey(context.getProcessDefinitionKey())
-        .setProcessInstanceKey(context.getProcessInstanceKey())
-        .setElementId(element.getId())
-        .setElementInstanceKey(context.getElementInstanceKey())
-        .setTenantId(context.getTenantId())
-        .setPriority(userTaskProperties.getPriority())
-        .setCreationTimestamp(clock.millis());
+    final var userTaskRecord =
+        new UserTaskRecord()
+            .setVariables(DocumentValue.EMPTY_DOCUMENT)
+            .setUserTaskKey(userTaskKey)
+            .setAssignee(userTaskProperties.getAssignee())
+            .setCandidateGroupsList(userTaskProperties.getCandidateGroups())
+            .setCandidateUsersList(userTaskProperties.getCandidateUsers())
+            .setDueDate(userTaskProperties.getDueDate())
+            .setFollowUpDate(userTaskProperties.getFollowUpDate())
+            .setFormKey(userTaskProperties.getFormKey())
+            .setExternalFormReference(userTaskProperties.getExternalFormReference())
+            .setCustomHeaders(encodedHeaders)
+            .setBpmnProcessId(context.getBpmnProcessId())
+            .setProcessDefinitionVersion(context.getProcessVersion())
+            .setProcessDefinitionKey(context.getProcessDefinitionKey())
+            .setProcessInstanceKey(context.getProcessInstanceKey())
+            .setElementId(element.getId())
+            .setElementInstanceKey(context.getElementInstanceKey())
+            .setTenantId(context.getTenantId())
+            .setPriority(userTaskProperties.getPriority())
+            .setCreationTimestamp(clock.millis());
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
     return userTaskRecord;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,7 +126,7 @@ public final class BpmnUserTaskBehavior {
         new UserTaskRecord()
             .setVariables(DocumentValue.EMPTY_DOCUMENT)
             .setUserTaskKey(userTaskKey)
-            .setAssignee(userTaskProperties.getAssignee())
+            .setAssignee(StringUtils.EMPTY)
             .setCandidateGroupsList(userTaskProperties.getCandidateGroups())
             .setCandidateUsersList(userTaskProperties.getCandidateUsers())
             .setDueDate(userTaskProperties.getDueDate())
@@ -328,9 +329,16 @@ public final class BpmnUserTaskBehavior {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
   }
 
-  public void userTaskAssigning(final UserTaskRecord userTaskRecord) {
+  public void userTaskAssigning(final UserTaskRecord userTaskRecord, final String assignee) {
     final long userTaskKey = userTaskRecord.getUserTaskKey();
+    userTaskRecord.setAssignee(assignee);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+  }
+
+  public void userTaskAssigned(final UserTaskRecord userTaskRecord, final String assignee) {
+    final long userTaskKey = userTaskRecord.getUserTaskKey();
+    userTaskRecord.setAssignee(assignee);
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
   }
 
   public static final class UserTaskProperties {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -328,6 +328,11 @@ public final class BpmnUserTaskBehavior {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
   }
 
+  public void userTaskAssigning(final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = userTaskRecord.getUserTaskKey();
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+  }
+
   public static final class UserTaskProperties {
 
     private String assignee;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -89,10 +89,9 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
               if (StringUtils.isNotEmpty(userTaskProperties.getAssignee())
                   && element.hasTaskListeners(ZeebeTaskListenerEventType.assignment)) {
                 userTaskBehavior.userTaskAssigning(userTaskRecord);
-                jobBehavior.createTaskListenerJob(
-                    element.getTaskListeners(ZeebeTaskListenerEventType.assignment).getFirst(),
-                    context,
-                    userTaskRecord);
+                final var listener =
+                    element.getTaskListeners(ZeebeTaskListenerEventType.assignment).getFirst();
+                jobBehavior.createNewTaskListenerJob(context, userTaskRecord, listener);
               }
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -86,12 +86,16 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
               userTaskBehavior.userTaskCreated(userTaskRecord);
               stateTransitionBehavior.transitionToActivated(context, element.getEventType());
 
-              if (StringUtils.isNotEmpty(userTaskProperties.getAssignee())
-                  && element.hasTaskListeners(ZeebeTaskListenerEventType.assignment)) {
-                userTaskBehavior.userTaskAssigning(userTaskRecord);
-                final var listener =
-                    element.getTaskListeners(ZeebeTaskListenerEventType.assignment).getFirst();
-                jobBehavior.createNewTaskListenerJob(context, userTaskRecord, listener);
+              final var assignee = userTaskProperties.getAssignee();
+              if (StringUtils.isNotEmpty(assignee)) {
+                userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
+                if (element.hasTaskListeners(ZeebeTaskListenerEventType.assignment)) {
+                  final var listener =
+                      element.getTaskListeners(ZeebeTaskListenerEventType.assignment).getFirst();
+                  jobBehavior.createNewTaskListenerJob(context, userTaskRecord, listener);
+                } else {
+                  userTaskBehavior.userTaskAssigned(userTaskRecord, assignee);
+                }
               }
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -22,6 +22,8 @@ import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 
 public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
 
@@ -75,9 +77,13 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
+    final String action =
+        Objects.requireNonNullElse(
+            StringUtils.firstNonEmpty(command.getValue().getAction(), userTaskRecord.getAction()),
+            StringUtils.EMPTY);
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
+    userTaskRecord.setAction(action);
 
     if (command.hasRequestMetadata()) {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -682,7 +682,10 @@ public final class NativeUserTaskTest {
             .getFirst()
             .getValue();
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNING),
@@ -716,7 +719,10 @@ public final class NativeUserTaskTest {
             .getFirst()
             .getValue();
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNING),
@@ -758,7 +764,10 @@ public final class NativeUserTaskTest {
             .getFirst()
             .getValue();
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.UPDATED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.UPDATING),
@@ -816,7 +825,10 @@ public final class NativeUserTaskTest {
             tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETING),
@@ -845,7 +857,10 @@ public final class NativeUserTaskTest {
             tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.COMPLETED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.COMPLETING),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -291,7 +291,7 @@ public final class NativeUserTaskTest {
 
     // then
     final Record<UserTaskRecordValue> userTask =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
@@ -311,7 +311,7 @@ public final class NativeUserTaskTest {
 
     // then
     final Record<UserTaskRecordValue> userTask =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
@@ -333,7 +333,7 @@ public final class NativeUserTaskTest {
 
     // then
     final Record<UserTaskRecordValue> userTask =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -214,11 +214,11 @@ public class TaskListenerTest {
                         .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_2"))
                         .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_3"))));
 
-    // then: verify the UT is created with the expected `assignee`
+    // then: verify the UT was created without the defined `assignee` and without action
     assertUserTaskRecordWithIntent(
         processInstanceKey,
         UserTaskIntent.CREATED,
-        userTask -> Assertions.assertThat(userTask).hasAssignee(assignee).hasAction(""));
+        userTask -> Assertions.assertThat(userTask).hasAssignee("").hasAction(""));
 
     // when
     completeJobs(processInstanceKey, LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3");
@@ -241,7 +241,13 @@ public class TaskListenerTest {
         UserTaskIntent.COMPLETE_TASK_LISTENER,
         UserTaskIntent.ASSIGNED);
 
-    // then: verify the UT was assigned with the expected `assignee` and default `action` values
+    // then: verify the UT was assigning with the provided `assignee` and without action
+    assertUserTaskRecordWithIntent(
+        processInstanceKey,
+        UserTaskIntent.ASSIGNING,
+        userTask -> Assertions.assertThat(userTask).hasAssignee(assignee).hasAction(""));
+
+    // verify the UT was assigned with the provided `assignee` and default `action` values
     assertUserTaskRecordWithIntent(
         processInstanceKey,
         UserTaskIntent.ASSIGNED,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -52,6 +52,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -203,6 +204,7 @@ public class TaskListenerTest {
   public void shouldTriggerAssignmentListenersAfterUserTaskCreationWithDefinedAssigneeProperty() {
     // given
     final var assignee = "peregrin";
+    final var action = StringUtils.EMPTY;
 
     // when: process instance is created with a UT having an `assignee` and `assignment` listeners
     final long processInstanceKey =
@@ -214,11 +216,10 @@ public class TaskListenerTest {
                         .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_2"))
                         .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_3"))));
 
-    // then: verify the UT was created without the defined `assignee` and without action
-    assertUserTaskRecordWithIntent(
-        processInstanceKey,
-        UserTaskIntent.CREATED,
-        userTask -> Assertions.assertThat(userTask).hasAssignee("").hasAction(""));
+    // await user task creation
+    RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
 
     // when
     completeJobs(processInstanceKey, LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3");
@@ -231,27 +232,23 @@ public class TaskListenerTest {
         LISTENER_TYPE + "_2",
         LISTENER_TYPE + "_3");
 
-    // verify that UT intents follows the expected sequence from `CREATING` to `ASSIGNED`
-    assertUserTaskIntentsSequence(
-        UserTaskIntent.CREATING,
-        UserTaskIntent.CREATED,
-        UserTaskIntent.ASSIGNING,
-        UserTaskIntent.COMPLETE_TASK_LISTENER,
-        UserTaskIntent.COMPLETE_TASK_LISTENER,
-        UserTaskIntent.COMPLETE_TASK_LISTENER,
-        UserTaskIntent.ASSIGNED);
-
-    // then: verify the UT was assigning with the provided `assignee` and without action
-    assertUserTaskRecordWithIntent(
-        processInstanceKey,
-        UserTaskIntent.ASSIGNING,
-        userTask -> Assertions.assertThat(userTask).hasAssignee(assignee).hasAction(""));
-
-    // verify the UT was assigned with the provided `assignee` and default `action` values
-    assertUserTaskRecordWithIntent(
-        processInstanceKey,
-        UserTaskIntent.ASSIGNED,
-        userTask -> Assertions.assertThat(userTask).hasAssignee(assignee).hasAction("assign"));
+    // verify that UT records follows the expected intents sequence from `CREATING` to `ASSIGNED`
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
+        .as(
+            "Verify the sequence of intents and `assignee`, `action` properties emitted for the user task")
+        .extracting(
+            Record::getIntent, r -> r.getValue().getAssignee(), r -> r.getValue().getAction())
+        .containsExactly(
+            tuple(UserTaskIntent.CREATING, StringUtils.EMPTY, action),
+            tuple(UserTaskIntent.CREATED, StringUtils.EMPTY, action),
+            tuple(UserTaskIntent.ASSIGNING, assignee, action),
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action),
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action),
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, assignee, action),
+            tuple(UserTaskIntent.ASSIGNED, assignee, action));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateUserTaskTest.java
@@ -208,9 +208,9 @@ public class MigrateUserTaskTest {
                     Map.entry("followup2", "PT10H")))
             .create();
 
-    // await user task creation
+    // await user task assignment
     final var userTask =
-        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+        RecordingExporter.userTaskRecords(UserTaskIntent.ASSIGNED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst()
             .getValue();


### PR DESCRIPTION
## Description
This pull request introduces the functionality for triggering `assignment` listeners when a UserTask is created with a defined `assignee` property.

Key changes:
- When a UserTask is configured with a predefined `assignee`:
  - `ASSIGNING` event is emitted after UserTask creation.
  - If `assignment` listeners are defined, they are triggered between the `ASSIGNING` and `ASSIGNED` events.
  - Without `assignment` listeners, the `ASSIGNED` event is emitted immediately after `ASSIGNING`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24233
