### PR TITLE
I can activate activities when entering an ad-hoc subprocess

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -216,6 +216,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.PlaneImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.ShapeImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.StyleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAdHocImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledDecisionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
@@ -672,6 +673,7 @@ public class Bpmn {
     ZeebeTaskListenerImpl.registerType(bpmnModelBuilder);
     ZeebePriorityDefinitionImpl.registerType(bpmnModelBuilder);
     ZeebeVersionTagImpl.registerType(bpmnModelBuilder);
+    ZeebeAdHocImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractAdHocSubProcessBuilder.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.instance.FlowElement;
 import io.camunda.zeebe.model.bpmn.instance.FlowNode;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 
 public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBuilder<B>>
     extends AbstractSubProcessBuilder<B> {
@@ -32,6 +33,18 @@ public class AbstractAdHocSubProcessBuilder<B extends AbstractAdHocSubProcessBui
       final AdHocSubProcess element,
       final Class<?> selfType) {
     super(modelInstance, element, selfType);
+  }
+
+  /**
+   * Sets the expression to retrieve the collection of active elements.
+   *
+   * @param expression the expression for the active elements collection
+   * @return the builder object
+   */
+  public B zeebeActiveElementsCollectionExpression(final String expression) {
+    final ZeebeAdHoc adHoc = getCreateSingleExtensionElement(ZeebeAdHoc.class);
+    adHoc.setActiveElementsCollection(asZeebeExpression(expression));
+    return myself;
   }
 
   @Override

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -64,6 +64,8 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_PRIORITY = "priority";
 
+  public static final String ATTRIBUTE_ACTIVE_ELEMENTS_COLLECTION = "activeElementsCollection";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";
@@ -109,4 +111,6 @@ public class ZeebeConstants {
   public static final String USER_TASK_FORM_KEY_BPMN_LOCATION = "bpmn";
 
   public static final String ELEMENT_PRIORITY_DEFINITION = "priorityDefinition";
+
+  public static final String ELEMENT_AD_HOC = "adHoc";
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeAdHocImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeAdHocImpl extends BpmnModelElementInstanceImpl implements ZeebeAdHoc {
+
+  private static Attribute<String> activeElementsCollectionAttribute;
+
+  public ZeebeAdHocImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeAdHoc.class, ZeebeConstants.ELEMENT_AD_HOC)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeAdHocImpl::new);
+
+    activeElementsCollectionAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_ACTIVE_ELEMENTS_COLLECTION)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+
+  @Override
+  public String getActiveElementsCollection() {
+    return activeElementsCollectionAttribute.getValue(this);
+  }
+
+  @Override
+  public void setActiveElementsCollection(final String activeElementsCollection) {
+    activeElementsCollectionAttribute.setValue(this, activeElementsCollection);
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeAdHoc.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+/** A Zeebe extension for an ad-hoc subprocess. */
+public interface ZeebeAdHoc extends BpmnModelElementInstance {
+
+  /**
+   * @return the collection of elements that should be activated when entering the ad-hoc
+   *     subprocess.
+   */
+  String getActiveElementsCollection();
+
+  /**
+   * Sets the collection of elements that should be activated when entering the ad-hoc subprocess.
+   *
+   * @param activateElements the collection of element to be activated
+   */
+  void setActiveElementsCollection(final String activateElements);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableAdHocSubProcess.java
@@ -7,22 +7,34 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
-import java.util.ArrayList;
-import java.util.List;
+import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.HashMap;
+import java.util.Map;
 
 public class ExecutableAdHocSubProcess extends ExecutableFlowElementContainer {
 
-  private final List<ExecutableFlowNode> adHocActivities = new ArrayList<>();
+  private Expression activeElementsCollection;
+  private final Map<String, ExecutableFlowNode> adHocActivitiesById = new HashMap<>();
 
   public ExecutableAdHocSubProcess(final String id) {
     super(id);
   }
 
-  public List<ExecutableFlowNode> getAdHocActivities() {
-    return adHocActivities;
+  public Expression getActiveElementsCollection() {
+    return activeElementsCollection;
+  }
+
+  public void setActiveElementsCollection(final Expression activeElementsCollection) {
+    this.activeElementsCollection = activeElementsCollection;
+  }
+
+  public Map<String, ExecutableFlowNode> getAdHocActivitiesById() {
+    return adHocActivitiesById;
   }
 
   public void addAdHocActivity(final ExecutableFlowNode adHocActivity) {
-    adHocActivities.add(adHocActivity);
+    final String elementId = BufferUtil.bufferAsString(adHocActivity.getId());
+    adHocActivitiesById.put(elementId, adHocActivity);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidators.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.instance.Message;
 import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.Signal;
 import io.camunda.zeebe.model.bpmn.instance.TimerEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
@@ -191,6 +192,12 @@ public final class ZeebeRuntimeValidators {
                                     staticExpression, expressionProcessor),
                             "be a valid Number between 0 and 100"))
             .build(expressionLanguage),
-        new ZeebePriorityDefinitionValidator());
+        new ZeebePriorityDefinitionValidator(),
+        // ----------------------------------------
+        ZeebeExpressionValidator.verifyThat(ZeebeAdHoc.class)
+            .hasValidExpression(
+                ZeebeAdHoc::getActiveElementsCollection,
+                expression -> expression.isOptional().isNonStatic())
+            .build(expressionLanguage));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/AdHocSubProcessTest.java
@@ -134,9 +134,9 @@ public final class AdHocSubProcessTest {
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSubsequence(
             tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
             tuple("C", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("C", ProcessInstanceIntent.ELEMENT_ACTIVATED));
 
@@ -262,13 +262,13 @@ public final class AdHocSubProcessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limit("B", ProcessInstanceIntent.ELEMENT_ACTIVATED))
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSequence(
             tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT));
   }
 
   @Test
