### PR TITLE
impl: bring job listeners to Camunda exporter

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
@@ -21,6 +21,8 @@ public class JobTemplate extends OperateTemplateDescriptor
   // String - human readable name
   public static final String FLOW_NODE_ID = "flowNodeId";
   public static final String TENANT_ID = "tenantId";
+  public static final String PROCESS_DEFINITION_KEY = "processDefinitionKey";
+  public static final String BPMN_PROCESS_ID = "bpmnProcessId";
   public static final String JOB_TYPE = "type";
   public static final String JOB_WORKER = "worker";
   public static final String RETRIES = "retries";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
@@ -271,26 +271,56 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
 
   @Override
   public String toString() {
-    return "JobEntity{" +
-        "processInstanceKey=" + processInstanceKey +
-        ", flowNodeInstanceId=" + flowNodeInstanceId +
-        ", flowNodeId='" + flowNodeId + '\'' +
-        ", processDefinitionKey=" + processDefinitionKey +
-        ", bpmnProcessId='" + bpmnProcessId + '\'' +
-        ", tenantId='" + tenantId + '\'' +
-        ", type='" + type + '\'' +
-        ", worker='" + worker + '\'' +
-        ", retries=" + retries +
-        ", state='" + state + '\'' +
-        ", errorMessage='" + errorMessage + '\'' +
-        ", errorCode='" + errorCode + '\'' +
-        ", deadline=" + deadline +
-        ", endTime=" + endTime +
-        ", customHeaders=" + customHeaders +
-        ", jobFailedWithRetriesLeft=" + jobFailedWithRetriesLeft +
-        ", jobKind='" + jobKind + '\'' +
-        ", listenerEventType='" + listenerEventType + '\'' +
-        ", position=" + position +
-        "} " + super.toString();
+    return "JobEntity{"
+        + "processInstanceKey="
+        + processInstanceKey
+        + ", flowNodeInstanceId="
+        + flowNodeInstanceId
+        + ", flowNodeId='"
+        + flowNodeId
+        + '\''
+        + ", processDefinitionKey="
+        + processDefinitionKey
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + ", type='"
+        + type
+        + '\''
+        + ", worker='"
+        + worker
+        + '\''
+        + ", retries="
+        + retries
+        + ", state='"
+        + state
+        + '\''
+        + ", errorMessage='"
+        + errorMessage
+        + '\''
+        + ", errorCode='"
+        + errorCode
+        + '\''
+        + ", deadline="
+        + deadline
+        + ", endTime="
+        + endTime
+        + ", customHeaders="
+        + customHeaders
+        + ", jobFailedWithRetriesLeft="
+        + jobFailedWithRetriesLeft
+        + ", jobKind='"
+        + jobKind
+        + '\''
+        + ", listenerEventType='"
+        + listenerEventType
+        + '\''
+        + ", position="
+        + position
+        + "} "
+        + super.toString();
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/JobEntity.java
@@ -16,6 +16,13 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
   private Long processInstanceKey;
   private Long flowNodeInstanceId;
   private String flowNodeId;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
+  private Long processDefinitionKey;
+
+  /** Attention! This field will be filled in only for data imported after v. 8.7.0. */
+  private String bpmnProcessId;
+
   private String tenantId;
   private String type;
   private String worker;
@@ -186,6 +193,24 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
     return this;
   }
 
