### PR TITLE
fix: don't use mutable keys for forms cache

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -242,7 +242,7 @@ public final class BpmnUserTaskBehavior {
   private Either<Failure, PersistedForm> findLatestFormById(
       final String formId, final String tenantId, final long scopeKey) {
     return formState
-        .findLatestFormById(wrapString(formId), tenantId)
+        .findLatestFormById(formId, tenantId)
         .<Either<Failure, PersistedForm>>map(Either::right)
         .orElseGet(
             () ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import static io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebePriorityDefinitionValidator.PRIORITY_LOWER_BOUND;
 import static io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebePriorityDefinitionValidator.PRIORITY_UPPER_BOUND;
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -220,8 +219,7 @@ public final class BpmnUserTaskBehavior {
         .flatMap(
             deploymentKey ->
                 formState
-                    .findFormByIdAndDeploymentKey(
-                        wrapString(formId), deploymentKey, context.getTenantId())
+                    .findFormByIdAndDeploymentKey(formId, deploymentKey, context.getTenantId())
                     .<Either<Failure, PersistedForm>>map(Either::right)
                     .orElseGet(
                         () ->
@@ -261,7 +259,7 @@ public final class BpmnUserTaskBehavior {
   private Either<Failure, PersistedForm> findFormByIdAndVersionTag(
       final String formId, final String versionTag, final String tenantId, final long scopeKey) {
     return formState
-        .findFormByIdAndVersionTag(wrapString(formId), versionTag, tenantId)
+        .findFormByIdAndVersionTag(formId, versionTag, tenantId)
         .<Either<Failure, PersistedForm>>map(Either::right)
         .orElseGet(
             () ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -143,7 +141,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     Optional.ofNullable(form.versionTag).ifPresent(formRecord::setVersionTag);
 
     formState
-        .findLatestFormById(wrapString(formRecord.getFormId()), tenantId)
+        .findLatestFormById(formRecord.getFormId(), tenantId)
         .ifPresentOrElse(
             latestForm -> {
               final boolean isDuplicate =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -134,8 +134,7 @@ public class DbFormState implements MutableFormState {
     dbPersistedForm.wrap(record);
     formsByKey.upsert(tenantAwareFormKey, dbPersistedForm);
     formsByTenantIdAndIdCache.put(
-        new TenantIdAndFormId(record.getTenantId(), record.getFormIdBuffer()),
-        dbPersistedForm.copy());
+        new TenantIdAndFormId(record.getTenantId(), record.getFormId()), dbPersistedForm.copy());
   }
 
   @Override
@@ -181,7 +180,7 @@ public class DbFormState implements MutableFormState {
     dbFormKey.wrapLong(record.getFormKey());
     formsByKey.deleteExisting(tenantAwareFormKey);
     formsByTenantIdAndIdCache.invalidate(
-        new TenantIdAndFormId(record.getTenantId(), record.getFormIdBuffer()));
+        new TenantIdAndFormId(record.getTenantId(), record.getFormId()));
   }
 
   @Override
@@ -215,8 +214,7 @@ public class DbFormState implements MutableFormState {
   }
 
   @Override
-  public Optional<PersistedForm> findLatestFormById(
-      final DirectBuffer formId, final String tenantId) {
+  public Optional<PersistedForm> findLatestFormById(final String formId, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
     final Optional<PersistedForm> cachedForm = getFormFromCache(tenantId, formId);
     if (cachedForm.isPresent()) {
@@ -271,8 +269,8 @@ public class DbFormState implements MutableFormState {
     versionManager.clear();
   }
 
-  private PersistedForm getPersistedFormById(final DirectBuffer formId, final String tenantId) {
-    dbFormId.wrapBuffer(formId);
+  private PersistedForm getPersistedFormById(final String formId, final String tenantId) {
+    dbFormId.wrapString(formId);
     final long latestVersion = versionManager.getLatestResourceVersion(formId, tenantId);
     formVersion.wrapLong(latestVersion);
     final PersistedForm persistedForm =
@@ -283,11 +281,10 @@ public class DbFormState implements MutableFormState {
     return persistedForm.copy();
   }
 
-  private Optional<PersistedForm> getFormFromCache(
-      final String tenantId, final DirectBuffer formId) {
+  private Optional<PersistedForm> getFormFromCache(final String tenantId, final String formId) {
     return Optional.ofNullable(
         formsByTenantIdAndIdCache.getIfPresent(new TenantIdAndFormId(tenantId, formId)));
   }
 
-  private record TenantIdAndFormId(String tenantId, DirectBuffer formId) {}
+  private record TenantIdAndFormId(String tenantId, String formId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -23,7 +23,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public class DbFormState implements MutableFormState {
 
@@ -238,9 +237,9 @@ public class DbFormState implements MutableFormState {
 
   @Override
   public Optional<PersistedForm> findFormByIdAndDeploymentKey(
-      final DirectBuffer formId, final long deploymentKey, final String tenantId) {
+      final String formId, final long deploymentKey, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
-    dbFormId.wrapBuffer(formId);
+    dbFormId.wrapString(formId);
     dbDeploymentKey.wrapLong(deploymentKey);
     return Optional.ofNullable(
             formKeyByFormIdAndDeploymentKeyColumnFamily.get(tenantAwareFormIdAndDeploymentKey))
@@ -249,9 +248,9 @@ public class DbFormState implements MutableFormState {
 
   @Override
   public Optional<PersistedForm> findFormByIdAndVersionTag(
-      final DirectBuffer formId, final String versionTag, final String tenantId) {
+      final String formId, final String versionTag, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
-    dbFormId.wrapBuffer(formId);
+    dbFormId.wrapString(formId);
     dbVersionTag.wrapString(versionTag);
     return Optional.ofNullable(
             formKeyByFormIdAndVersionTagColumnFamily.get(tenantAwareFormIdAndVersionTagKey))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public interface FormState {
 
@@ -42,7 +41,7 @@ public interface FormState {
    *     the given deployment
    */
   Optional<PersistedForm> findFormByIdAndDeploymentKey(
-      DirectBuffer formId, long deploymentKey, final String tenantId);
+      String formId, long deploymentKey, final String tenantId);
 
   /**
    * Query forms by the given form id and version tag and return the form.
@@ -54,7 +53,7 @@ public interface FormState {
    *     deployed
    */
   Optional<PersistedForm> findFormByIdAndVersionTag(
-      DirectBuffer formId, String versionTag, final String tenantId);
+      String formId, String versionTag, final String tenantId);
 
   /**
    * Gets the next version a form of a given id will receive. This is used, for example, when a new

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -21,7 +21,7 @@ public interface FormState {
    * @return the latest version of the form, or {@link Optional#empty()} if no form is deployed with
    *     the given id
    */
-  Optional<PersistedForm> findLatestFormById(DirectBuffer formId, final String tenantId);
+  Optional<PersistedForm> findLatestFormById(String formId, final String tenantId);
 
   /**
    * Query forms by the given form key and return the form.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AbstractFormCreatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/AbstractFormCreatedApplierTest.java
@@ -66,8 +66,7 @@ abstract class AbstractFormCreatedApplierTest {
     formCreatedApplier.applyState(formRecord2.getFormKey(), formRecord2);
 
     // when
-    final var maybePersistedForm =
-        formState.findLatestFormById(formRecord1.getFormIdBuffer(), TENANT_1);
+    final var maybePersistedForm = formState.findLatestFormById(formRecord1.getFormId(), TENANT_1);
 
     // then
     assertThat(maybePersistedForm).hasValueSatisfying(isEqualToFormRecord(formRecord2));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV1ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV1ApplierTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
@@ -38,8 +36,8 @@ public class FormCreatedV1ApplierTest extends AbstractFormCreatedApplierTest {
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
 
-    form1 = formState.findLatestFormById(wrapString(formId), TENANT_1).orElseThrow();
-    form2 = formState.findLatestFormById(wrapString(formId), TENANT_2).orElseThrow();
+    form1 = formState.findLatestFormById(formId, TENANT_1).orElseThrow();
+    form2 = formState.findLatestFormById(formId, TENANT_2).orElseThrow();
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV2ApplierTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
@@ -49,21 +48,13 @@ public class FormCreatedV2ApplierTest extends AbstractFormCreatedApplierTest {
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
 
-    form1 =
-        formState
-            .findFormByIdAndDeploymentKey(wrapString(formId), deploymentKey, TENANT_1)
-            .orElseThrow();
-    form2 =
-        formState
-            .findFormByIdAndDeploymentKey(wrapString(formId), deploymentKey, TENANT_2)
-            .orElseThrow();
+    form1 = formState.findFormByIdAndDeploymentKey(formId, deploymentKey, TENANT_1).orElseThrow();
+    form2 = formState.findFormByIdAndDeploymentKey(formId, deploymentKey, TENANT_2).orElseThrow();
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
 
-    form1 =
-        formState.findFormByIdAndVersionTag(wrapString(formId), versionTag, TENANT_1).orElseThrow();
-    form2 =
-        formState.findFormByIdAndVersionTag(wrapString(formId), versionTag, TENANT_2).orElseThrow();
+    form1 = formState.findFormByIdAndVersionTag(formId, versionTag, TENANT_1).orElseThrow();
+    form2 = formState.findFormByIdAndVersionTag(formId, versionTag, TENANT_2).orElseThrow();
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
   }
@@ -81,14 +72,10 @@ public class FormCreatedV2ApplierTest extends AbstractFormCreatedApplierTest {
     formCreatedApplier.applyState(form1Version2.getFormKey(), form1Version2);
 
     // when
-    final var maybePersistedForm1 =
-        formState.findFormByIdAndDeploymentKey(wrapString("form-1"), 1L, TENANT_1);
-    final var maybePersistedForm2 =
-        formState.findFormByIdAndDeploymentKey(wrapString("form-2"), 1L, TENANT_1);
-    final var maybePersistedForm3 =
-        formState.findFormByIdAndDeploymentKey(wrapString("form-1"), 2L, TENANT_1);
-    final var maybePersistedForm4 =
-        formState.findFormByIdAndDeploymentKey(wrapString("form-2"), 2L, TENANT_1);
+    final var maybePersistedForm1 = formState.findFormByIdAndDeploymentKey("form-1", 1L, TENANT_1);
+    final var maybePersistedForm2 = formState.findFormByIdAndDeploymentKey("form-2", 1L, TENANT_1);
+    final var maybePersistedForm3 = formState.findFormByIdAndDeploymentKey("form-1", 2L, TENANT_1);
+    final var maybePersistedForm4 = formState.findFormByIdAndDeploymentKey("form-2", 2L, TENANT_1);
 
     // then
     assertThat(maybePersistedForm1).hasValueSatisfying(isEqualToFormRecord(form1Version1));
@@ -110,14 +97,10 @@ public class FormCreatedV2ApplierTest extends AbstractFormCreatedApplierTest {
     formCreatedApplier.applyState(form1Version2.getFormKey(), form1Version2);
 
     // when
-    final var maybePersistedForm1 =
-        formState.findFormByIdAndVersionTag(wrapString("form-1"), "v1.0", TENANT_1);
-    final var maybePersistedForm2 =
-        formState.findFormByIdAndVersionTag(wrapString("form-2"), "v1.0", TENANT_1);
-    final var maybePersistedForm3 =
-        formState.findFormByIdAndVersionTag(wrapString("form-1"), "v2.0", TENANT_1);
-    final var maybePersistedForm4 =
-        formState.findFormByIdAndVersionTag(wrapString("form-2"), "v2.0", TENANT_1);
+    final var maybePersistedForm1 = formState.findFormByIdAndVersionTag("form-1", "v1.0", TENANT_1);
+    final var maybePersistedForm2 = formState.findFormByIdAndVersionTag("form-2", "v1.0", TENANT_1);
+    final var maybePersistedForm3 = formState.findFormByIdAndVersionTag("form-1", "v2.0", TENANT_1);
+    final var maybePersistedForm4 = formState.findFormByIdAndVersionTag("form-2", "v2.0", TENANT_1);
 
     // then
     assertThat(maybePersistedForm1).hasValueSatisfying(isEqualToFormRecord(form1Version1));
@@ -137,7 +120,7 @@ public class FormCreatedV2ApplierTest extends AbstractFormCreatedApplierTest {
     formCreatedApplier.applyState(formV1New.getFormKey(), formV1New);
 
     // then
-    assertThat(formState.findFormByIdAndVersionTag(wrapString("form-id"), "v1.0", TENANT_1))
+    assertThat(formState.findFormByIdAndVersionTag("form-id", "v1.0", TENANT_1))
         .hasValueSatisfying(isEqualToFormRecord(formV1New));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV2ApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedV2ApplierTest.java
@@ -44,8 +44,8 @@ public class FormCreatedV2ApplierTest extends AbstractFormCreatedApplierTest {
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
 
-    form1 = formState.findLatestFormById(wrapString(formId), TENANT_1).orElseThrow();
-    form2 = formState.findLatestFormById(wrapString(formId), TENANT_2).orElseThrow();
+    form1 = formState.findLatestFormById(formId, TENANT_1).orElseThrow();
+    form2 = formState.findLatestFormById(formId, TENANT_2).orElseThrow();
     assertPersistedForm(form1, formKey, formId, version, deploymentKey, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, deploymentKey, TENANT_2);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
@@ -200,19 +200,19 @@ public class FormDeletedApplierTest {
       assertThat(formState.findLatestFormById(tenant2Form.getFormId(), TENANT_2)).isNotEmpty();
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  tenant1Form.getFormIdBuffer(), tenant1Form.getDeploymentKey(), TENANT_1))
+                  tenant1Form.getFormId(), tenant1Form.getDeploymentKey(), TENANT_1))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  tenant2Form.getFormIdBuffer(), tenant2Form.getDeploymentKey(), TENANT_2))
+                  tenant2Form.getFormId(), tenant2Form.getDeploymentKey(), TENANT_2))
           .isNotEmpty();
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  tenant1Form.getFormIdBuffer(), tenant1Form.getVersionTag(), TENANT_1))
+                  tenant1Form.getFormId(), tenant1Form.getVersionTag(), TENANT_1))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  tenant2Form.getFormIdBuffer(), tenant2Form.getVersionTag(), TENANT_2))
+                  tenant2Form.getFormId(), tenant2Form.getVersionTag(), TENANT_2))
           .isNotEmpty();
     }
 
@@ -230,11 +230,11 @@ public class FormDeletedApplierTest {
       // then
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  formV1.getFormIdBuffer(), formV1.getDeploymentKey(), formV1.getTenantId()))
+                  formV1.getFormId(), formV1.getDeploymentKey(), formV1.getTenantId()))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  formV2.getFormIdBuffer(), formV2.getDeploymentKey(), formV2.getTenantId()))
+                  formV2.getFormId(), formV2.getDeploymentKey(), formV2.getTenantId()))
           .get()
           .extracting(PersistedForm::getFormKey, PersistedForm::getVersion)
           .containsExactly(2L, 2);
@@ -254,11 +254,11 @@ public class FormDeletedApplierTest {
       // then
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  formV1.getFormIdBuffer(), formV1.getVersionTag(), formV1.getTenantId()))
+                  formV1.getFormId(), formV1.getVersionTag(), formV1.getTenantId()))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  formV2.getFormIdBuffer(), formV2.getVersionTag(), formV2.getTenantId()))
+                  formV2.getFormId(), formV2.getVersionTag(), formV2.getTenantId()))
           .get()
           .extracting(PersistedForm::getFormKey, PersistedForm::getVersion)
           .containsExactly(2L, 2);
@@ -278,11 +278,11 @@ public class FormDeletedApplierTest {
       // then
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  formV2.getFormIdBuffer(), formV2.getDeploymentKey(), formV2.getTenantId()))
+                  formV2.getFormId(), formV2.getDeploymentKey(), formV2.getTenantId()))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndDeploymentKey(
-                  formV1.getFormIdBuffer(), formV1.getDeploymentKey(), formV1.getTenantId()))
+                  formV1.getFormId(), formV1.getDeploymentKey(), formV1.getTenantId()))
           .get()
           .extracting(PersistedForm::getFormKey, PersistedForm::getVersion)
           .containsExactly(1L, 1);
@@ -302,11 +302,11 @@ public class FormDeletedApplierTest {
       // then
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  formV2.getFormIdBuffer(), formV2.getVersionTag(), formV2.getTenantId()))
+                  formV2.getFormId(), formV2.getVersionTag(), formV2.getTenantId()))
           .isEmpty();
       assertThat(
               formState.findFormByIdAndVersionTag(
-                  formV1.getFormIdBuffer(), formV1.getVersionTag(), formV1.getTenantId()))
+                  formV1.getFormId(), formV1.getVersionTag(), formV1.getTenantId()))
           .get()
           .extracting(PersistedForm::getFormKey, PersistedForm::getVersion)
           .containsExactly(1L, 1);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
@@ -58,7 +58,7 @@ public class FormDeletedApplierTest {
       formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
       final var latestFormOpt =
-          formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
       assertThat(latestFormOpt).isNotEmpty();
       assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
@@ -67,7 +67,7 @@ public class FormDeletedApplierTest {
 
       // then
       final var latestFormV1Opt =
-          formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
       assertThat(latestFormV1Opt).isNotEmpty();
       assertThat(latestFormV1Opt.get().getVersion()).isEqualTo(1);
     }
@@ -81,7 +81,7 @@ public class FormDeletedApplierTest {
       formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
       final var latestFormOpt =
-          formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
       assertThat(latestFormOpt).isNotEmpty();
       assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
@@ -90,7 +90,7 @@ public class FormDeletedApplierTest {
 
       // then
       final var latestFormV2Opt =
-          formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
       assertThat(latestFormV2Opt).isNotEmpty();
       assertThat(latestFormV2Opt.get().getVersion()).isEqualTo(2);
     }
@@ -161,9 +161,8 @@ public class FormDeletedApplierTest {
       formDeletedApplier.applyState(tenant1Form.getFormKey(), tenant1Form);
 
       // then
-      assertThat(formState.findLatestFormById(tenant1Form.getFormIdBuffer(), TENANT_1)).isEmpty();
-      assertThat(formState.findLatestFormById(tenant2Form.getFormIdBuffer(), TENANT_2))
-          .isNotEmpty();
+      assertThat(formState.findLatestFormById(tenant1Form.getFormId(), TENANT_1)).isEmpty();
+      assertThat(formState.findLatestFormById(tenant2Form.getFormId(), TENANT_2)).isNotEmpty();
     }
   }
 
@@ -197,9 +196,8 @@ public class FormDeletedApplierTest {
       formDeletedApplier.applyState(tenant1Form.getFormKey(), tenant1Form);
 
       // then
-      assertThat(formState.findLatestFormById(tenant1Form.getFormIdBuffer(), TENANT_1)).isEmpty();
-      assertThat(formState.findLatestFormById(tenant2Form.getFormIdBuffer(), TENANT_2))
-          .isNotEmpty();
+      assertThat(formState.findLatestFormById(tenant1Form.getFormId(), TENANT_1)).isEmpty();
+      assertThat(formState.findLatestFormById(tenant2Form.getFormId(), TENANT_2)).isNotEmpty();
       assertThat(
               formState.findFormByIdAndDeploymentKey(
                   tenant1Form.getFormIdBuffer(), tenant1Form.getDeploymentKey(), TENANT_1))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.deployment;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
@@ -50,8 +49,7 @@ public class FormStateTest {
   @Test
   void shouldReturnEmptyIfNoFormIsDeployedForFormIdAndDeploymentKey() {
     // when
-    final var persistedForm =
-        formState.findFormByIdAndDeploymentKey(wrapString("form-1"), 1L, tenantId);
+    final var persistedForm = formState.findFormByIdAndDeploymentKey("form-1", 1L, tenantId);
 
     // then
     assertThat(persistedForm).isEmpty();
@@ -60,8 +58,7 @@ public class FormStateTest {
   @Test
   void shouldReturnEmptyIfNoFormIsDeployedForFormIdAndVersionTag() {
     // when
-    final var persistedForm =
-        formState.findFormByIdAndVersionTag(wrapString("form-1"), "v1.0", tenantId);
+    final var persistedForm = formState.findFormByIdAndVersionTag("form-1", "v1.0", tenantId);
 
     // then
     assertThat(persistedForm).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -32,7 +32,7 @@ public class FormStateTest {
   @Test
   void shouldReturnEmptyIfNoFormIsDeployedForFormId() {
     // when
-    final var persistedForm = formState.findLatestFormById(wrapString("form-1"), tenantId);
+    final var persistedForm = formState.findLatestFormById("form-1", tenantId);
 
     // then
     assertThat(persistedForm).isEmpty();


### PR DESCRIPTION
This fixes a severe bug where we were using mutable `DirectBuffer`s as the key when caching forms. As a result, the cache was corrupt and could cause inconsistent processing.

To avoid this, we are now using immutable `String`s for form ids everywhere. This is not just safer but also easier to use as most call sites apart from tests were already handling them as `String` and we can now avoid wrapping them in a temporary buffer.

Fixes #25504