### PR TITLE
ci: disable unused Go cache, since cache-dependency-path is missing

### DIFF
--- a/.github/workflows/c8run-build.yaml
+++ b/.github/workflows/c8run-build.yaml
@@ -33,6 +33,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23.1'
+          cache: false  # disabling since not working anyways without a cache-dependency-path specified
 
       - name: Build c8run
         run: go build
@@ -124,6 +125,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '>=1.23.1'
+          cache: false  # disabling since not working anyways without a cache-dependency-path specified
 
       - name: Build c8run
         run: go build


### PR DESCRIPTION
## Description

The C8run build uses `setup-go` which [fails to cache any artifacts](https://github.com/camunda/camunda/actions/runs/12029173314/job/33533878978).

This PR proposes to [hard-disable](https://github.com/actions/setup-go/blob/3041bf56c941b39c61721a86cd11f3bb1338122a/action.yml#L17) the unused functionality for #18750 to avoid confusions and accidental GHA cache overusage. The C8run builds seem to work fine even without caching and are fast enough.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #18750 
