### PR TITLE
fix: export VARIABLE_DOCUMENT records

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -21,6 +21,7 @@ import static io.camunda.zeebe.protocol.record.ValueType.TENANT;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
 import static io.camunda.zeebe.protocol.record.ValueType.USER_TASK;
 import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE;
+import static io.camunda.zeebe.protocol.record.ValueType.VARIABLE_DOCUMENT;
 
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ConfigValidator;
@@ -240,6 +241,7 @@ public class CamundaExporter implements Exporter {
             PROCESS_INSTANCE,
             ROLE,
             VARIABLE,
+            VARIABLE_DOCUMENT,
             JOB,
             INCIDENT,
             DECISION_EVALUATION,

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -12,10 +12,13 @@ import static io.camunda.zeebe.protocol.record.ValueType.DECISION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_EVALUATION;
 import static io.camunda.zeebe.protocol.record.ValueType.DECISION_REQUIREMENTS;
 import static io.camunda.zeebe.protocol.record.ValueType.FORM;
+import static io.camunda.zeebe.protocol.record.ValueType.GROUP;
 import static io.camunda.zeebe.protocol.record.ValueType.INCIDENT;
 import static io.camunda.zeebe.protocol.record.ValueType.JOB;
+import static io.camunda.zeebe.protocol.record.ValueType.MAPPING;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS;
 import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_INSTANCE;
+import static io.camunda.zeebe.protocol.record.ValueType.PROCESS_MESSAGE_SUBSCRIPTION;
 import static io.camunda.zeebe.protocol.record.ValueType.ROLE;
 import static io.camunda.zeebe.protocol.record.ValueType.TENANT;
 import static io.camunda.zeebe.protocol.record.ValueType.USER;
@@ -234,6 +237,8 @@ public class CamundaExporter implements Exporter {
     private static final Set<ValueType> VALUE_TYPES_2_EXPORT =
         Set.of(
             USER,
+            GROUP,
+            MAPPING,
             AUTHORIZATION,
             TENANT,
             DECISION,
@@ -242,6 +247,7 @@ public class CamundaExporter implements Exporter {
             ROLE,
             VARIABLE,
             VARIABLE_DOCUMENT,
+            PROCESS_MESSAGE_SUBSCRIPTION,
             JOB,
             INCIDENT,
             DECISION_EVALUATION,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
In order to mark variable update operations as completed, we need to export `VARIABLE_DOCUMENT` records.