### PR TITLE
feat: Introduce `CLAIMING` event and lifecycle state for User Task  

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -245,7 +245,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
       case CREATING -> ZeebeTaskListenerEventType.create;
-      case ASSIGNING -> ZeebeTaskListenerEventType.assignment;
+      case ASSIGNING, CLAIMING -> ZeebeTaskListenerEventType.assignment;
       case UPDATING -> ZeebeTaskListenerEventType.update;
       case COMPLETING -> ZeebeTaskListenerEventType.complete;
       case CANCELING -> ZeebeTaskListenerEventType.cancel;
@@ -280,6 +280,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var userTaskIntent =
         switch (lifecycleState) {
           case ASSIGNING -> UserTaskIntent.ASSIGN;
+          case CLAIMING -> UserTaskIntent.CLAIM;
           case UPDATING -> UserTaskIntent.UPDATE;
           case COMPLETING -> UserTaskIntent.COMPLETE;
           case CREATING, CANCELING ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskAssignProcessor.java
@@ -63,16 +63,6 @@ public final class UserTaskAssignProcessor implements UserTaskCommandProcessor {
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
   }
 
-  /// {@inheritDoc}
-  ///
-  /// @apiNote This method finalizes the [UserTaskIntent#ASSIGN] command by default but also handles
-  /// finalization for the [UserTaskIntent#CLAIM] command when `assignment` listeners are defined
-  /// for the user task.
-  ///
-  /// This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
-  /// `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this
-  /// state. Therefore, the current processor is selected to finalize the command after all task
-  /// listeners are processed when the user task is in the [LifecycleState#ASSIGNING] state.
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskClaimProcessor.java
@@ -67,24 +67,9 @@ public final class UserTaskClaimProcessor implements UserTaskCommandProcessor {
     userTaskRecord.setAssignee(command.getValue().getAssignee());
     userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
-    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CLAIMING, userTaskRecord);
   }
 
-  /// {@inheritDoc}
-  ///
-  /// @apiNote This method finalizes the [UserTaskIntent#CLAIM] command only when there are no
-  /// `assignment` listeners for the user task. If `assignment` listeners are defined,
-  /// [UserTaskAssignProcessor#onFinalizeCommand(TypedRecord, UserTaskRecord)] method will handle
-  /// this logic instead.
-  ///
-  /// This occurs because both `CLAIM` and `ASSIGN` commands transition the user task to the
-  /// `ASSIGNING` lifecycle state, making it indistinguishable which command initially led to this
-  /// state. Therefore, [UserTaskAssignProcessor] is selected to finalize the command after all task
-  /// listeners are processed when the user task is in the [LifecycleState#ASSIGNING] state.
-  ///
-  /// This approach is acceptable as long as `CLAIM` and `ASSIGN` commands share identical
-  /// finalization logic. Any need for distinct handling would require a further update to this
-  /// behavior.
   @Override
   public void onFinalizeCommand(
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -422,6 +422,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.ASSIGNING, 2, new UserTaskAssigningV2Applier(state));
     register(UserTaskIntent.ASSIGNED, 1, new UserTaskAssignedV1Applier(state));
     register(UserTaskIntent.ASSIGNED, 2, new UserTaskAssignedV2Applier(state));
+    register(UserTaskIntent.CLAIMING, new UserTaskClaimingApplier(state));
     register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
     register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
     register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskClaimingApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public class UserTaskClaimingApplier implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskClaimingApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.CLAIMING);