+  public Long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public JobEntity setProcessDefinitionKey(final Long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+    return this;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public JobEntity setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
@@ -193,11 +218,13 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         processInstanceKey,
         flowNodeInstanceId,
         flowNodeId,
+        processDefinitionKey,
+        bpmnProcessId,
         tenantId,
         type,
         worker,
-        state,
         retries,
+        state,
         errorMessage,
         errorCode,
         deadline,
@@ -225,11 +252,13 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
         && Objects.equals(processInstanceKey, jobEntity.processInstanceKey)
         && Objects.equals(flowNodeInstanceId, jobEntity.flowNodeInstanceId)
         && Objects.equals(flowNodeId, jobEntity.flowNodeId)
+        && Objects.equals(processDefinitionKey, jobEntity.processDefinitionKey)
+        && Objects.equals(bpmnProcessId, jobEntity.bpmnProcessId)
         && Objects.equals(tenantId, jobEntity.tenantId)
         && Objects.equals(type, jobEntity.type)
         && Objects.equals(worker, jobEntity.worker)
-        && Objects.equals(state, jobEntity.state)
         && Objects.equals(retries, jobEntity.retries)
+        && Objects.equals(state, jobEntity.state)
         && Objects.equals(errorMessage, jobEntity.errorMessage)
         && Objects.equals(errorCode, jobEntity.errorCode)
         && Objects.equals(deadline, jobEntity.deadline)
@@ -242,49 +271,26 @@ public class JobEntity extends OperateZeebeEntity<JobEntity> {
 
   @Override
   public String toString() {
-    return "JobEntity{"
-        + "processInstanceKey="
-        + processInstanceKey
-        + ", flowNodeInstanceId="
-        + flowNodeInstanceId
-        + ", flowNodeId="
-        + flowNodeId
-        + ", tenantId='"
-        + tenantId
-        + '\''
-        + ", type='"
-        + type
-        + '\''
-        + ", worker='"
-        + worker
-        + '\''
-        + ", retries="
-        + retries
-        + ", state='"
-        + state
-        + '\''
-        + ", errorMessage='"
-        + errorMessage
-        + '\''
-        + ", errorCode='"
-        + errorCode
-        + '\''
-        + ", deadline="
-        + deadline
-        + ", endTime="
-        + endTime
-        + ", customHeaders="
-        + customHeaders
-        + ", jobFailedWithRetriesLeft="
-        + jobFailedWithRetriesLeft
-        + ", jobKind='"
-        + jobKind
-        + '\''
-        + ", listenerEventType='"
-        + listenerEventType
-        + '\''
-        + ", position="
-        + position
-        + '}';
+    return "JobEntity{" +
+        "processInstanceKey=" + processInstanceKey +
+        ", flowNodeInstanceId=" + flowNodeInstanceId +
+        ", flowNodeId='" + flowNodeId + '\'' +
+        ", processDefinitionKey=" + processDefinitionKey +
+        ", bpmnProcessId='" + bpmnProcessId + '\'' +
+        ", tenantId='" + tenantId + '\'' +
+        ", type='" + type + '\'' +
+        ", worker='" + worker + '\'' +
+        ", retries=" + retries +
+        ", state='" + state + '\'' +
+        ", errorMessage='" + errorMessage + '\'' +
+        ", errorCode='" + errorCode + '\'' +
+        ", deadline=" + deadline +
+        ", endTime=" + endTime +
+        ", customHeaders=" + customHeaders +
+        ", jobFailedWithRetriesLeft=" + jobFailedWithRetriesLeft +
+        ", jobKind='" + jobKind + '\'' +
+        ", listenerEventType='" + listenerEventType + '\'' +
+        ", position=" + position +
+        "} " + super.toString();
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-job.json
@@ -14,6 +14,12 @@
       "flowNodeId": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
       "tenantId": {
         "type": "keyword"
       },

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/operate-job.json
@@ -14,6 +14,12 @@
       "flowNodeId": {
         "type": "keyword"
       },
+      "bpmnProcessId": {
+        "type": "keyword"
+      },
+      "processDefinitionKey": {
+        "type": "long"
+      },
       "tenantId": {
         "type": "keyword"
       },

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -72,6 +72,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTe
 import io.camunda.webapps.schema.descriptors.operate.template.EventTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
@@ -144,7 +145,8 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 new DraftTaskVariableTemplate(globalPrefix, isElasticsearch)),
             entry(
                 SnapshotTaskVariableTemplate.class,
-                new SnapshotTaskVariableTemplate(globalPrefix, isElasticsearch)));
+                new SnapshotTaskVariableTemplate(globalPrefix, isElasticsearch)),
+            entry(JobTemplate.class, new JobTemplate(globalPrefix, isElasticsearch)));
 
     indexDescriptorsMap =
         Map.ofEntries(

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -111,7 +111,7 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
       entity.setDeadline(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(jobDeadline)));
     }
 
