### PR TITLE
Reject assignment operation from task listener

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -40,10 +40,10 @@ import java.util.Optional;
 public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private static final String USER_TASK_COMPLETION_REJECTION =
-      "Completion of the User Task with key '%d' was rejected by Task Listener";
+      "Completion of the User Task with key '%d' was denied by Task Listener";
 
   private static final String USER_TASK_ASSIGNMENT_REJECTION =
-      "Assignment of the User Task with key '%d' was rejected by Task Listener";
+      "Assignment of the User Task with key '%d' was denied by Task Listener";
 
   private final UserTaskCommandProcessors commandProcessors;
   private final ProcessState processState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -115,11 +115,14 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var persistedRecord = userTaskState.getUserTask(command.getKey());
 
     switch (lifecycleState) {
-      case COMPLETING -> writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
-      case ASSIGNING -> writeRejectionForCommand(command, persistedRecord, UserTaskIntent.ASSIGNMENT_DENIED);
-      default -> throw new IllegalArgumentException(
-          "Expected to reject operation for user task: '%d', but operation could not be determined from the task's current lifecycle state: '%s'"
-              .formatted(command.getValue().getUserTaskKey(), lifecycleState));
+      case COMPLETING ->
+          writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
+      case ASSIGNING ->
+          writeRejectionForCommand(command, persistedRecord, UserTaskIntent.ASSIGNMENT_DENIED);
+      default ->
+          throw new IllegalArgumentException(
+              "Expected to reject operation for user task: '%d', but operation could not be determined from the task's current lifecycle state: '%s'"
+                  .formatted(command.getValue().getUserTaskKey(), lifecycleState));
     }
   }
 
@@ -253,12 +256,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   }
 
   private UserTaskIntent mapDeniedIntentToResponseIntent(final UserTaskIntent intent) {
-    return switch (intent){
+    return switch (intent) {
       case COMPLETION_DENIED -> UserTaskIntent.COMPLETE;
       case ASSIGNMENT_DENIED -> UserTaskIntent.ASSIGN;
       default ->
-          throw new IllegalArgumentException(
-              "Unexpected user task intent: '%s'".formatted(intent));
+          throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -217,7 +217,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
               command.getValue(),
               command.getValueType(),
               RejectionType.INVALID_STATE,
-              mapDeniedIntentToResponseReasonFormat(intent, persistedRecord.getUserTaskKey()),
+              mapDeniedIntentToResponseRejectionReason(intent, persistedRecord.getUserTaskKey()),
               metadata.getRequestId(),
               metadata.getRequestStreamId());
         });
@@ -264,7 +264,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     };
   }
 
