### PR TITLE
[POC]: Build treePath in engine (ProcessInstanceRecordValue)

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -56,7 +56,7 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
     testStandaloneCamunda =
-        new TestStandaloneCamunda().withElasticsearchExporter(false).withCamundaExporter();
+        new TestStandaloneCamunda().withElasticsearchExporter(true).withCamundaExporter();
   }
 
   @BeforeAll

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessInstanceAndFlowNodeInstanceQueryTest.java
@@ -55,7 +55,8 @@ public class ProcessInstanceAndFlowNodeInstanceQueryTest {
 
   @SuppressWarnings("unused")
   static void initTestStandaloneCamunda() {
-    testStandaloneCamunda = new TestStandaloneCamunda();
+    testStandaloneCamunda =
+        new TestStandaloneCamunda().withElasticsearchExporter(false).withCamundaExporter();
   }
 
   @BeforeAll

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
@@ -11,6 +11,7 @@ import io.camunda.tasklist.zeebeimport.v860.record.RecordValueWithPayloadImpl;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
 import java.util.Objects;
 
 public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
@@ -78,6 +79,21 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   @Override
   public BpmnEventType getBpmnEventType() {
     return bpmnEventType;
+  }
+
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    return null;
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    return null;
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    return null;
   }
 
   @Override

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
@@ -11,6 +11,7 @@ import io.camunda.tasklist.zeebeimport.v870.record.RecordValueWithPayloadImpl;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
 import java.util.Objects;
 
 public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