-    if (FAILED_JOB_EVENTS.contains(record.getIntent().name())) {
+    if (FAILED_JOB_EVENTS.contains(record.getIntent())) {
       // set flowNodeId to null to not overwrite it (because zeebe puts an error message there)
       entity.setFlowNodeId(null);
       if (recordValue.getRetries() > 0) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.CUSTOM_HEADERS;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_CODE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_STATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.RETRIES;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.TIME;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.operate.JobEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
+  protected static final Set<JobIntent> JOB_EVENTS =
+      Set.of(
+          JobIntent.CREATED,
+          JobIntent.COMPLETED,
+          JobIntent.TIMED_OUT,
+          JobIntent.FAILED,
+          JobIntent.RETRIES_UPDATED,
+          JobIntent.CANCELED,
+          JobIntent.ERROR_THROWN,
+          JobIntent.MIGRATED);
+  private static final Set<JobIntent> FAILED_JOB_EVENTS =
+      Set.of(JobIntent.FAILED, JobIntent.ERROR_THROWN);
+
+  protected final String indexName;
+  protected final boolean concurrencyMode;
+
+  public JobHandler(final String indexName, final boolean concurrencyMode) {
+    this.indexName = indexName;
+    this.concurrencyMode = concurrencyMode;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.JOB;
+  }
+
+  @Override
+  public Class<JobEntity> getEntityType() {
+    return JobEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<JobRecordValue> record) {
+    final JobIntent intent = (JobIntent) record.getIntent();
+    return JOB_EVENTS.contains(intent);
+  }
+
+  @Override
+  public List<String> generateIds(final Record<JobRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public JobEntity createNewEntity(final String id) {
+    return new JobEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<JobRecordValue> record, final JobEntity entity) {
+
+    final JobRecordValue recordValue = record.getValue();
+    entity.setKey(record.getKey());
+    entity
+        .setPartitionId(record.getPartitionId())
+        .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+        .setFlowNodeInstanceId(recordValue.getElementInstanceKey())
+        .setTenantId(recordValue.getTenantId())
+        .setType(recordValue.getType())
+        .setWorker(recordValue.getWorker())
+        .setState(record.getIntent().name())
+        .setRetries(recordValue.getRetries())
+        .setErrorMessage(recordValue.getErrorMessage())
+        .setErrorCode(recordValue.getErrorCode())
+        .setEndTime(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
+        .setCustomHeaders(recordValue.getCustomHeaders())
+        .setJobKind(recordValue.getJobKind().name())
+        .setFlowNodeId(recordValue.getElementId());
+
+    if (recordValue.getJobListenerEventType() != null) {
+      entity.setListenerEventType(recordValue.getJobListenerEventType().name());
+    }
+    final long jobDeadline = recordValue.getDeadline();
+    if (jobDeadline >= 0) {
+      entity.setDeadline(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(jobDeadline)));
+    }
+
+    if (FAILED_JOB_EVENTS.contains(record.getIntent().name())) {
+      // set flowNodeId to null to not overwrite it (because zeebe puts an error message there)
+      entity.setFlowNodeId(null);
+      if (recordValue.getRetries() > 0) {
+        entity.setJobFailedWithRetriesLeft(true);
+      } else {
+        entity.setJobFailedWithRetriesLeft(false);
+      }
+    }
+  }
+
+  @Override
+  public void flush(final JobEntity jobEntity, final BatchRequest batchRequest) {
+    final Map<String, Object> updateFields = new HashMap<>();
+    if (jobEntity.getFlowNodeId() != null) {
+      updateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
+    }
+    updateFields.put(JOB_WORKER, jobEntity.getWorker());
+    updateFields.put(JOB_STATE, jobEntity.getState());
+    updateFields.put(RETRIES, jobEntity.getRetries());
+    updateFields.put(ERROR_MESSAGE, jobEntity.getErrorMessage());
+    updateFields.put(ERROR_CODE, jobEntity.getErrorCode());
+    updateFields.put(TIME, jobEntity.getEndTime());
+    updateFields.put(CUSTOM_HEADERS, jobEntity.getCustomHeaders());
+    updateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
+    batchRequest.upsert(indexName, jobEntity.getId(), jobEntity, updateFields);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.exporter.handlers;
 
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.BPMN_PROCESS_ID;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.CUSTOM_HEADERS;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_CODE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_MESSAGE;
@@ -14,6 +15,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DEADLINE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.PROCESS_DEFINITION_KEY;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.RETRIES;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.TIME;
 
@@ -87,6 +89,8 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
         .setPartitionId(record.getPartitionId())
         .setProcessInstanceKey(recordValue.getProcessInstanceKey())
         .setFlowNodeInstanceId(recordValue.getElementInstanceKey())
+        .setBpmnProcessId(recordValue.getBpmnProcessId())
+        .setProcessDefinitionKey(recordValue.getProcessDefinitionKey())
         .setTenantId(recordValue.getTenantId())
         .setType(recordValue.getType())
         .setWorker(recordValue.getWorker())
@@ -132,6 +136,8 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     updateFields.put(TIME, jobEntity.getEndTime());
     updateFields.put(CUSTOM_HEADERS, jobEntity.getCustomHeaders());
     updateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
+    updateFields.put(PROCESS_DEFINITION_KEY, jobEntity.getProcessDefinitionKey());
+    updateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
     batchRequest.upsert(indexName, jobEntity.getId(), jobEntity, updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/JobHandler.java
@@ -13,6 +13,7 @@ import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_MESSAGE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.FLOW_NODE_ID;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_FAILED_WITH_RETRIES_LEFT;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_STATE;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_WORKER;
 import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.PROCESS_DEFINITION_KEY;
@@ -138,6 +139,9 @@ public class JobHandler implements ExportHandler<JobEntity, JobRecordValue> {
     updateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
     updateFields.put(PROCESS_DEFINITION_KEY, jobEntity.getProcessDefinitionKey());
     updateFields.put(BPMN_PROCESS_ID, jobEntity.getBpmnProcessId());
+    if (FAILED_JOB_EVENTS.stream().anyMatch(i -> jobEntity.getState().equals(i.name()))) {
+      updateFields.put(JOB_FAILED_WITH_RETRIES_LEFT, jobEntity.isJobFailedWithRetriesLeft());
+    }
     batchRequest.upsert(indexName, jobEntity.getId(), jobEntity, updateFields);
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -307,6 +307,7 @@ final class CamundaExporterIT {
             "custom-prefix-operate-process-8.3.0_",
             "custom-prefix-operate-sequence-flow-8.3.0_",
             "custom-prefix-operate-variable-8.3.0_",
+            "custom-prefix-operate-job-8.6.0_",
             "custom-prefix-tasklist-draft-task-variable-8.3.0_",
             "custom-prefix-tasklist-form-8.4.0_",
             "custom-prefix-tasklist-metric-8.3.0_",

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -208,6 +208,70 @@ final class JobHandlerTest {
   }
 
   @Test
+  void testUpdateEntityWithFailedIntentAndRetriesLeft() {
+    // given
+    final long recordKey = 789;
+    final String elementId = "elementId";
+    final int retries = 1;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withElementId(elementId)
+            .withRetries(retries)
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withKey(recordKey)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(recordKey));
+    assertThat(entity.getKey()).isEqualTo(recordKey);
+    assertThat(entity.getFlowNodeId()).isNull();
+    assertThat(entity.isJobFailedWithRetriesLeft()).isTrue();
+  }
+
+  @Test
+  void testUpdateEntityWithFailedIntentAndRetriesExhausted() {
+    // given
+    final long recordKey = 789;
+    final String elementId = "elementId";
+    final int retries = 0;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withElementId(elementId)
+            .withRetries(retries)
+            .withJobKind(JobKind.BPMN_ELEMENT)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.FAILED)
+                    .withKey(recordKey)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity().setId(String.valueOf(recordKey));
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(recordKey));
+    assertThat(entity.getKey()).isEqualTo(recordKey);
+    assertThat(entity.getFlowNodeId()).isNull();
+    assertThat(entity.isJobFailedWithRetriesLeft()).isFalse();
+  }
+
+  @Test
   void shouldUpsertEntityOnFlush() {
     // given
     final String jobId = "111";

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/JobHandlerTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.CUSTOM_HEADERS;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_CODE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.ERROR_MESSAGE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.FLOW_NODE_ID;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_DEADLINE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_STATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.JOB_WORKER;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.RETRIES;
+import static io.camunda.webapps.schema.descriptors.operate.template.JobTemplate.TIME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.descriptors.operate.template.JobTemplate;
+import io.camunda.webapps.schema.entities.operate.JobEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.camunda.zeebe.util.DateUtil;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
+import org.mockito.Mockito;
+
+final class JobHandlerTest {
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = JobTemplate.INDEX_NAME;
+
+  private final JobHandler underTest = new JobHandler(indexName, false);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.JOB);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(JobEntity.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobIntent.class,
+      names = {
+        "CREATED",
+        "COMPLETED",
+        "TIMED_OUT",
+        "FAILED",
+        "RETRIES_UPDATED",
+        "CANCELED",
+        "ERROR_THROWN",
+        "MIGRATED"
+      },
+      mode = Mode.INCLUDE)
+  void shouldHandleRecord(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record = generateRecord(intent);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = JobIntent.class,
+      names = {
+        "CREATED",
+        "COMPLETED",
+        "TIMED_OUT",
+        "FAILED",
+        "RETRIES_UPDATED",
+        "CANCELED",
+        "ERROR_THROWN",
+        "MIGRATED"
+      },
+      mode = Mode.EXCLUDE)
+  void shouldNotHandleRecord(final JobIntent intent) {
+    // given
+    final Record<JobRecordValue> record = generateRecord(intent);
+
+    // when - then
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+
+  @Test
+  void testGenerateIds() {
+    // given
+    final Record<JobRecordValue> record = factory.generateRecord(ValueType.JOB);
+
+    // when
+    final var ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids).containsExactly(String.valueOf(record.getKey()));
+  }
+
+  @Test
+  void testCreateNewEntity() {
+    // given
+    final String id = "id";
+
+    // when
+    final var entity = underTest.createNewEntity(id);
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo(id);
+  }
+
+  @Test
+  void testUpdateEntity() {
+    // given
+    final long recordKey = 789;
+    final int partitionId = 10;
+    final int processInstanceKey = 123;
+    final int elementInstanceKey = 456;
+    final String elementId = "elementId";
+    final String bpmnProcessId = "bpmnProcessId";
+    final String tenantId = "tenantId";
+    final String jobType = "jobType";
+    final int retries = 3;
+    final String jobWorker = "jobWorker";
+    final String errorMessage = "someErrorMessage";
+    final String errorCode = "errorCode";
+    final long deadline = Instant.now().toEpochMilli();
+    final JobKind jobKind = JobKind.BPMN_ELEMENT;
+    final JobListenerEventType jobListenerEventType = JobListenerEventType.END;
+    final var recordValue =
+        ImmutableJobRecordValue.builder()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementInstanceKey(elementInstanceKey)
+            .withElementId(elementId)
+            .withBpmnProcessId(bpmnProcessId)
+            .withType(jobType)
+            .withRetries(retries)
+            .withWorker(jobWorker)
+            .withCustomHeaders(Map.of("key", "val"))
+            .withTenantId(tenantId)
+            .withErrorMessage(errorMessage)
+            .withJobKind(jobKind)
+            .withJobListenerEventType(jobListenerEventType)
+            .withDeadline(deadline)
+            .withErrorCode(errorCode)
+            .build();
+    final Record<JobRecordValue> record =
+        factory.generateRecord(
+            ValueType.JOB,
+            r ->
+                r.withIntent(JobIntent.CREATED)
+                    .withKey(recordKey)
+                    .withPartitionId(partitionId)
+                    .withValueType(ValueType.JOB)
+                    .withValue(recordValue));
+    final var entity = new JobEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getId()).isEqualTo(String.valueOf(recordKey));
+    assertThat(entity.getKey()).isEqualTo(recordKey);
+    assertThat(entity.getPartitionId()).isEqualTo(partitionId);
+    assertThat(entity.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+    assertThat(entity.getFlowNodeInstanceId()).isEqualTo(elementInstanceKey);
+    assertThat(entity.getFlowNodeId()).isEqualTo(elementId);
+    assertThat(entity.getTenantId()).isEqualTo(tenantId);
+    assertThat(entity.getType()).isEqualTo(jobType);
+    assertThat(entity.getJobKind()).isEqualTo(jobKind);
+    assertThat(entity.getListenerEventType()).isEqualTo(jobListenerEventType);
+    assertThat(entity.getRetries()).isEqualTo(retries);
+    assertThat(entity.getWorker()).isEqualTo(jobWorker);
+    assertThat(entity.getCustomHeaders()).isEqualTo(Map.of("key", "val"));
+    assertThat(entity.getState()).isEqualTo("CREATED");
+    assertThat(entity.getErrorMessage()).isEqualTo(errorMessage);
+    assertThat(entity.getErrorCode()).isEqualTo(errorCode);
+    assertThat(entity.isJobFailedWithRetriesLeft()).isFalse();
+    assertThat(entity.getEndTime())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())));
+    assertThat(entity.getDeadline())
+        .isEqualTo(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(deadline)));
+  }
+
+  @Test
+  void shouldUpsertEntityOnFlush() {
+    // given
+    final String jobId = "111";
+    final String expectedIndexName = JobTemplate.INDEX_NAME;
+    final String elementId = "elementId";
+    final int retries = 3;
+    final String jobWorker = "jobWorker";
+    final String errorMessage = "someErrorMessage";
+    final String errorCode = "errorCode";
+    final OffsetDateTime deadline = OffsetDateTime.now().plus(1, ChronoUnit.DAYS);
+    final String state = "CREATED";
+    final OffsetDateTime endTime = OffsetDateTime.now();
+
+    final Map<String, String> customHeaders = Map.of("key", "val");
+    final JobEntity jobEntity =
+        new JobEntity()
+            .setId(jobId)
+            .setFlowNodeId(elementId)
+            .setWorker(jobWorker)
+            .setState(state)
+            .setRetries(retries)
+            .setErrorMessage(errorMessage)
+            .setErrorCode(errorCode)
+            .setEndTime(endTime)
+            .setCustomHeaders(customHeaders)
+            .setDeadline(deadline);
+
+    final Map<String, Object> expectedUpdateFields = new LinkedHashMap<>();
+    expectedUpdateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());
+    expectedUpdateFields.put(JOB_WORKER, jobEntity.getWorker());
+    expectedUpdateFields.put(JOB_STATE, jobEntity.getState());
+    expectedUpdateFields.put(RETRIES, jobEntity.getRetries());
+    expectedUpdateFields.put(ERROR_MESSAGE, jobEntity.getErrorMessage());
+    expectedUpdateFields.put(ERROR_CODE, jobEntity.getErrorCode());
+    expectedUpdateFields.put(TIME, jobEntity.getEndTime());
+    expectedUpdateFields.put(CUSTOM_HEADERS, jobEntity.getCustomHeaders());
+    expectedUpdateFields.put(JOB_DEADLINE, jobEntity.getDeadline());
+
+    final BatchRequest mockRequest = Mockito.mock(BatchRequest.class);
+
+    // when
+    underTest.flush(jobEntity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1))
+        .upsert(expectedIndexName, jobEntity.getId(), jobEntity, expectedUpdateFields);
+  }
+
+  private Record<JobRecordValue> generateRecord(final JobIntent intent) {
+    return factory.generateRecord(ValueType.JOB, r -> r.withIntent(intent));
+  }
+
+  private void assertShouldHandleRecord(final Record<JobRecordValue> record) {
+    assertThat(underTest.handlesRecord(record)).isTrue();
+  }
+
+  private void assertShouldNotHandleRecord(final Record<JobRecordValue> record) {
+    assertThat(underTest.handlesRecord(record)).isFalse();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
* "copy" importer job (and listeners) related code from importer to Camunda exporter
* add `bpmnProcessId` and `processDefinitionKey` fields for future resource based permission checks (similar to [this PR](https://github.com/camunda/operate/issues/3995))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22747 
