### PR TITLE
feat: rework OS exporter tests to support AWS

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/AWSSearchDBExtension.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/AWSSearchDBExtension.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.UUID;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class AWSSearchDBExtension extends SearchDBExtension {
+
+  private final String awsSearchDbUrl;
+
+  private ProtocolFactory recordFactory;
+  private OpensearchExporterConfiguration config;
+  private TemplateReader templateReader;
+  private RecordIndexRouter indexRouter;
+  private BulkIndexRequest bulkRequest;
+
+  private TestClient testClient;
+  private OpensearchClient client;
+
+  public AWSSearchDBExtension(final String awsSearchDbUrl) {
+    this.awsSearchDbUrl = awsSearchDbUrl;
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context) throws Exception {
+    recordFactory = new ProtocolFactory();
+    config = new OpensearchExporterConfiguration();
+    config.aws.enabled = true;
+    templateReader = new TemplateReader(config.index);
+    indexRouter = new RecordIndexRouter(config.index);
+    bulkRequest = new BulkIndexRequest();
+
+    // as all tests use the same endpoint, we need a per-test unique prefix
+    config.index.prefix = UUID.randomUUID() + "-test-record";
+    config.url = awsSearchDbUrl;
+    testClient = new TestClient(config, indexRouter);
+    client =
+        new OpensearchClient(
+            config,
+            bulkRequest,
+            RestClientFactory.of(config, true),
+            indexRouter,
+            templateReader,
+            new OpensearchMetrics(new SimpleMeterRegistry()));
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) throws Exception {
+    // No-Op
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) throws Exception {
+    // No-Op
+  }
+
+  @Override
+  public OpensearchExporterConfiguration config() {
+    return config;
+  }
+
+  @Override
+  public ProtocolFactory recordFactory() {
+    return recordFactory;
+  }
+
+  @Override
+  public TemplateReader templateReader() {
+    return templateReader;
+  }
+
+  @Override
+  public RecordIndexRouter indexRouter() {
+    return indexRouter;
+  }
+
+  @Override
+  public BulkIndexRequest bulkRequest() {
+    return bulkRequest;
+  }
+
+  @Override
+  public TestClient testClient() {
+    return testClient;
+  }
+
+  @Override
+  public OpensearchClient client() {
+    return client;
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/ContainerizedSearchDBExtension.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/ContainerizedSearchDBExtension.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.UUID;
+import org.agrona.CloseHelper;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.opensearch.testcontainers.OpensearchContainer;
+
+public class ContainerizedSearchDBExtension extends SearchDBExtension {
+
+  private static final String PASSWORD = "P@a$5w0rd";
+  private static final String ADMIN_PASSWORD_ENV_VAR = "OPENSEARCH_INITIAL_ADMIN_PASSWORD";
+
+  private static OpensearchContainer<?> opensearchContainer;
+
+  private ProtocolFactory recordFactory;
+  private OpensearchExporterConfiguration config;
+  private TemplateReader templateReader;
+  private RecordIndexRouter indexRouter;
+  private BulkIndexRequest bulkRequest;
+
+  private TestClient testClient;
+  private OpensearchClient client;
+
+  @Override
+  public void beforeAll(final ExtensionContext context) throws Exception {
+    opensearchContainer =
+        TestSearchContainers.createDefaultOpensearchContainer()
+            .withSecurityEnabled()
+            .withEnv(ADMIN_PASSWORD_ENV_VAR, PASSWORD);
+    opensearchContainer.start();
+  }
+
+  @Override
+  public void beforeEach(final ExtensionContext context) throws Exception {
+    recordFactory = new ProtocolFactory();
+    config = new OpensearchExporterConfiguration();
+    templateReader = new TemplateReader(config.index);
+    indexRouter = new RecordIndexRouter(config.index);
+    bulkRequest = new BulkIndexRequest();
+
+    // as all tests use the same endpoint, we need a per-test unique prefix
+    config.index.prefix = UUID.randomUUID() + "-test-record";
+    config.url = opensearchContainer.getHttpHostAddress();
+    config.getAuthentication().setUsername(opensearchContainer.getUsername());
+    config.getAuthentication().setPassword(PASSWORD);
+    testClient = new TestClient(config, indexRouter);
+    client =
+        new OpensearchClient(
+            config,
+            bulkRequest,
+            RestClientFactory.of(config, true),
+            indexRouter,
+            templateReader,
+            new OpensearchMetrics(new SimpleMeterRegistry()));
+  }
+
+  @Override
+  public void afterEach(final ExtensionContext context) throws Exception {
+    CloseHelper.quietCloseAll(testClient, client);
+  }
+
+  @Override
+  public OpensearchExporterConfiguration config() {
+    return config;
+  }
+
+  @Override
+  public ProtocolFactory recordFactory() {
+    return recordFactory;
+  }
+
+  @Override
+  public TemplateReader templateReader() {
+    return templateReader;
+  }
+
+  @Override
+  public RecordIndexRouter indexRouter() {
+    return indexRouter;
+  }
+
+  @Override
+  public BulkIndexRequest bulkRequest() {
+    return bulkRequest;
+  }
+
+  @Override
+  public TestClient testClient() {
+    return testClient;
+  }
+
+  @Override
+  public OpensearchClient client() {
+    return client;
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SearchDBExtension.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/SearchDBExtension.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.exporter.opensearch;
+
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.Optional;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+
+public abstract class SearchDBExtension
+    implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback {
+
+  protected static final String IT_OPENSEARCH_AWS_INSTANCE_URL_PROPERTY =
+      "camunda.it.opensearch.aws_instance_url";
+
+  private static boolean isAwsTest;
+
+  static SearchDBExtension create() {
+    final var openSearchAwsInstanceUrl =
+        Optional.ofNullable(System.getProperty(IT_OPENSEARCH_AWS_INSTANCE_URL_PROPERTY)).orElse("");
+    if (openSearchAwsInstanceUrl.isEmpty()) {
+      return new ContainerizedSearchDBExtension();
+    } else {
+      isAwsTest = true;
+      return new AWSSearchDBExtension(openSearchAwsInstanceUrl);
+    }
+  }
+
+  abstract OpensearchExporterConfiguration config();
+
+  abstract ProtocolFactory recordFactory();
+
+  abstract TemplateReader templateReader();
+
+  abstract RecordIndexRouter indexRouter();
+
+  abstract BulkIndexRequest bulkRequest();
+
+  abstract TestClient testClient();
+
+  abstract OpensearchClient client();
+
+  public boolean isAwsTest() {
+    return isAwsTest;
+  }
+}


### PR DESCRIPTION
## Description

Adopting OpenSearch exporter module to run against AWS.

Note: there will be an abstraction layer introduced since there's a lot of copy-paste logic currently in this PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to: https://github.com/camunda/team-data-engine-maintenance/issues/49