-  private String mapDeniedIntentToResponseReasonFormat(
+  private String mapDeniedIntentToResponseRejectionReason(
       final UserTaskIntent intent, final long userTaskKey) {
     return switch (intent) {
       case COMPLETION_DENIED -> USER_TASK_COMPLETION_REJECTION.formatted(userTaskKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -42,6 +42,9 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   private static final String USER_TASK_COMPLETION_REJECTION =
       "Completion of the User Task with key '%d' was rejected by Task Listener";
 
+  private static final String USER_TASK_ASSIGNMENT_REJECTION =
+      "Assignment of the User Task with key '%d' was rejected by Task Listener";
+
   private final UserTaskCommandProcessors commandProcessors;
   private final ProcessState processState;
   private final MutableUserTaskState userTaskState;
@@ -111,11 +114,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var lifecycleState = userTaskState.getLifecycleState(command.getKey());
     final var persistedRecord = userTaskState.getUserTask(command.getKey());
 
-    // Improvement: introduce switch case based on lifecycle stages in the future
-    if (lifecycleState == LifecycleState.COMPLETING) {
-      writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
-    } else {
-      throw new IllegalArgumentException(
+    switch (lifecycleState) {
+      case COMPLETING -> writeRejectionForCommand(command, persistedRecord, UserTaskIntent.COMPLETION_DENIED);
+      case ASSIGNING -> writeRejectionForCommand(command, persistedRecord, UserTaskIntent.ASSIGNMENT_DENIED);
+      default -> throw new IllegalArgumentException(
           "Expected to reject operation for user task: '%d', but operation could not be determined from the task's current lifecycle state: '%s'"
               .formatted(command.getValue().getUserTaskKey(), lifecycleState));
     }
@@ -208,11 +210,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
         metadata -> {
           responseWriter.writeRejection(
               command.getKey(),
-              UserTaskIntent.COMPLETE,
+              mapDeniedIntentToResponseIntent(intent),
               command.getValue(),
               command.getValueType(),
               RejectionType.INVALID_STATE,
-              USER_TASK_COMPLETION_REJECTION.formatted(persistedRecord.getUserTaskKey()),
+              mapDeniedIntentToResponseReasonFormat(intent, persistedRecord.getUserTaskKey()),
               metadata.getRequestId(),
               metadata.getRequestStreamId());
         });
@@ -247,6 +249,26 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       default ->
           throw new IllegalArgumentException(
               "Unexpected user task lifecycle state: '%s'".formatted(lifecycleState));
+    };
+  }
+
+  private UserTaskIntent mapDeniedIntentToResponseIntent(final UserTaskIntent intent) {
+    return switch (intent){
+      case COMPLETION_DENIED -> UserTaskIntent.COMPLETE;
+      case ASSIGNMENT_DENIED -> UserTaskIntent.ASSIGN;
+      default ->
+          throw new IllegalArgumentException(
+              "Unexpected user task intent: '%s'".formatted(intent));
+    };
+  }
+
+  private String mapDeniedIntentToResponseReasonFormat(
+      final UserTaskIntent intent, final long userTaskKey) {
+    return switch (intent) {
+      case COMPLETION_DENIED -> USER_TASK_COMPLETION_REJECTION.formatted(userTaskKey);
+      case ASSIGNMENT_DENIED -> USER_TASK_ASSIGNMENT_REJECTION.formatted(userTaskKey);
+      default ->
+          throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -427,6 +427,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));
     register(UserTaskIntent.CORRECTED, new UserTaskCorrectedApplier(state));
     register(UserTaskIntent.COMPLETION_DENIED, new UserTaskCompletionDeniedApplier(state));
+    register(UserTaskIntent.ASSIGNMENT_DENIED, new UserTaskAssignmentDeniedApplier(state));
   }
 
   private void registerCompensationSubscriptionApplier(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskAssignmentDeniedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public UserTaskAssignmentDeniedApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+    elementInstanceState = processingState.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CREATED);
+    userTaskState.deleteIntermediateState(key);
+    userTaskState.deleteRecordRequestMetadata(key);
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+    if (elementInstance != null) {
+      final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+      if (scopeInstance != null && scopeInstance.isActive()) {
+        elementInstance.resetTaskListenerIndices();
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -169,14 +169,7 @@ public class TaskListenerTest {
     final long processInstanceKey =
         createProcessInstance(createProcessWithAssignmentTaskListeners(LISTENER_TYPE));
 
-    ENGINE
-        .userTask()
-        .ofInstance(processInstanceKey)
-        .assign(
-            ut -> {
-              ut.setAssignee("new_assignee");
-              return ut;
-            });
+    ENGINE.userTask().ofInstance(processInstanceKey).assign(ut -> ut.setAssignee("new_assignee"));
     ENGINE
         .job()
         .ofInstance(processInstanceKey)
@@ -196,6 +189,8 @@ public class TaskListenerTest {
             RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey).limit(1))
         .extracting(Record::getValue)
         .extracting(UserTaskRecordValue::getAssignee)
+        .describedAs(
+            "The assignee should remain unchanged as assignment was denied by Task Listener")
         .containsExactly("");
   }
 
@@ -207,14 +202,7 @@ public class TaskListenerTest {
         createProcessInstance(
             createProcessWithAssignmentTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
-    ENGINE
-        .userTask()
-        .ofInstance(processInstanceKey)
-        .assign(
-            ut -> {
-              ut.setAssignee("new_assignee");
-              return ut;
-            });
+    ENGINE.userTask().ofInstance(processInstanceKey).assign(ut -> ut.setAssignee("new_assignee"));
     // assignment fails
     ENGINE
         .job()
@@ -223,14 +211,7 @@ public class TaskListenerTest {
         .withResult(new JobResult().setDenied(true))
         .complete();
 
-    ENGINE
-        .userTask()
-        .ofInstance(processInstanceKey)
-        .assign(
-            ut -> {
-              ut.setAssignee("new_assignee");
-              return ut;
-            });
+    ENGINE.userTask().ofInstance(processInstanceKey).assign(ut -> ut.setAssignee("new_assignee"));
     // assignment is successful
     completeRecreatedJobWithType(ENGINE, processInstanceKey, LISTENER_TYPE);
     completeJobs(processInstanceKey, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3");
@@ -253,6 +234,61 @@ public class TaskListenerTest {
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "new_assignee"),
             tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "new_assignee"),
             tuple(UserTaskIntent.ASSIGNED, "new_assignee"));
+  }
+
+  @Test
+  public void
+      shouldRevertToPreviousAssigneeWhenRejectingAssignmentFromTaskListenerAfterPreviouslySuccessfulAssignment() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            createUserTaskWithTaskListenersAndAssignee(LISTENER_TYPE, "first_assignee"));
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(LISTENER_TYPE)
+        .withResult(new JobResult().setDenied(false))
+        .complete();
+
+    ENGINE
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .assign(ut -> ut.setAssignee("second_assignee"));
+
+    completeRecreatedJobWithTypeAndResult(
+        ENGINE, processInstanceKey, LISTENER_TYPE, new JobResult().setDenied(true));
+
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNMENT_DENIED))
+        .extracting(Record::getIntent, r -> r.getValue().getAssignee())
+        .describedAs(
+            "Verify that the assignee changes. The assignment of the second assignee should be rejected.")
+        .containsSequence(
+            tuple(UserTaskIntent.CREATING, ""),
+            tuple(UserTaskIntent.CREATED, ""),
+            tuple(UserTaskIntent.ASSIGNING, "first_assignee"),
+            tuple(UserTaskIntent.COMPLETE_TASK_LISTENER, "first_assignee"),
+            tuple(UserTaskIntent.ASSIGNED, "first_assignee"),
+            tuple(UserTaskIntent.ASSIGN, "second_assignee"),
+            tuple(UserTaskIntent.ASSIGNING, "second_assignee"),
+            tuple(UserTaskIntent.DENY_TASK_LISTENER, "second_assignee"),
+            // second assignee was not persisted
+            tuple(UserTaskIntent.ASSIGNMENT_DENIED, "first_assignee"));
+
+    // then: ensure that the assignee value is rolled back to the first successfully assigned
+    // assignee
+    assertThat(
+            RecordingExporter.userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .filter(r -> r.getIntent() == UserTaskIntent.ASSIGNMENT_DENIED)
+                .limit(1))
+        .extracting(Record::getValue)
+        .extracting(UserTaskRecordValue::getAssignee)
+        .describedAs(
+            "The assignee should remain unchanged as assignment was denied by Task Listener and the original value is provided")
+        .containsExactly("first_assignee");
   }
 
   @Test
