### PR TITLE
fix: various fixes to enable exporting and searching tenants

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/TenantSearchColumn.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/sql/columns/TenantSearchColumn.java
@@ -11,7 +11,7 @@ import io.camunda.search.entities.TenantEntity;
 import java.util.function.Function;
 
 public enum TenantSearchColumn implements SearchColumn<TenantEntity> {
-  TENANT_KEY("tenantKey", TenantEntity::tenantKey),
+  TENANT_KEY("key", TenantEntity::key),
   TENANT_ID("tenantId", TenantEntity::tenantId),
   NAME("name", TenantEntity::name);
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -215,7 +215,9 @@ public class TenantIT {
   private static void compareTenant(final TenantEntity actual, final TenantDbModel expected) {
     assertThat(actual)
         .usingRecursiveComparison()
-        .ignoringFields("assignedMemberKeys")
+        .ignoringFields("assignedMemberKeys", "key")
         .isEqualTo(expected);
+
+    assertThat(actual.key()).isEqualTo(expected.tenantKey());
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantIT.java
@@ -173,7 +173,7 @@ public class TenantIT {
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().tenantKey()).isEqualTo(instance.tenantKey());
+    assertThat(searchResult.items().getFirst().key()).isEqualTo(instance.tenantKey());
   }
 
   @TestTemplate
@@ -204,7 +204,7 @@ public class TenantIT {
                                         new Object[] {
                                           instanceAfter.name(),
                                           instanceAfter.tenantId(),
-                                          instanceAfter.tenantKey()
+                                          instanceAfter.key()
                                         }))));
 
     assertThat(nextPage.total()).isEqualTo(20);

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSortIT.java
@@ -39,7 +39,7 @@ public class TenantSortIT {
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantKey().asc(),
-        Comparator.comparing(TenantEntity::tenantKey));
+        Comparator.comparing(TenantEntity::key));
   }
 
   @TestTemplate
