### PR TITLE
ci: update ci workflow to use centralized composite github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,13 @@ jobs:
     timeout-minutes: 5
     env:
       # renovate: datasource=github-releases depName=rhysd/actionlint
-      ACTIONLINT_VERSION: '1.7.4'
+      ACTIONLINT_VERSION: "1.7.4"
     steps:
-      - uses: actions/checkout@v4
-      - run: echo "::add-matcher::.github/actionlint-matcher.json"
-      - run: |
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) $ACTIONLINT_VERSION
-          ./actionlint -shellcheck '' -ignore 'property "vault_.+" is not defined in object type' -ignore 'object type "{}" cannot be filtered by object filtering `.*` since it has no object element'
+      - uses: camunda/infra-global-github-actions/actionlint@gh-620-centralized-infracheck-workflow
+        with:
+          version: $ACTIONLINT_VERSION
+          custom-config-file: .github/actionlint.yaml
+          sanitize-runner-labels: "false"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -213,13 +213,13 @@ jobs:
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
-    needs: [ detect-changes ]
+    needs: [detect-changes]
     timeout-minutes: 25
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
-        group: [ root, modules, qa-integration, qa-update ]
+        group: [root, modules, qa-integration, qa-update]
         include:
           - group: root
             name: "Root Integration Tests"
@@ -316,7 +316,7 @@ jobs:
   docker-checks:
     if: needs.detect-changes.outputs.camunda-docker-tests == 'true'
     name: Camunda docker tests
-    needs: [ detect-changes ]
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     services:
@@ -409,8 +409,8 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'yarn'
+          node-version: "20"
+          cache: "yarn"
           cache-dependency-path: identity/client/yarn.lock
       - name: Install dependencies
         run: yarn install --frozen-lockfile
@@ -468,7 +468,7 @@ jobs:
         uses: ./.github/actions/build-platform-docker
         with:
           dockerfile: operate.Dockerfile
-          repository: 'registry.camunda.cloud/team-operate/camunda-operate'
+          repository: "registry.camunda.cloud/team-operate/camunda-operate"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -507,7 +507,7 @@ jobs:
         uses: ./.github/actions/build-platform-docker
         with:
           dockerfile: tasklist.Dockerfile
-          repository: 'registry.camunda.cloud/team-hto/tasklist'
+          repository: "registry.camunda.cloud/team-hto/tasklist"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -647,7 +647,7 @@ jobs:
           push: false
           archive: false
           breaking: true
-          breaking_against: '${{ github.event.repository.clone_url }}#format=git,commit=${{ env.BASE_SHA }}'
+          breaking_against: "${{ github.event.repository.clone_url }}#format=git,commit=${{ env.BASE_SHA }}"
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -718,7 +718,7 @@ jobs:
 
   deploy-snapshots:
     name: Deploy snapshot artifacts
-    needs: [ check-results ]
+    needs: [check-results]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
@@ -739,10 +739,10 @@ jobs:
             secret/data/products/zeebe/ci/zeebe ARTIFACTS_PSW;
       - uses: actions/setup-java@v4.5.0
         with:
-          distribution: 'temurin'
-          java-version: '21'
+          distribution: "temurin"
+          java-version: "21"
       # Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
-      - name: 'Create settings.xml'
+      - name: "Create settings.xml"
         uses: s4u/maven-settings-action@v3.1.0
         with:
           githubServer: false
@@ -788,7 +788,7 @@ jobs:
 
   deploy-camunda-docker-snapshot:
     name: Deploy snapshot Camunda Docker image
-    needs: [ docker-checks, check-results ]
+    needs: [docker-checks, check-results]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:


### PR DESCRIPTION


## Description

This is a new PR as I messed with the previous one. With this PR the actionlint job will use a centralized composite action to generalize the actionlint configuration as much as possible

## Checklist

- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to: camunda/team-infrastructure#620
