### PR TITLE
fix: increase ES memlock for Optimize smoke tests

### DIFF
--- a/.github/actions/compose/docker-compose.smoketest.yml
+++ b/.github/actions/compose/docker-compose.smoketest.yml
@@ -16,6 +16,10 @@ services:
       - http.port=9200
       - ES_JAVA_OPTS=-Xms${ELASTIC_JVM_MEMORY:-1}g -Xmx${ELASTIC_JVM_MEMORY:-1}g
       - path.repo=/var/tmp
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
     ports:
       - 9200:9200
     healthcheck:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Lots of memlock errors in the deploy job: https://github.com/camunda/camunda/actions/runs/12119107370/attempts/1
We have already removed Operate, but I think this needs explicitly setting too

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
