### PR TITLE
feat: msgpack array value that uses delta encoding to save space

### DIFF
--- a/zeebe/msgpack-value/pom.xml
+++ b/zeebe/msgpack-value/pom.xml
@@ -61,6 +61,18 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>net.jqwik</groupId>
+      <artifactId>jqwik-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DeltaEncodedLongArrayProperty.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/property/DeltaEncodedLongArrayProperty.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack.property;
+
+import io.camunda.zeebe.msgpack.value.DeltaEncodedLongArrayValue;
+import java.util.Objects;
+
+public final class DeltaEncodedLongArrayProperty extends BaseProperty<DeltaEncodedLongArrayValue> {
+  public DeltaEncodedLongArrayProperty(final String keyString) {
+    super(keyString, new DeltaEncodedLongArrayValue());
+  }
+
+  public long[] getValues() {
+    return resolveValue().getValues();
+  }
+
+  public void setValues(final long[] values) {
+    resolveValue().setValues(Objects.requireNonNull(values));
+    isSet = true;
+  }
+}

--- a/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/DeltaEncodedLongArrayValue.java
+++ b/zeebe/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/DeltaEncodedLongArrayValue.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack.value;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A specialized version of {@link ArrayValue<LongValue>} that uses delta-encoding to reduce the
+ * encoded size in cases where the difference between subsequent values is small.
+ *
+ * <p>For example, the array [4, 13, 15, 16, 20] is encoded as [4, 9, 2, 1, 4], where the first
+ * value remains the same but the following values represent the difference to the previous value.
+ *
+ * <p>This encoding saves space in case that the values would usually require many bits to encode,
+ * but the difference between subsequent values is small and can be encoded with fewer bits.
+ *
+ * <p>Values are not delta encoded in memory, only when {@link
+ * DeltaEncodedLongArrayValue#write(MsgPackWriter) writing in MsgPack format} or, conversely, {@link
+ * DeltaEncodedLongArrayValue#read(MsgPackReader) reading from MsgPack format}, delta encoding is
+ * used.
+ *
+ * <p>{@link DeltaEncodedLongArrayValue#writeJSON(StringBuilder) Writing in JSON format} does not
+ * use delta encoding to keep this optimization internal and not leak to external systems. JSON is
+ * not space-efficient in any case, so we'd rather keep the delta-encoding internal as much as
+ * possible.
+ *
+ * @implNote This implementation relies on {@link MsgPackWriter#writeInteger(long)} automatically
+ *     picking the smallest possible encoding for the given deltas. By implementing this value type
+ *     in terms of a plain MsgPack array and integer values, we keep the implementation simple and
+ *     avoid the need to implement a custom encoding scheme. We lose a bit of efficiency by not
+ *     specializing for a fixed encoding of delta values but gain in flexibility because this type
+ *     can be used even in cases where delta encoding is not efficient because deltas are large
+ *     enough to require full 64-bit encoding.
+ *     <p>This encoding is a classic space-time trade-off: we save space by encoding the values as
+ *     deltas, but pay in time because reading, writing and calculating encoded size requires long
+ *     addition/subtraction and array lookbehind. We assume that this is easily optimized by any JVM
+ *     and that the space savings are worth the trade-off.
+ */
+public final class DeltaEncodedLongArrayValue extends BaseValue {
+  private long[] values;
+
+  @Override
+  public void writeJSON(final StringBuilder builder) {
+    builder.append("[");
+
+    for (var i = 0; i < values.length; i++) {
+      if (i > 0) {
+        builder.append(",");
+      }
+      builder.append(values[i]);
+    }
+
+    builder.append("]");
+  }
+
+  @Override
+  public void write(final MsgPackWriter writer) {
+    writer.writeArrayHeader(values.length);
+
+    for (int i = 0; i < values.length; i++) {
+      if (i == 0) {
+        writer.writeInteger(values[i]);
+      } else {
+        writer.writeInteger(values[i] - values[i - 1]);
+      }
+    }
+  }
+
+  @Override
+  public void read(final MsgPackReader reader) {
+    final int length = reader.readArrayHeader();
+
+    values = new long[length];
+
+    for (int i = 0; i < length; i++) {
+      if (i == 0) {
+        values[i] = reader.readInteger();
+      } else {
+        values[i] = values[i - 1] + reader.readInteger();
+      }
+    }
+  }
+
+  @Override
+  public int getEncodedLength() {
+    final int header = MsgPackWriter.getEncodedArrayHeaderLenght(values.length);
+    int data = 0;
+    for (int i = 0; i < values.length; i++) {
+      if (i == 0) {
+        data += MsgPackWriter.getEncodedLongValueLength(values[i]);
+      } else {
+        data += MsgPackWriter.getEncodedLongValueLength(values[i] - values[i - 1]);
+      }
+    }
+
+    return header + data;
+  }
+
+  @Override
+  public void reset() {
+    values = null;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(values);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (!(o instanceof final DeltaEncodedLongArrayValue that)) {
+      return false;
+    }
+    return Arrays.equals(values, that.values);
+  }
+
+  public long[] getValues() {
+    return values;
+  }
+
+  public void setValues(final long[] values) {
+    this.values = values;
+  }
+}

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueRandomizedPropertyTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueRandomizedPropertyTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackReader;
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.msgpack.value.DeltaEncodedLongArrayValue;
+import java.util.Arrays;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import org.agrona.concurrent.UnsafeBuffer;
+
+final class DeltaEncodedLongArrayValueRandomizedPropertyTest {
+  private final MsgPackWriter writer = new MsgPackWriter();
+  private final MsgPackReader reader = new MsgPackReader();
+
+  @Property
+  void shouldEncodeAndDecodeAnyArray(@ForAll final long[] array) {
+    // given
+    final var input = new DeltaEncodedLongArrayValue();
+    final var result = new DeltaEncodedLongArrayValue();
+    input.setValues(array);
+
+    // when
+    final int encodedLength = input.getEncodedLength();
+    final var buffer = new UnsafeBuffer(new byte[encodedLength]);
+
+    writer.wrap(buffer, 0);
+    input.write(writer);
+
+    reader.wrap(buffer, 0, encodedLength);
+    result.read(reader);
+
+    // then
+    assertArrayEquals(array, input.getValues());
+    assertArrayEquals(array, result.getValues());
+  }
+
+  @Property
+  void shouldWritePlainJson(@ForAll final long[] array) {
+    // given
+    final var input = new DeltaEncodedLongArrayValue();
+    input.setValues(array);
+
+    // when
+    final var output = new StringBuilder();
+    input.writeJSON(output);
+
+    // then
+    assertThat(output.toString())
+        .isEqualTo(
+            "[" + String.join(",", Arrays.stream(array).mapToObj(Long::toString).toList()) + "]");
+  }
+}

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DeltaEncodedLongArrayValueTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.msgpack;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.msgpack.value.DeltaEncodedLongArrayValue;
+import org.junit.jupiter.api.Test;
+
+final class DeltaEncodedLongArrayValueTest {
+  @Test
+  void shouldEncodeEfficiently() {
+    // given
+    final var value = new DeltaEncodedLongArrayValue();
+    value.setValues(
+        new long[] {
+          // Emulates how we generate keys in Protocol.java without adding a cyclic dependency
+          (3L << 51) + 1L,
+          (3L << 51) + 1000L,
+          (3L << 51) + 1234L,
+          (3L << 51) + 1238L,
+          (3L << 51) + 2127L
+        });
+
+    // when
+    final int compressedLength = value.getEncodedLength();
+
+    // then
+    assertThat(compressedLength).isEqualTo(19);
+  }
+
+  @Test
+  void shouldWriteExpectedJson() {
+    // given
+    final var value = new DeltaEncodedLongArrayValue();
+    value.setValues(new long[] {1, 1000, 1234, 1238, 2127});
+
+    // when
+    final var output = new StringBuilder();
+    value.writeJSON(output);
+
+    // then
+    assertThat(output.toString()).isEqualTo("[1,1000,1234,1238,2127]");
+  }
+}


### PR DESCRIPTION
This uses a simple delta-encoding optimization for arrays of longs that saves space if the array values are relatively close to each other and the difference between one value and the next can be encoded as a smaller MsgPack integer type than the value itself.

For example, imagine we need to encode an array of three keys from the same partition. Using the normal `ArrayValue<LongValue>` to encode these, we'd expect an encoding size of 3*64 bits + type marker and array header overhead. If the keys are relatively close to each other, using the new `DeltaEncodedLongArrayValue` is more efficient because the encoding only requires 64 bits for the first value + 2 * 8 bits +  type marker and array header overhead, assuming that the deltas fit in 8 bit.

This implementation is not perfectly efficient because we don't impose any restrictions on the usage of `DeltaEncodedLongArrayValue`. If we would require all deltas to be encodable with a certain integer type, we could save the type marker overhead for example. Instead we choose flexibility and a simple implementation that always works and _sometimes_ saves space.

The `writeJson` method does not use delta encoding. This is to keep this implementation mostly internal and not leak it in places where human readability and easy parsing is preferable over minuscule space savings.

This is a classic space-time tradeoff because calculating or reversing the delta encoding takes some additional instructions, 1 extra addition or subtraction and one array look-behind per array element.

The values stored in memory are _not_ delta encoded and thus don't benefit from the space saving. However, just by specializing for `long` directly instead of using the generic `ArrayValue<LongValue>`, we also save some memory overhead, for example object headers and indirection through references.

Randomized property tests were added to ensure that the new type can encode and decode any arbitrary array losslessly. Some additional sanity checks were added by testing the expected JSON encoding and encoded size.