@@ -301,14 +301,14 @@ public final class AdHocSubProcessTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limit("B", ProcessInstanceIntent.ELEMENT_ACTIVATED))
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSequence(
             tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT));
 
     final Record<VariableRecordValue> variableCreated =
         RecordingExporter.variableRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/AdHocSubProcessValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/AdHocSubProcessValidatorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.validation;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAdHoc;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+public class AdHocSubProcessValidatorTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  private BpmnModelInstance process(final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .adHocSubProcess(AD_HOC_SUB_PROCESS_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  void withNoActiveElementsCollection() {
+    // given
+    final BpmnModelInstance process = process(adHocSubProcess -> adHocSubProcess.task("A"));
+
+    // when/then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void withEmptyActiveElementsCollectionExpression() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("");
+              adHocSubProcess.task("A");
+            });
+
+    // when/then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void withActiveElementsCollectionExpression() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("elements");
+              adHocSubProcess.task("A");
+            });
+
+    // when/then
+    ProcessValidationUtil.validateProcess(process);
+  }
+
+  @Test
+  void withInvalidActiveElementsCollectionExpression() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("???");
+              adHocSubProcess.task("A");
+            });
+
+    // when/then
+    ProcessValidationUtil.validateProcess(
+        process,
+        ExpectedValidationResult.expect(ZeebeAdHoc.class, "failed to parse expression '???'"));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
@@ -225,13 +225,13 @@ public class AdHocSubProcessIncidentTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limit("B", ProcessInstanceIntent.ELEMENT_ACTIVATED))
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSequence(
             tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
-            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/AdHocSubProcessIncidentTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AdHocSubProcessBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AdHocSubProcessIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String AD_HOC_SUB_PROCESS_ELEMENT_ID = "ad-hoc";
+
+  @Rule public final RecordingExporterTestWatcher watcher = new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance process(final Consumer<AdHocSubProcessBuilder> modifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .adHocSubProcess(AD_HOC_SUB_PROCESS_ELEMENT_ID, modifier)
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldCreateIncidentIfActiveElementsIsNull() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", null)
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+            Failed to activate ad-hoc elements. Expected result of the expression 'activeElements' \
+            to be 'ARRAY', but was 'NULL'.""");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfActiveElementsIsNoListOfStrings() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", List.of(1))
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+            Failed to activate ad-hoc elements. Expected result of the expression 'activeElements' \
+            to be 'ARRAY' containing 'STRING' items, but was 'ARRAY' containing at least one \
+            non-'STRING' item.""");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfActiveElementsContainsInvalidId() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", List.of("A", "D", "E"))
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'D', 'E'.");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfActiveElementsContainsNonStartId() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A1").task("A2").task("A3");
+              adHocSubProcess.task("B");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", List.of("A1", "A2", "A3", "B"))
+            .create();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Failed to activate ad-hoc elements. No BPMN elements found with ids: 'A2', 'A3'.");
+  }
+
+  @Test
+  public void shouldResolveIncidentWithActiveElements() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A");
+              adHocSubProcess.task("B");
+              adHocSubProcess.task("C");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", null)
+            .create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when
+    ENGINE
+        .variables()
+        .ofScope(incidentCreated.getValue().getVariableScopeKey())
+        .withDocument(Map.of("activeElements", List.of("A", "B")))
+        .update();
+
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSequence(
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple("A", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple("B", ProcessInstanceIntent.ACTIVATE_ELEMENT),
+            tuple(AD_HOC_SUB_PROCESS_ELEMENT_ID, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldResolveIncidentIfTerminated() {
+    // given
+    final BpmnModelInstance process =
+        process(
+            adHocSubProcess -> {
+              adHocSubProcess.zeebeActiveElementsCollectionExpression("activeElements");
+              adHocSubProcess.task("A");
+            });
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("activeElements", null)
+            .create();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(AD_HOC_SUB_PROCESS_ELEMENT_ID)
+            .getFirst();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    assertThat(
+            RecordingExporter.incidentRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withRecordKey(incidentCreated.getKey())
+                .limit(2))
+        .extracting(Record::getIntent)
+        .contains(IncidentIntent.CREATED, IncidentIntent.RESOLVED);
+  }
+}


### PR DESCRIPTION
## Description

- Add a new BPMN extension element `adHoc` for ad-hoc subprocesses with one attribute `activeElementsCollection` (type: FEEL expression)
- Evaluate the expression when activating an ad-hoc subprocess. If the evaluation result is valid, it activates the BPMN child elements of the ad-hoc subprocess. If the result is not valid, it creates an incident.
- When the ad-hoc subprocess is terminated, the process instance terminates all child instances of the ad-hoc subprocess.

## Related issues

closes #25271 
