### PR TITLE
Add support for group entity add and remove exporting

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -16,7 +16,7 @@ public class GroupIndex extends UserManagementIndexDescriptor {
   public static final String INDEX_NAME = "groups";
   public static final String INDEX_VERSION = "8.7.0";
 
-  public static final EntityJoinRelationFactory joinRelationFactory =
+  public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory(
           EntityJoinRelation.IdentityJoinRelationshipType.GROUP,
           EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -8,11 +8,18 @@
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 
 public class GroupIndex extends UserManagementIndexDescriptor {
 
   public static final String INDEX_NAME = "groups";
   public static final String INDEX_VERSION = "8.7.0";
+
+  public static final EntityJoinRelationFactory joinRelationFactory =
+      new EntityJoinRelationFactory(
+          EntityJoinRelation.IdentityJoinRelationshipType.GROUP,
+          EntityJoinRelation.IdentityJoinRelationshipType.MEMBER);
 
   public GroupIndex(final String indexPrefix, final boolean isElasticsearch) {
     super(indexPrefix, isElasticsearch);

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -30,6 +30,25 @@ public class EntityJoinRelation {
     return this;
   }
 
+  public static class EntityJoinRelationFactory {
+
+    private IdentityJoinRelationshipType parent;
+    private IdentityJoinRelationshipType child;
+
+    public EntityJoinRelationFactory(final IdentityJoinRelationshipType parent, final IdentityJoinRelationshipType child) {
+      this.parent = parent;
+      this.child = child;
+    }
+
+    public EntityJoinRelation createParent() {
+      return new EntityJoinRelation().setName(parent.getType());
+    }
+
+    public EntityJoinRelation createChild(final long parentKey) {
+      return new EntityJoinRelation().setName(child.getType()).setParent(parentKey);
+    }
+  }
+
   public enum IdentityJoinRelationshipType {
     GROUP("group"),
     MEMBER("member");

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -7,45 +7,25 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
-public class EntityJoinRelation {
-
-  private String name;
-  private Long parent;
-
-  public String getName() {
-    return name;
-  }
-
-  public EntityJoinRelation setName(final String name) {
-    this.name = name;
-    return this;
-  }
-
-  public Long getParent() {
-    return parent;
-  }
-
-  public EntityJoinRelation setParent(final Long parent) {
-    this.parent = parent;
-    return this;
-  }
+public record EntityJoinRelation(String name, Long parent) {
 
   public static class EntityJoinRelationFactory {
 
-    private IdentityJoinRelationshipType parent;
-    private IdentityJoinRelationshipType child;
+    private final IdentityJoinRelationshipType parent;
+    private final IdentityJoinRelationshipType child;
 
-    public EntityJoinRelationFactory(final IdentityJoinRelationshipType parent, final IdentityJoinRelationshipType child) {
+    public EntityJoinRelationFactory(
+        final IdentityJoinRelationshipType parent, final IdentityJoinRelationshipType child) {
       this.parent = parent;
       this.child = child;
     }
 
     public EntityJoinRelation createParent() {
-      return new EntityJoinRelation().setName(parent.getType());
+      return new EntityJoinRelation(parent.getType(), null);
     }
 
     public EntityJoinRelation createChild(final long parentKey) {
-      return new EntityJoinRelation().setName(child.getType()).setParent(parentKey);
+      return new EntityJoinRelation(child.getType(), parentKey);
     }
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/EntityJoinRelation.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.usermanagement;
+
+public class EntityJoinRelation {
+
+  private String name;
+  private Long parent;
+
+  public String getName() {
+    return name;
+  }
+
+  public EntityJoinRelation setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public Long getParent() {
+    return parent;
+  }
+
+  public EntityJoinRelation setParent(final Long parent) {
+    this.parent = parent;
+    return this;
+  }
+
+  public enum IdentityJoinRelationshipType {
+    GROUP("group"),
+    MEMBER("member");
+
+    private final String type;
+
+    IdentityJoinRelationshipType(final String type) {
+      this.type = type;
+    }
+
+    public String getType() {
+      return type;
+    }
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -8,13 +8,14 @@
 package io.camunda.webapps.schema.entities.usermanagement;
 
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import java.util.Set;
 
 public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
   private Long groupKey;
   private String name;
-  private Set<Long> assignedMemberKeys;
+  private Long entityKey;
+
+  private EntityJoinRelation join;
 
   public Long getGroupKey() {
     return groupKey;
@@ -34,12 +35,25 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public Set<Long> getAssignedMemberKeys() {
-    return assignedMemberKeys;
+  public Long getEntityKey() {
+    return entityKey;
   }
 
-  public GroupEntity setAssignedMemberKeys(final Set<Long> entityKey) {
-    assignedMemberKeys = entityKey;
+  public GroupEntity setEntityKey(final Long entityKey) {
+    this.entityKey = entityKey;
     return this;
+  }
+
+  public EntityJoinRelation getJoin() {
+    return join;
+  }
+
+  public GroupEntity setJoin(final EntityJoinRelation join) {
+    this.join = join;
+    return this;
+  }
+
+  public static String getMemberKey(final long groupKey, final long entityKey) {
+    return String.format("%d-%d", groupKey, entityKey);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -13,7 +13,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
   private Long groupKey;
   private String name;
-  private Long entityKey;
+  private Long memberKey;
 
   private EntityJoinRelation join;
 
@@ -35,12 +35,12 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public Long getEntityKey() {
-    return entityKey;
+  public Long getMemberKey() {
+    return memberKey;
   }
 
-  public GroupEntity setEntityKey(final Long entityKey) {
-    this.entityKey = entityKey;
+  public GroupEntity setMemberKey(final Long memberKey) {
+    this.memberKey = memberKey;
     return this;
   }
 
@@ -53,7 +53,7 @@ public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
     return this;
   }
 
-  public static String getMemberKey(final long groupKey, final long entityKey) {
-    return String.format("%d-%d", groupKey, entityKey);
+  public static String getChildKey(final long groupKey, final long memberKey) {
+    return String.format("%d-%d", groupKey, memberKey);
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-groups.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-groups.json
@@ -11,8 +11,14 @@
       "name": {
         "type": "keyword"
       },
-      "assignedMemberKeys": {
+      "memberKey": {
         "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "relations": {
+          "group": "member"
+        }
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-groups.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-groups.json
@@ -16,8 +16,9 @@
       },
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
-          "group": "member"
+          "group": ["member"]
         }
       }
     }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-groups.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-groups.json
@@ -11,8 +11,14 @@
       "name": {
         "type": "keyword"
       },
-      "assignedMemberKeys": {
+      "memberKey": {
         "type": "long"
+      },
+      "join": {
+        "type": "join",
+        "relations": {
+          "group": "member"
+        }
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-groups.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-groups.json
@@ -16,8 +16,9 @@
       },
       "join": {
         "type": "join",
+        "eager_global_ordinals": true,
         "relations": {
-          "group": "member"
+          "group": ["member"]
         }
       }
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/GroupDeletedApplier.java
@@ -10,25 +10,17 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
-import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableUserState;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
-import io.camunda.zeebe.protocol.record.value.EntityType;
-import java.util.function.BiConsumer;
 
 public class GroupDeletedApplier implements TypedEventApplier<GroupIntent, GroupRecord> {
 
   private final MutableGroupState groupState;
-  private final MutableUserState userState;
-  private final MutableMappingState mappingState;
   private final MutableAuthorizationState authorizationState;
 
   public GroupDeletedApplier(final MutableProcessingState processingState) {
     groupState = processingState.getGroupState();
-    userState = processingState.getUserState();
-    mappingState = processingState.getMappingState();
     authorizationState = processingState.getAuthorizationState();
   }
 
@@ -38,34 +30,11 @@ public class GroupDeletedApplier implements TypedEventApplier<GroupIntent, Group
     // may belong to the distribution command
     final var groupKey = value.getGroupKey();
 
-    // delete group key from entity states (user, mapping)
-    final var entitiesByTypeMap = groupState.getEntitiesByType(groupKey);
-    entitiesByTypeMap.forEach(
-        (entityType, entityKeys) -> {
-          final var removalConsumer = getRemovalFunction(entityType, value);
-          entityKeys.forEach(entityKey -> removalConsumer.accept(entityKey, groupKey));
-        });
-
     // delete group from authorization state
     authorizationState.deleteAuthorizationsByOwnerKeyPrefix(groupKey);
     authorizationState.deleteOwnerTypeByKey(groupKey);
 
     // delete group from group state
     groupState.delete(groupKey);
-  }
-
-  private BiConsumer<Long, Long> getRemovalFunction(
-      final EntityType entityType, final GroupRecord groupRecord) {
-    return switch (entityType) {
-      case EntityType.USER -> userState::removeGroup;
-      case EntityType.MAPPING -> mappingState::removeGroup;
-      default ->
-          throw new IllegalStateException(
-              String.format(
-                  "Expected to remove entity '%d' for group '%d', but entities of type '%s' are not supported by groups.",
-                  groupRecord.getEntityKey(),
-                  groupRecord.getGroupKey(),
-                  groupRecord.getEntityType()));
-    };
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/GroupAppliersTest.java
@@ -220,28 +220,6 @@ public class GroupAppliersTest {
     final var groupName = "group";
     final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
     groupCreatedApplier.applyState(groupKey, groupRecord);
-    // a mapping entry
-    final var mappingKey = 2L;
-    final var mappingRecord =
-        new MappingRecord()
-            .setMappingKey(mappingKey)
-            .setClaimName("claimName")
-            .setClaimValue("claimValue");
-    mappingState.create(mappingRecord);
-    groupEntityAddedApplier.applyState(
-        groupKey, groupRecord.setEntityKey(mappingKey).setEntityType(EntityType.MAPPING));
-    // a user entry
-    final var userKey = 3L;
-    final var userRecord =
-        new UserRecord()
-            .setUserKey(userKey)
-            .setName("test")
-            .setUsername("username")
-            .setPassword("password")
-            .setEmail("test@example.com");
-    userState.create(userRecord);
-    groupEntityAddedApplier.applyState(
-        groupKey, groupRecord.setEntityKey(userKey).setEntityType(EntityType.USER));
 
     // when
     groupDeletedApplier.applyState(groupKey, groupRecord);
@@ -254,11 +232,5 @@ public class GroupAppliersTest {
     assertThat(groupKeyByName.isPresent()).isFalse();
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();
-    // the mapping state is cleaned up
-    final var groupKeysByMapping = mappingState.get(mappingKey).get().getGroupKeysList();
-    assertThat(groupKeysByMapping).isEmpty();
-    // the user state is cleaned up
-    final var groupKeysByUser = userState.getUser(userKey).get().getGroupKeysList();
-    assertThat(groupKeysByUser).isEmpty();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
 import java.util.function.Function;
 
 public class GroupClient {
@@ -228,6 +229,14 @@ public class GroupClient {
                 .withIntent(GroupIntent.DELETED)
                 .withSourceRecordPosition(position)
                 .getFirst();
+
+    private static final Function<Long, List<Record<GroupRecordValue>>>
+        SUCCESS_WITH_ENTITIES_SUPPLIER =
+            (position) ->
+                RecordingExporter.groupRecords()
+                    .withIntents(GroupIntent.ENTITY_REMOVED, GroupIntent.DELETED)
+                    .withSourceRecordPosition(position)
+                    .asList();
 
     private static final Function<Long, Record<GroupRecordValue>> REJECTION_SUPPLIER =
         (position) ->

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/GroupClient.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import java.util.List;
 import java.util.function.Function;
 
 public class GroupClient {
@@ -229,14 +228,6 @@ public class GroupClient {
                 .withIntent(GroupIntent.DELETED)
                 .withSourceRecordPosition(position)
                 .getFirst();
-
-    private static final Function<Long, List<Record<GroupRecordValue>>>
-        SUCCESS_WITH_ENTITIES_SUPPLIER =
-            (position) ->
-                RecordingExporter.groupRecords()
-                    .withIntents(GroupIntent.ENTITY_REMOVED, GroupIntent.DELETED)
-                    .withSourceRecordPosition(position)
-                    .asList();
 
     private static final Function<Long, Record<GroupRecordValue>> REJECTION_SUPPLIER =
         (position) ->

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -29,6 +29,8 @@ import io.camunda.exporter.handlers.FlowNodeInstanceFromProcessInstanceHandler;
 import io.camunda.exporter.handlers.FormHandler;
 import io.camunda.exporter.handlers.GroupCreatedUpdatedHandler;
 import io.camunda.exporter.handlers.GroupDeletedHandler;
+import io.camunda.exporter.handlers.GroupEntityAddedHandler;
+import io.camunda.exporter.handlers.GroupEntityRemovedHandler;
 import io.camunda.exporter.handlers.IncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromIncidentHandler;
 import io.camunda.exporter.handlers.ListViewFlowNodeFromJobHandler;
@@ -193,6 +195,10 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new TenantCreateUpdateHandler(
                 indexDescriptorsMap.get(TenantIndex.class).getFullQualifiedName()),
             new GroupCreatedUpdatedHandler(
+                indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),
+            new GroupEntityAddedHandler(
+                indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),
+            new GroupEntityRemovedHandler(
                 indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),
             new GroupDeletedHandler(
                 indexDescriptorsMap.get(GroupIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -58,7 +58,7 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.joinRelationFactory.createParent();
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
     entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -57,7 +59,9 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    entity.setGroupKey(value.getGroupKey()).setName(value.getName());
+    final var joinRelation =
+        new EntityJoinRelation().setName(IdentityJoinRelationshipType.GROUP.getType());
+    entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -9,8 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -59,8 +58,7 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation =
-        new EntityJoinRelation().setName(IdentityJoinRelationshipType.GROUP.getType());
+    final var joinRelation = GroupIndex.joinRelationFactory.createParent();
     entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -54,7 +54,7 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.joinRelationFactory.createParent();
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
     entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -9,6 +9,8 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -53,7 +55,9 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    entity.setGroupKey(value.getGroupKey()).setName(value.getName());
+    final var joinRelation =
+        new EntityJoinRelation().setName(IdentityJoinRelationshipType.GROUP.getType());
+    entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -9,8 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -55,8 +54,7 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation =
-        new EntityJoinRelation().setName(IdentityJoinRelationshipType.GROUP.getType());
+    final var joinRelation = GroupIndex.joinRelationFactory.createParent();
     entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -55,7 +55,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
     entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -9,8 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,10 +55,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation =
-        new EntityJoinRelation()
-            .setName(IdentityJoinRelationshipType.MEMBER.getType())
-            .setParent(value.getGroupKey());
+    final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
     entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import java.util.List;
+
+public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
+
+  private final String indexName;
+
+  public GroupEntityAddedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.GROUP;
+  }
+
+  @Override
+  public Class<GroupEntity> getEntityType() {
+    return GroupEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<GroupRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && GroupIntent.ENTITY_ADDED.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<GroupRecordValue> record) {
+    final var groupRecord = record.getValue();
+    return List.of(GroupEntity.getMemberKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+  }
+
+  @Override
+  public GroupEntity createNewEntity(final String id) {
+    return new GroupEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
+    final GroupRecordValue value = record.getValue();
+    final var joinRelation =
+        new EntityJoinRelation()
+            .setName(IdentityJoinRelationshipType.MEMBER.getType())
+            .setParent(value.getGroupKey());
+    entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
+  }
+
+  @Override
+  public void flush(final GroupEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().getParent()));
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -44,7 +44,7 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    return List.of(GroupEntity.getMemberKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
   }
 
   @Override
@@ -56,13 +56,13 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
-    entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
+    entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
   }
 
   @Override
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().getParent()));
+    batchRequest.addWithRouting(indexName, entity, String.valueOf(entity.getJoin().parent()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import java.util.List;
+
+public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, GroupRecordValue> {
+
+  private final String indexName;
+
+  public GroupEntityRemovedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.GROUP;
+  }
+
+  @Override
+  public Class<GroupEntity> getEntityType() {
+    return GroupEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<GroupRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && GroupIntent.ENTITY_REMOVED.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<GroupRecordValue> record) {
+    final var groupRecord = record.getValue();
+    return List.of(GroupEntity.getMemberKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+  }
+
+  @Override
+  public GroupEntity createNewEntity(final String id) {
+    return new GroupEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
+    final GroupRecordValue value = record.getValue();
+    final var joinRelation =
+        new EntityJoinRelation()
+            .setName(IdentityJoinRelationshipType.MEMBER.getType())
+            .setParent(value.getGroupKey());
+    entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
+  }
+
+  @Override
+  public void flush(final GroupEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.deleteWithRouting(
+        indexName, entity.getId(), String.valueOf(entity.getJoin().getParent()));
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -44,7 +44,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public List<String> generateIds(final Record<GroupRecordValue> record) {
     final var groupRecord = record.getValue();
-    return List.of(GroupEntity.getMemberKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
+    return List.of(GroupEntity.getChildKey(groupRecord.getGroupKey(), groupRecord.getEntityKey()));
   }
 
   @Override
@@ -56,14 +56,14 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
-    entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
+    entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
   }
 
   @Override
   public void flush(final GroupEntity entity, final BatchRequest batchRequest)
       throws PersistenceException {
     batchRequest.deleteWithRouting(
-        indexName, entity.getId(), String.valueOf(entity.getJoin().getParent()));
+        indexName, entity.getId(), String.valueOf(entity.getJoin().parent()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -55,7 +55,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
     entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityRemovedHandler.java
@@ -9,8 +9,7 @@ package io.camunda.exporter.handlers;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
-import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -56,10 +55,7 @@ public class GroupEntityRemovedHandler implements ExportHandler<GroupEntity, Gro
   @Override
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
-    final var joinRelation =
-        new EntityJoinRelation()
-            .setName(IdentityJoinRelationshipType.MEMBER.getType())
-            .setParent(value.getGroupKey());
+    final var joinRelation = GroupIndex.joinRelationFactory.createChild(value.getGroupKey());
     entity.setEntityKey(value.getEntityKey()).setJoin(joinRelation);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/BatchRequest.java
@@ -55,6 +55,8 @@ public interface BatchRequest {
 
   BatchRequest delete(String index, String id);
 
+  BatchRequest deleteWithRouting(String index, String id, String routing);
+
   /**
    * Applies all updates in this batch.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/ElasticsearchBatchRequest.java
@@ -213,6 +213,14 @@ public class ElasticsearchBatchRequest implements BatchRequest {
   }
 
   @Override
+  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+    LOGGER.debug(
+        "Add delete index request with routing {} for index {} and entity {} ", routing, index, id);
+    bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(index).id(id).routing(routing)));
+    return this;
+  }
+
+  @Override
   public void execute() throws PersistenceException {
     execute(false);
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/store/OpensearchBatchRequest.java
@@ -206,6 +206,14 @@ public class OpensearchBatchRequest implements BatchRequest {
   }
 
   @Override
+  public BatchRequest deleteWithRouting(final String index, final String id, final String routing) {
+    LOGGER.debug(
+        "Add delete index request with routing {} for index {} and entity {} ", routing, index, id);
+    bulkRequestBuilder.operations(op -> op.delete(idx -> idx.index(index).id(id).routing(routing)));
+    return this;
+  }
+
+  @Override
   public void execute() throws PersistenceException {
     execute(false);
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -77,7 +77,7 @@ public class GroupEntityAddedHandlerTest {
   @Test
   void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = GroupIndex.joinRelationFactory.createChild(111L);
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
     final GroupEntity inputEntity =
         new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class GroupEntityAddedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-group";
+  private final GroupEntityAddedHandler underTest = new GroupEntityAddedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.GROUP);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(GroupEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final io.camunda.zeebe.protocol.record.Record<GroupRecordValue> groupDeletedRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_ADDED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(groupDeletedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<GroupRecordValue> groupRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_ADDED);
+
+    // when
+    final var idList = underTest.generateIds(groupRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getEntityKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
+    // given
+    final GroupEntity inputEntity = new GroupEntity().setId("111").setEntityKey(222L);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).add(indexName, inputEntity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityAddedHandlerTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
 import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -58,7 +59,9 @@ public class GroupEntityAddedHandlerTest {
     final var idList = underTest.generateIds(groupRecord);
 
     // then
-    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getEntityKey()));
+    final var value = groupRecord.getValue();
+    assertThat(idList)
+        .containsExactly(GroupEntity.getChildKey(value.getGroupKey(), value.getEntityKey()));
   }
 
   @Test
@@ -74,13 +77,16 @@ public class GroupEntityAddedHandlerTest {
   @Test
   void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
     // given
-    final GroupEntity inputEntity = new GroupEntity().setId("111").setEntityKey(222L);
+    final var joinRelation = GroupIndex.joinRelationFactory.createChild(111L);
+    final GroupEntity inputEntity =
+        new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
     underTest.flush(inputEntity, mockRequest);
 
     // then
-    verify(mockRequest, times(1)).add(indexName, inputEntity);
+    verify(mockRequest, times(1))
+        .addWithRouting(indexName, inputEntity, String.valueOf(joinRelation.parent()));
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -77,7 +77,7 @@ public class GroupEntityRemovedHandlerTest {
   @Test
   void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
     // given
-    final var joinRelation = GroupIndex.joinRelationFactory.createChild(111L);
+    final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(111L);
     final GroupEntity inputEntity =
         new GroupEntity().setId("111").setMemberKey(222L).setJoin(joinRelation);
     final BatchRequest mockRequest = mock(BatchRequest.class);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/GroupEntityRemovedHandlerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.GroupEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import org.junit.jupiter.api.Test;
+
+public class GroupEntityRemovedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-group";
+  private final GroupEntityRemovedHandler underTest = new GroupEntityRemovedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.GROUP);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(GroupEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<GroupRecordValue> groupDeletedRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_REMOVED);
+
+    // when - then
+    assertThat(underTest.handlesRecord(groupDeletedRecord)).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final Record<GroupRecordValue> groupRecord =
+        factory.generateRecordWithIntent(ValueType.GROUP, GroupIntent.ENTITY_REMOVED);
+
+    // when
+    final var idList = underTest.generateIds(groupRecord);
+
+    // then
+    assertThat(idList).containsExactly(String.valueOf(groupRecord.getValue().getEntityKey()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final var result = underTest.createNewEntity("id");
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.getId()).isEqualTo("id");
+  }
+
+  @Test
+  void shouldUpdateGroupEntityOnFlush() throws PersistenceException {
+    // given
+    final GroupEntity inputEntity = new GroupEntity().setId("111").setEntityKey(222L);
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(inputEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).delete(indexName, inputEntity.getId());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/store/OpensearchBatchRequestTest.java
@@ -333,6 +333,32 @@ class OpensearchBatchRequestTest {
   }
 
   @Test
+  void shouldDeleteEntityWithRouting() throws IOException, PersistenceException {
+    // given
+    final String routing = "routing";
+
+    // when
+    batchRequest.deleteWithRouting(INDEX, ID, routing);
+    batchRequest.execute();
+
+    // then
+    final ArgumentCaptor<BulkRequest> captor = ArgumentCaptor.forClass(BulkRequest.class);
+    verify(osClient).bulk(captor.capture());
+
+    // verify that an index operation is added
+    final List<BulkOperation> operations = captor.getValue().operations();
+    assertThat(operations).hasSize(1);
+
+    final var bulkOperation = operations.getFirst();
+    assertThat(bulkOperation.isDelete()).isTrue();
+
+    final var delete = bulkOperation.delete();
+    assertThat(delete.index()).isEqualTo(INDEX);
+    assertThat(delete.id()).isEqualTo(ID);
+    assertThat(delete.routing()).isEqualTo(routing);
+  }
+
+  @Test
   void shouldExecuteWithMultipleOperationsInBatch() throws PersistenceException, IOException {
     // Given
     final TestExporterEntity entity = new TestExporterEntity().setId(ID);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Add support for group entity add and remove event exporting.

The PR is larger as we needed to add support for:
1. ES/OS delete with routing operations
2. Adjust the behavior of Group deletion to generate `ENTITY_REMOVED` events.
   - This was done so that the exporter can remove group entities separately, instead of in bulk, which is currently not supported.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24580
