### PR TITLE
[POC]: Add intra treePath cache to Exporter 

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -180,6 +180,13 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 indexDescriptorsMap.get(FormIndex.class).getFullQualifiedName()),
             new ExporterCacheMetrics("form", meterRegistry));
 
+    final var intraTreePathCache =
+        new ExporterEntityCacheImpl<>(
+            10_000, // yolo
+            entityCacheProvider.getIntraTreePathCacheLoader(
+                templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
+            new ExporterCacheMetrics("fni", meterRegistry));
+
     exportHandlers =
         Set.of(
             new RoleCreateUpdateHandler(
@@ -220,7 +227,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new FlowNodeInstanceFromIncidentHandler(
                 templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
             new FlowNodeInstanceFromProcessInstanceHandler(
-                templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName()),
+                templateDescriptorsMap.get(FlowNodeInstanceTemplate.class).getFullQualifiedName(),
+                intraTreePathCache),
             new IncidentHandler(
                 templateDescriptorsMap.get(IncidentTemplate.class).getFullQualifiedName(),
                 false,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/ElasticsearchAdapter.java
@@ -15,6 +15,8 @@ import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.ElasticSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.cache.process.ElasticSearchProcessCacheLoader;
+import io.camunda.exporter.cache.treePath.CachedTreePathKey;
+import io.camunda.exporter.cache.treePath.ElasticSearchIntraTreePathCacheLoader;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.elasticsearch.ElasticsearchEngineClient;
@@ -70,6 +72,12 @@ class ElasticsearchAdapter implements ClientAdapter {
     @Override
     public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
       return new ElasticSearchFormCacheLoader(client, formIndexName);
+    }
+
+    @Override
+    public CacheLoader<CachedTreePathKey, String> getIntraTreePathCacheLoader(
+        final String fniIndexName) {
+      return new ElasticSearchIntraTreePathCacheLoader(client, fniIndexName);
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/adapters/OpensearchAdapter.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.form.OpenSearchFormCacheLoader;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
 import io.camunda.exporter.cache.process.OpenSearchProcessCacheLoader;
+import io.camunda.exporter.cache.treePath.CachedTreePathKey;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.schema.opensearch.OpensearchEngineClient;
@@ -70,6 +71,12 @@ class OpensearchAdapter implements ClientAdapter {
     @Override
     public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
       return new OpenSearchFormCacheLoader(client, formIndexName);
+    }
+
+    @Override
+    public CacheLoader<CachedTreePathKey, String> getIntraTreePathCacheLoader(
+        final String fniIndexName) {
+      return k -> null;
     }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/ExporterEntityCacheProvider.java
@@ -10,6 +10,7 @@ package io.camunda.exporter.cache;
 import com.github.benmanes.caffeine.cache.CacheLoader;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.cache.treePath.CachedTreePathKey;
 import io.camunda.exporter.utils.XMLUtil;
 
 public interface ExporterEntityCacheProvider {
@@ -18,4 +19,6 @@ public interface ExporterEntityCacheProvider {
       String processIndexName, final XMLUtil xmlUtil);
 
   CacheLoader<String, CachedFormEntity> getFormCacheLoader(String formIndexName);
+
+  CacheLoader<CachedTreePathKey, String> getIntraTreePathCacheLoader(final String fniIndexName);
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/treePath/CachedTreePathKey.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/treePath/CachedTreePathKey.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.treePath;
+
+public record CachedTreePathKey(long flowNodeInstanceKey, long processInstanceKey) {}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/treePath/ElasticSearchIntraTreePathCacheLoader.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/cache/treePath/ElasticSearchIntraTreePathCacheLoader.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache.treePath;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ElasticSearchIntraTreePathCacheLoader
+    implements CacheLoader<CachedTreePathKey, String> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ElasticSearchIntraTreePathCacheLoader.class);
+
+  private final ElasticsearchClient client;
+  private final String indexName;
+
+  public ElasticSearchIntraTreePathCacheLoader(
+      final ElasticsearchClient client, final String indexName) {
+    this.client = client;
+    this.indexName = indexName;
+  }
+
+  @Override
+  public String load(final CachedTreePathKey cachedTreePathKey) throws IOException {
+    final var response =
+        client.get(
+            request ->
+                request
+                    .index(indexName)
+                    .id(String.valueOf(cachedTreePathKey.flowNodeInstanceKey())),
+            FlowNodeInstanceEntity.class);
+    if (response.found() && response.source() != null) {
+      final var flowNodeInstanceEntity = response.source();
+      return flowNodeInstanceEntity.getTreePath();
+    } else {
+      // This should only happen if the process was deleted from ElasticSearch which should
+      //     never
+      // happen. Normally, the process is exported before the process instance is exporter. So
+      //     the
+      // process should be found in ElasticSearch index.
+      LOG.debug("FNI '{}' not found in Elasticsearch", cachedTreePathKey.flowNodeInstanceKey());
+      return null;
+    }
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -13,7 +13,7 @@ import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEM
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_MIGRATED;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_TERMINATED;
 
-import io.camunda.exporter.cache.ExporterEntityCacheImpl;
+import io.camunda.exporter.cache.ExporterEntityCache;
 import io.camunda.exporter.cache.treePath.CachedTreePathKey;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
@@ -48,11 +48,11 @@ public class FlowNodeInstanceFromProcessInstanceHandler
   private static final Set<Intent> AI_START_STATES = Set.of(ELEMENT_ACTIVATING);
 
   private final String indexName;
-  private final ExporterEntityCacheImpl<CachedTreePathKey, String> intraTreePathCache;
+  private final ExporterEntityCache<CachedTreePathKey, String> intraTreePathCache;
 
   public FlowNodeInstanceFromProcessInstanceHandler(
       final String indexName,
-      final ExporterEntityCacheImpl<CachedTreePathKey, String> intraTreePathCache) {
+      final ExporterEntityCache<CachedTreePathKey, String> intraTreePathCache) {
     this.indexName = indexName;
     this.intraTreePathCache = intraTreePathCache;
   }
@@ -162,6 +162,7 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     updateFields.put(FlowNodeInstanceTemplate.TYPE, entity.getType());
     updateFields.put(FlowNodeInstanceTemplate.STATE, entity.getState());
     if (entity.getState() == FlowNodeState.ACTIVE) {
+      // we are only updating tree path when active
       updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, entity.getTreePath());
     }
     updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, entity.getFlowNodeId());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterTest.java
@@ -14,6 +14,7 @@ import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.cache.form.CachedFormEntity;
 import io.camunda.exporter.cache.process.CachedProcessEntity;
+import io.camunda.exporter.cache.treePath.CachedTreePathKey;
 import io.camunda.exporter.config.ExporterConfiguration;
 import io.camunda.exporter.schema.SearchEngineClient;
 import io.camunda.exporter.store.BatchRequest;
@@ -65,6 +66,12 @@ final class CamundaExporterTest {
 
     @Override
     public CacheLoader<String, CachedFormEntity> getFormCacheLoader(final String formIndexName) {
+      return k -> null;
+    }
+
+    @Override
+    public CacheLoader<CachedTreePathKey, String> getIntraTreePathCacheLoader(
+        final String fniIndexName) {
       return k -> null;
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestIntraTreePathCache.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/cache/TestIntraTreePathCache.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.cache;
+
+import io.camunda.exporter.cache.treePath.CachedTreePathKey;
+import java.util.HashMap;
+import java.util.Optional;
+
+public class TestIntraTreePathCache implements ExporterEntityCache<CachedTreePathKey, String> {
+
+  private final HashMap<CachedTreePathKey, String> cache = new HashMap<>();
+
+  @Override
+  public Optional<String> get(final CachedTreePathKey entityKey) {
+    return Optional.ofNullable(cache.get(entityKey));
+  }
+
+  @Override
+  public void put(final CachedTreePathKey entityKey, final String treePath) {
+    cache.put(entityKey, treePath);
+  }
+
+  @Override
+  public void remove(final CachedTreePathKey entityKey) {
+    cache.remove(entityKey);
+  }
+
+  @Override
+  public void clear() {
+    cache.clear();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandlerTest.java
@@ -39,7 +39,7 @@ public class FlowNodeInstanceFromProcessInstanceHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
   private final String indexName = "test-list-view";
   private final FlowNodeInstanceFromProcessInstanceHandler underTest =
-      new FlowNodeInstanceFromProcessInstanceHandler(indexName);
+      new FlowNodeInstanceFromProcessInstanceHandler(indexName, intraTreePathCache);
 
   @Test
   public void testGetHandledValueType() {


### PR DESCRIPTION
## Description


> [!Note]
>
> More details [here](https://docs.google.com/document/d/1PrWLli07nLDterUe8AMDAyjs_mICNx0kYQfgC5v3Fro/edit?tab=t.0)

The general looks already much more impacted

![general](https://github.com/user-attachments/assets/7e0e1c99-5901-47d9-811f-c7911c60bd4b)

compared to the base.
![base-general](https://github.com/user-attachments/assets/f7f4a8f7-4d6e-474c-ade5-a3d147ed9b48)

We later realized that the benchmarks were quite fragile as the CPU throttling was kicking in (due to node restart, bad scheduling, etc.) it had a major effect on the benchmarks.

### Benchmarks results

It is not really clear how much we can get out of these, as the CPU throttling was quite high (which can be due to bad Kubernetes scheduling, that we for real more CPU usage, or just stumbled and have to catch up with jobs and messages, etc.)

![cpu](https://github.com/user-attachments/assets/26812304-64f5-4487-adc4-5c9a52031980)
![gc](https://github.com/user-attachments/assets/7bf0926d-5930-41ac-b464-db5ea079604b)
![memory](https://github.com/user-attachments/assets/ab318b7b-24c8-4f0f-a411-8b727628097a)

#### Latency
![overall-latency](https://github.com/user-attachments/assets/e3657379-ffc3-4f82-8462-7e7ccc701b31)
![processing-latency](https://github.com/user-attachments/assets/abe11c9c-166f-4cf1-ae16-09d4a75d3294)
![exporter-latency](https://github.com/user-attachments/assets/0bfe7d87-b985-4902-9d0d-d0a43582f5ff)

#### Cache 

We can see in the caching metrics that we request ~30-50 times per second the treePath, and this can take from 3 to 10 ms. Meaning per partition per second we have to do ~300ms for resolving the tree path.

![cachemetrics](https://github.com/user-attachments/assets/90e74222-e113-4c5a-be9a-20e3668ca05d)

#### ES CPU

Interesting was that the ES CPU was slightly impacted, as we doing more requests against ES. That also impacts the ES performance, and potential also the writing.

![ES-CPU](https://github.com/user-attachments/assets/8c4d5211-4dbe-49ee-bc53-0ff3eeaa156c)


<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
