### PR TITLE
feat: Operate: fallback to legacy authorization parameter

### DIFF
--- a/dist/src/main/resources/application-operate.properties
+++ b/dist/src/main/resources/application-operate.properties
@@ -16,3 +16,8 @@ camunda.identity.clientId=${camunda.operate.identity.clientId:${CAMUNDA_OPERATE_
 camunda.identity.clientSecret=${camunda.operate.identity.clientSecret:${CAMUNDA_OPERATE_IDENTITY_CLIENT_SECRET:}}
 camunda.identity.audience=${camunda.operate.identity.audience:}
 camunda.identity.baseUrl=${camunda.operate.identity.baseUrl:}
+
+#---
+spring.config.activate.on-profile=standalone
+# Fallback authorizations configuration for deprecated env variable naming
+camunda.security.authorizations.enabled=${camunda.operate.identity.resourcePermissionsEnabled:false}

--- a/operate/common/src/main/java/io/camunda/operate/property/IdentityProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/IdentityProperties.java
@@ -18,7 +18,6 @@ public class IdentityProperties {
   private String clientId;
   private String clientSecret;
   private String audience;
-  private boolean resourcePermissionsEnabled = false;
 
   private long resourcePermissionsUpdatePeriod = DEFAULT_RESOURCE_PERMISSIONS_UPDATE_PERIOD;
 
@@ -77,15 +76,6 @@ public class IdentityProperties {
 
   public void setAudience(final String audience) {
     this.audience = audience;
-  }
-
-  public boolean isResourcePermissionsEnabled() {
-    return resourcePermissionsEnabled;
-  }
-
-  public IdentityProperties setResourcePermissionsEnabled(boolean resourcePermissionsEnabled) {
-    this.resourcePermissionsEnabled = resourcePermissionsEnabled;
-    return this;
   }
 
   public long getResourcePermissionsUpdatePeriod() {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/properties/PropertiesIT.java
@@ -9,8 +9,10 @@ package io.camunda.operate.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
+import io.camunda.security.configuration.SecurityConfiguration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,12 +22,17 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(
-    classes = {TestApplicationWithNoBeans.class, OperateProperties.class},
+    classes = {
+      TestApplicationWithNoBeans.class,
+      OperateProperties.class,
+      ServiceSecurityProperties.class
+    },
     webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@ActiveProfiles("test-properties")
+@ActiveProfiles({"test-properties", "operate", "standalone"})
 public class PropertiesIT {
 
   @Autowired private OperateProperties operateProperties;
+  @Autowired private SecurityConfiguration securityConfiguration;
 
   @Test
   // TODO extend for new properties
@@ -55,7 +62,8 @@ public class PropertiesIT {
     assertThat(operateProperties.getIdentity().getClientId()).isEqualTo("someClientId");
     assertThat(operateProperties.getIdentity().getClientSecret()).isEqualTo("jahktewpofsdifhsdg");
     assertThat(operateProperties.getIdentity().getAudience()).isEqualTo("operateAudience");
-    assertThat(operateProperties.getIdentity().isResourcePermissionsEnabled()).isTrue();
+    // assert that it can be set from ${camunda.operate.identity.resourcePermissionsEnabled}
+    assertThat(securityConfiguration.getAuthorizations().isEnabled()).isTrue();
     assertThat(operateProperties.getMultiTenancy().isEnabled()).isTrue();
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
@@ -27,6 +27,7 @@ import com.auth0.AuthorizeUrl;
 import com.auth0.IdentityVerificationException;
 import com.auth0.Tokens;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.management.IndicesCheck;
 import io.camunda.operate.property.OperateProperties;
@@ -93,6 +94,7 @@ import org.springframework.web.client.RestTemplate;
       OperateProfileService.class,
       OperateIndexController.class,
       WebappsModuleConfiguration.class,
+      ServiceSecurityProperties.class,
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
@@ -27,6 +27,7 @@ import com.auth0.AuthenticationController;
 import com.auth0.AuthorizeUrl;
 import com.auth0.IdentityVerificationException;
 import com.auth0.Tokens;
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
 import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.conditions.DatabaseInfo;
@@ -123,6 +124,7 @@ import org.springframework.web.client.RestTemplate;
       DatabaseInfo.class,
       OperateIndexController.class,
       WebappsModuleConfiguration.class,
+      ServiceSecurityProperties.class,
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationWithPersistentSessionsIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/CsrfTokenIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/CsrfTokenIT.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.when;
 import com.auth0.AuthenticationController;
 import com.auth0.AuthorizeUrl;
 import com.auth0.Tokens;
+import io.camunda.application.commons.service.ServiceSecurityConfiguration.ServiceSecurityProperties;
 import io.camunda.operate.OperateProfileService;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.SpringContextHolder;
@@ -91,7 +92,8 @@ import org.springframework.web.client.RestTemplate;
       OperateProperties.class,
       OperateProfileService.class,
       ProcessRestService.class,
-      ProcessDefinitionController.class
+      ProcessDefinitionController.class,
+      ServiceSecurityProperties.class,
     },
     properties = {
       "server.servlet.context-path=" + CsrfTokenIT.CONTEXT_PATH,

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityAuthentication.java
@@ -20,6 +20,7 @@ import io.camunda.operate.webapp.security.Permission;
 import io.camunda.operate.webapp.security.SessionRepository;
 import io.camunda.operate.webapp.security.tenant.OperateTenant;
 import io.camunda.operate.webapp.security.tenant.TenantAwareAuthentication;
+import io.camunda.security.configuration.SecurityConfiguration;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -189,7 +190,7 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
   }
 
   private void retrieveResourcePermissions() {
-    if (getOperateProperties().getIdentity().isResourcePermissionsEnabled()) {
+    if (getSecurityConfiguration().getAuthorizations().isEnabled()) {
       try {
         authorizations =
             IdentityAuthorization.createFrom(
@@ -308,5 +309,9 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
 
   private PermissionConverter getPermissionConverter() {
     return SpringContextHolder.getBean(PermissionConverter.class);
+  }
+
+  private SecurityConfiguration getSecurityConfiguration() {
+    return SpringContextHolder.getBean(SecurityConfiguration.class);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/TokenAuthentication.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/TokenAuthentication.java
@@ -22,6 +22,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.SpringContextHolder;
 import io.camunda.operate.webapp.security.Permission;
 import io.camunda.operate.webapp.security.identity.IdentityAuthorization;
+import io.camunda.security.configuration.SecurityConfiguration;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -163,8 +164,7 @@ public class TokenAuthentication extends AbstractAuthenticationToken {
   }
 
   private void updateResourcePermissions() {
-    if (getOperateProperties().getIdentity().isResourcePermissionsEnabled()
-        && getIdentity() != null) {
+    if (getSecurityConfiguration().getAuthorizations().isEnabled() && getIdentity() != null) {
       try {
         final List<IdentityAuthorization> identityAuthorizations =
             IdentityAuthorization.createFrom(
@@ -319,5 +319,9 @@ public class TokenAuthentication extends AbstractAuthenticationToken {
 
   private OperateProperties getOperateProperties() {
     return SpringContextHolder.getBean(OperateProperties.class);
+  }
+
+  private SecurityConfiguration getSecurityConfiguration() {
+    return SpringContextHolder.getBean(SecurityConfiguration.class);
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
- replace the use of `operateProperties.getIdentity().isResourcePermissionEnabled` by `securityConfiguration.getAuthorizations().isEnabled()`
- when Operate runs as `STANDALONE`, allow fallback to `camunda.operate.identity.resourcePermissionEnabled` to set `camunda.security.authorizations.enabled`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/25373
