### PR TITLE
feat: camunda services support add and remove meber to tenant with endpoints

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -109,6 +109,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/io/camunda/service/TenantServices.java
+++ b/service/src/main/java/io/camunda/service/TenantServices.java
@@ -83,25 +83,18 @@ public class TenantServices extends SearchQueryService<TenantServices, TenantQue
 
   public CompletableFuture<?> addMember(
       final Long tenantKey, final EntityType entityType, final long entityKey) {
-    return modifyEntity(tenantKey, entityType, entityKey, true);
+    return sendBrokerRequest(
+        BrokerTenantEntityRequest.createAddRequest()
+            .setTenantKey(tenantKey)
+            .setEntity(entityType, entityKey));
   }
 
   public CompletableFuture<?> removeMember(
       final Long tenantKey, final EntityType entityType, final long entityKey) {
-    return modifyEntity(tenantKey, entityType, entityKey, false);
-  }
-
-  private CompletableFuture<?> modifyEntity(
-      final long parentKey,
-      final EntityType entityType,
-      final long entityKey,
-      final boolean isAdd) {
-    final var request =
-        isAdd
-            ? BrokerTenantEntityRequest.createAddRequest()
-            : BrokerTenantEntityRequest.createRemoveRequest();
-    request.setTenantKey(parentKey).setEntity(entityType, entityKey);
-    return sendBrokerRequest(request);
+    return sendBrokerRequest(
+        BrokerTenantEntityRequest.createRemoveRequest()
+            .setTenantKey(tenantKey)
+            .setEntity(entityType, entityKey));
   }
 
   public record TenantDTO(Long key, String tenantId, String name) {}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -601,6 +601,88 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /tenants/{tenantKey}/mapping-rules/{mappingKey}:
+    put:
+      tags:
+        - Tenant
+      operationId: assignMappingRuleToTenant
+      summary: Assign a mapping rule to a tenant
+      description: Assign a single mapping rule to a specified tenant.
+      parameters:
+        - name: tenantKey
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: integer
+            format: int64
+        - name: mappingKey
+          in: path
+          required: true
+          description: The unique identifier of the mapping rule.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "202":
+          description: The mapping rule was successfully assigned to the tenant.
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The tenant or mapping rule was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    delete:
+      tags:
+        - Tenant
+      operationId: removeMappingRuleFromTenant
+      summary: Remove a mapping rule from a tenant
+      description: Removes a single mapping rule from a specified tenant without deleting the rule.
+      parameters:
+        - name: tenantKey
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: integer
+            format: int64
+        - name: mappingKey
+          in: path
+          required: true
+          description: The unique identifier of the mapping rule.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "202":
+          description: The mapping rule was successfully removed from the tenant.
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The tenant or mapping rule was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
 
   /tenants/search:
     post:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -518,6 +518,89 @@ paths:
         "500":
           $ref: "#/components/responses/InternalServerError"
 
+  /tenants/{tenantKey}/users/{userKey}:
+    put:
+      tags:
+        - Tenant
+      operationId: assignUserToTenant
+      summary: Assign a user to a tenant
+      description: Assign a single user to a specified tenant.
+      parameters:
+        - name: tenantKey
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: integer
+            format: int64
+        - name: userKey
+          in: path
+          required: true
+          description: The unique identifier of the user.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "202":
+          description: The user was successfully assigned to the tenant.
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The tenant or user was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
+    delete:
+      tags:
+        - Tenant
+      operationId: removeUserFromTenant
+      summary: Remove a user from a tenant
+      description: Removes a single user from a specified tenant without deleting the user.
+      parameters:
+        - name: tenantKey
+          in: path
+          required: true
+          description: The unique identifier of the tenant.
+          schema:
+            type: integer
+            format: int64
+        - name: userKey
+          in: path
+          required: true
+          description: The unique identifier of the user.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "202":
+          description: The user was successfully removed from the tenant.
+        "400":
+          description: The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: Not found. The tenant or user was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+
 
   /tenants/search:
     post:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -107,4 +107,28 @@ public class TenantController {
                 .withAuthentication(RequestMapper.getAuthentication())
                 .removeMember(tenantKey, EntityType.USER, userKey));
   }
+
+  @PutMapping(
+      path = "/{tenantKey}/mapping-rules/{mappingKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> assignMappingToTenant(
+      @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .addMember(tenantKey, EntityType.MAPPING, mappingKey));
+  }
+
+  @DeleteMapping(
+      path = "/{tenantKey}/mapping-rules/{mappingKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> removeMappingFromTenant(
+      @PathVariable final long tenantKey, @PathVariable final long mappingKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .removeMember(tenantKey, EntityType.MAPPING, mappingKey));
+  }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -80,10 +80,6 @@ public class TenantController {
         ResponseMapper::toTenantUpdateResponse);
   }
 
