### PR TITLE
feat: expose /me endpoint including application access

### DIFF
--- a/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
+++ b/authentication/src/main/java/io/camunda/authentication/CamundaUserDetailsService.java
@@ -9,9 +9,17 @@ package io.camunda.authentication;
 
 import static io.camunda.authentication.entity.CamundaUser.CamundaUserBuilder.aCamundaUser;
 
+import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.security.entity.Permission;
+import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -19,9 +27,12 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 public class CamundaUserDetailsService implements UserDetailsService {
 
   private final UserServices userServices;
+  private final AuthorizationServices authorizationServices;
 
-  public CamundaUserDetailsService(final UserServices userServices) {
+  public CamundaUserDetailsService(
+      final UserServices userServices, final AuthorizationServices authorizationServices) {
     this.userServices = userServices;
+    this.authorizationServices = authorizationServices;
   }
 
   @Override
@@ -29,17 +40,35 @@ public class CamundaUserDetailsService implements UserDetailsService {
     final var userQuery =
         SearchQueryBuilders.userSearchQuery(
             fn -> fn.filter(f -> f.username(username)).page(p -> p.size(1)));
-    return userServices.search(userQuery).items().stream()
-        .filter(Objects::nonNull)
-        .findFirst()
-        .map(
-            candidate ->
-                aCamundaUser()
-                    .withUserKey(candidate.userKey())
-                    .withName(candidate.name())
-                    .withUsername(candidate.username())
-                    .withPassword(candidate.password())
-                    .build())
-        .orElseThrow(() -> new UsernameNotFoundException(username));
+    final var storedUser =
+        userServices.search(userQuery).items().stream()
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElseThrow(() -> new UsernameNotFoundException(username));
+
+    final var authorizationQuery =
+        SearchQueryBuilders.authorizationSearchQuery(
+            fn ->
+                fn.filter(
+                    f ->
+                        f.ownerKeys(storedUser.userKey())
+                            .permissionType(PermissionType.ACCESS)
+                            .resourceType(AuthorizationResourceType.APPLICATION.name())));
+
+    final var authorizedApplications =
+        authorizationServices.search(authorizationQuery).items().stream()
+            .map(AuthorizationEntity::permissions)
+            .flatMap(List::stream)
+            .map(Permission::resourceIds)
+            .flatMap(Set::stream)
+            .collect(Collectors.toList());
+
+    return aCamundaUser()
+        .withUserKey(storedUser.userKey())
+        .withName(storedUser.name())
+        .withUsername(storedUser.username())
+        .withPassword(storedUser.password())
+        .withAuthorizedApplications(authorizedApplications)
+        .build();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
+++ b/authentication/src/main/java/io/camunda/authentication/config/WebSecurityConfig.java
@@ -58,8 +58,9 @@ public class WebSecurityConfig {
 
   @Bean
   @Profile("auth-basic")
-  public CamundaUserDetailsService camundaUserDetailsService(final UserServices userServices) {
-    return new CamundaUserDetailsService(userServices);
+  public CamundaUserDetailsService camundaUserDetailsService(
+      final UserServices userServices, final AuthorizationServices authorizationServices) {
+    return new CamundaUserDetailsService(userServices, authorizationServices);
   }
 
   @Bean

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.authentication.entity;
 
-import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.entity.ClusterMetadata;
+import io.camunda.service.TenantServices.TenantDTO;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,7 +22,7 @@ public class CamundaUser extends User {
   private final Long userKey;
   private final String displayName;
   private List<String> authorizedApplications = List.of();
-  private List<TenantEntity> tenants = List.of();
+  private List<TenantDTO> tenants = List.of();
   private List<String> groups = List.of();
   private String salesPlanType;
   private Map<ClusterMetadata.AppName, String> c8Links = new HashMap<>();
@@ -53,7 +53,7 @@ public class CamundaUser extends User {
       final String password,
       final List<String> roles,
       final List<String> authorizedApplications,
-      final List<TenantEntity> tenants,
+      final List<TenantDTO> tenants,
       final List<String> groups,
       final String salesPlanType,
       final Map<ClusterMetadata.AppName, String> c8Links,
@@ -91,11 +91,15 @@ public class CamundaUser extends User {
     return getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
   }
 
+  public List<String> getGroups() {
+    return groups;
+  }
+
   public List<String> getAuthorizedApplications() {
     return authorizedApplications;
   }
 
-  public List<TenantEntity> getTenants() {
+  public List<TenantDTO> getTenants() {
     return tenants;
   }
 
@@ -104,11 +108,18 @@ public class CamundaUser extends User {
   }
 
   public Map<ClusterMetadata.AppName, String> getC8Links() {
+    if (c8Links == null) {
+      return Collections.emptyMap();
+    }
     return c8Links;
   }
 
   public boolean canLogout() {
     return canLogout;
+  }
+
+  public boolean isApiUser() {
+    return apiUser;
   }
 
   private static List<SimpleGrantedAuthority> prepareAuthorities(final List<String> roles) {
@@ -122,7 +133,7 @@ public class CamundaUser extends User {
     private String password;
     private List<String> roles = List.of();
     private List<String> authorizedApplications = List.of();
-    private List<TenantEntity> tenants = List.of();
+    private List<TenantDTO> tenants = List.of();
     private List<String> groups = List.of();
     private String salesPlanType;
     private Map<ClusterMetadata.AppName, String> c8Links;
@@ -166,7 +177,7 @@ public class CamundaUser extends User {
       return this;
     }
 
-    public CamundaUserBuilder withTenants(final List<TenantEntity> tenants) {
+    public CamundaUserBuilder withTenants(final List<TenantDTO> tenants) {
       this.tenants = tenants;
       return this;
     }

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -9,7 +9,6 @@ package io.camunda.authentication.entity;
 
 import io.camunda.search.entities.TenantEntity;
 import io.camunda.security.entity.ClusterMetadata;
-import io.camunda.security.entity.Permission;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -22,7 +21,7 @@ public class CamundaUser extends User {
 
   private final Long userKey;
   private final String displayName;
-  private List<Permission> permissions = List.of();
+  private List<String> authorizedApplications = List.of();
   private List<TenantEntity> tenants = List.of();
   private List<String> groups = List.of();
   private String salesPlanType;
@@ -53,7 +52,7 @@ public class CamundaUser extends User {
       final String username,
       final String password,
       final List<String> roles,
-      final List<Permission> permissions,
+      final List<String> authorizedApplications,
       final List<TenantEntity> tenants,
       final List<String> groups,
       final String salesPlanType,
@@ -63,7 +62,7 @@ public class CamundaUser extends User {
     super(username, password, prepareAuthorities(roles));
     this.userKey = userKey;
     this.displayName = displayName;
-    this.permissions = permissions;
+    this.authorizedApplications = authorizedApplications;
     this.tenants = tenants;
     this.groups = groups;
     this.salesPlanType = salesPlanType;
@@ -92,8 +91,8 @@ public class CamundaUser extends User {
     return getAuthorities().stream().map(GrantedAuthority::getAuthority).toList();
   }
 
-  public List<Permission> getPermissions() {
-    return permissions;
+  public List<String> getAuthorizedApplications() {
+    return authorizedApplications;
   }
 
   public List<TenantEntity> getTenants() {
@@ -122,7 +121,7 @@ public class CamundaUser extends User {
     private String username;
     private String password;
     private List<String> roles = List.of();
-    private List<Permission> permissions = List.of();
+    private List<String> authorizedApplications = List.of();
     private List<TenantEntity> tenants = List.of();
     private List<String> groups = List.of();
     private String salesPlanType;
@@ -161,8 +160,9 @@ public class CamundaUser extends User {
       return this;
     }
 
-    public CamundaUserBuilder withPermissions(final List<Permission> permissions) {
-      this.permissions = permissions;
+    public CamundaUserBuilder withAuthorizedApplications(
+        final List<String> authorizedApplications) {
+      this.authorizedApplications = authorizedApplications;
       return this;
     }
 
@@ -203,7 +203,7 @@ public class CamundaUser extends User {
           username,
           password,
           roles,
-          permissions,
+          authorizedApplications,
           tenants,
           groups,
           salesPlanType,

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUser.java
@@ -13,6 +13,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -34,6 +35,7 @@ public class CamundaUser extends User {
     super(username, password, Collections.emptyList());
     this.userKey = userKey;
     this.displayName = displayName;
+    c8Links = Objects.requireNonNullElse(c8Links, Collections.emptyMap());
   }
 
   public CamundaUser(
@@ -44,6 +46,7 @@ public class CamundaUser extends User {
     super(username, password, prepareAuthorities(roles));
     userKey = null;
     this.displayName = displayName;
+    c8Links = Objects.requireNonNullElse(c8Links, Collections.emptyMap());
   }
 
   public CamundaUser(
@@ -66,7 +69,7 @@ public class CamundaUser extends User {
     this.tenants = tenants;
     this.groups = groups;
     this.salesPlanType = salesPlanType;
-    this.c8Links = c8Links;
+    this.c8Links = Objects.requireNonNullElse(c8Links, Collections.emptyMap());
     this.canLogout = canLogout;
     this.apiUser = apiUser;
   }
@@ -108,9 +111,6 @@ public class CamundaUser extends User {
   }
 
   public Map<ClusterMetadata.AppName, String> getC8Links() {
-    if (c8Links == null) {
-      return Collections.emptyMap();
-    }
     return c8Links;
   }
 

--- a/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
+++ b/authentication/src/main/java/io/camunda/authentication/entity/CamundaUserDTO.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.authentication.entity;
+
+import io.camunda.security.entity.ClusterMetadata;
+import io.camunda.service.TenantServices.TenantDTO;
+import java.util.List;
+import java.util.Map;
+
+public record CamundaUserDTO(
+    String userId,
+    Long userKey,
+    String displayName,
+    String username,
+    List<String> authorizedApplications,
+    List<TenantDTO> tenants,
+    List<String> groups,
+    List<String> roles,
+    String salesPlanType,
+    Map<ClusterMetadata.AppName, String> c8Links,
+    boolean canLogout,
+    boolean apiUser) {}

--- a/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/BasicCamundaUserService.java
@@ -8,6 +8,7 @@
 package io.camunda.authentication.service;
 
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.authentication.entity.CamundaUserDTO;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -17,17 +18,28 @@ import org.springframework.stereotype.Service;
 public class BasicCamundaUserService implements CamundaUserService {
 
   @Override
-  public CamundaUser getCurrentUser() {
-    return (CamundaUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  public CamundaUserDTO getCurrentUser() {
+    final var authenticatedUser =
+        (CamundaUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    return new CamundaUserDTO(
+        authenticatedUser.getUserId(),
+        authenticatedUser.getUserKey(),
+        authenticatedUser.getDisplayName(),
+        authenticatedUser
+            .getDisplayName(), // migrated for historical purposes username -> displayName
+        authenticatedUser.getAuthorizedApplications(),
+        authenticatedUser.getTenants(),
+        authenticatedUser.getGroups(),
+        authenticatedUser.getRoles(),
+        authenticatedUser.getSalesPlanType(),
+        authenticatedUser.getC8Links(),
+        authenticatedUser.canLogout(),
+        authenticatedUser.isApiUser());
   }
 
   @Override
   public String getUserToken() {
     return null;
-  }
-
-  @Override
-  public String getCurrentUsername() {
-    return getCurrentUser().getUsername();
   }
 }

--- a/authentication/src/main/java/io/camunda/authentication/service/CamundaUserService.java
+++ b/authentication/src/main/java/io/camunda/authentication/service/CamundaUserService.java
@@ -7,12 +7,10 @@
  */
 package io.camunda.authentication.service;
 
-import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.authentication.entity.CamundaUserDTO;
 
 public interface CamundaUserService {
-  CamundaUser getCurrentUser();
+  CamundaUserDTO getCurrentUser();
 
   String getUserToken();
-
-  String getCurrentUsername();
 }

--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -13,11 +13,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import io.camunda.authentication.entity.CamundaUser;
+import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
+import io.camunda.security.entity.Permission;
+import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -29,12 +36,13 @@ public class CamundaUserDetailsServiceTest {
   private static final String TEST_USER_ID = "username1";
 
   @Mock private UserServices userService;
+  @Mock private AuthorizationServices authorizationServices;
   private CamundaUserDetailsService userDetailsService;
 
   @Before
   public void setup() throws Exception {
     MockitoAnnotations.openMocks(this).close();
-    userDetailsService = new CamundaUserDetailsService(userService);
+    userDetailsService = new CamundaUserDetailsService(userService, authorizationServices);
   }
 
   @Test
@@ -46,6 +54,19 @@ public class CamundaUserDetailsServiceTest {
                 1,
                 List.of(new UserEntity(1L, TEST_USER_ID, "Foo Bar", "not@tested", "password1")),
                 null));
+
+    when(authorizationServices.search(any()))
+        .thenReturn(
+            new SearchQueryResult<>(
+                1,
+                List.of(
+                    new AuthorizationEntity(
+                        1L,
+                        AuthorizationOwnerType.USER.name(),
+                        AuthorizationResourceType.APPLICATION.name(),
+                        List.of(
+                            new Permission(PermissionType.ACCESS, Set.of("operate", "identity"))))),
+                null));
     // when
     final CamundaUser user = (CamundaUser) userDetailsService.loadUserByUsername(TEST_USER_ID);
 
@@ -55,6 +76,7 @@ public class CamundaUserDetailsServiceTest {
     assertThat(user.getName()).isEqualTo("Foo Bar");
     assertThat(user.getUsername()).isEqualTo(TEST_USER_ID);
     assertThat(user.getPassword()).isEqualTo("password1");
+    assertThat(user.getAuthorizedApplications()).containsExactlyInAnyOrder("operate", "identity");
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.client.protocol.rest.UserRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.util.Base64Util;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +71,7 @@ public class BasicAuthIT {
     content =
         objectMapper.writeValueAsString(
             new UserRequest()
-                .username("demo")
+                .username("demo-".concat(UUID.randomUUID().toString()))
                 .name("Demo")
                 .password("password")
                 .email("demo@email.com"));

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -16,14 +16,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.application.commons.CommonsModuleConfiguration;
+import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
+import io.camunda.security.entity.Permission;
+import io.camunda.service.AuthorizationServices;
 import io.camunda.service.UserServices;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.client.protocol.rest.UserRequest;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.util.Base64Util;
@@ -51,6 +58,7 @@ public class BasicAuthIT {
   private static final String USERNAME = "correct_username";
   private static final String PASSWORD = "correct_password";
   @MockBean UserServices userService;
+  @MockBean AuthorizationServices authorizationServices;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private MockMvc mockMvc;
@@ -66,6 +74,18 @@ public class BasicAuthIT {
             new SearchQueryResult<>(
                 1,
                 List.of(new UserEntity(1L, USERNAME, "name", "", passwordEncoder.encode(PASSWORD))),
+                null));
+
+    when(authorizationServices.search(any()))
+        .thenReturn(
+            new SearchQueryResult<>(
+                1,
+                List.of(
+                    new AuthorizationEntity(
+                        1L,
+                        AuthorizationOwnerType.USER.name(),
+                        AuthorizationResourceType.APPLICATION.name(),
+                        List.of(new Permission(PermissionType.ACCESS, Set.of("*"))))),
                 null));
 
     content =

--- a/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
+++ b/security/security-core/src/main/java/io/camunda/zeebe/protocol/record/value/PermissionType.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.protocol.record.value;
 
 public enum PermissionType {
+  ACCESS,
+
   CREATE,
   CREATE_PROCESS_INSTANCE,
   CREATE_DECISION_INSTANCE,

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -24,6 +24,7 @@ servers:
         description: The schema of the Camunda 8 REST API server.
 
 tags:
+  - name: Authentication
   - name: Authorization
   - name: Clock
   - name: Cluster

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -86,7 +86,7 @@ paths:
   /authentication/me:
     get:
       tags:
-        - authentication
+        - Authentication
       operationId: getAuthentication
       summary: Get current user
       description: Retrieves the current authenticated user.

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -4270,6 +4270,7 @@ components:
     PermissionTypeEnum:
       description: Specifies the type of permissions.
       enum:
+        - ACCESS
         - CREATE
         - CREATE_PROCESS_INSTANCE
         - CREATE_DECISION_INSTANCE

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -81,6 +81,26 @@ paths:
                 $ref: "#/components/schemas/LicenseResponse"
         "500":
           $ref: "#/components/responses/InternalServerError"
+
+  /authentication/me:
+    get:
+      tags:
+        - authentication
+      operationId: getAuthentication
+      summary: Get current user
+      description: Retrieves the current authenticated user.
+      responses:
+        "200":
+          description: The current user is successfully returned.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CamundaUser"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
   /jobs/activation:
     post:
       tags:
@@ -4442,6 +4462,63 @@ components:
         email:
           description: The email of the user.
           type: "string"
+    CamundaUser:
+      type: "object"
+      properties:
+          userId:
+            description: The ID of the user.
+            type: "string"
+          userKey:
+            description: The system generated key of the User
+            type: "integer"
+            format: "int64"
+          displayName:
+            description: The display name of the User
+            type: "string"
+          authorizedApplications:
+            description: The applications the User is authorized to use
+            type: array
+            items:
+              type: "string"
+          tenants:
+            description: The tenants the User is a member of
+            type: array
+            items:
+              type: "object"
+              properties:
+                tenantId:
+                  type: "string"
+                name:
+                  type: "string"
+          groups:
+            description: The groups assigned to the user
+            type: array
+            items:
+              type: "string"
+          roles:
+            description: The roles assigned to the user
+            type: array
+            items:
+              type: "string"
+          salesPlanType:
+            description: The plan of the user
+            type: "string"
+          c8Links:
+            description: The links to the components in the C8 stack
+            type: array
+            items:
+              type: "object"
+              properties:
+                name:
+                  type: "string"
+                link:
+                  type: "string"
+          canLogout:
+            description: Flag for understanding if the user is able to perform logout
+            type: boolean
+          apiUser:
+            description: Flag for understanding if the user is an API user
+            type: boolean
     UserResponse:
       type: "object"
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AuthenticationController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/AuthenticationController.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.authentication.entity.CamundaUserDTO;
+import io.camunda.authentication.service.CamundaUserService;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Profile("auth-basic")
+@CamundaRestController
+@RequestMapping("/v2/authentication")
+public class AuthenticationController {
+  private final CamundaUserService camundaUserService;
+
+  public AuthenticationController(final CamundaUserService camundaUserService) {
+    this.camundaUserService = camundaUserService;
+  }
+
+  @GetMapping(
+      path = "/me",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CamundaUserDTO getCurrentUser() {
+    return camundaUserService.getCurrentUser();
+  }
+}


### PR DESCRIPTION
## Description
<!-- Describe the goal and purpose of this PR. -->
As described in the linked issue, webapps need to use a new method of applying access to the UI, this PR tackles a couple of important parts:
- [Refactor] expose a refined user object to only show the fields that are relevant to the end users
- [Feat] implement a new AuthenticationController that exposes an `/authentication/me` endpoint to retrieve the logged in user
- [Feat] add a field to show the authorized applications 

## Related issues

closes https://github.com/camunda/camunda/issues/25416
