### PR TITLE
Implement getFlowNodesInstanceInListView for ES repository

### DIFF
--- a/zeebe/exporters/camunda-exporter/pom.xml
+++ b/zeebe/exporters/camunda-exporter/pom.xml
@@ -167,6 +167,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -59,6 +59,7 @@ public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpd
           FieldValue.of(OperationState.SENT.name()),
           FieldValue.of(OperationState.COMPLETED.name()));
   private static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
+  private static final int SCROLL_PAGE_SIZE = 100;
 
   private final int partitionId;
   private final String pendingUpdateAlias;
@@ -129,6 +130,7 @@ public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpd
             .query(q -> q.bool(b -> b.must(idQ, typeQ)))
             .source(s -> s.fetch(false))
             .scroll(SCROLL_KEEP_ALIVE)
+            .size(SCROLL_PAGE_SIZE)
             .build();
 
     return client

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * There is no way to test in integration if the scroll context was cleared, because there is no API
+ * on the ES side for it. So the closest we can get is using mocks to ensure we are clearing scroll
+ * contexts.
+ */
+@ExtendWith(MockitoExtension.class)
+public final class ElasticsearchIncidentUpdateRepositoryTest {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchIncidentUpdateRepositoryTest.class);
+
+  @Mock private ElasticsearchAsyncClient client;
+
+  @Test
+  void shouldClearScrollOnGetFlowNodesInListView() {
+    // given
+    final var repository = createRepository();
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
+    Mockito.when(client.clearScroll(Mockito.any(ClearScrollRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalClearScrollResponse()));
+
+    // when
+    final var result = repository.getFlowNodesInListView(List.of("1", "2"));
+
+    // then
+    final var inOrder = Mockito.inOrder(client);
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    inOrder.verify(client, Mockito.times(1)).clearScroll(Mockito.any(ClearScrollRequest.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  @Test
+  void shouldNotClearScrollOnGetFlowNodesInListViewOnSearchFailure() {
+    // given
+    final var repository = createRepository();
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException("failure")));
+
+    // when
+    final var result = repository.getFlowNodesInListView(List.of("1", "2"));
+
+    // then
+    assertThat(result).failsWithin(Duration.ofSeconds(5));
+    Mockito.verify(client, Mockito.never()).clearScroll(Mockito.any(ClearScrollRequest.class));
+  }
+
+  @Test
+  void shouldClearScrollOnGetFlowNodesInListViewEvenOnFailure() {
+    // given
+    final var repository = createRepository();
+    final SearchResponse<Object> searchResponse =
+        buildMinimalSearchResponse(b -> b.hits(h -> h.hits(Hit.of(d -> d.id("1").index("index")))));
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+        .thenReturn(CompletableFuture.completedFuture(searchResponse));
+    Mockito.when(client.scroll(Mockito.any(Function.class), Mockito.any()))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalScrollResponse()));
+    Mockito.when(client.clearScroll(Mockito.any(ClearScrollRequest.class)))
+        .thenReturn(CompletableFuture.completedFuture(buildMinimalClearScrollResponse()));
+
+    // when
+    final var result = repository.getFlowNodesInListView(List.of("1", "2"));
+
+    // then
+    final var inOrder = Mockito.inOrder(client);
+    assertThat(result).succeedsWithin(Duration.ofSeconds(5));
+    inOrder.verify(client, Mockito.times(1)).clearScroll(Mockito.any(ClearScrollRequest.class));
+    inOrder.verifyNoMoreInteractions();
+  }
+
+  private ScrollResponse<Object> buildMinimalScrollResponse() {
+    return new ScrollResponse.Builder<>()
+        .took(1)
+        .timedOut(false)
+        .hits(h -> h.hits(List.of()))
+        .shards(s -> s.failed(0).successful(0).total(0))
+        .build();
+  }
+
+  private ClearScrollResponse buildMinimalClearScrollResponse() {
+    return new ClearScrollResponse.Builder().succeeded(true).numFreed(1).build();
+  }
+
+  private SearchResponse<Object> buildMinimalSearchResponse() {
+    return buildMinimalSearchResponse(ignored -> {});
+  }
+
+  private SearchResponse<Object> buildMinimalSearchResponse(
+      final Consumer<SearchResponse.Builder<?>> modifier) {
+    // need to specify all the required fields
+    final var response =
+        new SearchResponse.Builder<>()
+            .scrollId("foo")
+            .hits(h -> h.hits(List.of()))
+            .took(1)
+            .timedOut(false)
+            .shards(s -> s.total(0).failed(0).successful(0));
+
+    modifier.accept(response);
+    return response.build();
+  }
+
+  private ElasticsearchIncidentUpdateRepository createRepository() {
+    return new ElasticsearchIncidentUpdateRepository(
+        1,
+        "pendingUpdateAlias",
+        "incidentAlias",
+        "listViewAlias",
+        "flowNodeAlias",
+        "operationAlias",
+        client,
+        Runnable::run,
+        LOGGER);
+  }
+}


### PR DESCRIPTION
## Description

This PR implements `getFlowNodeInstancesInListView` for the ES incident update repository. It migrates the usage of scrolling from the previous application, as it could be we have many more FNIs than we have incidents.

> [!Note]
> To clear the scroll, there is no API to verify that the context has been cleared in ES, so the only verification method I found relies on mocking :( Happy to hear suggestions

> [!Note]
> Scrolling has a default page size of 10, and as the previous code was not actually setting a different size, I kept it as is. I think it may be a little small, but let's start with that.

## Related issues

related to #24930 
