### PR TITLE
CI: add custom GHA best practices rules & linter

### DIFF
--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,17 +1,17 @@
 {
-    "problemMatcher": [
-      {
-        "owner": "actionlint",
-        "pattern": [
-          {
-            "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
-            "file": 1,
-            "line": 2,
-            "column": 3,
-            "message": 4,
-            "code": 5
-          }
-        ]
-      }
-    ]
-  }
+  "problemMatcher": [
+    {
+      "owner": "actionlint",
+      "pattern": [
+        {
+          "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "code": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -135,6 +135,7 @@ runs:
           - '.github/actions/**'
           - '.github/workflows/**'
           - '.github/actionlint*'
+          - '.github/conftest-*.rego'
 
         # We use specific src/main and src/test path to:
         #  * react on java code (production + test) changes

--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -1,0 +1,110 @@
+package main
+
+# The `input` variable is a data structure that contains a YAML file's contents
+# as objects and arrays. See https://www.openpolicyagent.org/docs/latest/philosophy/#how-does-opa-work
+
+deny[msg] {
+    # only enforced on workflows that have jobs defined (prevents problems on empty YAML documents)
+    input.jobs
+
+    # check if the workflow specifies a human-readable name, helps with debugging
+    not input.name
+
+    msg := "This GitHub Actions workflow has no name property!"
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == ["CI", "Zeebe CI"][_]
+
+    count(get_jobs_without_timeoutminutes(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs without timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_timeoutminutes(input.jobs))])
+}
+
+warn[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == ["CI", "Zeebe CI"][_]
+
+    count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs with too high (>15) timeout-minutes! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_timeoutminutes_higher_than(input.jobs, 15))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == ["CI", "Zeebe CI"][_]
+
+    count(get_jobs_without_cihealth(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs that don't send CI Health metrics! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_cihealth(input.jobs))])
+}
+
+deny[msg] {
+    # The "on" key gets transformed by conftest into "true" due to some legacy
+    # YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
+    # "on.push" becomes "true.push" which is why below statements use "true"
+    # instead of "on". Weird quirk...
+
+    # This rule should encourage using "on.pull_request" trigger for workflows
+    # that should run on PRs since that trigger allows to do change detection
+    # and has more CI health metrics available (target branch).
+
+    # enforce on workflows that have on.push trigger defined
+    input["true"].push
+    # but don't specify a set of branches
+    not input["true"].push.branches
+
+    msg := "This GitHub Actions workflows triggers on.push to any branch! Use on.pull_request for non-main/stable* branches."
+}
+
+###########################   RULE HELPERS   ##################################
+
+get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if there is timeout-minutes specified
+        not job["timeout-minutes"]
+    }
+}
+
+get_jobs_with_timeoutminutes_higher_than(jobInput, max_timeout) = jobs_without_timeoutminutes {
+    jobs_without_timeoutminutes := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check if timeout-minutes is higher than allowed maximum
+        job["timeout-minutes"] > max_timeout
+    }
+}
+
+get_jobs_without_cihealth(jobInput) = jobs_without_cihealth {
+    jobs_without_cihealth := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on "special" jobs needed for control flow in Unified CI
+        job_id != "detect-changes"
+        job_id != "check-results"
+        job_id != "test-summary"
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        # check that there is at least one step that invokes CI Health metric submission helper action
+        cihealth_steps := { step |
+            step := job.steps[_]
+            step.name == "Observe build status"
+            step.uses == "./.github/actions/observe-build-status"
+        }
+        count(cihealth_steps) < 1
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,12 +60,17 @@ jobs:
     env:
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: '1.7.4'
+      # renovate: datasource=github-tags depName=open-policy-agent/conftest
+      CONFTEST_VERSION: '0.56.0'
     steps:
       - uses: actions/checkout@v4
       - run: echo "::add-matcher::.github/actionlint-matcher.json"
       - run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
           ./actionlint -shellcheck '' -ignore 'property "vault_.+" is not defined in object type' -ignore 'object type "{}" cannot be filtered by object filtering `.*` since it has no object element'
+      - run: |
+          curl -s -L "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" | tar xvz conftest
+          ./conftest test -o github --policy .github/conftest-*.rego .github/workflows/*.yml
       - name: Observe build status
         if: always()
         continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,6 +694,7 @@ jobs:
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     needs:
       - actionlint
       - build-operate-backend
@@ -725,6 +726,7 @@ jobs:
     name: Deploy snapshot artifacts
     needs: [ check-results ]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-maven-snapshot
@@ -795,6 +797,7 @@ jobs:
     name: Deploy snapshot Camunda Docker image
     needs: [ docker-checks, check-results ]
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-camunda-docker-snapshot

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -320,6 +320,7 @@ jobs:
     name: Test summary
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     needs:
       - smoke-tests
       - property-tests
@@ -440,6 +441,7 @@ jobs:
     # the GitHub token passed around.
     name: Auto-merge backport and release PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     needs: [ test-summary ]
     if: |
       github.repository == 'camunda/camunda' &&


### PR DESCRIPTION
## Description

This PR aims to introduce additional linting rules for GHA workflows on top of what `actionlint` has to solve https://github.com/camunda/camunda/issues/25306. The new rules are opinionated and specifically tailored for the C8 monorepo CI and its CI Health observability framework (thus no standard tool has those rules).

MUST rules will fail the build, SHOULD rules are warnings but allow merging.

The new rules introduced are:

* all workflows MUST specify `name`
    * otherwise other rules relying on the name property might not work correctly
* all workflows MUST specify `on.push.branches` when using the `on.push` trigger
    * to make sure they only run on a small selected set of branches, e.g. `main` and `stable/*` - for PRs we use `on.pull_request` since that allows change detection and has more valuable CI health metrics (using target branch)
* all Unified CI related workflow jobs MUST specify `timeout-minutes`
* all Unified CI related workflow jobs SHOULD specify `timeout-minutes` with value of at most 15 minutes
* all Unified CI related workflow jobs MUST send CI Health metrics

This PR extends the `ci.yml` `actionlint` job, codifies the above rules as [OPA Rego policies](https://www.openpolicyagent.org/docs/latest/policy-language/) (good experience from Infra team) and uses `conftest` to verify them automatically.

This new framework allows adding more rules over time, extending scope and tightening rules from SHOULD to MUST if appropriate.

## Testing

Install https://www.conftest.dev/ locally and run e.g. `conftest test --policy .github/conftest-*.rego .github/workflows/*.yml` to execute the same rules on the same files as the new GHA step will do.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25306
