### PR TITLE
pg-migrate-variables-fix

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -41,6 +41,7 @@ import io.camunda.exporter.handlers.MappingCreatedHandler;
 import io.camunda.exporter.handlers.MappingDeletedHandler;
 import io.camunda.exporter.handlers.MetricFromDecisionEvaluationHandler;
 import io.camunda.exporter.handlers.MetricFromProcessInstanceHandler;
+import io.camunda.exporter.handlers.MigratedVariableHandler;
 import io.camunda.exporter.handlers.PostImporterQueueFromIncidentHandler;
 import io.camunda.exporter.handlers.ProcessHandler;
 import io.camunda.exporter.handlers.RoleCreateUpdateHandler;
@@ -293,7 +294,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new MappingDeletedHandler(
                 indexDescriptorsMap.get(MappingIndex.class).getFullQualifiedName()),
             new MetricFromDecisionEvaluationHandler(
-                indexDescriptorsMap.get(MetricIndex.class).getFullQualifiedName()));
+                indexDescriptorsMap.get(MetricIndex.class).getFullQualifiedName()),
+            new MigratedVariableHandler(
+                templateDescriptorsMap.get(VariableTemplate.class).getFullQualifiedName()));
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/MigratedVariableHandler.java
@@ -39,8 +39,7 @@ public class MigratedVariableHandler implements ExportHandler<VariableEntity, Va
 
   @Override
   public boolean handlesRecord(final Record<VariableRecordValue> record) {
-    return getHandledValueType().equals(record.getValueType())
-        && record.getIntent().name().equals(VariableIntent.MIGRATED.name());
+    return record.getIntent().equals(VariableIntent.MIGRATED);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -40,8 +40,7 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
 
   @Override
   public boolean handlesRecord(final Record<VariableRecordValue> record) {
-    return getHandledValueType().equals(record.getValueType())
-        && !record.getIntent().name().equals(VariableIntent.MIGRATED.name());
+    return !record.getIntent().equals(VariableIntent.MIGRATED);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/VariableHandler.java
@@ -10,12 +10,16 @@ package io.camunda.exporter.handlers;
 import static io.camunda.exporter.utils.ExporterUtil.tenantOrDefault;
 
 import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.webapps.schema.entities.operate.listview.VariableForListViewEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class VariableHandler implements ExportHandler<VariableEntity, VariableRecordValue> {
 
@@ -69,6 +73,34 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
         .setName(recordValue.getName())
         .setTenantId(tenantOrDefault(recordValue.getTenantId()))
         .setPosition(record.getPosition());
+
+    if (!record.getIntent().name().equals(VariableIntent.MIGRATED.name())) {
+      setVariableValues(recordValue, entity);
+    }
+  }
+
+  @Override
+  public void flush(final VariableEntity entity, final BatchRequest batchRequest) {
+    final Map<String, Object> updateFields = new HashMap<>();
+
+    if (!entity.getValue().equals("null")) {
+      updateFields.put(VariableTemplate.VALUE, entity.getValue());
+      updateFields.put(VariableTemplate.FULL_VALUE, entity.getFullValue());
+      updateFields.put(VariableTemplate.IS_PREVIEW, entity.getIsPreview());
+    }
+    updateFields.put(VariableTemplate.PROCESS_DEFINITION_KEY, entity.getProcessDefinitionKey());
+    updateFields.put(VariableTemplate.BPMN_PROCESS_ID, entity.getBpmnProcessId());
+
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private void setVariableValues(
+      final VariableRecordValue recordValue, final VariableEntity entity) {
     if (recordValue.getValue().length() > variableSizeThreshold) {
       entity.setValue(recordValue.getValue().substring(0, variableSizeThreshold));
       entity.setFullValue(recordValue.getValue());
@@ -78,15 +110,5 @@ public class VariableHandler implements ExportHandler<VariableEntity, VariableRe
       entity.setFullValue(null);
       entity.setIsPreview(false);
     }
-  }
-
-  @Override
-  public void flush(final VariableEntity entity, final BatchRequest batchRequest) {
-    batchRequest.add(indexName, entity);
-  }
-
-  @Override
-  public String getIndexName() {
-    return indexName;
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/MigratedVariableHandlerTest.java
@@ -21,10 +21,12 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 public class MigratedVariableHandlerTest {
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -51,19 +53,18 @@ public class MigratedVariableHandlerTest {
     assertThat(underTest.handlesRecord(decisionRecord)).isTrue();
   }
 
-  @Test
-  void shouldNotHandleRecord() {
+  @ParameterizedTest
+  @EnumSource(
+      value = VariableIntent.class,
+      names = {"MIGRATED"},
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final VariableIntent intent) {
     // given
-    for (final VariableIntent intent :
-        Arrays.stream(VariableIntent.values())
-            .filter(i -> i != VariableIntent.MIGRATED)
-            .toArray(VariableIntent[]::new)) {
-      final Record<VariableRecordValue> decisionRecord =
-          factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(intent));
+    final Record<VariableRecordValue> decisionRecord =
+        factory.generateRecord(ValueType.VARIABLE, r -> r.withIntent(intent));
 
-      // when - then
-      assertThat(underTest.handlesRecord(decisionRecord)).isFalse();
-    }
+    // when - then
+    assertThat(underTest.handlesRecord(decisionRecord)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adjust VariableHandler to take into account `MIGRATED` intents that, by definition, do not contain the variable `value` and would otherwise nullify the variable's value fields.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues
Ref: [Slack thread](https://camunda.slack.com/archives/C06F0GLJNFM/p1732721264015329) 
closes #
