### PR TITLE
[Backport stable/8.4] Add go job timeouts to stable branches

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -435,6 +435,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-lint:
     name: Go linting
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -464,6 +465,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-apidiff:
     name: Go Backward Compatibility
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     env:
       # set the comparison based on the type of workflow trigger:


### PR DESCRIPTION
# Description
Backport of #25056 to `stable/8.4`.

relates to 
original author: @berkaycanbc