### PR TITLE
Create intra treepath in Engine

### DIFF
--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
@@ -29,6 +29,10 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   private long parentElementInstanceKey;
   private String tenantId;
 
+  private List<List<Long>> elementInstancePath;
+  private List<Long> processDefinitionPath;
+  private List<Integer> callingElementPath;
+
   public ProcessInstanceRecordValueImpl() {}
 
   @Override
@@ -83,17 +87,17 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
 
   @Override
   public List<List<Long>> getElementInstancePath() {
-    return List.of();
+    return elementInstancePath;
   }
 
   @Override
   public List<Long> getProcessDefinitionPath() {
-    return List.of();
+    return processDefinitionPath;
   }
 
   @Override
   public List<Integer> getCallingElementPath() {
-    return List.of();
+    return callingElementPath;
   }
 
   @Override

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/ProcessInstanceRecordValueImpl.java
@@ -11,6 +11,7 @@ import io.camunda.tasklist.zeebeimport.v860.record.RecordValueWithPayloadImpl;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
 import java.util.Objects;
 
 public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
@@ -78,6 +79,21 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   @Override
   public BpmnEventType getBpmnEventType() {
     return bpmnEventType;
+  }
+
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    return List.of();
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    return List.of();
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    return List.of();
   }
 
   @Override

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
@@ -29,6 +29,10 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   private long parentElementInstanceKey;
   private String tenantId;
 
+  private List<List<Long>> elementInstancePath;
+  private List<Long> processDefinitionPath;
+  private List<Integer> callingElementPath;
+
   public ProcessInstanceRecordValueImpl() {}
 
   @Override
@@ -83,17 +87,17 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
 
   @Override
   public List<List<Long>> getElementInstancePath() {
-    return List.of();
+    return elementInstancePath;
   }
 
   @Override
   public List<Long> getProcessDefinitionPath() {
-    return List.of();
+    return processDefinitionPath;
   }
 
   @Override
   public List<Integer> getCallingElementPath() {
-    return List.of();
+    return callingElementPath;
   }
 
   @Override

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/record/value/ProcessInstanceRecordValueImpl.java
@@ -11,6 +11,7 @@ import io.camunda.tasklist.zeebeimport.v870.record.RecordValueWithPayloadImpl;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import java.util.List;
 import java.util.Objects;
 
 public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
