### PR TITLE
[Backport stable/8.3] Properly handle connection closed error in the gRPC server

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -124,7 +124,8 @@ public final class GrpcErrorMapper {
     } else if (error instanceof MessagingException.ConnectionClosed) {
         builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
         logger.warn(
-            "Expected to handle gRPC request, but the connection was cut between with the broker",
+            "Expected to handle gRPC request, but the connection was cut prematurely with the broker; "
+                + "the request may or may not have been accepted, and may not be safe to retry.",
             rootError);
       }
     } else {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -122,11 +122,11 @@ public final class GrpcErrorMapper {
           "Expected to handle gRPC request, but there was a connection error with one of the brokers",
           rootError);
     } else if (error instanceof MessagingException.ConnectionClosed) {
-        builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
-        logger.warn(
-            "Expected to handle gRPC request, but the connection was cut prematurely with the broker; "
-                + "the request may or may not have been accepted, and may not be safe to retry.",
-            rootError);
+      builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
+      logger.warn(
+          "Expected to handle gRPC request, but the connection was cut prematurely with the broker; "
+              + "the request may or may not have been accepted, and may not be safe to retry.",
+          rootError);
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -12,6 +12,7 @@ import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.google.rpc.Status.Builder;
+import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.cmd.BrokerErrorException;
 import io.camunda.zeebe.gateway.cmd.BrokerRejectionException;
@@ -120,6 +121,12 @@ public final class GrpcErrorMapper {
       logger.warn(
           "Expected to handle gRPC request, but there was a connection error with one of the brokers",
           rootError);
+    } else if (error instanceof MessagingException.ConnectionClosed) {
+        builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
+        logger.warn(
+            "Expected to handle gRPC request, but the connection was cut between with the broker",
+            rootError);
+      }
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -127,7 +127,6 @@ public final class GrpcErrorMapper {
             "Expected to handle gRPC request, but the connection was cut prematurely with the broker; "
                 + "the request may or may not have been accepted, and may not be safe to retry.",
             rootError);
-      }
     } else {
       builder
           .setCode(Code.INTERNAL_VALUE)

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Status;
+import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.zeebe.gateway.cmd.BrokerErrorException;
 import io.camunda.zeebe.gateway.impl.broker.RequestRetriesExhaustedException;
 import io.camunda.zeebe.gateway.impl.broker.response.BrokerError;
@@ -166,5 +167,18 @@ final class GrpcErrorMapperTest {
       final LogEvent event = recorder.getAppendedEvents().get(0);
       assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
     }
+  }
+
+  @Test
+  void shouldReturnAbortedOnConnectionClosed() {
+    // given
+    final var error = new ConnectionClosed("Closed");
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(error, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ABORTED);
   }
 }


### PR DESCRIPTION
# Description
Backport of #20066 to `stable/8.3`.

relates to #18339
original author: @npepinpe