### PR TITLE
fix: reintroduce noop Operate's schema migration app

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/SchemaMigration.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.migration;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SchemaMigration {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaMigration.class);
+
+  public static void main(final String[] args) {
+    // For now, keeping the class so that the init container does not
+    // crash loop when running the (old) migration app before starting
+    // the old importer-archiver.
+    LOGGER.info("No Schema Migration anymore.");
+  }
+}


### PR DESCRIPTION
## Description

In SaaS, the Operate's migration app runs as an init container by executing this [script](https://github.com/camunda/camunda/blob/main/dist/pom.xml#L719-L722). Since the class has been removed, the init container crash loops.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