@@ -47,7 +47,7 @@ public class TenantSortIT {
     testSorting(
         testApplication.getRdbmsService(),
         b -> b.tenantKey().desc(),
-        Comparator.comparing(TenantEntity::tenantKey).reversed());
+        Comparator.comparing(TenantEntity::key).reversed());
   }
 
   @TestTemplate

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/tenant/TenantSpecificFilterIT.java
@@ -69,7 +69,7 @@ public class TenantSpecificFilterIT {
 
     assertThat(searchResult.total()).isEqualTo(1);
     assertThat(searchResult.items()).hasSize(1);
-    assertThat(searchResult.items().getFirst().tenantKey()).isEqualTo(42L);
+    assertThat(searchResult.items().getFirst().key()).isEqualTo(42L);
   }
 
   static List<TenantFilter> shouldFindTenantWithSpecificFilterParameters() {

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -315,8 +315,8 @@ class RdbmsExporterIT {
     // then
     final var tenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
     assertThat(tenant).isNotEmpty();
-    assertThat(tenant.get().tenantKey()).isEqualTo(tenantRecord.getKey());
-    assertThat(tenant.get().tenantKey()).isEqualTo(tenantRecordValue.getTenantKey());
+    assertThat(tenant.get().key()).isEqualTo(tenantRecord.getKey());
+    assertThat(tenant.get().key()).isEqualTo(tenantRecordValue.getTenantKey());
     assertThat(tenant.get().tenantId()).isEqualTo(tenantRecordValue.getTenantId());
     assertThat(tenant.get().name()).isEqualTo(tenantRecordValue.getName());
 
@@ -331,7 +331,7 @@ class RdbmsExporterIT {
     // then
     final var updatedTenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
     assertThat(updatedTenant).isNotEmpty();
-    assertThat(updatedTenant.get().tenantKey()).isEqualTo(updateTenantRecordValue.getTenantKey());
+    assertThat(updatedTenant.get().key()).isEqualTo(updateTenantRecordValue.getTenantKey());
     assertThat(updatedTenant.get().tenantId()).isEqualTo(updateTenantRecordValue.getTenantId());
     assertThat(updatedTenant.get().name()).isEqualTo(updateTenantRecordValue.getName());
   }
@@ -349,7 +349,7 @@ class RdbmsExporterIT {
     // then
     final var tenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
     assertThat(tenant).isNotEmpty();
-    assertThat(tenant.get().tenantKey()).isEqualTo(tenantRecordValue.getTenantKey());
+    assertThat(tenant.get().key()).isEqualTo(tenantRecordValue.getTenantKey());
     assertThat(tenant.get().name()).isEqualTo(tenantRecordValue.getName());
 
     // when

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/TenantEntityTransformer.java
@@ -19,9 +19,9 @@ public class TenantEntityTransformer
   public TenantEntity apply(
       final io.camunda.webapps.schema.entities.usermanagement.TenantEntity source) {
     return new TenantEntity(
-        source.getTenantKey(),
+        source.getKey(),
         source.getTenantId(),
         source.getName(),
-        source.getJoin() != null ? Set.of(source.getJoin().parent()) : Set.of());
+        source.getJoin().parent() != null ? Set.of(source.getJoin().parent()) : Set.of());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -30,6 +30,6 @@ public class TenantFilterTransformer implements FilterTransformer<TenantFilter> 
 
   @Override
   public List<String> toIndices(final TenantFilter filter) {
-    return List.of("identity-tenant-8.7.0_alias");
+    return List.of("identity-tenants-8.7.0_alias");
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/TenantFieldSortingTransformer.java
@@ -16,7 +16,7 @@ public class TenantFieldSortingTransformer implements FieldSortingTransformer {
   @Override
   public String apply(final String domainField) {
     return switch (domainField) {
-      case "tenantKey" -> KEY;
+      case "key" -> KEY;
       case "tenantId" -> TENANT_ID;
       case "name" -> NAME;
       default -> throw new IllegalArgumentException("Unknown sortField: " + domainField);

--- a/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/TenantEntity.java
@@ -11,5 +11,4 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.Set;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TenantEntity(
-    Long tenantKey, String tenantId, String name, Set<Long> assignedMemberKeys) {}
+public record TenantEntity(Long key, String tenantId, String name, Set<Long> assignedMemberKeys) {}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/TenantSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/TenantSort.java
@@ -26,7 +26,7 @@ public record TenantSort(List<FieldSorting> orderings) implements SortOption {
       implements ObjectBuilder<TenantSort> {
 
     public Builder tenantKey() {
-      currentOrdering = new FieldSorting("tenantKey", null);
+      currentOrdering = new FieldSorting("key", null);
       return this;
     }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/TenantEntity.java
@@ -11,19 +11,19 @@ import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 
 public class TenantEntity extends AbstractExporterEntity<TenantEntity> {
 
-  private Long tenantKey;
+  private Long key;
   private String tenantId;
   private String name;
   private Long memberKey;
 
   private EntityJoinRelation join;
 
-  public Long getTenantKey() {
-    return tenantKey;
+  public Long getKey() {
+    return key;
   }
 
-  public TenantEntity setTenantKey(final Long tenantKey) {
-    this.tenantKey = tenantKey;
+  public TenantEntity setKey(final Long key) {
+    this.key = key;
     return this;
   }
 

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-tenants.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/identity-tenants.json
@@ -14,6 +14,9 @@
       "name": {
         "type": "keyword"
       },
+      "memberKey": {
+        "type": "long"
+      },
       "join": {
         "type": "join",
         "eager_global_ordinals": true,

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-tenants.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/identity-tenants.json
@@ -14,6 +14,9 @@
       "name": {
         "type": "keyword"
       },
+      "memberKey": {
+        "type": "long"
+      },
       "join": {
         "type": "join",
         "eager_global_ordinals": true,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantCreateUpdateHandler.java
@@ -59,7 +59,7 @@ public class TenantCreateUpdateHandler implements ExportHandler<TenantEntity, Te
     final TenantRecordValue value = record.getValue();
     final var joinRelation = TenantIndex.JOIN_RELATION_FACTORY.createParent();
     entity
-        .setTenantKey(value.getTenantKey())
+        .setKey(value.getTenantKey())
         .setTenantId(value.getTenantId())
         .setName(value.getName())
         .setJoin(joinRelation);

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/TenantEntityAddedHandler.java
@@ -60,7 +60,7 @@ public class TenantEntityAddedHandler implements ExportHandler<TenantEntity, Ten
     final EntityJoinRelation joinRelation =
         TenantIndex.JOIN_RELATION_FACTORY.createChild(value.getTenantKey());
     entity
-        .setTenantKey(value.getTenantKey())
+        .setKey(value.getTenantKey())
         .setTenantId(value.getTenantId())
         .setName(value.getName())
         .setJoin(joinRelation);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -662,7 +662,7 @@ public final class SearchQueryRequestMapper {
       validationErrors.add(ERROR_SORT_FIELD_MUST_NOT_BE_NULL);
     } else {
       switch (field) {
-        case "tenantKey" -> builder.tenantKey();
+        case "key" -> builder.tenantKey();
         case "name" -> builder.name();
         case "tenantId" -> builder.tenantId();
         default -> validationErrors.add(ERROR_UNKNOWN_SORT_BY.formatted(field));

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -268,7 +268,7 @@ public final class SearchQueryResponseMapper {
 
   public static TenantItem toTenant(final TenantEntity tenantEntity) {
     return new TenantItem()
-        .tenantKey(tenantEntity.tenantKey())
+        .tenantKey(tenantEntity.key())
         .name(tenantEntity.name())
         .tenantId(tenantEntity.tenantId())
         .assignedMemberKeys(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -75,15 +75,15 @@ public class TenantQueryControllerTest extends RestControllerTest {
        }
       """
           .formatted(
-              TENANT_ENTITIES.get(0).tenantKey(),
+              TENANT_ENTITIES.get(0).key(),
               TENANT_ENTITIES.get(0).name(),
               TENANT_ENTITIES.get(0).tenantId(),
               formatSet(TENANT_ENTITIES.get(0).assignedMemberKeys()),
-              TENANT_ENTITIES.get(1).tenantKey(),
+              TENANT_ENTITIES.get(1).key(),
               TENANT_ENTITIES.get(1).name(),
               TENANT_ENTITIES.get(1).tenantId(),
               formatSet(TENANT_ENTITIES.get(1).assignedMemberKeys()),
-              TENANT_ENTITIES.get(2).tenantKey(),
+              TENANT_ENTITIES.get(2).key(),
               TENANT_ENTITIES.get(2).name(),
               TENANT_ENTITIES.get(2).tenantId(),
               formatSet(TENANT_ENTITIES.get(2).assignedMemberKeys()),
@@ -106,12 +106,12 @@ public class TenantQueryControllerTest extends RestControllerTest {
     final var tenantName = "Tenant Name";
     final var tenantId = "tenant-id";
     final var tenant = new TenantEntity(100L, tenantId, tenantName, Set.of());
-    when(tenantServices.getByKey(tenant.tenantKey())).thenReturn(tenant);
+    when(tenantServices.getByKey(tenant.key())).thenReturn(tenant);
 
     // when
     webClient
         .get()
-        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.tenantKey()))
+        .uri("%s/%s".formatted(TENANT_BASE_URL, tenant.key()))
         .accept(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
@@ -126,10 +126,10 @@ public class TenantQueryControllerTest extends RestControllerTest {
               "assignedMemberKeys": []
             }
             """
-                .formatted(tenant.tenantKey(), tenantName, tenantId));
+                .formatted(tenant.key(), tenantName, tenantId));
 
     // then
-    verify(tenantServices, times(1)).getByKey(tenant.tenantKey());
+    verify(tenantServices, times(1)).getByKey(tenant.key());
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
I noticed as part of running the app locally that som errors came up, this PR adds in fixes to that and I can confirm that locally I can create/search for tenants. Notably however:

- We need a `key` field on the index otherwise the search classes fail as its expected there is a `key` field
- We need to declare `memberKey` in the index as its on the core entity we use and if this field is not on the index, the batch fails because the mappings are set to strict
