### PR TITLE
Implement getActiveIncidentsByTreePath for ES

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -19,6 +19,7 @@ import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
@@ -122,15 +123,23 @@ public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpd
             t ->
                 t.field(ListViewTemplate.JOIN_RELATION)
                     .value(ListViewTemplate.ACTIVITIES_JOIN_RELATION));
-    return fetchUnboundedDocumentCollection(
-        listViewAlias, QueryBuilders.bool(b -> b.must(idQ, typeQ)));
+    final var request =
+        new SearchRequest.Builder()
+            .index(listViewAlias)
+            .query(q -> q.bool(b -> b.must(idQ, typeQ)))
+            .source(s -> s.fetch(false));
+
+    return fetchUnboundedDocumentCollection(request, hit -> new Document(hit.id(), hit.index()));
   }
 
   @Override
   public CompletionStage<Collection<Document>> getFlowNodeInstances(
       final List<String> flowNodeKeys) {
     final var query = QueryBuilders.ids(i -> i.values(flowNodeKeys));
-    return fetchUnboundedDocumentCollection(flowNodeAlias, query);
+    final var request =
+        new SearchRequest.Builder().index(flowNodeAlias).query(query).source(s -> s.fetch(false));
+
+    return fetchUnboundedDocumentCollection(request, hit -> new Document(hit.id(), hit.index()));
   }
 
   @Override
@@ -186,28 +195,56 @@ public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpd
             response -> response.tokens().stream().map(AnalyzeToken::token).toList(), executor);
   }
 
-  private CompletableFuture<Collection<Document>> fetchUnboundedDocumentCollection(
-      final String indexAlias, final Query query) {
+  @Override
+  public CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
+      final Collection<String> treePathTerms) {
+    final var treePathValues = treePathTerms.stream().map(FieldValue::of).toList();
+    final var pathQ =
+        QueryBuilders.terms(
+            t -> t.field(IncidentTemplate.TREE_PATH).terms(v -> v.value(treePathValues)));
+    final var stateQ =
+        QueryBuilders.term(t -> t.field(IncidentTemplate.STATE).value(IncidentState.ACTIVE.name()));
     final var request =
         new SearchRequest.Builder()
-            .index(indexAlias)
+            .query(q -> q.bool(b -> b.must(pathQ, stateQ)))
+            .source(s -> s.filter(f -> f.includes(IncidentTemplate.TREE_PATH)))
+            .index(incidentAlias);
+
+    return fetchUnboundedDocumentCollection(
+        request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
+  }
+
+  /**
+   * Variant of {@link #fetchUnboundedDocumentCollection(Builder, Class, Function)} to use when you
+   * don't care about the source document, meaning you won't be using any deserialization
+   * functionality.
+   */
+  private <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
+      final SearchRequest.Builder requestBuilder, final Function<Hit<Object>, T> transformer) {
+    return fetchUnboundedDocumentCollection(requestBuilder, Object.class, transformer);
+  }
+
+  private <TDocument, TResult>
+      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
+          final SearchRequest.Builder requestBuilder,
+          final Class<TDocument> type,
+          final Function<Hit<TDocument>, TResult> transformer) {
+    final var request =
+        requestBuilder
             .allowNoIndices(true)
             .ignoreUnavailable(true)
-            .query(query)
-            .source(s -> s.fetch(false))
             .scroll(SCROLL_KEEP_ALIVE)
             .size(SCROLL_PAGE_SIZE)
             .build();
 
     return client
-        // pass Object as the document type, because we will not read the source anyway and we don't
-        // want to couple ourselves to whatever the entity type really be
-        .search(request, Object.class)
+        .search(request, type)
         .thenComposeAsync(
             r ->
                 clearScrollOnComplete(
                     r.scrollId(),
-                    scrollDocuments(r.hits().hits(), r.scrollId(), new ArrayList<>())),
+                    scrollDocuments(
+                        r.hits().hits(), r.scrollId(), new ArrayList<>(), transformer, type)),
             executor);
   }
 
