### PR TITLE
ci: move Tasklist backend + Docker build to Unified CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -42,13 +42,24 @@ outputs:
         steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
   operate-backend-changes:
-    description: Output whether Operate backend tests should be run based on GitHub event and files changed
+    description: Output whether Operate backend build should be run based on GitHub event and files changed
     value: >-
       ${{
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
         steps.filter-operate.outputs.operate-backend-change == 'true' ||
-        steps.filter-common.outputs.maven-change == 'true'
+        steps.filter-common.outputs.maven-change == 'true' ||
+        steps.filter-common.outputs.dockerfile-change == 'true'
+      }}
+  tasklist-backend-changes:
+    description: Output whether Tasklist backend build should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-tasklist.outputs.tasklist-backend-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true' ||
+        steps.filter-common.outputs.dockerfile-change == 'true'
       }}
   optimize-frontend-changes:
     description: Output whether Optimize frontend tests should be run based on GitHub event and files changed
@@ -188,6 +199,15 @@ runs:
       filters: |
         operate-backend-change:
           - 'operate/!(client/**)/**'
+
+  - uses: dorny/paths-filter@v3
+    id: filter-tasklist
+    with:
+      base: ${{ github.event.merge_group.base_ref || '' }}
+      ref: ${{ github.event.merge_group.head_ref || github.ref }}
+      filters: |
+        tasklist-backend-change:
+          - 'tasklist/!(client/**)/**'
 
   - uses: dorny/paths-filter@v3
     id: filter-optimize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       frontend-changes: ${{ steps.filter.outputs.frontend-changes }}
       zeebe-changes: ${{ steps.filter.outputs.zeebe-changes }}
       operate-backend-changes: ${{ steps.filter.outputs.operate-backend-changes }}
+      tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
       optimize-frontend-changes: ${{ steps.filter.outputs.optimize-frontend-changes }}
       optimize-backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
       protobuf-changes: ${{ steps.filter.outputs.protobuf-changes }}
@@ -478,6 +479,45 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  build-tasklist-backend:
+    if: needs.detect-changes.outputs.tasklist-backend-changes == 'true'
+    needs: [detect-changes]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: ./.github/actions/setup-build
+        name: Build setup
+        with:
+          java-distribution: adopt
+          maven-cache-key-modifier: tasklist
+          maven-version: 3.8.6
+          vault-address: ${{ secrets.VAULT_ADDR }}
+          vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
+          vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}
+      - name: Build Maven
+        run: |
+          ./mvnw clean deploy -B -T1C -PskipFrontendBuild -DskipTests -DskipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+      # Build the docker image to verify the built artifacts and the Dockerfile
+      # It does NOT push the image to the registry
+      - name: Build Docker image
+        uses: ./.github/actions/build-platform-docker
+        with:
+          dockerfile: tasklist.Dockerfile
+          repository: 'registry.camunda.cloud/team-hto/tasklist'
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   optimize-frontend-unit-tests:
     if: needs.detect-changes.outputs.optimize-frontend-changes == 'true'
     needs: [detect-changes]
@@ -653,6 +693,7 @@ jobs:
       - actionlint
       - build-operate-backend
       - build-platform-frontend
+      - build-tasklist-backend
       - docker-checks
       - identity-frontend-tests
       - integration-tests

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -12,14 +12,6 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
-  run-build:
-    name: run-build
-    uses: ./.github/workflows/tasklist-ci-build-reusable.yml
-    secrets: inherit
-    with:
-      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
-      pushDocker: false
-
   run-fe-ci:
     name: run-frontend-tests
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
@@ -32,7 +24,6 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     needs:
-      - run-build
       - run-fe-ci
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}


### PR DESCRIPTION
## Description

This PR works towards the goal of #21437 by migrating one of the 2 jobs from `tasklist-merge-ci.yml` to the `ci.yml`. This migration is done by analyzing which steps of the `run-build` job (calls `./.github/workflows/tasklist-ci-build-reusable.yml`) are not covered yet in `ci.yml` and transferring them. Steps that are already covered:

* ✔️ building the Tasklist frontend (in `ci.yml` in `build-platform-frontend` job)
* ⏩ pushing the preview environment/Harbor Docker image (can be skipped since `tasklist-merge-ci.yml` uses `pushDocker: false`)
* ⏩ pushing the SNAPSHOT Docker image (can be skipped since `tasklist-merge-ci.yml` never runs on `main` branch, instead invoked by `tasklist-ci.yml`)

Steps that need to be transferred (in this PR):

* 🚧 building the backend (needed for next bullet point...)
* 🚧 building the Docker image using `tasklist.Dockerfile` (to prevent merging breaking Renovate updates e.g.)

**After merging this PR we should have unblocked #19222 since the `run-build` job is the actual last blocker for merging PRs from forked repositories by contributors!** ([test](https://github.com/camunda/camunda/actions/runs/11952224901?pr=24676))

The 2nd job still needs to be migrated to fulfill #21437 completely.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21437