-  // The API will accept only a single userKey for now to maintain atomicity and align
-  // with REST principles.
-  // Bulk operations would require adapting the broker request and adding a new event like
-  // ENTITIES_ADDED, which is out of scope for this iteration.
   @PutMapping(
       path = "/{tenantKey}/users/{userKey}",
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantController.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.controller.CamundaRestController;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -77,5 +78,33 @@ public class TenantController {
                 .withAuthentication(RequestMapper.getAuthentication())
                 .updateTenant(tenantDTO),
         ResponseMapper::toTenantUpdateResponse);
+  }
+
+  // The API will accept only a single userKey for now to maintain atomicity and align
+  // with REST principles.
+  // Bulk operations would require adapting the broker request and adding a new event like
+  // ENTITIES_ADDED, which is out of scope for this iteration.
+  @PutMapping(
+      path = "/{tenantKey}/users/{userKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> assignUsersToTenant(
+      @PathVariable final long tenantKey, @PathVariable final long userKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .addMember(tenantKey, EntityType.USER, userKey));
+  }
+
+  @DeleteMapping(
+      path = "/{tenantKey}/users/{userKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> removeUserFromTenant(
+      @PathVariable final long tenantKey, @PathVariable final long userKey) {
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            tenantServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .removeMember(tenantKey, EntityType.USER, userKey));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantControllerTest.java
@@ -268,4 +268,48 @@ public class TenantControllerTest extends RestControllerTest {
     // then
     verify(tenantServices, times(1)).removeMember(tenantKey, EntityType.USER, userKey);
   }
+
+  @Test
+  void assignMappingToTenantShouldReturnNoContent() {
+    // given
+    final var tenantKey = 100L;
+    final var mappingKey = 42L;
+
+    when(tenantServices.addMember(tenantKey, EntityType.MAPPING, mappingKey))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    webClient
+        .put()
+        .uri("%s/%s/mapping-rules/%s".formatted(TENANT_BASE_URL, tenantKey, mappingKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(tenantServices, times(1)).addMember(tenantKey, EntityType.MAPPING, mappingKey);
+  }
+
+  @Test
+  void removeMappingFromTenantShouldReturnNoContent() {
+    // given
+    final var tenantKey = 100L;
+    final var mappingKey = 42L;
+
+    when(tenantServices.removeMember(tenantKey, EntityType.MAPPING, mappingKey))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when
+    webClient
+        .delete()
+        .uri("%s/%s/mapping-rules/%s".formatted(TENANT_BASE_URL, tenantKey, mappingKey))
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+
+    // then
+    verify(tenantServices, times(1)).removeMember(tenantKey, EntityType.MAPPING, mappingKey);
+  }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -37,7 +37,7 @@ public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<Tenant
   public BrokerTenantEntityRequest setEntity(final EntityType entityType, final long entityKey) {
     if (entityType != EntityType.USER && entityType != EntityType.MAPPING) {
       throw new IllegalArgumentException(
-          "For now, tenant can only be granted to users and mappings");
+          "For now, tenants can only be assigned to users and mappings");
     }
     tenantDto.setEntityType(entityType);
     tenantDto.setEntityKey(entityKey);

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerTenantEntityRequest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import org.agrona.DirectBuffer;
+
+public final class BrokerTenantEntityRequest extends BrokerExecuteCommand<TenantRecord> {
+  private final TenantRecord tenantDto = new TenantRecord();
+
+  private BrokerTenantEntityRequest(final TenantIntent intent) {
+    super(ValueType.TENANT, intent);
+  }
+
+  public static BrokerTenantEntityRequest createAddRequest() {
+    return new BrokerTenantEntityRequest(TenantIntent.ADD_ENTITY);
+  }
+
+  public static BrokerTenantEntityRequest createRemoveRequest() {
+    return new BrokerTenantEntityRequest(TenantIntent.REMOVE_ENTITY);
+  }
+
+  public BrokerTenantEntityRequest setTenantKey(final long tenantKey) {
+    tenantDto.setTenantKey(tenantKey);
+    return this;
+  }
+
+  public BrokerTenantEntityRequest setEntity(final EntityType entityType, final long entityKey) {
+    if (entityType != EntityType.USER && entityType != EntityType.MAPPING) {
+      throw new IllegalArgumentException(
+          "For now, tenant can only be granted to users and mappings");
+    }
+    tenantDto.setEntityType(entityType);
+    tenantDto.setEntityKey(entityKey);
+    return this;
+  }
+
+  @Override
+  public TenantRecord getRequestWriter() {
+    return tenantDto;
+  }
+
+  @Override
+  protected TenantRecord toResponseDto(final DirectBuffer buffer) {
+    final TenantRecord response = new TenantRecord();
+    response.wrap(buffer);
+    return response;
+  }
+}


### PR DESCRIPTION
## Description

 - support add member in TenantServices;
 - support remove member in TenantServices
 - added endpoins : 
     `DELETE /v2/tenants/{tenantKey}/users/{userKey}`
     `PUT /v2/tenants/{tenantKey}/users/{userKey}`
     `DELETE /v2/tenants/{tenantKey}/mapping-rules/{mappingKey}`
     `PUT /v2/tenants/{tenantKey}/mapping-rules/{mappingKey}`
- added tests; 


by [spec](https://docs.google.com/document/d/1rS989EESojWRrCMLH7Nscy1UppbgOanvzVeOljCc_iA/edit#heading=h.a9ktiwwmxjw0)  should be implemented endpoint `POST /v2/tenants/{key}/users` , but as was [discussed in the slack ](https://camunda.slack.com/archives/C06UYJMMETZ/p1733150844530149) decided to implement for now` PUT /{tenantKey}/users/{userKey}`

also , in the  [spec](https://docs.google.com/document/d/1rS989EESojWRrCMLH7Nscy1UppbgOanvzVeOljCc_iA/edit#heading=h.a9ktiwwmxjw0)  I am not found endpoints for assign mapping, so it implemented similar to assign users


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to 
 - https://github.com/camunda/camunda/issues/22390

closes #24877
