### PR TITLE
Forward user claims to the broker

### DIFF
--- a/zeebe/auth/pom.xml
+++ b/zeebe/auth/pom.xml
@@ -40,6 +40,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/JwtDecoder.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/JwtDecoder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.auth;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.Claim;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class JwtDecoder {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private final String token;
+  private DecodedJWT decodedJwt;
+
+  public JwtDecoder(final String token) {
+    if (token == null || token.trim().isEmpty()) {
+      throw new IllegalArgumentException("Token cannot be null or empty");
+    }
+    this.token = token;
+  }
+
+  /**
+   * Explicitly decode the JWT. This is optional since claims access auto-decodes.
+   *
+   * @return the current JwtDecoder instance
+   * @throws RuntimeException if decoding fails
+   */
+  public JwtDecoder decode() {
+    if (decodedJwt == null) {
+      try {
+        decodedJwt = JWT.decode(token);
+      } catch (final Exception e) {
+        throw new RuntimeException("Failed to decode JWT: " + e.getMessage(), e);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Retrieves all claims as a Map<String, Object>. Automatically decodes the token if it hasn't
+   * been decoded yet.
+   *
+   * @return Map of claims
+   */
+  public Map<String, Object> getClaims() {
+    if (decodedJwt == null) {
+      decode();
+    }
+    return convertClaimsToMap();
+  }
+
+  /**
+   * Converts claims from DecodedJWT into a Map<String, Object>.
+   *
+   * @return Map of claims
+   */
+  private Map<String, Object> convertClaimsToMap() {
+    final Map<String, Claim> claims = decodedJwt.getClaims();
+    if (claims.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    final Map<String, Object> claimsMap = new HashMap<>();
+    claims.forEach((key, claim) -> claimsMap.put(key, convertClaimValue(claim)));
+    return claimsMap;
+  }
+
+  /**
+   * Converts a Claim object into a generic Java Object. Supports nested JSON objects, lists, and
+   * standard data types.
+   *
+   * @param claim the Claim to convert
+   * @return the value as an Object
+   */
+  private Object convertClaimValue(final Claim claim) {
+    if (claim.isNull()) {
+      return null;
+    }
+
+    try {
+      return objectMapper.readValue(claim.asString(), new TypeReference<Map<String, Object>>() {});
+    } catch (final Exception e) {
+      // Fallback to basic types
+      if (claim.asBoolean() != null) {
+        return claim.asBoolean();
+      }
+      if (claim.asInt() != null) {
+        return claim.asInt();
+      }
+      if (claim.asLong() != null) {
+        return claim.asLong();
+      }
+      if (claim.asDouble() != null) {
+        return claim.asDouble();
+      }
+      if (claim.asList(String.class) != null) {
+        return claim.asList(String.class);
+      }
+      return claim.asString(); // Default to string if no other type matches
+    }
+  }
+}

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/JwtDecoder.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/JwtDecoder.java
@@ -18,7 +18,7 @@ import java.util.Map;
 
 public class JwtDecoder {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final String token;
   private DecodedJWT decodedJwt;
 
@@ -88,7 +88,7 @@ public class JwtDecoder {
     }
 
     try {
-      return objectMapper.readValue(claim.asString(), new TypeReference<Map<String, Object>>() {});
+      return OBJECT_MAPPER.readValue(claim.asString(), new TypeReference<Map<String, Object>>() {});
     } catch (final Exception e) {
       // Fallback to basic types
       if (claim.asBoolean() != null) {

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/api/JwtAuthorizationBuilder.java
@@ -19,7 +19,6 @@ public interface JwtAuthorizationBuilder<T extends JwtAuthorizationBuilder<T, A,
   public static String DEFAULT_ISSUER = "zeebe-gateway";
   public static String DEFAULT_AUDIENCE = "zeebe-broker";
   public static String DEFAULT_SUBJECT = "zeebe-client";
-  public static final String USER_TOKEN_CLAIM_PREFIX = "user_token_";
 
   /**
    * Sets the token subject.

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/Authorization.java
@@ -11,6 +11,7 @@ public class Authorization {
 
   public static final String AUTHORIZED_TENANTS = "authorized_tenants";
   public static final String AUTHORIZED_USER_KEY = "authorized_user_key";
+  public static final String USER_TOKEN_CLAIM_PREFIX = "user_token_";
 
   public static JwtAuthorizationEncoder jwtEncoder() {
     return new JwtAuthorizationEncoder();

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -93,6 +93,7 @@ public class JwtAuthorizationDecoder
     claimMap.putAll(
         decodedJWT.getClaims().entrySet().stream()
             .filter(entry -> entry.getKey().startsWith(Authorization.USER_TOKEN_CLAIM_PREFIX))
+            .filter(entry -> !entry.getValue().isNull())
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey, claimEntry -> claimEntry.getValue().as(Object.class))));

--- a/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
+++ b/zeebe/auth/src/main/java/io/camunda/zeebe/auth/impl/JwtAuthorizationDecoder.java
@@ -92,7 +92,7 @@ public class JwtAuthorizationDecoder
 
     claimMap.putAll(
         decodedJWT.getClaims().entrySet().stream()
-            .filter(entry -> entry.getKey().startsWith(USER_TOKEN_CLAIM_PREFIX))
+            .filter(entry -> entry.getKey().startsWith(Authorization.USER_TOKEN_CLAIM_PREFIX))
             .collect(
                 Collectors.toMap(
                     Map.Entry::getKey, claimEntry -> claimEntry.getValue().as(Object.class))));

--- a/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
+++ b/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtAuthorizationTest.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.auth;
 import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_AUDIENCE;
 import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_ISSUER;
 import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.DEFAULT_SUBJECT;
-import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.USER_TOKEN_CLAIM_PREFIX;
+import static io.camunda.zeebe.auth.impl.Authorization.USER_TOKEN_CLAIM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtDecoderTest.java
+++ b/zeebe/auth/src/test/java/io/camunda/zeebe/auth/JwtDecoderTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import java.util.Date;
+import org.junit.jupiter.api.Test;
+
+public class JwtDecoderTest {
+
+  @Test
+  void shouldDecodeAndGetClaims() {
+    // given
+    final var jwtDecoder = new JwtDecoder(generateToken());
+
+    // when
+    final var claims = jwtDecoder.decode().getClaims();
+
+    // then
+    assertThat(claims)
+        .containsEntry("role", "admin")
+        .containsEntry("foo", "bar")
+        .containsEntry("baz", "qux");
+  }
+
+  @Test
+  void shouldDecodeAndGetClaimsWithoutDecodingFirst() {
+    // given
+    final var jwtDecoder = new JwtDecoder(generateToken());
+
+    // when
+    final var claims = jwtDecoder.getClaims();
+
+    // then
+    assertThat(claims)
+        .containsEntry("role", "admin")
+        .containsEntry("foo", "bar")
+        .containsEntry("baz", "qux");
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenTokenIsNull() {
+    assertThrows(IllegalArgumentException.class, () -> new JwtDecoder(null));
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenTokenIsEmpty() {
+    assertThrows(IllegalArgumentException.class, () -> new JwtDecoder(""));
+  }
+
+  @Test
+  void shouldRaiseExceptionWhenTokenIsInvalid() {
+    // given
+    final var decoder = new JwtDecoder("invalid-token");
+
+    // then
+    assertThrows(RuntimeException.class, decoder::decode);
+  }
+
+  private String generateToken() {
+    final Algorithm algorithm = Algorithm.HMAC256("secret-key");
+
+    return JWT.create()
+        .withIssuer("test-issuer")
+        .withSubject("test-user")
+        .withAudience("test-audience")
+        .withClaim("role", "admin")
+        .withClaim("foo", "bar")
+        .withClaim("baz", "qux")
+        .withExpiresAt(new Date(System.currentTimeMillis() + 60 * 60 * 1000)) // Expires in 1 hour
+        .sign(algorithm);
+  }
+}

--- a/zeebe/gateway-grpc/pom.xml
+++ b/zeebe/gateway-grpc/pom.xml
@@ -228,6 +228,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.auth0</groupId>
+      <artifactId>java-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
       <scope>runtime</scope>

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -506,7 +507,7 @@ public final class EndpointManager {
 
     // retrieve the user claims from the context and add them to the token
     final Map<String, Object> userClaims =
-        Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get());
+        Context.current().call(AuthenticationInterceptor.USER_CLAIMS::get);
     if (userClaims != null) {
       userClaims.forEach(
           (key, value) -> {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.ContextInjectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.DecoratedInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
@@ -394,6 +395,7 @@ public final class Gateway implements CloseableSilently {
       } else {
         interceptors.add(new IdentityInterceptor(identityCfg, gatewayCfg.getMultiTenancy()));
       }
+      interceptors.add(new AuthenticationInterceptor());
     }
 
     return ServerInterceptors.intercept(service, interceptors);

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -7,16 +7,20 @@
  */
 package io.camunda.zeebe.gateway.interceptors;
 
+import com.auth0.jwt.interfaces.Claim;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.grpc.Context;
 import io.grpc.Context.Key;
 import java.util.List;
+import java.util.Map;
 
 /** A set of utilities which interceptor authors can use in their interceptors. */
 public final class InterceptorUtil {
   private static final Key<QueryApi> QUERY_API_KEY = Context.key("zeebe-query-api");
   private static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
       Context.key("io.camunda.zeebe:authorized_tenants");
+  private static final Context.Key<Map<String, Claim>> USER_CLAIMS =
+      Context.key("io.camunda.zeebe:user_claim");
 
   private InterceptorUtil() {}
 
@@ -107,5 +111,19 @@ public final class InterceptorUtil {
    */
   public static Context setAuthorizedTenants(final List<String> authorizedTenants) {
     return Context.current().withValue(getAuthorizedTenantsKey(), authorizedTenants);
+  }
+
+  public static Key<Map<String, Claim>> getUserClaimsKey() {
+    return USER_CLAIMS;
+  }
+
+  /**
+   * A helper method to set a {@link Map<String, Claim>} of user claims on the {@code USER_CLAIMS} gRPC Context key.
+   *
+   * @param userClaims - a Map of Strings to Claims that specify the user claims for the gRPC request
+   * @return the current {@link Context}
+   */
+  public static Context setUserClaims(final Map<String, Claim> userClaims) {
+    return Context.current().withValue(getUserClaimsKey(), userClaims);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.interceptors;
 
-import com.auth0.jwt.interfaces.Claim;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.grpc.Context;
 import io.grpc.Context.Key;
@@ -19,7 +18,7 @@ public final class InterceptorUtil {
   private static final Key<QueryApi> QUERY_API_KEY = Context.key("zeebe-query-api");
   private static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
       Context.key("io.camunda.zeebe:authorized_tenants");
-  private static final Context.Key<Map<String, Claim>> USER_CLAIMS =
+  private static final Context.Key<Map<String, Object>> USER_CLAIMS =
       Context.key("io.camunda.zeebe:user_claim");
 
   private InterceptorUtil() {}
@@ -113,19 +112,19 @@ public final class InterceptorUtil {
     return Context.current().withValue(getAuthorizedTenantsKey(), authorizedTenants);
   }
 
-  public static Key<Map<String, Claim>> getUserClaimsKey() {
+  public static Key<Map<String, Object>> getUserClaimsKey() {
     return USER_CLAIMS;
   }
 
   /**
-   * A helper method to set a {@link Map<String, Claim>} of user claims on the {@code USER_CLAIMS}
+   * A helper method to set a {@link Map<String, Object>} of user claims on the {@code USER_CLAIMS}
    * gRPC Context key.
    *
    * @param userClaims - a Map of Strings to Claims that specify the user claims for the gRPC
    *     request
    * @return the current {@link Context}
    */
-  public static Context setUserClaims(final Map<String, Claim> userClaims) {
+  public static Context setUserClaims(final Map<String, Object> userClaims) {
     return Context.current().withValue(getUserClaimsKey(), userClaims);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -118,9 +118,11 @@ public final class InterceptorUtil {
   }
 
   /**
-   * A helper method to set a {@link Map<String, Claim>} of user claims on the {@code USER_CLAIMS} gRPC Context key.
+   * A helper method to set a {@link Map<String, Claim>} of user claims on the {@code USER_CLAIMS}
+   * gRPC Context key.
    *
-   * @param userClaims - a Map of Strings to Claims that specify the user claims for the gRPC request
+   * @param userClaims - a Map of Strings to Claims that specify the user claims for the gRPC
+   *     request
    * @return the current {@link Context}
    */
   public static Context setUserClaims(final Map<String, Claim> userClaims) {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -11,15 +11,12 @@ import io.camunda.zeebe.gateway.query.QueryApi;
 import io.grpc.Context;
 import io.grpc.Context.Key;
 import java.util.List;
-import java.util.Map;
 
 /** A set of utilities which interceptor authors can use in their interceptors. */
 public final class InterceptorUtil {
   private static final Key<QueryApi> QUERY_API_KEY = Context.key("zeebe-query-api");
   private static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
       Context.key("io.camunda.zeebe:authorized_tenants");
-  private static final Context.Key<Map<String, Object>> USER_CLAIMS =
-      Context.key("io.camunda.zeebe:user_claim");
 
   private InterceptorUtil() {}
 
@@ -110,21 +107,5 @@ public final class InterceptorUtil {
    */
   public static Context setAuthorizedTenants(final List<String> authorizedTenants) {
     return Context.current().withValue(getAuthorizedTenantsKey(), authorizedTenants);
-  }
-
-  public static Key<Map<String, Object>> getUserClaimsKey() {
-    return USER_CLAIMS;
-  }
-
-  /**
-   * A helper method to set a {@link Map<String, Object>} of user claims on the {@code USER_CLAIMS}
-   * gRPC Context key.
-   *
-   * @param userClaims - a Map of Strings to Claims that specify the user claims for the gRPC
-   *     request
-   * @return the current {@link Context}
-   */
-  public static Context setUserClaims(final Map<String, Object> userClaims) {
-    return Context.current().withValue(getUserClaimsKey(), userClaims);
   }
 }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import com.auth0.jwt.JWT;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthenticationInterceptor implements ServerInterceptor {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationInterceptor.class);
+  private static final Metadata.Key<String> AUTH_KEY =
+      Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
+      final Metadata headers, final ServerCallHandler<ReqT, RespT> next) {
+    final var methodDescriptor = call.getMethodDescriptor();
+
+    final var authorization = headers.get(AUTH_KEY);
+    if (authorization == null) {
+      LOGGER.debug(
+          "Denying call {} as no token was provided", methodDescriptor.getFullMethodName());
+      return deny(
+          call,
+          Status.UNAUTHENTICATED.augmentDescription(
+              "Expected bearer token at header with key [%s], but found nothing"
+                  .formatted(AUTH_KEY.name())));
+    }
+
+    final String token = authorization.replaceFirst("^Bearer ", "");
+
+    // TODO verify the token, do we really want to delete the identity SDK ? It's not easy to verify a token
+
+    try {
+      // get user claims and set them in the context
+      final var decodedJWT = JWT.decode(token);
+      final var claims = decodedJWT.getClaims();
+      final var context = InterceptorUtil.setUserClaims(claims);
+      return Contexts.interceptCall(context, call, headers, next);
+
+    } catch (final RuntimeException e) {
+      LOGGER.debug(
+          "Denying call {} as the token is not valid. Error message: {}",
+          methodDescriptor.getFullMethodName(),
+          e.getMessage());
+      return deny(
+          call,
+          Status.UNAUTHENTICATED
+              .augmentDescription(
+                  "Expected a valid token, see cause for details")
+              .withCause(e));
+    }
+  }
+
+  private <ReqT> ServerCall.Listener<ReqT> deny(
+      final ServerCall<ReqT, ?> call, final Status status) {
+    call.close(status, new Metadata());
+    return new ServerCall.Listener<>() {};
+  }
+}

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -26,8 +26,10 @@ public class AuthenticationInterceptor implements ServerInterceptor {
       Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
   @Override
-  public <ReqT, RespT> Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> call,
-      final Metadata headers, final ServerCallHandler<ReqT, RespT> next) {
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
     final var methodDescriptor = call.getMethodDescriptor();
 
     final var authorization = headers.get(AUTH_KEY);
@@ -43,7 +45,8 @@ public class AuthenticationInterceptor implements ServerInterceptor {
 
     final String token = authorization.replaceFirst("^Bearer ", "");
 
-    // TODO verify the token, do we really want to delete the identity SDK ? It's not easy to verify a token
+    // TODO verify the token, do we really want to delete the identity SDK ? It's not easy to verify
+    // a token
 
     try {
       // get user claims and set them in the context
@@ -60,8 +63,7 @@ public class AuthenticationInterceptor implements ServerInterceptor {
       return deny(
           call,
           Status.UNAUTHENTICATED
-              .augmentDescription(
-                  "Expected a valid token, see cause for details")
+              .augmentDescription("Expected a valid token, see cause for details")
               .withCause(e));
     }
   }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.interceptors.impl;
 
-import com.auth0.jwt.JWT;
+import io.camunda.zeebe.auth.JwtDecoder;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.grpc.Contexts;
 import io.grpc.Metadata;
@@ -50,8 +50,8 @@ public class AuthenticationInterceptor implements ServerInterceptor {
 
     try {
       // get user claims and set them in the context
-      final var decodedJWT = JWT.decode(token);
-      final var claims = decodedJWT.getClaims();
+      final JwtDecoder jwtDecoder = new JwtDecoder(token);
+      final var claims = jwtDecoder.decode().getClaims();
       final var context = InterceptorUtil.setUserClaims(claims);
       return Contexts.interceptCall(context, call, headers, next);
 

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
+import io.camunda.zeebe.gateway.interceptors.impl.AuthenticationInterceptor;
 import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayBlockingStub;
@@ -96,7 +97,10 @@ public final class StubbedGateway {
         InProcessServerBuilder.forName(SERVER_NAME)
             .addService(
                 ServerInterceptors.intercept(
-                    gatewayGrpcService, new IdentityInterceptor(identity, multiTenancy)));
+                    gatewayGrpcService, new IdentityInterceptor(identity, multiTenancy)))
+            .addService(
+                ServerInterceptors.intercept(
+                    gatewayGrpcService, new AuthenticationInterceptor()));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -99,8 +99,7 @@ public final class StubbedGateway {
                 ServerInterceptors.intercept(
                     gatewayGrpcService, new IdentityInterceptor(identity, multiTenancy)))
             .addService(
-                ServerInterceptors.intercept(
-                    gatewayGrpcService, new AuthenticationInterceptor()));
+                ServerInterceptors.intercept(gatewayGrpcService, new AuthenticationInterceptor()));
     server = serverBuilder.build();
     server.start();
   }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithAuthorizationInfoTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/impl/BrokerRequestWithAuthorizationInfoTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.gateway.api.deployment.DeployResourceStub;
+import io.camunda.zeebe.gateway.api.job.ActivateJobsStub;
+import io.camunda.zeebe.gateway.api.process.CreateProcessInstanceStub;
+import io.camunda.zeebe.gateway.api.signal.BroadcastSignalStub;
+import io.camunda.zeebe.gateway.api.util.GatewayTest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CreateProcessInstanceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.DeployResourceResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.EvaluateDecisionResponse;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+
+public class BrokerRequestWithAuthorizationInfoTest extends GatewayTest {
+
+  private final ActivateJobsStub activateJobsStub = new ActivateJobsStub();
+
+  @Before
+  public void setup() {
+    new DeployResourceStub().registerWith(brokerClient);
+    new CreateProcessInstanceStub().registerWith(brokerClient);
+    new TenantAwareEvaluateDecisionStub().registerWith(brokerClient);
+    new BroadcastSignalStub().registerWith(brokerClient);
+    activateJobsStub.registerWith(brokerClient);
+  }
+
+  @Test
+  public void deployResourceRequestShouldContainUserClaims() {
+    // when
+    final DeployResourceResponse response =
+        client.deployResource(DeployResourceRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertContainsUserClaims();
+  }
+
+  @Test
+  public void createProcessInstanceRequestShouldContainUserClaims() {
+    // when
+    final CreateProcessInstanceResponse response =
+        client.createProcessInstance(CreateProcessInstanceRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertContainsUserClaims();
+  }
+
+  @Test
+  public void evaluateDecisionRequestShouldContainUserClaims() {
+    // when
+    final EvaluateDecisionResponse response =
+        client.evaluateDecision(EvaluateDecisionRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertContainsUserClaims();
+  }
+
+  @Test
+  public void activateJobsRequestShouldContainUserClaims() {
+    // given
+    final String jobType = "testType";
+    final String jobWorker = "testWorker";
+    final int maxJobsToActivate = 1;
+    activateJobsStub.addAvailableJobs(jobType, maxJobsToActivate);
+
+    // when
+    final Iterator<ActivateJobsResponse> response =
+        client.activateJobs(
+            ActivateJobsRequest.newBuilder()
+                .setType(jobType)
+                .setWorker(jobWorker)
+                .setMaxJobsToActivate(maxJobsToActivate)
+                .build());
+    assertThat(response.hasNext()).isTrue();
+
+    // then
+    assertContainsUserClaims();
+  }
+
+  @Test
+  public void broadcastSignalRequestShouldContainUserClaims() {
+    // when
+    final BroadcastSignalResponse response =
+        client.broadcastSignal(BroadcastSignalRequest.newBuilder().build());
+    assertThat(response).isNotNull();
+
+    // then
+    assertContainsUserClaims();
+  }
+
+  private void assertContainsUserClaims() {
+    assertThatAuthorizationInfoIsSet(Map.of("role", "admin", "foo", "bar", "baz", "qux"));
+  }
+
+  private void assertThatAuthorizationInfoIsSet(final Map<String, Object> claims) {
+    final Map<String, Object> mapToCheck =
+        claims.entrySet().stream()
+            .map(
+                entry ->
+                    Map.entry(
+                        Authorization.USER_TOKEN_CLAIM_PREFIX + entry.getKey(), entry.getValue()))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    final BrokerExecuteCommand<?> brokerRequest = brokerClient.getSingleBrokerRequest();
+    final Map<String, Object> decodedMap = brokerRequest.getAuthorization().toDecodedMap();
+
+    assertThat(decodedMap).containsAllEntriesOf(mapToCheck);
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -8,10 +8,7 @@
 package io.camunda.zeebe.gateway.interceptors.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
@@ -25,7 +22,6 @@ import io.grpc.ServerCallHandler;
 import io.grpc.Status;
 import java.util.Date;
 import java.util.concurrent.atomic.AtomicReference;
-import org.assertj.core.api.ListAssert;
 import org.assertj.core.api.MapAssert;
 import org.junit.jupiter.api.Test;
 
@@ -36,7 +32,8 @@ public class AuthenticationInterceptorTest {
     // when
     final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
         new CloseStatusCapturingServerCall();
-    new AuthenticationInterceptor().interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
+    new AuthenticationInterceptor()
+        .interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
 
     // then
     assertThat(closeStatusCapturingServerCall.closeStatus)
@@ -81,14 +78,10 @@ public class AuthenticationInterceptorTest {
             metadata,
             (call, headers) -> {
               // then
-              assertUserClaims()
-                  .containsKey("role")
-                  .containsKey("foo")
-                  .containsKey("baz");
+              assertUserClaims().containsKey("role").containsKey("foo").containsKey("baz");
               call.close(Status.OK, headers);
               return null;
             });
-
   }
 
   private Metadata createAuthHeader() {
@@ -113,8 +106,7 @@ public class AuthenticationInterceptorTest {
 
   private static MapAssert<String, Claim> assertUserClaims() {
     try {
-      return assertThat(
-          Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get()));
+      return assertThat(Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve user claims from context", e);
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
@@ -105,7 +104,7 @@ public class AuthenticationInterceptorTest {
 
   private static MapAssert<String, Object> assertUserClaims() {
     try {
-      return assertThat(Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get()));
+      return assertThat(Context.current().call(() -> AuthenticationInterceptor.USER_CLAIMS.get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve user claims from context", e);
     }

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.Claim;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCallHandler;
+import io.grpc.Status;
+import java.util.Date;
+import java.util.concurrent.atomic.AtomicReference;
+import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.MapAssert;
+import org.junit.jupiter.api.Test;
+
+public class AuthenticationInterceptorTest {
+
+  @Test
+  public void missingTokenIsRejected() {
+    // when
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+    new AuthenticationInterceptor().interceptCall(closeStatusCapturingServerCall, new Metadata(), failingNextHandler());
+
+    // then
+    assertThat(closeStatusCapturingServerCall.closeStatus)
+        .hasValueSatisfying(
+            status -> {
+              assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
+              assertThat(status.getDescription())
+                  .isEqualTo(
+                      "Expected bearer token at header with key [authorization], but found nothing");
+            });
+  }
+
+  @Test
+  public void validTokenIsAccepted() {
+    // when
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+    new AuthenticationInterceptor()
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            createAuthHeader(),
+            (call, headers) -> {
+              call.close(Status.OK, headers);
+              return null;
+            });
+
+    // then
+    assertThat(closeStatusCapturingServerCall.closeStatus).hasValue(Status.OK);
+  }
+
+  @Test
+  public void addsUserClaimsToContext() {
+    // given
+    final Metadata metadata = createAuthHeader();
+    final CloseStatusCapturingServerCall closeStatusCapturingServerCall =
+        new CloseStatusCapturingServerCall();
+
+    // when
+    new AuthenticationInterceptor()
+        .interceptCall(
+            closeStatusCapturingServerCall,
+            metadata,
+            (call, headers) -> {
+              // then
+              assertUserClaims()
+                  .containsKey("role")
+                  .containsKey("foo")
+                  .containsKey("baz");
+              call.close(Status.OK, headers);
+              return null;
+            });
+
+  }
+
+  private Metadata createAuthHeader() {
+    final Metadata metadata = new Metadata();
+    metadata.put(Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), generateToken());
+    return metadata;
+  }
+
+  private String generateToken() {
+    final Algorithm algorithm = Algorithm.HMAC256("secret-key");
+
+    return JWT.create()
+        .withIssuer("test-issuer")
+        .withSubject("test-user")
+        .withAudience("test-audience")
+        .withClaim("role", "admin")
+        .withClaim("foo", "bar")
+        .withClaim("baz", "qux")
+        .withExpiresAt(new Date(System.currentTimeMillis() + 60 * 60 * 1000)) // Expires in 1 hour
+        .sign(algorithm);
+  }
+
+  private static MapAssert<String, Claim> assertUserClaims() {
+    try {
+      return assertThat(
+          Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get()));
+    } catch (final Exception e) {
+      throw new RuntimeException("Unable to retrieve user claims from context", e);
+    }
+  }
+
+  private ServerCallHandler<Object, Object> failingNextHandler() {
+    return (call, headers) -> {
+      throw new RuntimeException("Should not be invoked");
+    };
+  }
+
+  private static final class CloseStatusCapturingServerCall extends NoopServerCall<Object, Object> {
+    private final AtomicReference<Status> closeStatus = new AtomicReference<>();
+
+    @Override
+    public void close(final Status status, final Metadata trailers) {
+      closeStatus.set(status);
+    }
+
+    @Override
+    public MethodDescriptor<Object, Object> getMethodDescriptor() {
+      return mock(MethodDescriptor.class);
+    }
+  }
+}

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/AuthenticationInterceptorTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.Claim;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.grpc.Context;
 import io.grpc.Metadata;
@@ -104,7 +103,7 @@ public class AuthenticationInterceptorTest {
         .sign(algorithm);
   }
 
-  private static MapAssert<String, Claim> assertUserClaims() {
+  private static MapAssert<String, Object> assertUserClaims() {
     try {
       return assertThat(Context.current().call(() -> InterceptorUtil.getUserClaimsKey().get()));
     } catch (final Exception e) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.USER_TOKEN_CLAIM_PREFIX;
 import static io.camunda.zeebe.gateway.rest.validator.AuthorizationRequestValidator.validateAuthorizationAssignRequest;
 import static io.camunda.zeebe.gateway.rest.validator.ClockValidator.validateClockPinRequest;
 import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentLinkParams;
@@ -481,7 +480,9 @@ public class RequestMapper {
       if (requestAuthentication instanceof final JwtAuthenticationToken jwtAuthenticationToken) {
         jwtAuthenticationToken
             .getTokenAttributes()
-            .forEach((key, value) -> token.withClaim(USER_TOKEN_CLAIM_PREFIX + key, value));
+            .forEach(
+                (key, value) ->
+                    token.withClaim(Authorization.USER_TOKEN_CLAIM_PREFIX + key, value));
       }
     }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RequestMapperTest.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
-import static io.camunda.zeebe.auth.api.JwtAuthorizationBuilder.USER_TOKEN_CLAIM_PREFIX;
+import static io.camunda.zeebe.auth.impl.Authorization.USER_TOKEN_CLAIM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR adds a new interceptor to decode the token, get the user claims from the decoded token and set them into the gRPC context. When the request is forwarded to the broker the user claims are set into the Authorization metadata in a token format.
See commits messages for more details

❗ ❓  The token validation is NOT part of this PR. Since is not easy to implement we need to discuss more in details about it

## Related issues

closes #23907 