+    userTaskState.storeIntermediateState(value, LifecycleState.CLAIMING);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/UserTaskState.java
@@ -35,7 +35,9 @@ public interface UserTaskState {
 
     ASSIGNING((byte) 5),
 
-    UPDATING((byte) 6);
+    UPDATING((byte) 6),
+
+    CLAIMING((byte) 7);
 
     final byte value;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -725,7 +725,7 @@ public final class NativeUserTaskTest {
                 .limit(r -> r.getIntent() == UserTaskIntent.ASSIGNED))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
-            tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNING),
+            tuple(ValueType.USER_TASK, UserTaskIntent.CLAIMING),
             tuple(ValueType.USER_TASK, UserTaskIntent.ASSIGNED));
 
     Assertions.assertThat(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -313,10 +313,10 @@ public class TaskListenerTest {
         processInstanceKey, JobListenerEventType.ASSIGNMENT, LISTENER_TYPE, LISTENER_TYPE + "_2");
 
     // ensure that `COMPLETE_TASK_LISTENER` commands were triggered between
-    // `ASSIGNING` and `ASSIGNED` events
+    // `CLAIMING` and `ASSIGNED` events
     assertUserTaskIntentsSequence(
         UserTaskIntent.CLAIM,
-        UserTaskIntent.ASSIGNING,
+        UserTaskIntent.CLAIMING,
         UserTaskIntent.COMPLETE_TASK_LISTENER,
         UserTaskIntent.COMPLETE_TASK_LISTENER,
         UserTaskIntent.ASSIGNED);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -47,7 +47,7 @@ public class ClaimUserTaskTest {
   }
 
   @Test
-  public void shouldEmitAssigningEventForClaimedUserTask() {
+  public void shouldEmitClaimingEventForClaimedUserTask() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
@@ -66,7 +66,7 @@ public class ClaimUserTaskTest {
 
     Assertions.assertThat(claimedRecord)
         .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
+        .hasIntent(UserTaskIntent.CLAIMING);
 
     Assertions.assertThat(recordValue)
         .hasUserTaskKey(userTaskKey)
@@ -75,7 +75,7 @@ public class ClaimUserTaskTest {
   }
 
   @Test
-  public void shouldTrackCustomActionInAssigningEvent() {
+  public void shouldTrackCustomActionInClaimingEvent() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
@@ -99,7 +99,7 @@ public class ClaimUserTaskTest {
 
     Assertions.assertThat(claimedRecord)
         .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
+        .hasIntent(UserTaskIntent.CLAIMING);
 
     Assertions.assertThat(recordValue)
         .hasUserTaskKey(userTaskKey)
@@ -120,7 +120,7 @@ public class ClaimUserTaskTest {
     // then
     Assertions.assertThat(claimedRecord)
         .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
+        .hasIntent(UserTaskIntent.CLAIMING);
     Assertions.assertThat(claimedRecord.getValue()).hasAssignee("foo");
   }
 
@@ -212,7 +212,7 @@ public class ClaimUserTaskTest {
     // then
     Assertions.assertThat(claimedRecord)
         .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
+        .hasIntent(UserTaskIntent.CLAIMING);
     Assertions.assertThat(claimedRecord.getValue()).hasAssignee("foo");
   }
 
@@ -254,7 +254,7 @@ public class ClaimUserTaskTest {
 
     Assertions.assertThat(claimedRecord)
         .hasRecordType(RecordType.EVENT)
-        .hasIntent(UserTaskIntent.ASSIGNING);
+        .hasIntent(UserTaskIntent.CLAIMING);
 
     Assertions.assertThat(recordValue).hasTenantId(tenantId);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/UserTaskCorrectedApplierTest.java
@@ -62,9 +62,9 @@ public class UserTaskCorrectedApplierTest {
         Arguments.of(
             3, List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED), LifecycleState.UPDATING),
         Arguments.of(
-            4,
-            List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED),
-            LifecycleState.COMPLETING));
+            4, List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED), LifecycleState.COMPLETING),
+        Arguments.of(
+            5, List.of(UserTaskIntent.CREATING, UserTaskIntent.CREATED), LifecycleState.CLAIMING));
   }
 
   @ParameterizedTest(name = "on {2}")
@@ -131,6 +131,7 @@ public class UserTaskCorrectedApplierTest {
     return switch (state) {
       case CREATING -> UserTaskIntent.CREATING;
       case ASSIGNING -> UserTaskIntent.ASSIGNING;
+      case CLAIMING -> UserTaskIntent.CLAIMING;
       case UPDATING -> UserTaskIntent.UPDATING;
       case CANCELING -> UserTaskIntent.CANCELING;
       case COMPLETING -> UserTaskIntent.COMPLETING;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -52,6 +52,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * command.
    */
   COMPLETE_TASK_LISTENER(15),
+
   /**
    * Represents the intent that means Task Listener denied the operation and the creation of the
    * next task listener or the finalization of the original user task command (COMPLETE) is not
@@ -64,6 +65,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * CREATED state.
    */
   DENY_TASK_LISTENER(16),
+
   /**
    * Represents the intent indicating that the User Task will not be completed, but rather will be
    * reverted to the CREATED state.
@@ -82,7 +84,14 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
    * Represents the intent indicating that the User Task will not be assigned and the user task's
    * assignee remains unchanged. The user task will be reverted to the CREATED lifecycle state.
    */
-  ASSIGNMENT_DENIED(19);
+  ASSIGNMENT_DENIED(19),
+
+  /**
+   * Represents the intent indicating that a User Task is being claimed by a user for themselves.
+   * This intent is written during the processing of a CLAIM command and marks the User Task with
+   * the `CLAIMING` lifecycle state.
+   */
+  CLAIMING(20);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -142,6 +151,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return CORRECTED;
       case 19:
         return ASSIGNMENT_DENIED;
+      case 20:
+        return CLAIMING;
       default:
         return UNKNOWN;
     }
@@ -169,6 +180,7 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
       case COMPLETION_DENIED:
       case CORRECTED:
       case ASSIGNMENT_DENIED:
+      case CLAIMING:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

This PR introduces the `CLAIMING` event and `CLAIMING` lifecycle state for User Tasks.  

#### Key deliverables:  
1. **New lifecycle state**: Introduced the `CLAIMING` lifecycle state to differentiate between `ASSIGN` and `CLAIM` commands during user task processing.  
2. **CLAIMING Event**: Added a `CLAIMING` event that transitions the user task into the `CLAIMING` state.  
   - `UserTaskClaimProcessor` was updated to write `CLAIMING` event upon processing user task `CLAIM` command.
   - The transition is handled by the newly created `UserTaskClaimingApplier`.
   - The record stream for `claim` operations now follows this structure:  
     ```
     C CLAIM
     E CLAIMING -> Applied by `UserTaskClaimingApplier`, setting the `CLAIMING` lifecycle state.
     E ASSIGNED
     ```  
3. **Backward compatibility**: Maintained existing behavior by ensuring the `ASSIGNED` event is still written after the `CLAIMING` state.  
4. **Testing**:  
   - Unit and integration tests are updated to validate the correct processing of `claim` operation.  

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25408 