@@ -910,14 +946,26 @@ public class TaskListenerTest {
 
   private static void completeRecreatedJobWithType(
       final EngineRule engine, final long processInstanceKey, final String jobType) {
-    final long jobKey =
-        jobRecords(JobIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .withType(jobType)
-            .skip(1)
-            .getFirst()
-            .getKey();
+    final long jobKey = findRecreatedJobKey(processInstanceKey, jobType);
     engine.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
+  }
+
+  private static void completeRecreatedJobWithTypeAndResult(
+      final EngineRule engine,
+      final long processInstanceKey,
+      final String jobType,
+      final JobResult jobResult) {
+    final long jobKey = findRecreatedJobKey(processInstanceKey, jobType);
+    engine.job().ofInstance(processInstanceKey).withKey(jobKey).withResult(jobResult).complete();
+  }
+
+  private static long findRecreatedJobKey(final long processInstanceKey, final String jobType) {
+    return jobRecords(JobIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withType(jobType)
+        .skip(1)
+        .getFirst()
+        .getKey();
   }
 
   private void assertThatProcessInstanceCompleted(final long processInstanceKey) {
@@ -951,6 +999,15 @@ public class TaskListenerTest {
   private BpmnModelInstance createProcessWithAssignmentTaskListeners(
       final String... listenerTypes) {
     return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.assignment, listenerTypes);
+  }
+
+  private BpmnModelInstance createUserTaskWithTaskListenersAndAssignee(
+      final String listenerType, final String assignee) {
+    return createProcessWithZeebeUserTask(
+        taskBuilder ->
+            taskBuilder
+                .zeebeAssignee(assignee)
+                .zeebeTaskListener(l -> l.assignment().type(listenerType)));
   }
 
   private BpmnModelInstance createProcessWithCompleteTaskListeners(final String... listenerTypes) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -187,7 +187,8 @@ public class TaskListenerTest {
   }
 
   @Test
-  public void shouldCompleteAllAssignmentTaskListenersWhenFirstTaskListenerAcceptOperationAfterRejection() {
+  public void
+      shouldCompleteAllAssignmentTaskListenersWhenFirstTaskListenerAcceptOperationAfterRejection() {
     // given
     final long processInstanceKey =
         createProcessInstance(
@@ -912,7 +913,8 @@ public class TaskListenerTest {
         .done();
   }
 
-  private BpmnModelInstance createProcessWithAssignmentTaskListeners(final String... listenerTypes) {
+  private BpmnModelInstance createProcessWithAssignmentTaskListeners(
+      final String... listenerTypes) {
     return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.assignment, listenerTypes);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class UserTaskAssignmentDeniedApplierTest {
+
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  /** The class under test. */
+  private UserTaskAssignmentDeniedApplier userTaskAssignmentDeniedApplierApplier;
+
+  /** Used for state assertions. */
+  private MutableUserTaskState userTaskState;
+
+  /** For setting up the state before testing the applier. */
+  private TestSetup testSetup;
+
+  @BeforeEach
+  public void setup() {
+    userTaskAssignmentDeniedApplierApplier = new UserTaskAssignmentDeniedApplier(processingState);
+    userTaskState = processingState.getUserTaskState();
+    testSetup = new TestSetup(processingState);
+  }
+
+  @Test
+  public void shouldRevertAssigneeIfAssignmentDeniedByTaskListener() {
+    // given
+    final var userTaskKey = 1;
+    final var initialAssignee = "initial";
+    final var newAssignee = "changed";
+
+    final var given = new UserTaskRecord().setUserTaskKey(userTaskKey).setAssignee(initialAssignee);
+
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, given);
+    testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, given);
+    testSetup.applyEventToState(
+        userTaskKey, UserTaskIntent.ASSIGNING, given.setAssignee(newAssignee));
+
+    Assumptions.assumeThat(userTaskState.getUserTask(userTaskKey)).isNotNull();
+    Assumptions.assumeThat(userTaskState.getUserTask(userTaskKey).getAssignee())
+        .isEqualTo(initialAssignee);
+    Assumptions.assumeThat(userTaskState.getLifecycleState(userTaskKey))
+        .isEqualTo(LifecycleState.ASSIGNING);
+
+    // when
+    userTaskAssignmentDeniedApplierApplier.applyState(userTaskKey, given.setAssignee(newAssignee));
+
+    // then
+    Assertions.assertThat(userTaskState.getIntermediateState(userTaskKey))
+        .describedAs("Expect that intermediate state is not present anymore")
+        .isNull();
+    Assertions.assertThat(userTaskState.findRecordRequestMetadata(userTaskKey))
+        .describedAs("Expect that record request metadata is not present anymore")
+        .isEmpty();
+    Assertions.assertThat(userTaskState.getUserTask(userTaskKey).getAssignee())
+        .describedAs("Expect that user task assignee has not been updated")
+        .isEqualTo(initialAssignee);
+    Assertions.assertThat(userTaskState.getLifecycleState(userTaskKey))
+        .describedAs("Expect that lifecycle state is reverted to 'CREATED'")
+        .isEqualTo(LifecycleState.CREATED);
+  }
+
+  private static final class TestSetup {
+
+    private final EventAppliers eventAppliers;
+
+    TestSetup(final MutableProcessingState processingState) {
+      eventAppliers = new EventAppliers();
+      eventAppliers.registerEventAppliers(processingState);
+    }
+
+    /**
+     * Applies the event of the given intent to the state.
+     *
+     * @implNote applies the event using the latest version of the record.
+     * @param intent the intent of the event to apply
+     * @param userTaskRecord data of the event to apply
+     */
+    private void applyEventToState(
+        final long userTaskKey, final UserTaskIntent intent, final UserTaskRecord userTaskRecord) {
+      final int latestVersion = eventAppliers.getLatestVersion(intent);
+      eventAppliers.applyState(userTaskKey, intent, userTaskRecord, latestVersion);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -47,10 +47,16 @@ public class UserTaskAssignmentDeniedApplierTest {
     final var initialAssignee = "initial";
     final var newAssignee = "changed";
 
-    final var given = new UserTaskRecord().setUserTaskKey(userTaskKey).setAssignee(initialAssignee);
+    final var given = new UserTaskRecord().setUserTaskKey(userTaskKey);
 
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATING, given);
     testSetup.applyEventToState(userTaskKey, UserTaskIntent.CREATED, given);
+
+    testSetup.applyEventToState(
+        userTaskKey, UserTaskIntent.ASSIGNING, given.setAssignee(initialAssignee));
+    testSetup.applyEventToState(
+        userTaskKey, UserTaskIntent.ASSIGNED, given.setAssignee(initialAssignee));
+
     testSetup.applyEventToState(
         userTaskKey, UserTaskIntent.ASSIGNING, given.setAssignee(newAssignee));
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskAssignmentDeniedApplierTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,10 +54,9 @@ public class UserTaskAssignmentDeniedApplierTest {
     testSetup.applyEventToState(
         userTaskKey, UserTaskIntent.ASSIGNING, given.setAssignee(newAssignee));
 
-    Assumptions.assumeThat(userTaskState.getUserTask(userTaskKey)).isNotNull();
-    Assumptions.assumeThat(userTaskState.getUserTask(userTaskKey).getAssignee())
+    Assertions.assertThat(userTaskState.getUserTask(userTaskKey).getAssignee())
         .isEqualTo(initialAssignee);
-    Assumptions.assumeThat(userTaskState.getLifecycleState(userTaskKey))
+    Assertions.assertThat(userTaskState.getLifecycleState(userTaskKey))
         .isEqualTo(LifecycleState.ASSIGNING);
 
     // when

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -127,6 +127,18 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
+  public Record<UserTaskRecordValue> assign(
+      final Function<UserTaskRecord, UserTaskRecord> userTaskRecordBuilder) {
+    final long userTaskKey = findUserTaskKey();
+    final long position =
+        writer.writeCommand(
+            userTaskKey,
+            UserTaskIntent.ASSIGN,
+            userTaskRecordBuilder.apply(userTaskRecord.setUserTaskKey(userTaskKey)),
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+
   public Record<UserTaskRecordValue> claim() {
     final long userTaskKey = findUserTaskKey();
     final long position =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.test.util.MsgPackUtil;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -128,13 +129,15 @@ public final class UserTaskClient {
   }
 
   public Record<UserTaskRecordValue> assign(
-      final Function<UserTaskRecord, UserTaskRecord> userTaskRecordBuilder) {
+      final Consumer<UserTaskRecord> userTaskRecordCustomizer) {
     final long userTaskKey = findUserTaskKey();
+    final UserTaskRecord taskRecord = userTaskRecord.setUserTaskKey(userTaskKey);
+    userTaskRecordCustomizer.accept(taskRecord);
     final long position =
         writer.writeCommand(
             userTaskKey,
             UserTaskIntent.ASSIGN,
-            userTaskRecordBuilder.apply(userTaskRecord.setUserTaskKey(userTaskKey)),
+            taskRecord,
             authorizedTenantIds.toArray(new String[0]));
     return expectation.apply(position);
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -76,7 +76,13 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * Note that the changes are only applied to the User Task instance after all Task Listeners have
    * been handled and none denied the operation.
    */
-  CORRECTED(18);
+  CORRECTED(18),
+
+  /**
+   * Represents the intent indicating that the User Task will not be assigned and the user task's
+   * assignee remains unchanged. The user task will be reverted to the CREATED lifecycle state.
+   */
+  ASSIGNMENT_DENIED(19);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -134,6 +140,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return COMPLETION_DENIED;
       case 18:
         return CORRECTED;
+      case 19:
+        return ASSIGNMENT_DENIED;
       default:
         return UNKNOWN;
     }
@@ -160,6 +168,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case MIGRATED:
       case COMPLETION_DENIED:
       case CORRECTED:
+      case ASSIGNMENT_DENIED:
         return true;
       default:
         return false;

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -264,7 +264,7 @@ public class UserTaskListenersTest {
 
     final var rejectionReason =
         String.format(
-            "Command 'COMPLETE' rejected with code 'INVALID_STATE': Completion of the User Task with key '%s' was rejected by Task Listener",
+            "Command 'COMPLETE' rejected with code 'INVALID_STATE': Completion of the User Task with key '%s' was denied by Task Listener",
             userTaskKey);
 
     // verify the rejection


### PR DESCRIPTION
## Description

If the job is rejected by `assignment` Task Listener, then this should result in `ASSIGNMENT_DENIED`.

In this case:

- the user task's `assignee` remains unchanged
- the user task returns to the `CREATED` lifecycle state
- the assign request is rejected using the response writer, if this was a user requested assignment

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24235
