### PR TITLE
fix: exclude IDENTITY_SETUP from exported value types in tests

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestSupport.java
@@ -156,7 +156,8 @@ public final class TestSupport {
             ValueType.TENANT,
             ValueType.GROUP,
             ValueType.MAPPING,
-            ValueType.REDISTRIBUTION);
+            ValueType.REDISTRIBUTION,
+            ValueType.IDENTITY_SETUP);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestSupport.java
@@ -138,7 +138,8 @@ public final class TestSupport {
             ValueType.TENANT,
             ValueType.GROUP,
             ValueType.MAPPING,
-            ValueType.REDISTRIBUTION);
+            ValueType.REDISTRIBUTION,
+            ValueType.IDENTITY_SETUP);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In [PR](https://github.com/camunda/camunda/pull/25189) a new record type `IDENTITY_SETUP` was added to support the initialization of Identity entities in the Zeebe engine, this record type is causing issues with some exporter tests i.e. https://github.com/camunda/camunda/actions/runs/12034254379/job/33550362077?pr=25220. 

In this PR I add the record type to the list of excluded value types in the test utils. Running the tests locally shows that a previously failing test now passes.