@@ -243,17 +280,24 @@ public final class ElasticsearchIncidentUpdateRepository extends NoopIncidentUpd
         .thenComposeAsync(ignored -> endResult);
   }
 
-  private CompletionStage<Collection<Document>> scrollDocuments(
-      final List<Hit<Object>> hits, final String scrollId, final List<Document> accumulator) {
+  private <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
+      final List<Hit<TResult>> hits,
+      final String scrollId,
+      final List<TDocument> accumulator,
+      final Function<Hit<TResult>, TDocument> transformer,
+      final Class<TResult> type) {
     if (hits.isEmpty()) {
       return CompletableFuture.completedFuture(accumulator);
     }
 
-    hits.forEach(hit -> accumulator.add(new Document(hit.id(), hit.index())));
+    for (final var hit : hits) {
+      accumulator.add(transformer.apply(hit));
+    }
 
     return client
-        .scroll(r -> r.scrollId(scrollId).scroll(SCROLL_KEEP_ALIVE), Object.class)
-        .thenComposeAsync(r -> scrollDocuments(r.hits().hits(), r.scrollId(), accumulator));
+        .scroll(r -> r.scrollId(scrollId).scroll(SCROLL_KEEP_ALIVE), type)
+        .thenComposeAsync(
+            r -> scrollDocuments(r.hits().hits(), r.scrollId(), accumulator, transformer, type));
   }
 
   private Query createProcessInstanceDeletedQuery(final long processInstanceKey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -113,7 +113,8 @@ public interface IncidentUpdateRepository {
    * @param treePathTerms the complete list of tree path terms to filter on
    * @return a list of active incidents with at least one tree path term overlapping the given list
    */
-  CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(List<String> treePathTerms);
+  CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
+      final Collection<String> treePathTerms);
 
   /**
    * Represents an incident document: the source identity and its ID and index.
@@ -218,8 +219,8 @@ public interface IncidentUpdateRepository {
     }
 
     @Override
-    public CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(
-        final List<String> treePathTerms) {
+    public CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
+        final Collection<String> treePathTerms) {
       return CompletableFuture.completedFuture(List.of());
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateTask.java
@@ -427,7 +427,7 @@ public final class IncidentUpdateTask implements BackgroundTask {
             .map(CompletableFuture::join)
             .flatMap(List::stream)
             .collect(Collectors.toList());
-    final List<ActiveIncident> activeIncidentTreePaths =
+    final Collection<ActiveIncident> activeIncidentTreePaths =
         repository.getActiveIncidentsByTreePaths(treePathTerms).toCompletableFuture().join();
     for (final var activeIncidentTreePath : activeIncidentTreePaths) {
       final var treePath = new TreePath(activeIncidentTreePath.treePath());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -15,6 +15,7 @@ import co.elastic.clients.elasticsearch.core.ClearScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
+import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -46,10 +47,10 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
 
   @ParameterizedTest
   @MethodSource("scrollTestCases")
-  void shouldClearScrollOnGetFlowNodesInListView(final TestCase testCase) {
+  void shouldClearScroll(final ScrollTestCase testCase) {
     // given
     final var repository = createRepository();
-    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.any(Class.class)))
         .thenReturn(CompletableFuture.completedFuture(buildMinimalSearchResponse()));
     Mockito.when(client.clearScroll(Mockito.any(ClearScrollRequest.class)))
         .thenReturn(CompletableFuture.completedFuture(buildMinimalClearScrollResponse()));
@@ -66,10 +67,10 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
 
   @ParameterizedTest
   @MethodSource("scrollTestCases")
-  void shouldNotClearScrollOnGetFlowNodesInListViewOnSearchFailure(final TestCase testCase) {
+  void shouldNotClearScrollOnSearchFailure(final ScrollTestCase testCase) {
     // given
     final var repository = createRepository();
-    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.any(Class.class)))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("failure")));
 
     // when
@@ -82,12 +83,13 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
 
   @ParameterizedTest
   @MethodSource("scrollTestCases")
-  void shouldClearScrollOnGetFlowNodesInListViewEvenOnFailure(final TestCase testCase) {
+  <T> void shouldClearScrollOnScrollFailure(final ScrollTestCase<T> testCase) {
     // given
     final var repository = createRepository();
-    final SearchResponse<Object> searchResponse =
-        buildMinimalSearchResponse(b -> b.hits(h -> h.hits(Hit.of(d -> d.id("1").index("index")))));
-    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.eq(Object.class)))
+    final var hit = new Hit.Builder<T>().id("1").index("index").source(testCase.document()).build();
+    final SearchResponse<T> searchResponse =
+        buildMinimalSearchResponse(b -> b.hits(h -> h.hits(hit)));
+    Mockito.when(client.search(Mockito.any(SearchRequest.class), Mockito.any(Class.class)))
         .thenReturn(CompletableFuture.completedFuture(searchResponse));
     Mockito.when(client.scroll(Mockito.any(Function.class), Mockito.any()))
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException("failure")));
@@ -112,11 +114,11 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
     return buildMinimalSearchResponse(ignored -> {});
   }
 
-  private SearchResponse<Object> buildMinimalSearchResponse(
-      final Consumer<SearchResponse.Builder<?>> modifier) {
+  private <T> SearchResponse<T> buildMinimalSearchResponse(
+      final Consumer<SearchResponse.Builder<T>> modifier) {
     // need to specify all the required fields
     final var response =
-        new SearchResponse.Builder<>()
+        new SearchResponse.Builder<T>()
             .scrollId("foo")
             .hits(h -> h.hits(List.of()))
             .took(1)
@@ -140,15 +142,24 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
         LOGGER);
   }
 
-  private static Stream<Named<TestCase>> scrollTestCases() {
+  private static Stream<Named<ScrollTestCase>> scrollTestCases() {
     return Stream.of(
-        Named.of("getFlowNodeInstances", r -> r.getFlowNodeInstances(List.of("1", "2"))),
-        Named.of("getFlowNodesInListView", r -> r.getFlowNodesInListView(List.of("1", "2"))));
+        Named.of(
+            "getFlowNodeInstances",
+            new ScrollTestCase<>(null, r -> r.getFlowNodeInstances(List.of("1", "2")))),
+        Named.of(
+            "getFlowNodesInListView",
+            new ScrollTestCase<>(null, r -> r.getFlowNodesInListView(List.of("1", "2")))),
+        Named.of(
+            "getActiveIncidentsByTreePaths",
+            new ScrollTestCase<>(
+                new IncidentEntity(), r -> r.getActiveIncidentsByTreePaths(List.of("1", "2")))));
   }
 
-  @FunctionalInterface
-  private interface TestCase {
-    CompletionStage<?> executeScrollingMethod(
-        final ElasticsearchIncidentUpdateRepository repository);
+  record ScrollTestCase<T>(
+      T document, Function<IncidentUpdateRepository, CompletionStage<?>> scrollMethod) {
+    CompletionStage<?> executeScrollingMethod(final IncidentUpdateRepository repository) {
+      return scrollMethod.apply(repository);
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -574,7 +574,7 @@ abstract sealed class IncidentUpdateRepositoryIT {
       assertThat(terms)
           .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.list(String.class))
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               "PI_1",
               "PI_1/FN_call",
               "PI_1/FN_call/FNI_2",
@@ -700,7 +700,7 @@ abstract sealed class IncidentUpdateRepositoryIT {
       assertThat(flowNodes)
           .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.collection(Document.class))
-          .containsExactly(
+          .containsExactlyInAnyOrder(
               new Document("1", listViewTemplate.getFullQualifiedName()),
               new Document("2", listViewTemplate.getFullQualifiedName()));
     }
@@ -776,15 +776,15 @@ abstract sealed class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var flowNodes = repository.getFlowNodesInListView(List.of("1", "2"));
+      final var flowNodes = repository.getFlowNodeInstances(List.of("1", "2"));
 
       // then
       assertThat(flowNodes)
           .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.collection(Document.class))
-          .containsExactly(
-              new Document("1", listViewTemplate.getFullQualifiedName()),
-              new Document("2", listViewTemplate.getFullQualifiedName()));
+          .containsExactlyInAnyOrder(
+              new Document("1", flowNodeInstanceTemplate.getFullQualifiedName()),
+              new Document("2", flowNodeInstanceTemplate.getFullQualifiedName()));
     }
 
     @Test
@@ -799,13 +799,13 @@ abstract sealed class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var flowNodes = repository.getFlowNodesInListView(List.of("1"));
+      final var flowNodes = repository.getFlowNodeInstances(List.of("1"));
 
       // then
       assertThat(flowNodes)
           .succeedsWithin(REQUEST_TIMEOUT)
           .asInstanceOf(InstanceOfAssertFactories.collection(Document.class))
-          .containsExactly(new Document("1", listViewTemplate.getFullQualifiedName()));
+          .containsExactly(new Document("1", flowNodeInstanceTemplate.getFullQualifiedName()));
     }
   }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -879,7 +879,7 @@ abstract sealed class IncidentUpdateRepositoryIT {
       batchRequest.addWithId(
           incidentTemplate.getFullQualifiedName(),
           "7",
-          newIncident(7).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2"));
+          newIncident(7).setState(IncidentState.ACTIVE).setTreePath("PI_1/FNI_2/PI_7"));
       batchRequest.addWithId(
           incidentTemplate.getFullQualifiedName(),
           "8",
@@ -891,7 +891,8 @@ abstract sealed class IncidentUpdateRepositoryIT {
       batchRequest.executeWithRefresh();
 
       // when
-      final var incidents = repository.getActiveIncidentsByTreePaths(List.of("PI_1", "PI_3"));
+      final var incidents =
+          repository.getActiveIncidentsByTreePaths(List.of("PI_1/FNI_2", "PI_3/FNI_4"));
 
       // then
       assertThat(incidents)

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateTaskTest.java
@@ -85,7 +85,7 @@ final class IncidentUpdateTaskTest {
     private CompletableFuture<PendingIncidentUpdateBatch> batch;
     private CompletableFuture<Map<String, IncidentDocument>> incidents;
     private CompletableFuture<Collection<ProcessInstanceDocument>> processInstances;
-    private CompletableFuture<List<ActiveIncident>> activeIncidentsByTreePaths;
+    private CompletableFuture<Collection<ActiveIncident>> activeIncidentsByTreePaths;
     private CompletableFuture<Integer> bulkUpdate;
     private CompletableFuture<Collection<Document>> flowNodesInListView;
     private CompletableFuture<Collection<Document>> flowNodeInstances;
@@ -153,8 +153,8 @@ final class IncidentUpdateTaskTest {
     }
 
     @Override
-    public CompletionStage<List<ActiveIncident>> getActiveIncidentsByTreePaths(
-        final List<String> treePathTerms) {
+    public CompletionStage<Collection<ActiveIncident>> getActiveIncidentsByTreePaths(
+        final Collection<String> treePathTerms) {
       return activeIncidentsByTreePaths != null
           ? activeIncidentsByTreePaths
           : super.getActiveIncidentsByTreePaths(treePathTerms);


### PR DESCRIPTION
## Description

This PR implements the `getActiveIncidentsByTreePath` for the `ElasticsearchIncidentUpdateRepository`.

I refactored the scrolling logic to be a little more generic, since we want to scroll and deserialize now, as opposed to the previous implementation where we only cared about the index and ID.

I don't particularly like it - it's a little too verbose/cumbersome, but I will likely have to refactor it again for the next method (`getProcessInstances`) where we also scroll, so maybe we tackle that then.

## Related issues

related to #24930
