### PR TITLE
feat: include decision metadata in reconstructed deployment

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import io.camunda.zeebe.engine.state.deployment.PersistedProcess;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
+import io.camunda.zeebe.engine.state.immutable.DecisionState.DecisionIdentifier;
 import io.camunda.zeebe.engine.state.immutable.DeploymentState;
 import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.FormState.FormIdentifier;
@@ -208,7 +209,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
         });
 
     decisionState.forEachDecision(
-        null,
+        new DecisionIdentifier(tenantId, deploymentKey),
         decision -> {
           final var decisionDeploymentKey = decision.getDeploymentKey();
           if (decisionDeploymentKey == deploymentKey) {
@@ -233,7 +234,7 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
                     decisionRequirements.getPersistedDecisionRequirements(),
                     allDecisions));
           }
-          return true;
+          return decision.getTenantId().equals(tenantId) && decisionDeploymentKey == deploymentKey;
         });
 
     return resources;
@@ -277,9 +278,9 @@ public class DeploymentReconstructProcessor implements TypedRecordProcessor<Depl
         resourceUtil.applyFormMetadata(form, metadata);
       }
       case DecisionRequirementsResource(
-          final var deploymentKey,
-          final var decisionRequirements,
-          final var decisions) -> {
+              final var deploymentKey,
+              final var decisionRequirements,
+              final var decisions) -> {
         final var requirementsMetadata = deploymentRecord.decisionRequirementsMetadata().add();
         resourceUtil.applyDecisionRequirementsMetadata(decisionRequirements, requirementsMetadata);
         decisions.forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -347,26 +347,6 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
-  public void forEachDecision(
-      final DecisionIdentifier previousDecision, final PersistedDecisionVisitor visitor) {
-    if (previousDecision == null) {
-      decisionsByKey.whileTrue((key, value) -> visitor.visit(value));
-    } else {
-      tenantIdKey.wrapString(previousDecision.tenantId());
-      dbDecisionKey.wrapLong(previousDecision.decisionKey());
-      decisionsByKey.whileTrue(
-          tenantAwareDecisionKey,
-          (key, value) -> {
-            if (key.tenantKey().toString().equals(previousDecision.tenantId())
-                && key.wrappedKey().getValue() == previousDecision.decisionKey()) {
-              return true;
-            }
-            return visitor.visit(value);
-          });
-    }
-  }
-
-  @Override
   public void clearCache() {
     drgCache.invalidateAll();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -325,6 +325,26 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
+  public void forEachDecision(
+      final DecisionIdentifier previousDecision, final PersistedDecisionVisitor visitor) {
+    if (previousDecision == null) {
+      decisionsByKey.whileTrue((key, value) -> visitor.visit(value));
+    } else {
+      tenantIdKey.wrapString(previousDecision.tenantId());
+      dbDecisionKey.wrapLong(previousDecision.decisionKey());
+      decisionsByKey.whileTrue(
+          tenantAwareDecisionKey,
+          (key, value) -> {
+            if (key.tenantKey().toString().equals(previousDecision.tenantId())
+                && key.wrappedKey().getValue() == previousDecision.decisionKey()) {
+              return true;
+            }
+            return visitor.visit(value);
+          });
+    }
+  }
+
+  @Override
   public void clearCache() {
     drgCache.invalidateAll();
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbDecisionState.java
@@ -325,6 +325,28 @@ public final class DbDecisionState implements MutableDecisionState {
   }
 
   @Override
+  public void forEachDecisionRequirements(
+      final DecisionRequirementsIdentifier previousDecisionsRequirements,
+      final PersistedDecisionRequirementsVisitor visitor) {
+    if (previousDecisionsRequirements == null) {
+      decisionRequirementsByKey.whileTrue((key, value) -> visitor.visit(value));
+    } else {
+      tenantIdKey.wrapString(previousDecisionsRequirements.tenantId());
+      dbDecisionRequirementsKey.wrapLong(previousDecisionsRequirements.decisionRequirementsKey());
+      decisionRequirementsByKey.whileTrue(
+          tenantAwareDecisionRequirementsKey,
+          (key, value) -> {
+            if (key.tenantKey().toString().equals(previousDecisionsRequirements.tenantId())
+                && key.wrappedKey().getValue()
+                    == previousDecisionsRequirements.decisionRequirementsKey()) {
+              return true;
+            }
+            return visitor.visit(value);
+          });
+    }
+  }
+
+  @Override
   public void forEachDecision(
       final DecisionIdentifier previousDecision, final PersistedDecisionVisitor visitor) {
     if (previousDecision == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedDrg.java
@@ -61,4 +61,8 @@ public final class DeployedDrg {
   public String getTenantId() {
     return persistedDecisionRequirements.getTenantId();
   }
+
+  public PersistedDecisionRequirements getPersistedDecisionRequirements() {
+    return persistedDecisionRequirements;
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.deployment;
 
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormMetadataRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -47,5 +48,16 @@ public final class DeploymentResourceUtil {
     target.setDecisionRequirementsId(BufferUtil.bufferAsString(source.getDecisionRequirementsId()));
     target.setTenantId(source.getTenantId());
     target.setDeploymentKey(source.getDeploymentKey());
+  }
+
+  public void applyDecisionRequirementsMetadata(
+      final PersistedDecisionRequirements source, final DecisionRequirementsMetadataRecord target) {
+    target.setDecisionRequirementsKey(source.getDecisionRequirementsKey());
+    target.setDecisionRequirementsId(BufferUtil.bufferAsString(source.getDecisionRequirementsId()));
+    target.setDecisionRequirementsName(
+        BufferUtil.bufferAsString(source.getDecisionRequirementsName()));
+    target.setResourceName(BufferUtil.bufferAsString(source.getResourceName()));
+    target.setTenantId(source.getTenantId());
+    target.setChecksum(checksumGenerator.checksum(source.getResource()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentResourceUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.deployment;
 
 import io.camunda.zeebe.engine.processing.deployment.ChecksumGenerator;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormMetadataRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -35,5 +36,16 @@ public final class DeploymentResourceUtil {
     target.setTenantId(source.getTenantId());
     target.setDeploymentKey(source.getDeploymentKey());
     target.setChecksum(checksumGenerator.checksum(source.getResource()));
+  }
+
+  public void applyDecisionMetadata(final PersistedDecision source, final DecisionRecord target) {
+    target.setDecisionKey(source.getDecisionKey());
+    target.setDecisionId(BufferUtil.bufferAsString(source.getDecisionId()));
+    target.setDecisionName(BufferUtil.bufferAsString(source.getDecisionName()));
+    target.setVersion(source.getVersion());
+    target.setDecisionRequirementsKey(source.getDecisionRequirementsKey());
+    target.setDecisionRequirementsId(BufferUtil.bufferAsString(source.getDecisionRequirementsId()));
+    target.setTenantId(source.getTenantId());
+    target.setDeploymentKey(source.getDeploymentKey());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -104,21 +104,10 @@ public interface DecisionState {
       final DecisionRequirementsIdentifier previousDecisionsRequirements,
       final PersistedDecisionRequirementsVisitor visitor);
 
-  /**
-   * Iterates over all persisted decisions until the visitor returns false or all decisions have
-   * been visited. If {@code previousDecision} is not null, the iteration skips all decisions that
-   * appear before it. The visitor is <em>not</em> called with a copy of the decision to avoid
-   * needless copies of the relatively large {@link PersistedDecision} instances.
-   */
-  void forEachDecision(
-      final DecisionIdentifier previousDecision, final PersistedDecisionVisitor visitor);
-
   /** Completely clears all caches. */
   void clearCache();
 
   record DecisionRequirementsIdentifier(String tenantId, long decisionRequirementsKey) {}
-
-  record DecisionIdentifier(String tenantId, long decisionKey) {}
 
   interface PersistedDecisionRequirementsVisitor {
     boolean visit(PersistedDecisionRequirements decisionRequirements);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
-import io.camunda.zeebe.engine.state.deployment.PersistedForm;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecisionRequirements;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -94,6 +94,17 @@ public interface DecisionState {
       final String tenantId, long decisionRequirementsKey);
 
   /**
+   * Iterates over all persisted decision requirements until the visitor returns false or all
+   * decision requirements have been visited. If {@code previousDecisionRequirements} is not null,
+   * the iteration skips all decision requirements that appear before it. The visitor is
+   * <em>not</em> called with a copy of the decision requirements to avoid needless copies of the
+   * relatively large {@link PersistedDecisionRequirements} instances.
+   */
+  void forEachDecisionRequirements(
+      final DecisionRequirementsIdentifier previousDecisionsRequirements,
+      final PersistedDecisionRequirementsVisitor visitor);
+
+  /**
    * Iterates over all persisted decisions until the visitor returns false or all decisions have
    * been visited. If {@code previousDecision} is not null, the iteration skips all decisions that
    * appear before it. The visitor is <em>not</em> called with a copy of the decision to avoid
@@ -105,7 +116,13 @@ public interface DecisionState {
   /** Completely clears all caches. */
   void clearCache();
 
+  record DecisionRequirementsIdentifier(String tenantId, long decisionRequirementsKey) {}
+
   record DecisionIdentifier(String tenantId, long decisionKey) {}
+
+  interface PersistedDecisionRequirementsVisitor {
+    boolean visit(PersistedDecisionRequirements decisionRequirements);
+  }
 
   interface PersistedDecisionVisitor {
     boolean visit(PersistedDecision decision);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/DecisionState.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
+import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import java.util.List;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -92,6 +93,21 @@ public interface DecisionState {
   List<PersistedDecision> findDecisionsByTenantAndDecisionRequirementsKey(
       final String tenantId, long decisionRequirementsKey);
 
+  /**
+   * Iterates over all persisted decisions until the visitor returns false or all decisions have
+   * been visited. If {@code previousDecision} is not null, the iteration skips all decisions that
+   * appear before it. The visitor is <em>not</em> called with a copy of the decision to avoid
+   * needless copies of the relatively large {@link PersistedDecision} instances.
+   */
+  void forEachDecision(
+      final DecisionIdentifier previousDecision, final PersistedDecisionVisitor visitor);
+
   /** Completely clears all caches. */
   void clearCache();
+
+  record DecisionIdentifier(String tenantId, long decisionKey) {}
+
+  interface PersistedDecisionVisitor {
+    boolean visit(PersistedDecision decision);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -379,13 +379,14 @@ final class DeploymentReconstructProcessorTest {
         .satisfies(
             record -> {
               assertThat(record.getIntent()).isEqualTo(DeploymentIntent.RECONSTRUCTED);
-              assertThat(record.getKey()).isEqualTo(decisionKey);
+              assertThat(record.getKey()).isEqualTo(decisionRequirementsKey);
               assertThat(record.getValue())
                   .asInstanceOf(InstanceOfAssertFactories.type(DeploymentRecord.class))
                   .satisfies(
                       deploymentRecord -> {
                         assertThat(deploymentRecord.getDecisionsMetadata()).hasSize(1);
-                        assertThat(deploymentRecord.getDeploymentKey()).isEqualTo(decisionKey);
+                        assertThat(deploymentRecord.getDeploymentKey())
+                            .isEqualTo(decisionRequirementsKey);
                       });
             });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import java.util.function.LongConsumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -971,12 +972,18 @@ public final class DecisionStateTest {
     decisionState.storeDecisionRequirements(drg3);
 
     // when
-    final var visitor = Mockito.mock(PersistedDecisionRequirementsVisitor.class);
-    Mockito.when(visitor.visit(any())).thenReturn(true);
-    decisionState.forEachDecisionRequirements(null, visitor);
+    final var visitor = Mockito.mock(LongConsumer.class);
+    decisionState.forEachDecisionRequirements(
+        null,
+        (drg) -> {
+          visitor.accept(drg.getDecisionRequirementsKey());
+          return true;
+        });
 
     // then
-    Mockito.verify(visitor, Mockito.times(3)).visit(any());
+    Mockito.verify(visitor).accept(1L);
+    Mockito.verify(visitor).accept(2L);
+    Mockito.verify(visitor).accept(3L);
   }
 
   @Test
@@ -1013,12 +1020,18 @@ public final class DecisionStateTest {
     decisionState.storeDecisionRecord(decision3);
 
     // when
-    final var visitor = Mockito.mock(PersistedDecisionVisitor.class);
-    Mockito.when(visitor.visit(any())).thenReturn(true);
-    decisionState.forEachDecision(null, visitor);
+    final var visitor = Mockito.mock(LongConsumer.class);
+    decisionState.forEachDecision(
+        null,
+        (decision) -> {
+          visitor.accept(decision.getDecisionKey());
+          return true;
+        });
 
     // then
-    Mockito.verify(visitor, Mockito.times(3)).visit(any());
+    Mockito.verify(visitor).accept(1L);
+    Mockito.verify(visitor).accept(2L);
+    Mockito.verify(visitor).accept(3L);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/DecisionStateTest.java
@@ -13,10 +13,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
-import io.camunda.zeebe.engine.state.immutable.DecisionState.DecisionIdentifier;
 import io.camunda.zeebe.engine.state.immutable.DecisionState.DecisionRequirementsIdentifier;
 import io.camunda.zeebe.engine.state.immutable.DecisionState.PersistedDecisionRequirementsVisitor;
-import io.camunda.zeebe.engine.state.immutable.DecisionState.PersistedDecisionVisitor;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
@@ -1002,55 +1000,6 @@ public final class DecisionStateTest {
     decisionState.forEachDecisionRequirements(
         new DecisionRequirementsIdentifier(drg1.getTenantId(), drg1.getDecisionRequirementsKey()),
         visitor);
-
-    // then
-    Mockito.verify(visitor, Mockito.times(2)).visit(any());
-  }
-
-  @Test
-  void shouldIterateThroughAllDecisions() {
-    // given
-    final var drg = sampleDecisionRequirementsRecord();
-    final var decision1 = sampleDecisionRecord().setDecisionKey(1L);
-    final var decision2 = sampleDecisionRecord().setDecisionKey(2L);
-    final var decision3 = sampleDecisionRecord().setDecisionKey(3L);
-    decisionState.storeDecisionRequirements(drg);
-    decisionState.storeDecisionRecord(decision1);
-    decisionState.storeDecisionRecord(decision2);
-    decisionState.storeDecisionRecord(decision3);
-
-    // when
-    final var visitor = Mockito.mock(LongConsumer.class);
-    decisionState.forEachDecision(
-        null,
-        (decision) -> {
-          visitor.accept(decision.getDecisionKey());
-          return true;
-        });
-
-    // then
-    Mockito.verify(visitor).accept(1L);
-    Mockito.verify(visitor).accept(2L);
-    Mockito.verify(visitor).accept(3L);
-  }
-
-  @Test
-  void shouldSkipBeforeIteratingThroughDecisions() {
-    // given
-    final var drg = sampleDecisionRequirementsRecord();
-    final var decision1 = sampleDecisionRecord().setDecisionKey(1L);
-    final var decision2 = sampleDecisionRecord().setDecisionKey(2L);
-    final var decision3 = sampleDecisionRecord().setDecisionKey(3L);
-    decisionState.storeDecisionRequirements(drg);
-    decisionState.storeDecisionRecord(decision1);
-    decisionState.storeDecisionRecord(decision2);
-    decisionState.storeDecisionRecord(decision3);
-
-    // when
-    final var visitor = Mockito.mock(PersistedDecisionVisitor.class);
-    Mockito.when(visitor.visit(any())).thenReturn(true);
-    decisionState.forEachDecision(
-        new DecisionIdentifier(decision1.getTenantId(), decision1.getDecisionKey()), visitor);
 
     // then
     Mockito.verify(visitor, Mockito.times(2)).visit(any());


### PR DESCRIPTION
This extends deployment reconstruction with support for decision and decision requirements metadata. I've followed the same pattern that we used for processes and forms but adjusted it to respect the parent-child relationship between decision requirements and decisions.

relates to #24817
depends on #24993
