### PR TITLE
fix: copy version tag related changes from importer to exporter

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -62,7 +62,8 @@ public class ProcessDefinitionQueryTest {
             "manual_process.bpmn",
             "parent_process_v1.bpmn",
             "child_process_v1.bpmn",
-            "process_start_form.bpmn");
+            "process_start_form.bpmn",
+            "processWithVersionTag.bpmn");
     processes.forEach(
         process ->
             DEPLOYED_PROCESSES.addAll(
@@ -176,7 +177,7 @@ public class ProcessDefinitionQueryTest {
         zeebeClient.newProcessDefinitionQuery().filter(f -> f.version(version)).send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(7);
+    assertThat(result.items().size()).isEqualTo(8);
     assertThat(result.items().getFirst().getVersion()).isEqualTo(version);
   }
 
@@ -208,12 +209,12 @@ public class ProcessDefinitionQueryTest {
         zeebeClient.newProcessDefinitionQuery().filter(f -> f.tenantId(tenantId)).send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(7);
+    assertThat(result.items().size()).isEqualTo(8);
     assertThat(result.items().getFirst().getTenantId()).isEqualTo(tenantId);
   }
 
   @Test
-  void shouldRetrieveProcessDefinitionsByVersionTag() {
+  void shouldRetrieveProcessDefinitionsByNullVersionTag() {
     // given
     final String versionTag = null;
 
@@ -222,7 +223,21 @@ public class ProcessDefinitionQueryTest {
         zeebeClient.newProcessDefinitionQuery().filter(f -> f.versionTag(versionTag)).send().join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(7);
+    assertThat(result.items().size()).isEqualTo(8);
+    assertThat(result.items().getFirst().getVersionTag()).isEqualTo(versionTag);
+  }
+
+  @Test
+  void shouldRetrieveProcessDefinitionsByVersionTag() {
+    // given
+    final String versionTag = "1.1.0";
+
+    // when
+    final var result =
+        zeebeClient.newProcessDefinitionQuery().filter(f -> f.versionTag(versionTag)).send().join();
+
+    // then
+    assertThat(result.items().size()).isEqualTo(1);
     assertThat(result.items().getFirst().getVersionTag()).isEqualTo(versionTag);
   }
 
@@ -244,7 +259,7 @@ public class ProcessDefinitionQueryTest {
             .join();
 
     // then
-    assertThat(result.items().size()).isEqualTo(7);
+    assertThat(result.items().size()).isEqualTo(8);
     assertThat(result.items().stream().map(ProcessDefinition::getProcessDefinitionId).toList())
         .containsExactlyElementsOf(expectedProcessDefinitionIds);
   }
@@ -394,7 +409,7 @@ public class ProcessDefinitionQueryTest {
             .send()
             .join();
 
-    assertThat(resultAfter.items().size()).isEqualTo(6);
+    assertThat(resultAfter.items().size()).isEqualTo(7);
     final var keyAfter = resultAfter.items().getFirst().getProcessDefinitionKey();
     // apply searchBefore
     final var resultBefore =

--- a/qa/integration-tests/src/test/resources/process/processWithVersionTag.bpmn
+++ b/qa/integration-tests/src/test/resources/process/processWithVersionTag.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1y8clty" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.25.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:process id="processWithVersionTag" name="Process with version tag" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:versionTag value="1.1.0" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0bivl9y</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0bivl9y" sourceRef="StartEvent_1" targetRef="Activity_11476t4" />
+    <bpmn:endEvent id="Event_0pee5no">
+      <bpmn:incoming>Flow_11u3hx7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_11u3hx7" sourceRef="Activity_11476t4" targetRef="Event_0pee5no" />
+    <bpmn:serviceTask id="Activity_11476t4" name="Some task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="someTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0bivl9y</bpmn:incoming>
+      <bpmn:outgoing>Flow_11u3hx7</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="processWithVersionTag">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0pee5no_di" bpmnElement="Event_0pee5no">
+        <dc:Bounds x="372" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1mqi0wb_di" bpmnElement="Activity_11476t4">
+        <dc:Bounds x="250" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0bivl9y_di" bpmnElement="Flow_0bivl9y">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="250" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11u3hx7_di" bpmnElement="Flow_11u3hx7">
+        <di:waypoint x="350" y="117" />
+        <di:waypoint x="372" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandler.java
@@ -152,6 +152,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
     if (entity.getEndDate() != null) {
       updateFields.put(ListViewTemplate.END_DATE, entity.getEndDate());
     }
+    if (entity.getProcessVersionTag() != null) {
+      updateFields.put(ListViewTemplate.PROCESS_VERSION_TAG, entity.getProcessVersionTag());
+    }
     updateFields.put(ListViewTemplate.PROCESS_NAME, entity.getProcessName());
     updateFields.put(ListViewTemplate.PROCESS_VERSION, entity.getProcessVersion());
     updateFields.put(ListViewTemplate.PROCESS_KEY, entity.getProcessDefinitionKey());
@@ -200,6 +203,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
             + "ctx._source.%s = params.%s; " // process version
             + "ctx._source.%s = params.%s; " // process key
             + "ctx._source.%s = params.%s; " // bpmnProcessId
+            + "if (params.%s != null) { ctx._source.%s = params.%s; }" // process version tag
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // start date
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // end date
             + "if (params.%s != null) { ctx._source.%s = params.%s; }" // state
@@ -217,6 +221,9 @@ public class ListViewProcessInstanceFromProcessInstanceHandler
         PROCESS_KEY,
         BPMN_PROCESS_ID,
         BPMN_PROCESS_ID,
+        PROCESS_VERSION_TAG,
+        PROCESS_VERSION_TAG,
+        PROCESS_VERSION_TAG,
         START_DATE,
         START_DATE,
         START_DATE,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -70,6 +70,7 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
         .setKey(process.getProcessDefinitionKey())
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
+        .setVersionTag(process.getVersionTag())
         .setTenantId(ExporterUtil.tenantOrDefault(process.getTenantId()));
     final byte[] byteArray = process.getResource();
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/ProcessHandler.java
@@ -70,7 +70,6 @@ public class ProcessHandler implements ExportHandler<ProcessEntity, Process> {
         .setKey(process.getProcessDefinitionKey())
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
-        .setVersionTag(process.getVersionTag())
         .setTenantId(ExporterUtil.tenantOrDefault(process.getTenantId()));
     final byte[] byteArray = process.getResource();
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/ListViewProcessInstanceFromProcessInstanceHandlerTest.java
@@ -175,6 +175,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setId("111")
             .setProcessName("process")
             .setProcessVersion(2)
+            .setProcessVersionTag("versionTag")
             .setProcessDefinitionKey(444L)
             .setBpmnProcessId("bpmnProcessId")
             .setPosition(123L)
@@ -186,6 +187,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(ListViewTemplate.PROCESS_NAME, "process");
     expectedUpdateFields.put(ListViewTemplate.PROCESS_VERSION, 2);
+    expectedUpdateFields.put(ListViewTemplate.PROCESS_VERSION_TAG, "versionTag");
     expectedUpdateFields.put(ListViewTemplate.PROCESS_KEY, 444L);
     expectedUpdateFields.put(ListViewTemplate.BPMN_PROCESS_ID, "bpmnProcessId");
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
@@ -211,6 +213,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
             .setProcessInstanceKey(111L)
             .setProcessName("process")
             .setProcessVersion(2)
+            .setProcessVersionTag("versionTag")
             .setProcessDefinitionKey(444L)
             .setBpmnProcessId("bpmnProcessId")
             .setPosition(123L)
@@ -222,6 +225,7 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
     final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
     expectedUpdateFields.put(ListViewTemplate.PROCESS_NAME, "process");
     expectedUpdateFields.put(ListViewTemplate.PROCESS_VERSION, 2);
+    expectedUpdateFields.put(ListViewTemplate.PROCESS_VERSION_TAG, "versionTag");
     expectedUpdateFields.put(ListViewTemplate.PROCESS_KEY, 444L);
     expectedUpdateFields.put(ListViewTemplate.BPMN_PROCESS_ID, "bpmnProcessId");
     expectedUpdateFields.put(ListViewTemplate.STATE, ProcessInstanceState.ACTIVE);
@@ -291,6 +295,8 @@ public class ListViewProcessInstanceFromProcessInstanceHandlerTest {
         .isEqualTo(processInstanceRecordValue.getBpmnProcessId());
     assertThat(processInstanceForListViewEntity.getProcessVersion())
         .isEqualTo(processInstanceRecordValue.getVersion());
+    assertThat(processInstanceForListViewEntity.getProcessVersionTag())
+        .isEqualTo("test-version-tag");
     assertThat(processInstanceForListViewEntity.getState()).isEqualTo(ProcessInstanceState.ACTIVE);
     assertThat(processInstanceForListViewEntity.getStartDate())
         .isEqualTo(OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneOffset.UTC));


### PR DESCRIPTION
PR contains some leftovers from commits https://github.com/camunda/camunda/commit/b763d697cc9c2cf9b7d9423c729702e7d7ae7fd4, https://github.com/camunda/camunda/commit/53368f14c0e9d8cf19a82e8f03be7055a82d177f, https://github.com/camunda/camunda/commit/e77d2c44856feac22f55f404fcf7c4510c15cd9d , that we not applied to exporter code earlier.

related with #22747