@@ -78,6 +79,21 @@ public class ProcessInstanceRecordValueImpl extends RecordValueWithPayloadImpl
   @Override
   public BpmnEventType getBpmnEventType() {
     return bpmnEventType;
+  }
+
+  @Override
+  public List<List<Long>> getElementInstancePath() {
+    return List.of();
+  }
+
+  @Override
+  public List<Long> getProcessDefinitionPath() {
+    return List.of();
+  }
+
+  @Override
+  public List<Integer> getCallingElementPath() {
+    return List.of();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -64,7 +64,7 @@ public final class BpmnIncidentBehavior {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(context.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -63,7 +63,7 @@ public final class BpmnIncidentBehavior {
 
     final var treePathProperties =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(context.getElementInstanceKey())
             .build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -9,6 +9,8 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
@@ -20,6 +22,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
@@ -51,6 +54,19 @@ public final class BpmnStateBehavior {
 
   public ElementInstance getElementInstance(final long elementInstanceKey) {
     return elementInstanceState.getInstance(elementInstanceKey);
+  }
+
+  public ElementTreePathProperties getElementTreePath(
+      final long elementInstanceKey,
+      final long flowScopeKey,
+      final ProcessInstanceRecordValue processInstanceRecordValue) {
+    return new ElementTreePathBuilder()
+        .withElementInstanceProvider(elementInstanceState::getInstance)
+        .withCallActivityIndexProvider(processState::getFlowElement)
+        .withElementInstanceKey(elementInstanceKey)
+        .withFlowScopeKey(flowScopeKey)
+        .withRecordValue(processInstanceRecordValue)
+        .build();
   }
 
   public JobState getJobState() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CallActivityIndexProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CallActivityIndexProvider.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import org.agrona.DirectBuffer;
+
+public interface CallActivityIndexProvider {
+
+  /**
+   * Provides the flow element identified by the element id in a process definition, identified by
+   * the process definition key.
+   *
+   * @param processDefinitionKey the process definition where the element belongs to
+   * @param tenantId the tenant in use
+   * @param elementId the element id of the element
+   * @param elementType the class of the element
+   * @return the executable flow element
+   * @param <T> the type that corresponds to the flow element
+   */
+  <T extends ExecutableFlowElement> T getFlowElement(
+      long processDefinitionKey, String tenantId, DirectBuffer elementId, Class<T> elementType);
+
+  /**
+   * For given call activity, identified by element id, in corresponding process definition,
+   * identified by process definition key, return the lexicographical index in that process
+   * definition.
+   *
+   * <p>The tenant is used to make sure we have the right permission to see the definition.
+   *
+   * @param processDefinitionKey the process definition where the call activity belongs to
+   * @param tenant the tenant in use
+   * @param elementIdBuffer the element id of a call activity
+   * @return the lexicographical index of a call activity in a process definition, null if not found
+   */
+  default Integer getLexicographicIndex(
+      final long processDefinitionKey, final String tenant, final DirectBuffer elementIdBuffer) {
+    final ExecutableCallActivity callActivityFlowElement =
+        getCallActivityFlowElement(processDefinitionKey, tenant, elementIdBuffer);
+    if (callActivityFlowElement != null) {
+      return callActivityFlowElement.getLexicographicIndex();
+    }
+    return null;
+  }
+
+  default ExecutableCallActivity getCallActivityFlowElement(
+      final long processDefinitionKey, final String tenantId, final DirectBuffer elementId) {
+    return getFlowElement(processDefinitionKey, tenantId, elementId, ExecutableCallActivity.class);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementInstanceProvider.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementInstanceProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+
+public interface ElementInstanceProvider {
+
+  /**
+   * Provides an element instance identified by the given elements instance key.
+   *
+   * @param elementsInstanceKey identifier of the element instance
+   * @return the element instance
+   */
+  ElementInstance getInstance(final long elementsInstanceKey);
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -51,6 +51,13 @@ public class ElementTreePathBuilder {
     final List<Long> elementInstancePath = new LinkedList<>();
     elementInstancePath.add(elementInstanceKey);
     ElementInstance instance = elementInstanceProvider.getInstance(elementInstanceKey);
+    if (instance == null) {
+      throw new IllegalStateException(
+          String.format(
+              "Expected to find element instance for given key '%d', but didn't exist.",
+              elementInstanceKey));
+    }
+
     long parentElementInstanceKey = instance.getParentKey();
     while (parentElementInstanceKey != -1) {
       instance = elementInstanceProvider.getInstance(parentElementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -60,7 +60,7 @@ public class ElementTreePathBuilder {
 
     if (processInstanceRecordValue != null) {
       Objects.requireNonNull(flowScopeKey, "flowScopeKey cannot be null");
-      buildElementTreePathProperties(flowScopeKey, processInstanceRecordValue);
+      buildElementTreePathProperties(elementInstanceKey, flowScopeKey, processInstanceRecordValue);
     } else {
       buildElementTreePathProperties(elementInstanceKey);
     }
@@ -77,17 +77,20 @@ public class ElementTreePathBuilder {
     }
 
     final long parentElementInstanceKey = instance.getParentKey();
-    buildElementTreePathProperties(parentElementInstanceKey, instance.getValue());
+    buildElementTreePathProperties(
+        elementInstanceKey, parentElementInstanceKey, instance.getValue());
   }
 
   private void buildElementTreePathProperties(
-      long parentElementInstanceKey, final ProcessInstanceRecordValue processInstanceRecord) {
+      final long currentElementInstanceKey,
+      long parentElementInstanceKey,
+      final ProcessInstanceRecordValue processInstanceRecord) {
 
     properties.processDefinitionPath.addFirst(processInstanceRecord.getProcessDefinitionKey());
 
     // collect all element instance keys in one process instance
     final List<Long> elementInstancePath = new LinkedList<>();
-    elementInstancePath.add(elementInstanceKey);
+    elementInstancePath.add(currentElementInstanceKey);
     while (parentElementInstanceKey != -1) {
       final var instance = elementInstanceProvider.getInstance(parentElementInstanceKey);
       elementInstancePath.addFirst(parentElementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.common;
 
-import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.LinkedList;
 import java.util.List;
@@ -15,14 +14,14 @@ import java.util.Objects;
 
 public class ElementTreePathBuilder {
 
-  private ElementInstanceState elementInstanceState;
+  private ElementInstanceProvider elementInstanceProvider;
   private CallActivityIndexProvider callActivityIndexProvider;
   private Long elementInstanceKey;
   private ElementTreePathProperties properties;
 
-  public ElementTreePathBuilder withElementInstanceState(
-      final ElementInstanceState elementInstanceState) {
-    this.elementInstanceState = elementInstanceState;
+  public ElementTreePathBuilder withElementInstanceProvider(
+      final ElementInstanceProvider elementInstanceState) {
+    elementInstanceProvider = elementInstanceState;
     return this;
   }
 
@@ -38,7 +37,7 @@ public class ElementTreePathBuilder {
   }
 
   public ElementTreePathProperties build() {
-    Objects.requireNonNull(elementInstanceState, "elementInstanceState cannot be null");
+    Objects.requireNonNull(elementInstanceProvider, "elementInstanceProvider cannot be null");
     Objects.requireNonNull(
         callActivityIndexProvider, "call activity index provider cannot be null");
     Objects.requireNonNull(elementInstanceKey, "elementInstanceKey cannot be null");
@@ -51,10 +50,10 @@ public class ElementTreePathBuilder {
   private void buildElementTreePathProperties(final long elementInstanceKey) {
     final List<Long> elementInstancePath = new LinkedList<>();
     elementInstancePath.add(elementInstanceKey);
-    ElementInstance instance = elementInstanceState.getInstance(elementInstanceKey);
+    ElementInstance instance = elementInstanceProvider.getInstance(elementInstanceKey);
     long parentElementInstanceKey = instance.getParentKey();
     while (parentElementInstanceKey != -1) {
-      instance = elementInstanceState.getInstance(parentElementInstanceKey);
+      instance = elementInstanceProvider.getInstance(parentElementInstanceKey);
       elementInstancePath.addFirst(parentElementInstanceKey);
       parentElementInstanceKey = instance.getParentKey();
     }
@@ -71,7 +70,7 @@ public class ElementTreePathBuilder {
 
   private Integer getCallActivityIndex(final long callingElementInstanceKey) {
     final ElementInstance callActivityElementInstance =
-        elementInstanceState.getInstance(callingElementInstanceKey);
+        elementInstanceProvider.getInstance(callingElementInstanceKey);
     final var callActivityInstanceRecord = callActivityElementInstance.getValue();
 
     return callActivityIndexProvider.getLexicographicIndex(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -7,17 +7,16 @@
  */
 package io.camunda.zeebe.engine.processing.common;
 
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
-import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
 public class ElementTreePathBuilder {
+
   private ElementInstanceState elementInstanceState;
-  private ProcessState processState;
+  private CallActivityIndexProvider callActivityIndexProvider;
   private Long elementInstanceKey;
   private ElementTreePathProperties properties;
 
@@ -27,8 +26,9 @@ public class ElementTreePathBuilder {
     return this;
   }
 
-  public ElementTreePathBuilder withProcessState(final ProcessState processState) {
-    this.processState = processState;
+  public ElementTreePathBuilder withCallActivityIndexProvider(
+      final CallActivityIndexProvider callActivityIndexProvider) {
+    this.callActivityIndexProvider = callActivityIndexProvider;
     return this;
   }
 
@@ -39,7 +39,8 @@ public class ElementTreePathBuilder {
 
   public ElementTreePathProperties build() {
     Objects.requireNonNull(elementInstanceState, "elementInstanceState cannot be null");
-    Objects.requireNonNull(processState, "processState cannot be null");
+    Objects.requireNonNull(
+        callActivityIndexProvider, "call activity index provider cannot be null");
     Objects.requireNonNull(elementInstanceKey, "elementInstanceKey cannot be null");
     properties =
         new ElementTreePathProperties(new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
@@ -73,14 +74,10 @@ public class ElementTreePathBuilder {
         elementInstanceState.getInstance(callingElementInstanceKey);
     final var callActivityInstanceRecord = callActivityElementInstance.getValue();
 
-    final ExecutableCallActivity callActivity =
-        processState.getFlowElement(
-            callActivityInstanceRecord.getProcessDefinitionKey(),
-            callActivityInstanceRecord.getTenantId(),
-            callActivityInstanceRecord.getElementIdBuffer(),
-            ExecutableCallActivity.class);
-
-    return callActivity.getLexicographicIndex();
+    return callActivityIndexProvider.getLexicographicIndex(
+        callActivityInstanceRecord.getProcessDefinitionKey(),
+        callActivityInstanceRecord.getTenantId(),
+        callActivityInstanceRecord.getElementIdBuffer());
   }
 
   public record ElementTreePathProperties(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -153,7 +153,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     final var treePathProperties =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -154,7 +154,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -175,7 +175,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
 
     final var treePathProperties =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(value.getElementInstanceKey())
             .build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -176,7 +176,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(value.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -171,7 +171,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -170,7 +170,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
 
     final var treePathProperties =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(processState::getFlowElement)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -11,6 +11,8 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
@@ -28,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.agrona.DirectBuffer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -71,7 +74,7 @@ public class ElementTreePathBuilderTest {
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(new CallActivityIdProvider(null))
             .withElementInstanceKey(subProcess2.getKey());
 
     final ElementTreePathProperties properties = builder.build();
@@ -133,7 +136,7 @@ public class ElementTreePathBuilderTest {
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
-            .withProcessState(processState)
+            .withCallActivityIndexProvider(new CallActivityIdProvider(0))
             .withElementInstanceKey(subProcessC.getKey());
 
     final ElementTreePathProperties properties = builder.build();
@@ -204,5 +207,35 @@ public class ElementTreePathBuilderTest {
         .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     return processRecord;
+  }
+
+  private class CallActivityIdProvider implements CallActivityIndexProvider {
+
+    private final Integer index;
+
+    private CallActivityIdProvider(final Integer index) {
+      this.index = index;
+    }
+
+    @Override
+    public <T extends ExecutableFlowElement> T getFlowElement(
+        final long processDefinitionKey,
+        final String tenantId,
+        final DirectBuffer elementId,
+        final Class<T> elementType) {
+      throw new UnsupportedOperationException("not implemented");
+    }
+
+    @Override
+    public Integer getLexicographicIndex(
+        final long processDefinitionKey, final String tenant, final DirectBuffer elementIdBuffer) {
+      return index;
+    }
+
+    @Override
+    public ExecutableCallActivity getCallActivityFlowElement(
+        final long processDefinitionKey, final String tenantId, final DirectBuffer elementId) {
+      throw new UnsupportedOperationException("not implemented");
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -14,66 +14,68 @@ import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementT
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
-import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.util.ProcessingStateRule;
-import io.camunda.zeebe.model.bpmn.Bpmn;
-import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
-import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
-import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class ElementTreePathBuilderTest {
   private static final AtomicLong PROCESS_DEFINITION_KEY_SEQUENCER = new AtomicLong(1000);
-  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
-  private MutableElementInstanceState elementInstanceState;
-  private MutableProcessState processState;
+  private Map<Long, ElementInstance> elementInstanceMap;
 
   @Before
   public void setUp() {
-    final MutableProcessingState processingState = stateRule.getProcessingState();
-    elementInstanceState = processingState.getElementInstanceState();
-    processState = processingState.getProcessState();
+    elementInstanceMap = new HashMap<>();
   }
 
   @Test
-  public void shouldBuildElementInstanceTreePath() {
+  public void shouldBuildSimpleElementInstanceTreePath() {
     // given
     final var parentProcessInstanceRecord = createProcessInstanceRecord();
     final ElementInstance parentInstance =
-        elementInstanceState.newInstance(
-            100, parentProcessInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-
-    final var subProcessInstanceRecord = createProcessInstanceRecord();
-    subProcessInstanceRecord.setElementId("subProcess");
-    elementInstanceState.newInstance(
-        parentInstance, 101, subProcessInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-
-    final var subProcess2InstanceRecord = createProcessInstanceRecord();
-    subProcess2InstanceRecord.setElementId("subProcess2");
-    final ElementInstance subProcess2 =
-        elementInstanceState.newInstance(
-            parentInstance,
-            102,
-            subProcess2InstanceRecord,
-            ProcessInstanceIntent.ELEMENT_ACTIVATING);
+        createElementInstanceForRecord(100, parentProcessInstanceRecord, "Activity");
 
     // when
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
-            .withElementInstanceProvider(elementInstanceState::getInstance)
+            .withElementInstanceProvider(elementInstanceMap::get)
+            .withCallActivityIndexProvider(new CallActivityIdProvider(null))
+            .withElementInstanceKey(parentInstance.getKey());
+
+    final ElementTreePathProperties properties = builder.build();
+
+    assertThat(properties.elementInstancePath()).isNotNull();
+    assertThat(properties.elementInstancePath()).hasSize(1); // no call activities
+    assertThat(properties.elementInstancePath().getFirst()).containsExactly(100L);
+    assertThat(properties.processDefinitionPath()).hasSize(1);
+    assertThat(properties.processDefinitionPath())
+        .containsExactly(parentProcessInstanceRecord.getProcessDefinitionKey());
+    assertThat(properties.callingElementPath()).isEmpty();
+  }
+
+  @Test
+  public void shouldBuildMoreComplexElementInstanceTreePath() {
+    // given
+    final var parentProcessInstanceRecord = createProcessInstanceRecord();
+    final ElementInstance parentInstance =
+        createElementInstanceForRecord(100, parentProcessInstanceRecord, "Process");
+
+    createElementInstanceForRecord(101, createProcessInstanceRecord(), "subProcess");
+
+    final var subProcess2InstanceRecord = createProcessInstanceRecord();
+    final ElementInstance subProcess2 =
+        createElementInstanceWithParentForRecord(
+            102, parentInstance, subProcess2InstanceRecord, "subProcess2");
+
+    // when
+    final ElementTreePathBuilder builder =
+        new ElementTreePathBuilder()
+            .withElementInstanceProvider(elementInstanceMap::get)
             .withCallActivityIndexProvider(new CallActivityIdProvider(null))
             .withElementInstanceKey(subProcess2.getKey());
 
@@ -85,57 +87,35 @@ public class ElementTreePathBuilderTest {
     assertThat(properties.processDefinitionPath()).hasSize(1);
     assertThat(properties.processDefinitionPath())
         .containsExactly(parentProcessInstanceRecord.getProcessDefinitionKey());
+    assertThat(properties.callingElementPath()).isEmpty();
   }
 
   @Test
   public void shouldIncludeProcessDefinitionAndCallingElementTreePaths() {
     // given
-    final String callActivityId = "callActivity";
-
     final var processARecord = createProcessInstanceRecord();
-    processARecord.setElementId("processA");
-    final ElementInstance processA =
-        elementInstanceState.newInstance(
-            100, processARecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
-    processState.putProcess(
-        processARecord.getProcessDefinitionKey(),
-        createParentProcess(
-            processARecord.getProcessDefinitionKey(),
-            "processA",
-            c -> c.id(callActivityId).zeebeProcessId("processB")));
+    final ElementInstance processAInstance =
+        createElementInstanceForRecord(100, processARecord, "processA");
 
     final var callActivityRecord =
         createProcessInstanceRecord(processARecord.getProcessDefinitionKey());
-    callActivityRecord.setElementId(callActivityId);
     final ElementInstance callActivityElementInstance =
-        elementInstanceState.newInstance(
-            processA, 101, callActivityRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+        createElementInstanceWithParentForRecord(
+            101, processAInstance, callActivityRecord, "callActivity");
 
     final var processBRecord = createProcessInstanceRecord();
-    processBRecord.setElementId("processB");
     processBRecord.setParentElementInstanceKey(callActivityElementInstance.getKey());
     final ElementInstance processB =
-        elementInstanceState.newInstance(
-            102, processBRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    processState.putProcess(
-        processBRecord.getProcessDefinitionKey(),
-        createChildProcess(
-            processBRecord.getProcessDefinitionKey(), "processB", ServiceTaskBuilder::done));
+        createElementInstanceForRecord(102, processBRecord, "processB");
 
     final var subProcessCRecord = createProcessInstanceRecord();
-    subProcessCRecord.setElementId("subProcessC");
     final ElementInstance subProcessC =
-        elementInstanceState.newInstance(
-            processB, 103, subProcessCRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
-    processState.putProcess(
-        subProcessCRecord.getProcessDefinitionKey(),
-        createChildProcess(
-            subProcessCRecord.getProcessDefinitionKey(), "subProcessC", ServiceTaskBuilder::done));
+        createElementInstanceWithParentForRecord(103, processB, subProcessCRecord, "subProcessC");
 
     // when
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
-            .withElementInstanceProvider(elementInstanceState::getInstance)
+            .withElementInstanceProvider(elementInstanceMap::get)
             .withCallActivityIndexProvider(new CallActivityIdProvider(0))
             .withElementInstanceKey(subProcessC.getKey());
 
@@ -151,6 +131,27 @@ public class ElementTreePathBuilderTest {
             processARecord.getProcessDefinitionKey(), processBRecord.getProcessDefinitionKey());
     assertThat(properties.callingElementPath()).hasSize(1);
     assertThat(properties.callingElementPath().getFirst()).isEqualTo(0);
+  }
+
+  private ElementInstance createElementInstanceForRecord(
+      final long key, final ProcessInstanceRecord instanceRecord, final String elementId) {
+    instanceRecord.setElementId(elementId);
+    final ElementInstance callActivityElementInstance =
+        new ElementInstance(key, ProcessInstanceIntent.ELEMENT_ACTIVATING, instanceRecord);
+    elementInstanceMap.put(key, callActivityElementInstance);
+    return callActivityElementInstance;
+  }
+
+  private ElementInstance createElementInstanceWithParentForRecord(
+      final long key,
+      final ElementInstance parent,
+      final ProcessInstanceRecord instanceRecord,
+      final String elementId) {
+    instanceRecord.setElementId(elementId);
+    final ElementInstance callActivityElementInstance =
+        new ElementInstance(key, parent, ProcessInstanceIntent.ELEMENT_ACTIVATING, instanceRecord);
+    elementInstanceMap.put(key, callActivityElementInstance);
+    return callActivityElementInstance;
   }
 
   private ProcessInstanceRecord createProcessInstanceRecord() {
@@ -170,52 +171,7 @@ public class ElementTreePathBuilderTest {
     return processInstanceRecord;
   }
 
-  private static ProcessRecord createParentProcess(
-      final long processKey, final String processId, final Consumer<CallActivityBuilder> consumer) {
-    final var builder = Bpmn.createExecutableProcess(processId).startEvent().callActivity();
-
-    consumer.accept(builder);
-    final var modelInstance = builder.endEvent().done();
-    return createProcessRecord(processKey, processId, modelInstance);
-  }
-
-  private static ProcessRecord createChildProcess(
-      final long processKey, final String processId, final Consumer<ServiceTaskBuilder> consumer) {
-    final var builder = Bpmn.createExecutableProcess(processId).startEvent().serviceTask();
-
-    consumer.accept(builder);
-    final var modelInstance = builder.endEvent().done();
-    return createProcessRecord(processKey, processId, modelInstance);
-  }
-
-  private static ProcessRecord createProcessRecord(
-      final long processKey, final String processId, final BpmnModelInstance modelInstance) {
-
-    final ProcessRecord processRecord = new ProcessRecord();
-    final String resourceName = "process.bpmn";
-    final var resource = wrapString(Bpmn.convertToString(modelInstance));
-    final var checksum = wrapString("checksum" + TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-
-    processRecord
-        .setResourceName(wrapString(resourceName))
-        .setResource(resource)
-        .setBpmnProcessId(BufferUtil.wrapString(processId))
-        .setVersion(1)
-        .setKey(processKey)
-        .setResourceName(resourceName)
-        .setChecksum(checksum)
-        .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-
-    return processRecord;
-  }
-
-  private class CallActivityIdProvider implements CallActivityIndexProvider {
-
-    private final Integer index;
-
-    private CallActivityIdProvider(final Integer index) {
-      this.index = index;
-    }
+  private record CallActivityIdProvider(Integer index) implements CallActivityIndexProvider {
 
     @Override
     public <T extends ExecutableFlowElement> T getFlowElement(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.common;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
@@ -56,6 +57,21 @@ public class ElementTreePathBuilderTest {
     assertThat(properties.processDefinitionPath())
         .containsExactly(parentProcessInstanceRecord.getProcessDefinitionKey());
     assertThat(properties.callingElementPath()).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowWhenElementInstanceDoesntExist() {
+    // given
+    final ElementTreePathBuilder builder =
+        new ElementTreePathBuilder()
+            .withElementInstanceProvider(elementInstanceMap::get)
+            .withCallActivityIndexProvider(new CallActivityIdProvider(null))
+            .withElementInstanceKey(0xCAFE);
+
+    // when
+    assertThatThrownBy(builder::build)
+        .hasMessageContaining("Expected to find element instance")
+        .isInstanceOf(IllegalStateException.class);
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -73,7 +73,7 @@ public class ElementTreePathBuilderTest {
     // when
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(new CallActivityIdProvider(null))
             .withElementInstanceKey(subProcess2.getKey());
 
@@ -135,7 +135,7 @@ public class ElementTreePathBuilderTest {
     // when
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
-            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceProvider(elementInstanceState::getInstance)
             .withCallActivityIndexProvider(new CallActivityIdProvider(0))
             .withElementInstanceKey(subProcessC.getKey());
 

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -51,6 +51,15 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "elementInstancePath": {
+              "enabled": false
+            },
+            "processDefinitionPath": {
+              "enabled": false
+            },
+            "callingElementPath": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-instance-template.json
@@ -51,6 +51,15 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "elementInstancePath": {
+              "enabled": false
+            },
+            "processDefinitionPath": {
+              "enabled": false
+            },
+            "callingElementPath": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -186,7 +186,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  @JsonIgnore
   public List<List<Long>> getElementInstancePath() {
     final var elementInstancePath = new ArrayList<List<Long>>();
     elementInstancePathProp.forEach(
@@ -209,7 +208,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  @JsonIgnore
   public List<Long> getProcessDefinitionPath() {
     final var processDefinitionPath = new ArrayList<Long>();
     processDefinitionPathProp.forEach(e -> processDefinitionPath.add(e.getValue()));
@@ -223,7 +221,6 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
   }
 
   @Override
-  @JsonIgnore
   public List<Integer> getCallingElementPath() {
     final var callingElementPath = new ArrayList<Integer>();
     callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1639,6 +1639,9 @@ final class JsonSerializableToJsonTest {
               final String elementId = "activity";
               final int flowScopeKey = 123;
               final BpmnElementType bpmnElementType = BpmnElementType.SERVICE_TASK;
+              final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
+              final var processDefinitionPath = List.of(101L, 102L);
+              final var callingElementPath = List.of(12345, 67890);
 
               return new ProcessInstanceRecord()
                   .setElementId(elementId)
@@ -1650,7 +1653,10 @@ final class JsonSerializableToJsonTest {
                   .setFlowScopeKey(flowScopeKey)
                   .setParentProcessInstanceKey(11)
                   .setParentElementInstanceKey(22)
-                  .setBpmnEventType(BpmnEventType.UNSPECIFIED);
+                  .setBpmnEventType(BpmnEventType.UNSPECIFIED)
+                  .setElementInstancePath(elementInstancePath)
+                  .setProcessDefinitionPath(processDefinitionPath)
+                  .setCallingElementPath(callingElementPath);
             },
         """
         {
@@ -1664,7 +1670,10 @@ final class JsonSerializableToJsonTest {
           "parentProcessInstanceKey": 11,
           "parentElementInstanceKey": 22,
           "bpmnEventType": "UNSPECIFIED",
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "elementInstancePath":[[101, 102], [103, 104]],
+          "processDefinitionPath": [101, 102],
+          "callingElementPath": [12345, 67890]
         }
         """
       },
@@ -1687,7 +1696,10 @@ final class JsonSerializableToJsonTest {
           "parentProcessInstanceKey": -1,
           "parentElementInstanceKey": -1,
           "bpmnEventType": "UNSPECIFIED",
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "elementInstancePath":[],
+          "processDefinitionPath": [],
+          "callingElementPath": []
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ProcessInstanceRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
@@ -82,4 +83,55 @@ public interface ProcessInstanceRecordValue
    * @return the BPMN event type of the current process element.
    */
   BpmnEventType getBpmnEventType();
+
+  /**
+   * A multi-list of element instances.
+   *
+   * <p>It contains a list per process instance in the hierarchy, each contains all the instance
+   * keys of all the elements in the call hierarchy within this process instance
+   *
+   * <p>Example:
+   *
+   * <pre>
+   * [ PI ROOT -> Call Activity 1 -> PI SUB 1 -> Call activity 2 -> PI SUB 2]
+   *
+   * List:
+   *   - 0:
+   *     - PI ROOT key
+   *     - Call activity 1 elements instance key
+   *   - 1:
+   *     - PI SUB 1 key
+   *     - Call activity 2 elements instance key
+   *   - 2:
+   *     - PI SUB 2 key
+   * </pre>
+   *
+   * @return tree path information about all element instances in the call hierarchy
+   */
+  List<List<Long>> getElementInstancePath();
+
+  /**
+   * @return tree path information for all process definitions in the hierarchy. Each entry is a
+   *     process definition key for the corresponding process instance
+   */
+  List<Long> getProcessDefinitionPath();
+
+  /**
+   * List of lexicographical ids of calling elements in BPMN Process models.
+   *
+   * Example:
+   * <pre>
+   * [ PI ROOT -> Call Activity 1 -> PI SUB 1 -> Call activity 2 -> PI SUB 2]
+   * - Process Model of PI ROOT, contains 3 call activities. Call Activity 1 is the second.
+   * - Process Model of PI SUB 1, contains 6 call activities. Call activity 2 is the fifth.
+   *
+   * Result (indices start by zero):
+   *   - 0: 1
+   *   - 1: 4
+   * </p>
+   *
+   * @return tree path information about call activities in the hierarchy. Each entry is a reference
+   *     to the call activity in BPMN model containing an incident.
+   */
+  List<Integer> getCallingElementPath();
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 334]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 398]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 335);
+    final var recordBatch = new RecordBatch((count, size) -> size < 399);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);


### PR DESCRIPTION
## Description

This PR creates the inter tree-path in the engine and piggybacks it in the ProcessInstanceRecord (in the ACTIVATING EVENT only).

Creating such allows the exporter to reconstruct the tree path, export such to ES, and make use in e.g. Operate.

![2024-12-02_10-15](https://github.com/user-attachments/assets/a882b256-36d9-4720-a0b8-17965a0a77fc)
![2024-12-02_10-13](https://github.com/user-attachments/assets/2fbd7d97-d876-47ce-a47d-756ce062affd)


For more details on why we are building this please see https://github.com/camunda/camunda/issues/25474

### Different Tree paths

There is a difference between inter and intra TreePath. The inter treePath goes over process definitions, including call activities and is used for showing incidents in Operate.

The intra treePath is just inside a process instance, and will/can be used to have a possibility to resolve existing variable scopes and understand the hierarchy in the PI.

We need both versions of treePaths, to support all current features!


### Details: What this PR contains

1. Extend the ProcessInstanceRecord API (and implementation)
    - Allows to piggyback the tree path properties as part of the ACTIVITING event
    - Allows to consume the tree path properties in the exporter - to make it available for the webapps
1. Refactor the tree path builder
    - Remove dependencies to state classes
    - Allows to for easier test set up and less boiler plate code
    - Furthermore, make it easier to test certain cases (e.g. failures)
1. Extend the tree path builder
    - As in the ACTIVATING case no element instance exists yet, we need to pass in the actual flow scope and current RecordValue
3. Add treePath properties to the ProcessInstanceRecord in the ACTIVATING transition
    - During processing the ACTIVATE Command we transition to ACTIVATING (write such event), before this happens we fill the even with necessary details 
    - Doing it in the transition behavior allows us to do it in one place
6. Adjust test cases
    - For tree builder more test cases has been added for flow scope and record value
    - more edge cases have been tested
    - Add tests cases in engine, for processing, that verify tree path is filled in records

### Related issue

relates to https://github.com/camunda/camunda/issues/25474