@@ -78,6 +79,21 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   @Override
   public BpmnEventType getBpmnEventType() {
     return bpmnEventType;
+  }
+
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    return null;
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    return null;
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    return null;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
@@ -51,6 +53,14 @@ public final class BpmnStateBehavior {
 
   public ElementInstance getElementInstance(final long elementInstanceKey) {
     return elementInstanceState.getInstance(elementInstanceKey);
+  }
+
+  public ElementTreePathProperties getElementTreePath(final long elementInstanceKey) {
+    return new ElementTreePathBuilder()
+        .withElementInstanceState(elementInstanceState)
+        .withProcessState(processState)
+        .withElementInstanceKey(elementInstanceKey)
+        .build();
   }
 
   public JobState getJobState() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
@@ -55,11 +56,16 @@ public final class BpmnStateBehavior {
     return elementInstanceState.getInstance(elementInstanceKey);
   }
 
-  public ElementTreePathProperties getElementTreePath(final long elementInstanceKey) {
+  public ElementTreePathProperties getElementTreePath(
+      final long elementInstanceKey,
+      final long flowScopeKey,
+      final ProcessInstanceRecordValue processInstanceRecordValue) {
     return new ElementTreePathBuilder()
         .withElementInstanceState(elementInstanceState)
         .withProcessState(processState)
         .withElementInstanceKey(elementInstanceKey)
+        .withFlowScopeKey(flowScopeKey)
+        .withRecordValue(processInstanceRecordValue)
         .build();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -98,8 +98,17 @@ public final class BpmnStateTransitionBehavior {
     }
 
     // create tree path?!
+
+    // BE AWARE THE ELEMENT INSTANCE DOESNT EXIST YET
+    // We need to work with the parent key and record value
+    final long flowScopeKey = transitionContext.getFlowScopeKey();
+    //    final var scopeKey = flowScopeKey == -1 ? context.getProcessInstanceKey() : flowScopeKey;
+
     final ElementTreePathProperties elementTreePath =
-        stateBehavior.getElementTreePath(transitionContext.getElementInstanceKey());
+        stateBehavior.getElementTreePath(
+            transitionContext.getElementInstanceKey(),
+            flowScopeKey,
+            transitionContext.getRecordValue());
     transitionContext
         .getRecordValue()
         .setElementInstancePath(elementTreePath.elementInstancePath())

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -101,24 +101,14 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       // hierarchy:
       // PI_<parentProcessInstanceKey>/FN_<parentCallActivityId>/FNI_<parentCallActivityInstanceKey>/
       // PI_<secondLevelProcessInstanceKey>/FN_<secondLevelCallActivityId>/FNI_<secondLevelCallActivityInstanceKey>/PI_<currentProcessInstanceKey>
-      //      final TreePath treePath = new TreePath();
-      //      for (int i = 0; i < elementInstancePath.size(); i++) {
-      //        final List<Long> keysWithinOnePI = elementInstancePath.get(i);
-      //        treePath.appendProcessInstance(processInstanceKey);
-      //        for (final var elementInstanceKEy : keysWithinOnePI) {
-      //          treePath.appendFlowNodeInstance(String.valueOf(elementInstanceKEy));
-      //        }
-      //      }
+      final StringBuilder treeBuilder = new StringBuilder(Long.toString(processInstanceKey));
+      for (final List<Long> keysWithinOnePI : elementInstancePath) {
+        for (final var elementInstanceKEy : keysWithinOnePI) {
+          treeBuilder.append('/').append(elementInstanceKEy);
+        }
+      }
 
-      final var elementInstancePathString =
-          String.join(
-              "/",
-              elementInstancePath.get(0).stream()
-                  .map(l -> Long.toString(l))
-                  .toArray(String[]::new));
-      final String treePathString =
-          String.format("%s/%s", processInstanceKey, elementInstancePathString);
-
+      final String treePathString = treeBuilder.toString();
       // we set the default value here, which may be updated later within incident export
       entity.setTreePath(treePathString);
       entity.setLevel(treePathString.split("/").length);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -101,10 +101,15 @@ public class FlowNodeInstanceFromProcessInstanceHandler
       // hierarchy:
       // PI_<parentProcessInstanceKey>/FN_<parentCallActivityId>/FNI_<parentCallActivityInstanceKey>/
       // PI_<secondLevelProcessInstanceKey>/FN_<secondLevelCallActivityId>/FNI_<secondLevelCallActivityInstanceKey>/PI_<currentProcessInstanceKey>
-      final StringBuilder treeBuilder = new StringBuilder(Long.toString(processInstanceKey));
+      final StringBuilder treeBuilder = new StringBuilder();
       for (final List<Long> keysWithinOnePI : elementInstancePath) {
+
         for (final var elementInstanceKEy : keysWithinOnePI) {
-          treeBuilder.append('/').append(elementInstanceKEy);
+
+          if (!treeBuilder.isEmpty()) {
+            treeBuilder.append("/");
+          }
+          treeBuilder.append(elementInstanceKEy);
         }
       }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/FlowNodeInstanceFromProcessInstanceHandler.java
@@ -147,12 +147,14 @@ public class FlowNodeInstanceFromProcessInstanceHandler
     updateFields.put(FlowNodeInstanceTemplate.PARTITION_ID, entity.getPartitionId());
     updateFields.put(FlowNodeInstanceTemplate.TYPE, entity.getType());
     updateFields.put(FlowNodeInstanceTemplate.STATE, entity.getState());
-    updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, entity.getTreePath());
+    if (entity.getTreePath() != null) {
+      updateFields.put(FlowNodeInstanceTemplate.TREE_PATH, entity.getTreePath());
+      updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
+    }
     updateFields.put(FlowNodeInstanceTemplate.FLOW_NODE_ID, entity.getFlowNodeId());
     updateFields.put(
         FlowNodeInstanceTemplate.PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
     updateFields.put(FlowNodeInstanceTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
-    updateFields.put(FlowNodeInstanceTemplate.LEVEL, entity.getLevel());
     if (entity.getStartDate() != null) {
       updateFields.put(FlowNodeInstanceTemplate.START_DATE, entity.getStartDate());
     }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValue.java
@@ -84,7 +84,7 @@ public class CompressedLongArrayValue extends BaseValue {
     return values;
   }
 
-  void setValues(final long[] values) {
+  public void setValues(final long[] values) {
     this.values = values;
   }
 }

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValue.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack.value;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+
+public class CompressedLongArrayValue extends BaseValue {
+  private long[] values;
+
+  @Override
+  public void writeJSON(final StringBuilder builder) {
+    builder.append("[");
+
+    long currentValue = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (i == 0) {
+        currentValue = values[i];
+        builder.append(values[i]);
+      } else {
+        builder.append(",");
+        currentValue += values[i];
+        builder.append(currentValue);
+      }
+    }
+
+    builder.append("]");
+  }
+
+  @Override
+  public void write(final MsgPackWriter writer) {
+    writer.writeArrayHeader(values.length);
+
+    for (int i = 0; i < values.length; i++) {
+      if (i == 0) {
+        writer.writeInteger(values[i]);
+      } else {
+        writer.writeInteger(values[i] - values[i - 1]);
+      }
+    }
+  }
+
+  @Override
+  public void read(final MsgPackReader reader) {
+    final int length = reader.readArrayHeader();
+
+    values = new long[length];
+
+    for (int i = 0; i < length; i++) {
+      if (i == 0) {
+        values[i] = reader.readInteger();
+      } else {
+        values[i] = values[i - 1] + reader.readInteger();
+      }
+    }
+  }
+
+  @Override
+  public int getEncodedLength() {
+    final int header = MsgPackWriter.getEncodedArrayHeaderLenght(values.length);
+    int data = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (i == 0) {
+        data += MsgPackWriter.getEncodedLongValueLength(values[i]);
+      } else {
+        data += MsgPackWriter.getEncodedLongValueLength(values[i] - values[i - 1]);
+      }
+    }
+
+    return header + data;
+  }
+
+  @Override
+  public void reset() {
+    values = null;
+  }
+
+  public long[] getValues() {
+    return values;
+  }
+
+  void setValues(final long[] values) {
+    this.values = values;
+  }
+}

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValueTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/value/CompressedLongArrayValueTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack.value;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.Protocol;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class CompressedLongArrayValueTest {
+  private final MsgPackWriter writer = new MsgPackWriter();
+  private final MsgPackReader reader = new MsgPackReader();
+
+  @Test
+  void shouldWriteAndReadArray() {
+    // given
+    final CompressedLongArrayValue value = new CompressedLongArrayValue();
+    value.setValues(new long[] {1, 2, 3, 4, 5});
+
+    // when
+    final int encodedLength = value.getEncodedLength();
+    System.out.println(encodedLength);
+    final MutableDirectBuffer buffer = new UnsafeBuffer(new byte[encodedLength]);
+
+    writer.wrap(buffer, 0);
+    value.write(writer);
+
+    reader.wrap(buffer, 0, encodedLength);
+
+    final CompressedLongArrayValue result = new CompressedLongArrayValue();
+    result.read(reader);
+
+    // then
+    assertArrayEquals(new long[] {1, 2, 3, 4, 5}, result.getValues());
+  }
+
+  @Test
+  void shouldEncodeCompressed() {
+    final long[] values =
+        new long[] {
+          Protocol.encodePartitionId(3, 1),
+          Protocol.encodePartitionId(3, 1000),
+          Protocol.encodePartitionId(3, 1234),
+          Protocol.encodePartitionId(3, 1238),
+          Protocol.encodePartitionId(3, 2127)
+        };
+    final int compressedLength = encodeCompressed(values);
+    final int uncompressedLength = encodeUncompressed(values);
+
+    System.out.println(compressedLength);
+    System.out.println(uncompressedLength);
+
+    assertTrue(compressedLength < uncompressedLength);
+  }
+
+  private int encodeCompressed(final long[] values) {
+    final var value = new CompressedLongArrayValue();
+    value.setValues(values);
+    final var json = new StringBuilder();
+    value.writeJSON(json);
+    System.out.println(json.toString());
+    return value.getEncodedLength();
+  }
+
+  private int encodeUncompressed(final long[] values) {
+    final var value = new ArrayValue<>(LongValue::new);
+    for (final var v : values) {
+      value.add().setValue(v);
+    }
+
+    return value.getEncodedLength();
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -186,6 +186,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
+  @JsonIgnore
   public List<List<Long>> getElementInstancePath() {
     final var elementInstancePath = new ArrayList<List<Long>>();
     elementInstancePathProp.forEach(
@@ -208,6 +209,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
+  @JsonIgnore
   public List<Long> getProcessDefinitionPath() {
     final var processDefinitionPath = new ArrayList<Long>();
     processDefinitionPathProp.forEach(e -> processDefinitionPath.add(e.getValue()));
@@ -221,6 +223,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
+  @JsonIgnore
   public List<Integer> getCallingElementPath() {
     final var callingElementPath = new ArrayList<Integer>();
     callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -10,15 +10,21 @@ package io.camunda.zeebe.protocol.impl.record.value.processinstance;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ArrayValue;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.ArrayList;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
 public final class ProcessInstanceRecord extends UnifiedRecordValue
@@ -59,6 +65,13 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   private final LongProperty parentElementInstanceKeyProp =
       new LongProperty("parentElementInstanceKey", -1L);
 
+  private final ArrayProperty<ArrayValue<LongValue>> elementInstancePathProp =
+      new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
+  private final ArrayProperty<LongValue> processDefinitionPathProp =
+      new ArrayProperty<>("processDefinitionPath", LongValue::new);
+  private final ArrayProperty<IntegerValue> callingElementPathProp =
+      new ArrayProperty<>("callingElementPath", IntegerValue::new);
+
   public ProcessInstanceRecord() {
     super(11);
     declareProperty(bpmnElementTypeProp)
@@ -71,7 +84,10 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
         .declareProperty(bpmnEventTypeProp)
         .declareProperty(parentProcessInstanceKeyProp)
         .declareProperty(parentElementInstanceKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(elementInstancePathProp)
+        .declareProperty(processDefinitionPathProp)
+        .declareProperty(callingElementPathProp);
   }
 
   public void wrap(final ProcessInstanceRecord record) {
@@ -169,6 +185,54 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    final var elementInstancePath = new ArrayList<List<Long>>();
+    elementInstancePathProp.forEach(
+        pe -> {
+          final var pathEntry = new ArrayList<Long>();
+          pe.forEach(e -> pathEntry.add(e.getValue()));
+          elementInstancePath.add(pathEntry);
+        });
+    return elementInstancePath;
+  }
+
+  public ProcessInstanceRecord setElementInstancePath(final List<List<Long>> elementInstancePath) {
+    elementInstancePathProp.reset();
+    elementInstancePath.forEach(
+        pathEntry -> {
+          final var entry = elementInstancePathProp.add();
+          pathEntry.forEach(element -> entry.add().setValue(element));
+        });
+    return this;
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    final var processDefinitionPath = new ArrayList<Long>();
+    processDefinitionPathProp.forEach(e -> processDefinitionPath.add(e.getValue()));
+    return processDefinitionPath;
+  }
+
+  public ProcessInstanceRecord setProcessDefinitionPath(final List<Long> processDefinitionPath) {
+    processDefinitionPathProp.reset();
+    processDefinitionPath.forEach(e -> processDefinitionPathProp.add().setValue(e));
+    return this;
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<Integer>();
+    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
+    return callingElementPath;
+  }
+
+  public ProcessInstanceRecord setCallingElementPath(final List<Integer> callingElementPath) {
+    callingElementPathProp.reset();
+    callingElementPath.forEach(e -> callingElementPathProp.add().setValue(e));
+    return this;
+  }
+
   public ProcessInstanceRecord setParentProcessInstanceKey(final long parentProcessInstanceKey) {
     parentProcessInstanceKeyProp.setValue(parentProcessInstanceKey);
     return this;
@@ -210,6 +274,21 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
 
   public ProcessInstanceRecord setBpmnProcessId(final DirectBuffer directBuffer) {
     bpmnProcessIdProp.setValue(directBuffer);
+    return this;
+  }
+
+  public ProcessInstanceRecord resetElementInstancePath() {
+    elementInstancePathProp.reset();
+    return this;
+  }
+
+  public ProcessInstanceRecord resetCallingElementPath() {
+    callingElementPathProp.reset();
+    return this;
+  }
+
+  public ProcessInstanceRecord resetProcessDefinitionPath() {
+    processDefinitionPathProp.reset();
     return this;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
@@ -82,4 +83,24 @@ public interface ProcessInstanceRecordValue
    * @return the BPMN event type of the current process element.
    */
   BpmnEventType getBpmnEventType();
+
+  /**
+   * @return tree path information about all element instances in the call hierarchy leading to an
+   *     incident. It contains an entry per process instance in the hierarchy of the incident, each
+   *     contains all the instance keys of all the elements in the call hierarchy within this
+   *     process instance
+   */
+  List<List<Long>> getElementInstancePath();
+
+  /**
+   * @return tree path information for all process definitions in the hierarchy of the incident.
+   *     Each entry is a process definition key for the corresponding process instance
+   */
+  List<Long> getProcessDefinitionPath();
+
+  /**
+   * @return tree path information about call activities in the hierarchy of the incident. Each
+   *     entry is a reference to the call activity in BPMN model containing an incident.
+   */
+  List<Integer> getCallingElementPath();
 }


### PR DESCRIPTION
## Description

> [!Note]
>
> More details [here](https://docs.google.com/document/d/1PrWLli07nLDterUe8AMDAyjs_mICNx0kYQfgC5v3Fro/edit?tab=t.0)


This is one of the POC we planned to do to evaluate what the effort and impact is to build the treePath in different places.


![general](https://github.com/user-attachments/assets/b6d626b3-5ec1-4890-8757-4db76e1e7d3a)

In general the performance was looking pretty good, until we encountered an pod restart, which influenced the complete cluster. It caused high CPU throttling and in consequence, all metrics were impacted.

![restart-cpu-throttle](https://github.com/user-attachments/assets/e3ac97fa-a2af-4f92-b7be-0fc808f59ee0)


When we compare to base, we see that the throughput was for a while quite similar to our base weekly medic benchmarks.
![comp-general](https://github.com/user-attachments/assets/819b6d76-8ac3-41ae-a036-48aeabbc9ffb)

This is also for throughput and latency
![throughput](https://github.com/user-attachments/assets/4d4876af-0f60-4106-92c7-b74ab2b0dd3f)
![latency](https://github.com/user-attachments/assets/7ac1760b-6a13-45aa-bd1f-cd465ce38a94)

For the request sizes, we can see a slight increase (as expected). The increase for P99 was ~10KB and for P90 ~1KB.
![requests-sizes](https://github.com/user-attachments/assets/f73ba46c-b6c5-43e5-a7de-2806efe06798)

In the CPU panels, we can see similar numbers until encounter our pod restart.

![cpu](https://github.com/user-attachments/assets/6b5eb75b-c62d-4af1-a645-8041a9811717)

To validate that the ES is not impacted, we also checked the ES CPU resources and the seem to be comparable.

![es-cpu](https://github.com/user-attachments/assets/3ce2dfde-3c2d-4f95-b362-0c4d1ae2e69f)



### Working POC 

In ES we can see that the treePath is correctly set for the list view and FNI index.

![list-view-treepath](https://github.com/user-attachments/assets/d886e8b4-bcc8-4534-b8b9-b9f0807999c4)
![operate-fni](https://github.com/user-attachments/assets/c3a2db54-3aff-4ccb-b3f8-3af571ac5e28)





<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

See related POC #25310 
