### PR TITLE
I can activate an ad-hoc subprocess

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -38,6 +38,7 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
               BpmnModelConstants.BPMN_ELEMENT_PROCESS,
               BpmnModelConstants.BPMN_ELEMENT_SUB_PROCESS,
               BpmnModelConstants.BPMN_ELEMENT_CALL_ACTIVITY,
+              BpmnModelConstants.BPMN_ELEMENT_AD_HOC_SUB_PROCESS,
               // tasks
               BpmnModelConstants.BPMN_ELEMENT_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SEND_TASK,

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -134,7 +134,7 @@ public class ZeebeExecutionListenersValidationTest {
         expect(
             ZeebeExecutionListeners.class,
             "Execution listeners are not supported for the 'sequenceFlow' element. "
-                + "Currently, only [process, subProcess, callActivity, task, sendTask, serviceTask, "
+                + "Currently, only [process, subProcess, callActivity, adHocSubProcess, task, sendTask, serviceTask, "
                 + "scriptTask, userTask, receiveTask, businessRuleTask, manualTask, startEvent, "
                 + "intermediateThrowEvent, intermediateCatchEvent, boundaryEvent, endEvent, "
                 + "exclusiveGateway, inclusiveGateway, parallelGateway, eventBasedGateway] "

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessors.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.container.AdHocSubProcessProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.container.CallActivityProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.container.EventSubProcessProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.container.MultiInstanceBodyProcessor;
@@ -96,6 +97,9 @@ public final class BpmnElementProcessors {
     processors.put(
         BpmnElementType.CALL_ACTIVITY,
         new CallActivityProcessor(bpmnBehaviors, stateTransitionBehavior));
+    processors.put(
+        BpmnElementType.AD_HOC_SUB_PROCESS,
+        new AdHocSubProcessProcessor(bpmnBehaviors, stateTransitionBehavior));
 
     // events
     processors.put(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/AdHocSubProcessProcessor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.container;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContainerProcessor;
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableAdHocSubProcess;
+import io.camunda.zeebe.util.Either;
+
+public class AdHocSubProcessProcessor
+    implements BpmnElementContainerProcessor<ExecutableAdHocSubProcess> {
+
+  private final BpmnStateBehavior stateBehavior;
+  private final BpmnStateTransitionBehavior stateTransitionBehavior;
+  private final BpmnVariableMappingBehavior variableMappingBehavior;
+  private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
+  private final BpmnJobBehavior jobBehavior;
+  private final BpmnIncidentBehavior incidentBehavior;
+
+  public AdHocSubProcessProcessor(
+      final BpmnBehaviors bpmnBehaviors,
+      final BpmnStateTransitionBehavior stateTransitionBehavior) {
+    stateBehavior = bpmnBehaviors.stateBehavior();
+    variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
+    eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
+    jobBehavior = bpmnBehaviors.jobBehavior();
+    incidentBehavior = bpmnBehaviors.incidentBehavior();
+    this.stateTransitionBehavior = stateTransitionBehavior;
+  }
+
+  @Override
+  public Class<ExecutableAdHocSubProcess> getType() {
+    return ExecutableAdHocSubProcess.class;
+  }
+
+  @Override
+  public Either<Failure, ?> onActivate(
+      final ExecutableAdHocSubProcess element, final BpmnElementContext context) {
+    return variableMappingBehavior.applyInputMappings(context, element);
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeActivation(
+      final ExecutableAdHocSubProcess element, final BpmnElementContext context) {
+
+    return eventSubscriptionBehavior
+        .subscribeToEvents(element, context)
+        .thenDo(
+            ok -> stateTransitionBehavior.transitionToActivated(context, element.getEventType()));
+  }
+
+  @Override
+  public void onTerminate(
+      final ExecutableAdHocSubProcess element, final BpmnElementContext terminating) {
+
+    if (element.hasExecutionListeners()) {
+      jobBehavior.cancelJob(terminating);
+    }
+    eventSubscriptionBehavior.unsubscribeFromEvents(terminating);
+    incidentBehavior.resolveIncidents(terminating);
+
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(terminating);
+
+    eventSubscriptionBehavior
+        .findEventTrigger(terminating)
+        .filter(eventTrigger -> flowScopeInstance.isActive() && !flowScopeInstance.isInterrupted())
+        .ifPresentOrElse(
+            eventTrigger -> {
+              final var terminated =
+                  stateTransitionBehavior.transitionToTerminated(
+                      terminating, element.getEventType());
+
+              eventSubscriptionBehavior.activateTriggeredEvent(
+                  terminated.getElementInstanceKey(),
+                  terminated.getFlowScopeKey(),
+                  eventTrigger,
+                  terminated);
+            },
+            () -> {
+              final var terminated =
+                  stateTransitionBehavior.transitionToTerminated(
+                      terminating, element.getEventType());
+
+              stateTransitionBehavior.onElementTerminated(element, terminated);
+            });
+  }
+
+  @Override
+  public void afterExecutionPathCompleted(
+      final ExecutableAdHocSubProcess element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext,
+      final Boolean satisfiesCompletionCondition) {}
+
+  @Override
+  public void onChildTerminated(
+      final ExecutableAdHocSubProcess element,
+      final BpmnElementContext flowScopeContext,
+      final BpmnElementContext childContext) {}
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementTypeTest.java
@@ -393,6 +393,16 @@ public final class BpmnElementTypeTest {
                   .endEvent()
                   .done();
             }
+          },
+          new BpmnElementTypeScenario("Ad-hoc subprocess", BpmnElementType.AD_HOC_SUB_PROCESS) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .adHocSubProcess(elementId(), adHocSubProcess -> adHocSubProcess.task("task"))
+                  .endEvent()
+                  .done();
+            }
           });
 
   @Rule

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
@@ -7,17 +7,27 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity;
 
-import static io.camunda.zeebe.protocol.record.RecordAssert.assertThat;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -56,5 +66,179 @@ public final class AdHocSubProcessTest {
 
     // then
     assertThat(deploymentEvent).hasRecordType(RecordType.EVENT).hasIntent(DeploymentIntent.CREATED);
+  }
+
+  @Test
+  public void shouldActivateAdHocSubProcess() {
+    // given
+    final BpmnModelInstance process = process(adHocSubProcess -> adHocSubProcess.task("A"));
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    final var activatedEvent =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    Assertions.assertThat(activatedEvent.getValue())
+        .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+        .hasBpmnElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+        .hasBpmnEventType(BpmnEventType.UNSPECIFIED)
+        .hasFlowScopeKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldApplyInputMappings() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeInputExpression("x+1", "local_x");
+              adHocSubProcess.task("A");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("x", 1).create();
+
+    // then
+    final Record<ProcessInstanceRecordValue> adHocSubProcessActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+            .getFirst();
+
+    assertThat(
+            RecordingExporter.variableRecords().withProcessInstanceKey(processInstanceKey).limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            VariableRecordValue::getName,
+            VariableRecordValue::getValue,
+            VariableRecordValue::getScopeKey)
+        .contains(
+            tuple("x", "1", processInstanceKey),
+            tuple("local_x", "2", adHocSubProcessActivated.getKey()));
+  }
+
+  @Test
+  public void shouldInvokeStartExecutionListener() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeStartExecutionListener("start-EL");
+              adHocSubProcess.task("A");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType("start-EL")
+        .withVariable("x", 1)
+        .complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSequence(
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                BpmnElementType.AD_HOC_SUB_PROCESS,
+                ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    final Record<VariableRecordValue> variableCreated =
+        RecordingExporter.variableRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("x")
+            .getFirst();
+
+    assertThat(variableCreated.getValue()).hasValue("1");
+  }
+
+  @Test
+  public void shouldInterruptAdHocSubProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .adHocSubProcess(
+                AD_HOC_SUB_PROCESS_ELEMENT_ID, adHocSubProcess -> adHocSubProcess.task("A"))
+            .boundaryEvent()
+            .timerWithDuration(Duration.ZERO)
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCancelAdHocSubProcess() {
+    // given
+    final BpmnModelInstance process = process(adHocSubProcess -> adHocSubProcess.task("A"));
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.AD_HOC_SUB_PROCESS)
+        .await();
+
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceTerminated())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.AD_HOC_SUB_PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED));
   }
 }


### PR DESCRIPTION
## Description

Adds a BPMN stream processor to execute ad-hoc subprocesses. When entering an ad-hoc subprocess, the process instance
- Applies input mappings
- Invokes start execution listeners

The ad-hoc subprocess can be terminated by a cancel command and interrupted by a boundary event. The completion is not implemented because the inner activities can't be activated yet.

## Related issues

closes #25270 
