### PR TITLE
feat: introduce custom REST DTOs with string key attributes

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -52,6 +52,7 @@ import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponseStringKeys;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -66,6 +67,14 @@ public class CamundaServicesConfiguration {
       final BrokerClient brokerClient,
       final SecurityContextProvider securityContextProvider,
       final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
+    return new JobServices<>(brokerClient, securityContextProvider, activateJobsHandler, null);
+  }
+
+  @Bean
+  public JobServices<JobActivationResponseStringKeys> jobServicesWithStringKeys(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final ActivateJobsHandler<JobActivationResponseStringKeys> activateJobsHandler) {
     return new JobServices<>(brokerClient, securityContextProvider, activateJobsHandler, null);
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -102,6 +102,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/JobActivationResponse"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/JobActivationResponse"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/JobActivationResponseStringKeys"
         "400":
           description: >
             The provided data is not valid.
@@ -444,6 +450,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TenantItem"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/TenantItem"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/TenantItemStringKeys"
         "400":
           description: The provided data is not valid.
           content:
@@ -850,6 +862,12 @@ paths:
           application/json:
             schema:
               $ref: "#/components/schemas/UserTaskSearchQueryRequest"
+          application/vnd.camunda.api.keys.number+json:
+            schema:
+              $ref: "#/components/schemas/UserTaskSearchQueryRequest"
+          application/vnd.camunda.api.keys.string+json:
+            schema:
+              $ref: "#/components/schemas/UserTaskSearchQueryRequestStringKeys"
       responses:
         "200":
           description: >
@@ -858,6 +876,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/UserTaskSearchQueryResponse"
+            application/vnd.camunda.api.keys.number+json:
+              schema:
+                $ref: "#/components/schemas/UserTaskSearchQueryResponse"
+            application/vnd.camunda.api.keys.string+json:
+              schema:
+                $ref: "#/components/schemas/UserTaskSearchQueryResponseStringKeys"
         "400":
           description: >
             The user task search query failed.
@@ -3133,6 +3157,25 @@ components:
             type: integer
             format: int64
 
+    TenantItemStringKeys:
+      description: Tenant search response item.
+      type: object
+      properties:
+        tenantKey:
+          type: string
+          description: The unique system-generated internal tenant ID.
+        name:
+          type: string
+          description: The tenant name.
+        tenantId:
+          type: string
+          description: The unique external tenant ID.
+        assignedMemberKeys:
+          type: array
+          description: The set of keys of members assigned to the tenant.
+          items:
+            type: string
+
     TenantSearchQueryRequest:
       description: Tenant search request
       type: object
@@ -3177,6 +3220,16 @@ components:
           description: The user task search filters.
           allOf:
             - $ref: "#/components/schemas/UserTaskFilterRequest"
+    UserTaskSearchQueryRequestStringKeys:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      description: User task search query request.
+      type: object
+      properties:
+        filter:
+          description: The user task search filters.
+          allOf:
+            - $ref: "#/components/schemas/UserTaskFilterRequestStringKeys"
     UserTaskVariableSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
@@ -3193,6 +3246,17 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/UserTaskItem"
+    UserTaskSearchQueryResponseStringKeys:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      description: User task search query response.
+      type: object
+      properties:
+        items:
+          description: The matching user tasks.
+          type: array
+          items:
+            $ref: "#/components/schemas/UserTaskItemStringKeys"
     UserTaskFilterRequest:
       description: User task filter request.
       type: object
@@ -3251,6 +3315,60 @@ components:
           description: Variables associated with the user task.
           items:
             $ref: "#/components/schemas/UserTaskVariableFilterRequest"
+    UserTaskFilterRequestStringKeys:
+      description: User task filter request.
+      type: object
+      properties:
+        userTaskKey:
+          type: string
+          description: The key for this user task.
+        state:
+          type: string
+          description: The state of the user task.
+          enum:
+            - CREATED
+            - COMPLETED
+            - CANCELED
+            - FAILED
+        assignee:
+          description: The assignee of the user task.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        priority:
+          description: The priority of the user task.
+          allOf:
+            - $ref: "#/components/schemas/IntegerFilterProperty"
+        elementId:
+          type: string
+          description: The element ID of the user task.
+        candidateGroup:
+          description: The candidate group for this user task.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        candidateUser:
+          description: The candidate user for this user task.
+          allOf:
+            - $ref: "#/components/schemas/StringFilterProperty"
+        processDefinitionKey:
+          type: string
+          description: The key of the process definition.
+        processInstanceKey:
+          type: string
+          description: The key of the process instance.
+        tenantId:
+          type: string
+          description: Tenant ID of this user task.
+        processDefinitionId:
+          type: string
+          description: The ID of the process definition.
+        elementInstanceKey:
+          type: string
+          description: The key of the element instance.
+        variables:
+          type: array
+          description: Variables associated with the user task.
+          items:
+            $ref: "#/components/schemas/UserTaskVariableFilterRequest"
     UserTaskVariableFilterRequest:
       type: object
       properties:
@@ -3260,13 +3378,9 @@ components:
         value:
           type: string
           description: The value of the variable.
-    UserTaskItem:
+    UserTaskItemBase:
       type: object
       properties:
-        userTaskKey:
-          description: The key of the user task.
-          type: integer
-          format: int64
         state:
           type: string
           description: The state of the user task.
@@ -3281,10 +3395,6 @@ components:
         elementId:
           type: string
           description: The element ID of the user task.
-        elementInstanceKey:
-          type: integer
-          description: The key of the element instance.
-          format: int64
         candidateGroups:
           type: array
           description: The candidate groups for this user task.
@@ -3298,18 +3408,6 @@ components:
         processDefinitionId:
           type: string
           description: The ID of the process definition.
-        processDefinitionKey:
-          type: integer
-          description: The key of the process definition.
-          format: int64
-        processInstanceKey:
-          type: integer
-          description: The key of the process instance.
-          format: int64
-        formKey:
-          type: integer
-          description: The key of the form.
-          format: int64
         creationDate:
           type: string
           description: The creation date of a user task.
@@ -3347,6 +3445,51 @@ components:
           minimum: 0
           maximum: 100
           default: 50
+    UserTaskItem:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/UserTaskItemBase"
+      properties:
+        userTaskKey:
+          description: The key of the user task.
+          type: integer
+          format: int64
+        elementInstanceKey:
+          type: integer
+          description: The key of the element instance.
+          format: int64
+        processDefinitionKey:
+          type: integer
+          description: The key of the process definition.
+          format: int64
+        processInstanceKey:
+          type: integer
+          description: The key of the process instance.
+          format: int64
+        formKey:
+          type: integer
+          description: The key of the form.
+          format: int64
+    UserTaskItemStringKeys:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/UserTaskItemBase"
+      properties:
+        userTaskKey:
+          description: The key of the user task.
+          type: string
+        elementInstanceKey:
+          type: string
+          description: The key of the element instance.
+        processDefinitionKey:
+          type: string
+          description: The key of the process definition.
+        processInstanceKey:
+          type: string
+          description: The key of the process instance.
+        formKey:
+          type: string
+          description: The key of the form.
     VariableSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
@@ -4829,28 +4972,29 @@ components:
         - timeout
         - maxJobsToActivate
     JobActivationResponse:
-      description: The list of activated jobs
+      description: The list of activated jobs with keys as numbers.
       type: object
       properties:
         jobs:
-          description: The activated jobs.
+          description: The activated jobs with keys as numbers.
           type: array
           items:
             $ref: "#/components/schemas/ActivatedJob"
-    ActivatedJob:
+    JobActivationResponseStringKeys:
+      description: The list of activated jobs with keys as strings.
       type: object
       properties:
-        jobKey:
-          description: the key, a unique identifier for the job
-          type: integer
-          format: int64
+        jobs:
+          description: The activated jobs with keys as strings.
+          type: array
+          items:
+            $ref: "#/components/schemas/ActivatedJobStringKeys"
+    ActivatedJobBase:
+      type: object
+      properties:
         type:
           description: the type of the job (should match what was requested)
           type: string
-        processInstanceKey:
-          description: the job's process instance key
-          type: integer
-          format: int64
         processDefinitionId:
           description: the bpmn process ID of the job's process definition
           type: string
@@ -4858,19 +5002,9 @@ components:
           description: the version of the job's process definition
           type: integer
           format: int32
-        processDefinitionKey:
-          description: the key of the job's process definition
-          type: integer
-          format: int64
         elementId:
           description: the associated task element ID
           type: string
-        elementInstanceKey:
-          description: >
-            the unique key identifying the associated task, unique within the scope of the
-            process instance
-          type: integer
-          format: int64
         customHeaders:
           description: a set of custom headers defined during modelling; returned as a serialized JSON document
           type: object
@@ -4892,6 +5026,48 @@ components:
           additionalProperties: true
         tenantId:
           description: The ID of the tenant that owns the job
+          type: string
+    ActivatedJob:
+      allOf:
+        - $ref: "#/components/schemas/ActivatedJobBase"
+      type: object
+      properties:
+        jobKey:
+          description: the key, a unique identifier for the job
+          type: integer
+          format: int64
+        processInstanceKey:
+          description: the job's process instance key
+          type: integer
+          format: int64
+        processDefinitionKey:
+          description: the key of the job's process definition
+          type: integer
+          format: int64
+        elementInstanceKey:
+          description: >
+            the unique key identifying the associated task, unique within the scope of the
+            process instance
+          type: integer
+          format: int64
+    ActivatedJobStringKeys:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/ActivatedJobBase"
+      properties:
+        jobKey:
+          description: the key, a unique identifier for the job
+          type: string
+        processInstanceKey:
+          description: the job's process instance key
+          type: string
+        processDefinitionKey:
+          description: the key of the job's process definition
+          type: string
+        elementInstanceKey:
+          description: >
+            the unique key identifying the associated task, unique within the scope of the
+            process instance
           type: string
     JobFailRequest:
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -124,6 +124,11 @@ import org.springframework.web.multipart.MultipartFile;
 
 public class RequestMapper {
 
+  public static final String MEDIA_TYPE_KEYS_STRING =
+      "application/vnd.camunda.api.keys.string+json";
+  public static final String MEDIA_TYPE_KEYS_NUMBER =
+      "application/vnd.camunda.api.keys.number+json";
+
   public static CompleteUserTaskRequest toUserTaskCompletionRequest(
       final UserTaskCompletionRequest completionRequest, final long userTaskKey) {
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -61,11 +61,14 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleItem;
 import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.TenantItem;
+import io.camunda.zeebe.gateway.protocol.rest.TenantItemStringKeys;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskItemStringKeys;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResponseStringKeys;
 import io.camunda.zeebe.gateway.protocol.rest.VariableItem;
 import io.camunda.zeebe.gateway.protocol.rest.VariableSearchQueryResponse;
 import java.util.Arrays;
@@ -171,6 +174,17 @@ public final class SearchQueryResponseMapper {
         .items(
             ofNullable(result.items())
                 .map(SearchQueryResponseMapper::toUserTasks)
+                .orElseGet(Collections::emptyList));
+  }
+
+  public static UserTaskSearchQueryResponseStringKeys toUserTaskSearchQueryResponseStringKeys(
+      final SearchQueryResult<UserTaskEntity> result) {
+    final var page = toSearchQueryPageResponse(result);
+    return new UserTaskSearchQueryResponseStringKeys()
+        .page(page)
+        .items(
+            ofNullable(result.items())
+                .map(SearchQueryResponseMapper::toUserTasksStringKeys)
                 .orElseGet(Collections::emptyList));
   }
 
@@ -283,6 +297,20 @@ public final class SearchQueryResponseMapper {
                 : tenantEntity.assignedMemberKeys().stream().sorted().toList());
   }
 
+  public static TenantItemStringKeys toTenantStringKeys(final TenantEntity tenantEntity) {
+    return new TenantItemStringKeys()
+        .tenantKey(String.valueOf(tenantEntity.tenantKey()))
+        .name(tenantEntity.name())
+        .tenantId(tenantEntity.tenantId())
+        .assignedMemberKeys(
+            tenantEntity.assignedMemberKeys() == null
+                ? null
+                : tenantEntity.assignedMemberKeys().stream()
+                    .sorted()
+                    .map(Object::toString)
+                    .toList());
+  }
+
   private static List<DecisionDefinitionItem> toDecisionDefinitions(
       final List<DecisionDefinitionEntity> instances) {
     return instances.stream().map(SearchQueryResponseMapper::toDecisionDefinition).toList();
@@ -341,6 +369,11 @@ public final class SearchQueryResponseMapper {
     return tasks.stream().map(SearchQueryResponseMapper::toUserTask).toList();
   }
 
+  private static List<UserTaskItemStringKeys> toUserTasksStringKeys(
+      final List<UserTaskEntity> tasks) {
+    return tasks.stream().map(SearchQueryResponseMapper::toUserTaskStringKeys).toList();
+  }
+
   private static List<IncidentItem> toIncidents(final List<IncidentEntity> incidents) {
     return incidents.stream().map(SearchQueryResponseMapper::toIncident).toList();
   }
@@ -375,6 +408,30 @@ public final class SearchQueryResponseMapper {
         .candidateUsers(t.candidateUsers())
         .candidateGroups(t.candidateGroups())
         .formKey(t.formKey())
+        .elementId(t.elementId())
+        .creationDate(formatDate(t.creationDate()))
+        .completionDate(formatDate(t.completionDate()))
+        .dueDate(formatDate(t.dueDate()))
+        .followUpDate(formatDate(t.followUpDate()))
+        .externalFormReference(t.externalFormReference())
+        .processDefinitionVersion(t.processDefinitionVersion())
+        .customHeaders(t.customHeaders())
+        .priority(t.priority());
+  }
+
+  public static UserTaskItemStringKeys toUserTaskStringKeys(final UserTaskEntity t) {
+    return new UserTaskItemStringKeys()
+        .tenantId(t.tenantId())
+        .userTaskKey(String.valueOf(t.userTaskKey()))
+        .processInstanceKey(String.valueOf(t.processInstanceKey()))
+        .processDefinitionKey(String.valueOf(t.processDefinitionKey()))
+        .elementInstanceKey(String.valueOf(t.elementInstanceKey()))
+        .processDefinitionId(t.processDefinitionId())
+        .state(UserTaskItemStringKeys.StateEnum.fromValue(t.state().name()))
+        .assignee(t.assignee())
+        .candidateUsers(t.candidateUsers())
+        .candidateGroups(t.candidateGroups())
+        .formKey(String.valueOf(t.formKey()))
         .elementId(t.elementId())
         .creationDate(formatDate(t.creationDate()))
         .completionDate(formatDate(t.completionDate()))

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseWithStringKeysObserver.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseWithStringKeysObserver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponseStringKeys;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.ResponseEntity;
+
+public class JobActivationRequestResponseWithStringKeysObserver
+    implements ResponseObserver<JobActivationResponseStringKeys> {
+  protected JobActivationResponseStringKeys response = new JobActivationResponseStringKeys();
+  protected CompletableFuture<ResponseEntity<Object>> result;
+
+  private Runnable cancelationHandler;
+
+  public JobActivationRequestResponseWithStringKeysObserver(
+      final CompletableFuture<ResponseEntity<Object>> result) {
+    this.result = result;
+  }
+
+  @Override
+  public void onCompleted() {
+    result.complete(ResponseEntity.ok(response));
+  }
+
+  @Override
+  public void onNext(final JobActivationResponseStringKeys element) {
+    if (element.getJobs() != null && !element.getJobs().isEmpty()) {
+      element.getJobs().forEach(response::addJobsItem);
+    }
+  }
+
+  @Override
+  public boolean isCancelled() {
+    // the CompletableFuture will be canceled eventually if the request is canceled
+    return result.isCancelled() || result.isCompletedExceptionally();
+  }
+
+  @Override
+  public void onError(final Throwable throwable) {
+    result.complete(
+        RestErrorMapper.mapProblemToResponse(
+            RestErrorMapper.mapErrorToProblem(
+                throwable, RestErrorMapper.DEFAULT_REJECTION_MAPPER)));
+  }
+
+  public void setCancelationHandler(final Runnable handler) {
+    cancelationHandler = handler;
+  }
+
+  public void invokeCancelationHandler() {
+    if (cancelationHandler != null) {
+      cancelationHandler.run();
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResponseWithStringKeysObserverProvider.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ResponseWithStringKeysObserverProvider.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import org.springframework.http.ResponseEntity;
+
+public interface ResponseWithStringKeysObserverProvider
+    extends Function<
+        CompletableFuture<ResponseEntity<Object>>,
+        JobActivationRequestResponseWithStringKeysObserver> {}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -18,6 +18,7 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.service.JobServices;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponseStringKeys;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobResult;
@@ -25,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -39,556 +41,568 @@ public class JobControllerTest extends RestControllerTest {
 
   @MockBean JobServices<JobActivationResponse> jobServices;
   @MockBean ResponseObserverProvider responseObserverProvider;
+  @MockBean JobServices<JobActivationResponseStringKeys> jobServicesStringKeys;
+  @MockBean ResponseWithStringKeysObserverProvider responseWithStringKeysObserverProvider;
 
   @BeforeEach
   void setup() {
     when(jobServices.withAuthentication(any(Authentication.class))).thenReturn(jobServices);
   }
 
-  @Test
-  void shouldFailJob() {
-    // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+  @Nested
+  class ImplicitNumberKeys {
+    @Test
+    void shouldFailJob() {
+      // given
+      when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
-    final var request =
-        """
+      final var request =
+          """
+              {
+                "retries": 1,
+                "errorMessage": "error",
+                "retryBackOff": 1,
+                "variables": {
+                  "foo": "bar"
+                }
+              }""";
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/failure")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).failJob(1L, 1, "error", 1L, Map.of("foo", "bar"));
+    }
+
+    @Test
+    void shouldFailJobWithoutBody() {
+      // given
+      when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/failure")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).failJob(1L, 0, "", 0L, Map.of());
+    }
+
+    @Test
+    void shouldFailJobWithEmptyBody() {
+      // given
+      when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+              {}
+              """;
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/failure")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).failJob(1L, 0, "", 0L, Map.of());
+    }
+
+    @Test
+    void shouldThrowErrorJob() {
+      // given
+      when(jobServices.errorJob(anyLong(), anyString(), anyString(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+              {
+                "errorCode": "400",
+                "errorMessage": "error",
+                "variables": {
+                  "foo": "bar"
+                }
+              }""";
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/error")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).errorJob(1L, "400", "error", Map.of("foo", "bar"));
+    }
+
+    @Test
+    void shouldRejectThrowErrorJobWithoutBody() {
+      // given
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "Bad Request",
+                "detail": "Required request body is missing",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1/error");
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/error")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
+
+    @Test
+    void shouldRejectThrowErrorJobWithoutErrorCode() {
+      // given
+      final var request =
+          """
+              {
+                "errorMessage": "error",
+                "variables": {
+                  "foo": "bar"
+                }
+              }""";
+
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "No errorCode provided.",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1/error");
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/error")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
+
+    @Test
+    void shouldRejectThrowErrorJobWithEmptyErrorCode() {
+      // given
+      final var request =
+          """
+              {
+                "errorCode": "",
+                "errorMessage": "error",
+                "variables": {
+                  "foo": "bar"
+                }
+              }""";
+
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "No errorCode provided.",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1/error");
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/error")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
+
+    @Test
+    void shouldRejectThrowErrorJobWithOnlySpacesErrorCode() {
+      // given
+      final var request =
+          """
+              {
+                "errorCode": "    ",
+                "errorMessage": "error",
+                "variables": {
+                  "foo": "bar"
+                }
+              }""";
+
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "No errorCode provided.",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1/error");
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/error")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
+
+    @Test
+    void shouldCompleteJob() {
+      // given
+      when(jobServices.completeJob(anyLong(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/completion")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of()), any(JobResult.class));
+    }
+
+    @Test
+    void shouldCompleteJobWithResultDeniedTrue() {
+      // given
+      when(jobServices.completeJob(anyLong(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
             {
-              "retries": 1,
-              "errorMessage": "error",
-              "retryBackOff": 1,
+              "result": {
+                "denied": true
+              }
+            }
+          """;
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/completion")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
+          ArgumentCaptor.forClass(JobResult.class);
+      Mockito.verify(jobServices)
+          .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
+      Assertions.assertTrue(jobResultArgumentCaptor.getValue().isDenied());
+    }
+
+    @Test
+    void shouldCompleteJobWithResultDeniedFalse() {
+      // given
+      when(jobServices.completeJob(anyLong(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+            {
+              "result": {
+                "denied": false
+              }
+            }
+          """;
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/completion")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
+          ArgumentCaptor.forClass(JobResult.class);
+      Mockito.verify(jobServices)
+          .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
+      Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
+    }
+
+    @Test
+    void shouldCompleteJobWithResultAndIgnoreUnknownField() {
+      // given
+      when(jobServices.completeJob(anyLong(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+            {
+              "result": {
+                "unknownField": true
+              }
+            }
+          """;
+
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/completion")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
+          ArgumentCaptor.forClass(JobResult.class);
+      Mockito.verify(jobServices)
+          .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
+      Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
+    }
+
+    @Test
+    void shouldCompleteJobWithVariables() {
+      // given
+      when(jobServices.completeJob(anyLong(), any(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+            {
               "variables": {
                 "foo": "bar"
               }
-            }""";
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/failure")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).failJob(1L, 1, "error", 1L, Map.of("foo", "bar"));
-  }
-
-  @Test
-  void shouldFailJobWithoutBody() {
-    // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/failure")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).failJob(1L, 0, "", 0L, Map.of());
-  }
-
-  @Test
-  void shouldFailJobWithEmptyBody() {
-    // given
-    when(jobServices.failJob(anyLong(), anyInt(), anyString(), anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-            {}
-            """;
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/failure")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).failJob(1L, 0, "", 0L, Map.of());
-  }
-
-  @Test
-  void shouldThrowErrorJob() {
-    // given
-    when(jobServices.errorJob(anyLong(), anyString(), anyString(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-            {
-              "errorCode": "400",
-              "errorMessage": "error",
-              "variables": {
-                "foo": "bar"
-              }
-            }""";
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/error")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).errorJob(1L, "400", "error", Map.of("foo", "bar"));
-  }
-
-  @Test
-  void shouldRejectThrowErrorJobWithoutBody() {
-    // given
-    final var expectedBody =
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "Bad Request",
-              "detail": "Required request body is missing",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1/error");
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/error")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
-  }
-
-  @Test
-  void shouldRejectThrowErrorJobWithoutErrorCode() {
-    // given
-    final var request =
-        """
-            {
-              "errorMessage": "error",
-              "variables": {
-                "foo": "bar"
-              }
-            }""";
-
-    final var expectedBody =
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No errorCode provided.",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1/error");
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/error")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
-  }
-
-  @Test
-  void shouldRejectThrowErrorJobWithEmptyErrorCode() {
-    // given
-    final var request =
-        """
-            {
-              "errorCode": "",
-              "errorMessage": "error",
-              "variables": {
-                "foo": "bar"
-              }
-            }""";
-
-    final var expectedBody =
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No errorCode provided.",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1/error");
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/error")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
-  }
-
-  @Test
-  void shouldRejectThrowErrorJobWithOnlySpacesErrorCode() {
-    // given
-    final var request =
-        """
-            {
-              "errorCode": "    ",
-              "errorMessage": "error",
-              "variables": {
-                "foo": "bar"
-              }
-            }""";
-
-    final var expectedBody =
-        """
-            {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "No errorCode provided.",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1/error");
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/error")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
-  }
-
-  @Test
-  void shouldCompleteJob() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of()), any(JobResult.class));
-  }
-
-  @Test
-  void shouldCompleteJobWithResultDeniedTrue() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "result": {
-              "denied": true
             }
-          }
-        """;
+          """;
 
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+      // when/then
+      webClient
+          .post()
+          .uri(JOBS_BASE_URL + "/1/completion")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
-        ArgumentCaptor.forClass(JobResult.class);
-    Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertTrue(jobResultArgumentCaptor.getValue().isDenied());
-  }
+      Mockito.verify(jobServices)
+          .completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class));
+    }
 
-  @Test
-  void shouldCompleteJobWithResultDeniedFalse() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+    @Test
+    void shouldUpdateJob() {
+      // given
+      when(jobServices.updateJob(anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
-    final var request =
-        """
-          {
-            "result": {
-              "denied": false
-            }
-          }
-        """;
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
-        ArgumentCaptor.forClass(JobResult.class);
-    Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
-  }
-
-  @Test
-  void shouldCompleteJobWithResultAndIgnoreUnknownField() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "result": {
-              "unknownField": true
-            }
-          }
-        """;
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    final ArgumentCaptor<JobResult> jobResultArgumentCaptor =
-        ArgumentCaptor.forClass(JobResult.class);
-    Mockito.verify(jobServices)
-        .completeJob(eq(1L), eq(Map.of()), jobResultArgumentCaptor.capture());
-    Assertions.assertFalse(jobResultArgumentCaptor.getValue().isDenied());
-  }
-
-  @Test
-  void shouldCompleteJobWithVariables() {
-    // given
-    when(jobServices.completeJob(anyLong(), any(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "variables": {
-              "foo": "bar"
-            }
-          }
-        """;
-
-    // when/then
-    webClient
-        .post()
-        .uri(JOBS_BASE_URL + "/1/completion")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).completeJob(eq(1L), eq(Map.of("foo", "bar")), any(JobResult.class));
-  }
-
-  @Test
-  void shouldUpdateJob() {
-    // given
-    when(jobServices.updateJob(anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "changeset": {
-              "retries": 5,
-              "timeout": 1000
-            }
-          }
-        """;
-    // when/then
-    webClient
-        .patch()
-        .uri(JOBS_BASE_URL + "/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(5, 1000L));
-  }
-
-  @Test
-  void shouldUpdateJobWithOnlyRetries() {
-    // given
-    when(jobServices.updateJob(anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
-          {
-            "changeset": {
-              "retries": 5
-            }
-          }
-        """;
-    // when/then
-    webClient
-        .patch()
-        .uri(JOBS_BASE_URL + "/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
-
-    Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(5, null));
-  }
-
-  @Test
-  void shouldUpdateJobWithOnlyTimeout() {
-    // given
-    when(jobServices.updateJob(anyLong(), any()))
-        .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
-
-    final var request =
-        """
+      final var request =
+          """
             {
               "changeset": {
+                "retries": 5,
                 "timeout": 1000
               }
-            }""";
-    // when/then
-    webClient
-        .patch()
-        .uri(JOBS_BASE_URL + "/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isNoContent();
+            }
+          """;
+      // when/then
+      webClient
+          .patch()
+          .uri(JOBS_BASE_URL + "/1")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(null, 1000L));
-  }
+      Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(5, 1000L));
+    }
 
-  @Test
-  void shouldRejectUpdateJob() {
-    // given
-    final var request =
-        """
-          {
-            "changeset": {}
-          }
-        """;
+    @Test
+    void shouldUpdateJobWithOnlyRetries() {
+      // given
+      when(jobServices.updateJob(anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
 
-    final var expectedBody =
-        """
+      final var request =
+          """
             {
-              "type": "about:blank",
-              "status": 400,
-              "title": "INVALID_ARGUMENT",
-              "detail": "At least one of [retries, timeout] is required.",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1");
+              "changeset": {
+                "retries": 5
+              }
+            }
+          """;
+      // when/then
+      webClient
+          .patch()
+          .uri(JOBS_BASE_URL + "/1")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
 
-    // when/then
-    webClient
-        .patch()
-        .uri(JOBS_BASE_URL + "/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue(request)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
-  }
+      Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(5, null));
+    }
 
-  @Test
-  void shouldRejectUpdateJobNoBody() {
-    // given
-    final var expectedBody =
-        """
+    @Test
+    void shouldUpdateJobWithOnlyTimeout() {
+      // given
+      when(jobServices.updateJob(anyLong(), any()))
+          .thenReturn(CompletableFuture.completedFuture(new JobRecord()));
+
+      final var request =
+          """
+              {
+                "changeset": {
+                  "timeout": 1000
+                }
+              }""";
+      // when/then
+      webClient
+          .patch()
+          .uri(JOBS_BASE_URL + "/1")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isNoContent();
+
+      Mockito.verify(jobServices).updateJob(1L, new UpdateJobChangeset(null, 1000L));
+    }
+
+    @Test
+    void shouldRejectUpdateJob() {
+      // given
+      final var request =
+          """
             {
-              "type": "about:blank",
-              "status": 400,
-              "title": "Bad Request",
-              "detail": "Required request body is missing",
-              "instance": "%s"
-            }"""
-            .formatted(JOBS_BASE_URL + "/1");
+              "changeset": {}
+            }
+          """;
 
-    // when/then
-    webClient
-        .patch()
-        .uri(JOBS_BASE_URL + "/1")
-        .accept(MediaType.APPLICATION_JSON)
-        .contentType(MediaType.APPLICATION_JSON)
-        .exchange()
-        .expectStatus()
-        .isBadRequest()
-        .expectHeader()
-        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
-        .expectBody()
-        .json(expectedBody);
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "INVALID_ARGUMENT",
+                "detail": "At least one of [retries, timeout] is required.",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1");
+
+      // when/then
+      webClient
+          .patch()
+          .uri(JOBS_BASE_URL + "/1")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .bodyValue(request)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
+
+    @Test
+    void shouldRejectUpdateJobNoBody() {
+      // given
+      final var expectedBody =
+          """
+              {
+                "type": "about:blank",
+                "status": 400,
+                "title": "Bad Request",
+                "detail": "Required request body is missing",
+                "instance": "%s"
+              }"""
+              .formatted(JOBS_BASE_URL + "/1");
+
+      // when/then
+      webClient
+          .patch()
+          .uri(JOBS_BASE_URL + "/1")
+          .accept(MediaType.APPLICATION_JSON)
+          .contentType(MediaType.APPLICATION_JSON)
+          .exchange()
+          .expectStatus()
+          .isBadRequest()
+          .expectHeader()
+          .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+          .expectBody()
+          .json(expectedBody);
+    }
   }
+
+  @Nested
+  class ExplicitNumberKeys {}
+
+  @Nested
+  class ExplicitStringKeys {}
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -27,6 +27,7 @@ import io.camunda.search.sort.UserTaskSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.rest.JacksonConfig;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
@@ -68,6 +69,42 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       "candidateUsers": [],
                       "candidateGroups": [],
                       "formKey": 0,
+                      "elementId": "e",
+                      "creationDate": "2020-11-11T00:00:00.000Z",
+                      "completionDate": "2020-11-11T00:00:00.000Z",
+                      "dueDate": "2020-11-11T00:00:00.000Z",
+                      "followUpDate": "2020-11-11T00:00:00.000Z",
+                      "externalFormReference": "efr",
+                      "processDefinitionVersion": 1,
+                      "customHeaders": {},
+                      "priority": 50
+                  }
+              ],
+              "page": {
+                  "totalItems": 1,
+                  "firstSortValues": ["v"],
+                  "lastSortValues": [
+                      "v"
+                  ]
+              }
+          }""";
+
+  private static final String EXPECTED_SEARCH_RESPONSE_STRING_KEYS =
+      """
+          {
+              "items": [
+                  {
+                      "tenantId": "t",
+                      "userTaskKey": "0",
+                      "processInstanceKey": "1",
+                      "processDefinitionKey": "2",
+                      "elementInstanceKey": "3",
+                      "processDefinitionId": "b",
+                      "state": "CREATED",
+                      "assignee": "a",
+                      "candidateUsers": [],
+                      "candidateGroups": [],
+                      "formKey": "0",
                       "elementId": "e",
                       "creationDate": "2020-11-11T00:00:00.000Z",
                       "completionDate": "2020-11-11T00:00:00.000Z",
@@ -245,6 +282,46 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         .contentType(APPLICATION_JSON)
         .expectBody()
         .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(userTaskServices).search(new UserTaskQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSearchUserTasksWithEmptyBodyNumberKeys() {
+    // given
+    when(userTaskServices.search(any(UserTaskQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(USER_TASKS_SEARCH_URL)
+        .header("Accept", RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(userTaskServices).search(new UserTaskQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSearchUserTasksWithEmptyBodyStringKeys() {
+    // given
+    when(userTaskServices.search(any(UserTaskQuery.class))).thenReturn(SEARCH_QUERY_RESULT);
+    // when / then
+    webClient
+        .post()
+        .uri(USER_TASKS_SEARCH_URL)
+        .header("Accept", RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE_STRING_KEYS);
 
     verify(userTaskServices).search(new UserTaskQuery.Builder().build());
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.search.query.TenantQuery;
 import io.camunda.search.sort.TenantSort;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.TenantServices;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import java.util.Set;
@@ -121,6 +122,74 @@ public class TenantQueryControllerTest extends RestControllerTest {
             """
             {
               "tenantKey": %d,
+              "name": "%s",
+              "tenantId": "%s",
+              "assignedMemberKeys": []
+            }
+            """
+                .formatted(tenant.tenantKey(), tenantName, tenantId));
+
+    // then
+    verify(tenantServices, times(1)).getByKey(tenant.tenantKey());
+  }
+
+  @Test
+  void getTenantShouldReturnOkWithNumberKeys() {
+    // given
+    final var tenantName = "Tenant Name";
+    final var tenantId = "tenant-id";
+    final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
+    when(tenantServices.getByKey(tenant.tenantKey())).thenReturn(tenant);
+
+    // when
+    webClient
+        .get()
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.tenantKey()))
+        .header("Accept", RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_NUMBER)
+        .expectBody()
+        .json(
+            """
+            {
+              "tenantKey": %d,
+              "name": "%s",
+              "tenantId": "%s",
+              "assignedMemberKeys": []
+            }
+            """
+                .formatted(tenant.tenantKey(), tenantName, tenantId));
+
+    // then
+    verify(tenantServices, times(1)).getByKey(tenant.tenantKey());
+  }
+
+  @Test
+  void getTenantShouldReturnOkWithStringKeys() {
+    // given
+    final var tenantName = "Tenant Name";
+    final var tenantId = "tenant-id";
+    final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
+    when(tenantServices.getByKey(tenant.tenantKey())).thenReturn(tenant);
+
+    // when
+    webClient
+        .get()
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.tenantKey()))
+        .header("Accept", RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(RequestMapper.MEDIA_TYPE_KEYS_STRING)
+        .expectBody()
+        .json(
+            """
+            {
+              "tenantKey": "%s",
               "name": "%s",
               "tenantId": "%s",
               "assignedMemberKeys": []

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/util/ResettableJobActivationRequestResponseStringKeysObserver.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/util/ResettableJobActivationRequestResponseStringKeysObserver.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller.util;
+
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponseStringKeys;
+import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseWithStringKeysObserver;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.http.ResponseEntity;
+
+public class ResettableJobActivationRequestResponseStringKeysObserver
+    extends JobActivationRequestResponseWithStringKeysObserver {
+
+  public ResettableJobActivationRequestResponseStringKeysObserver(
+      final CompletableFuture<ResponseEntity<Object>> result) {
+    super(result);
+  }
+
+  public void reset() {
+    response = new JobActivationResponseStringKeys();
+  }
+
+  public ResettableJobActivationRequestResponseStringKeysObserver setResult(
+      final CompletableFuture<ResponseEntity<Object>> result) {
+    this.result = result;
+    return this;
+  }
+}


### PR DESCRIPTION
## Description

* Introduces custom media types for select endpoints to showcase media type negotiation
  * Job activation - collect results with string keys in REST response observer
  * User task search - mixed request and response types (request with plain, receive with custom)
  * Tenant fetching - accept results with string keys only

Hints:
* The job activation adjustments are pretty pragmatic and POC-style. For production code, we should look into refactoring this into a more generalized approach that doesn't copy that many classes and code.
* Content types are allowed to be mixed, e.g. send a request with plain json and expect a response with a specific type (even the "other" format with keys as strings) back
* This does not make keys as strings the default yet for simplicity (a lot of tests have to be adjusted for this to reflect the new default behavior).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #25424 
