### PR TITLE
Implement getProcessInstances for ES

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepositoryTest.java
@@ -16,6 +16,7 @@ import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
+import io.camunda.webapps.schema.entities.operate.listview.ProcessInstanceForListViewEntity;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -177,7 +178,12 @@ public final class ElasticsearchIncidentUpdateRepositoryTest {
         Named.of(
             "getActiveIncidentsByTreePaths",
             new ScrollTestCase<>(
-                new IncidentEntity(), r -> r.getActiveIncidentsByTreePaths(List.of("1", "2")))));
+                new IncidentEntity(), r -> r.getActiveIncidentsByTreePaths(List.of("1", "2")))),
+        Named.of(
+            "getProcessInstances",
+            new ScrollTestCase<>(
+                new ProcessInstanceForListViewEntity(),
+                r -> r.getProcessInstances(List.of("1", "2")))));
   }
 
   record ScrollTestCase<T>(


### PR DESCRIPTION
## Description

Implements `getProcessInstances` for the `ElasticsearchIncidentUpdateRepository`. One difference from the original implementation here, is that I also check the join relation property - the original only did for the FNIs, but I figured it's risky to rely on the ID always being correct.

> [!Note]
> With the additional tests to the clear scroll stuff, and the changes to fix it, I'm now thinking a good follow up would be to extract that to a utility you can test - that way, we don't need to keep adding new tests for each scrolling method using it. The fact it scrolls is pretty deep implementation detail imo.

## Related issues

closes #24930 
