### PR TITLE
fix: don't use mutable keys for resource cache

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableResourceState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ResourceRecord;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public class DbResourceState implements MutableResourceState {
 
@@ -256,9 +255,9 @@ public class DbResourceState implements MutableResourceState {
 
   @Override
   public Optional<PersistedResource> findResourceByIdAndDeploymentKey(
-      final DirectBuffer resourceId, final long deploymentKey, final String tenantId) {
+      final String resourceId, final long deploymentKey, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
-    dbResourceId.wrapBuffer(resourceId);
+    dbResourceId.wrapString(resourceId);
     dbDeploymentKey.wrapLong(deploymentKey);
     return Optional.ofNullable(
             resourceKeyByResourceIdAndDeploymentKeyColumnFamily.get(
@@ -268,9 +267,9 @@ public class DbResourceState implements MutableResourceState {
 
   @Override
   public Optional<PersistedResource> findResourceByIdAndVersionTag(
-      final DirectBuffer resourceId, final String versionTag, final String tenantId) {
+      final String resourceId, final String versionTag, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
-    dbResourceId.wrapBuffer(resourceId);
+    dbResourceId.wrapString(resourceId);
     dbVersionTag.wrapString(versionTag);
     return Optional.ofNullable(
             resourceKeyByResourceIdAndVersionTagColumnFamily.get(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbResourceState.java
@@ -142,8 +142,7 @@ public class DbResourceState implements MutableResourceState {
     dbPersistedResource.wrap(record);
     resourcesByKey.upsert(tenantAwareResourceKey, dbPersistedResource);
     resourcesByTenantIdAndIdCache.put(
-        new DbResourceState.TenantIdAndResourceId(
-            record.getTenantId(), record.getResourceIdBuffer()),
+        new DbResourceState.TenantIdAndResourceId(record.getTenantId(), record.getResourceId()),
         dbPersistedResource.copy());
   }
 
@@ -193,8 +192,7 @@ public class DbResourceState implements MutableResourceState {
     dbResourceKey.wrapLong(record.getResourceKey());
     resourcesByKey.deleteExisting(tenantAwareResourceKey);
     resourcesByTenantIdAndIdCache.invalidate(
-        new DbResourceState.TenantIdAndResourceId(
-            record.getTenantId(), record.getResourceIdBuffer()));
+        new DbResourceState.TenantIdAndResourceId(record.getTenantId(), record.getResourceId()));
   }
 
   @Override
@@ -233,7 +231,7 @@ public class DbResourceState implements MutableResourceState {
 
   @Override
   public Optional<PersistedResource> findLatestResourceById(
-      final DirectBuffer resourceId, final String tenantId) {
+      final String resourceId, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
     final Optional<PersistedResource> cachedResource = getResourceFromCache(tenantId, resourceId);
     if (cachedResource.isPresent()) {
@@ -292,8 +290,8 @@ public class DbResourceState implements MutableResourceState {
   }
 
   private PersistedResource getPersistedResourceById(
-      final DirectBuffer resourceId, final String tenantId) {
-    dbResourceId.wrapBuffer(resourceId);
+      final String resourceId, final String tenantId) {
+    dbResourceId.wrapString(resourceId);
     final long latestVersion = versionManager.getLatestResourceVersion(resourceId, tenantId);
     resourceVersion.wrapLong(latestVersion);
     final Optional<PersistedResource> persistedResource =
@@ -303,11 +301,11 @@ public class DbResourceState implements MutableResourceState {
   }
 
   private Optional<PersistedResource> getResourceFromCache(
-      final String tenantId, final DirectBuffer resourceId) {
+      final String tenantId, final String resourceId) {
     return Optional.ofNullable(
         resourcesByTenantIdAndIdCache.getIfPresent(
             new DbResourceState.TenantIdAndResourceId(tenantId, resourceId)));
   }
 
-  private record TenantIdAndResourceId(String tenantId, DirectBuffer resourceId) {}
+  private record TenantIdAndResourceId(String tenantId, String resourceId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.PersistedResource;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public interface ResourceState {
   /**
@@ -20,8 +19,7 @@ public interface ResourceState {
    * @return the latest version of the resource, or {@link Optional#empty()} if no resource is
    *     deployed with the given id
    */
-  Optional<PersistedResource> findLatestResourceById(
-      String resourceId, final String tenantId);
+  Optional<PersistedResource> findLatestResourceById(String resourceId, final String tenantId);
 
   /**
    * Query Resource by the given resource key and return the resource.
@@ -42,7 +40,7 @@ public interface ResourceState {
    *     with the given deployment
    */
   Optional<PersistedResource> findResourceByIdAndDeploymentKey(
-      DirectBuffer resourceId, long deploymentKey, final String tenantId);
+      String resourceId, long deploymentKey, final String tenantId);
 
   /**
    * Query Resource by the given resource id and version tag and return the resource.
@@ -54,7 +52,7 @@ public interface ResourceState {
    *     tag is deployed
    */
   Optional<PersistedResource> findResourceByIdAndVersionTag(
-      DirectBuffer resourceId, String versionTag, final String tenantId);
+      String resourceId, String versionTag, final String tenantId);
 
   /**
    * Gets the next version a resource of a given id will receive. This is used, for example, when a

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ResourceState.java
@@ -21,7 +21,7 @@ public interface ResourceState {
    *     deployed with the given id
    */
   Optional<PersistedResource> findLatestResourceById(
-      DirectBuffer resourceId, final String tenantId);
+      String resourceId, final String tenantId);
 
   /**
    * Query Resource by the given resource key and return the resource.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
@@ -34,8 +34,7 @@ public class ResourceStateTest {
   @Test
   void shouldReturnEmptyIfNoResourceIsDeployedForResourceId() {
     // when
-    final var persistedResource =
-        resourceState.findLatestResourceById(wrapString("form-1"), tenantId);
+    final var persistedResource = resourceState.findLatestResourceById("form-1", tenantId);
 
     // then
     assertThat(persistedResource).isEmpty();
@@ -93,7 +92,7 @@ public class ResourceStateTest {
     resourceState.storeResourceInResourceByIdAndVersionColumnFamily(resourceRecord);
 
     final Optional<PersistedResource> resourceByKey =
-        resourceState.findLatestResourceById(resourceRecord.getResourceIdBuffer(), tenantId);
+        resourceState.findLatestResourceById(resourceRecord.getResourceId(), tenantId);
     assertThat(resourceByKey).isPresent();
     assertThat(bufferAsString(resourceByKey.get().getResourceId())).isEqualTo("resource-id");
     assertThat(resourceByKey.get().getVersion()).isEqualTo(0);
@@ -103,7 +102,7 @@ public class ResourceStateTest {
     resourceState.deleteResourceInResourceByIdAndVersionColumnFamily(resourceRecord);
     resourceState.clearCache();
     final Optional<PersistedResource> deleted =
-        resourceState.findLatestResourceById(resourceRecord.getResourceIdBuffer(), tenantId);
+        resourceState.findLatestResourceById(resourceRecord.getResourceId(), tenantId);
     assertThat(deleted).isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ResourceStateTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.state.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -53,7 +52,7 @@ public class ResourceStateTest {
   void shouldReturnEmptyIfNoResourceIsDeployedForResourceIdAndDeploymentKey() {
     // when
     final var persistedResource =
-        resourceState.findResourceByIdAndDeploymentKey(wrapString("form-1"), 1L, tenantId);
+        resourceState.findResourceByIdAndDeploymentKey("form-1", 1L, tenantId);
 
     // then
     assertThat(persistedResource).isEmpty();
@@ -63,7 +62,7 @@ public class ResourceStateTest {
   void shouldReturnEmptyIfNoResourceIsDeployedForResourceIdAndVersionTag() {
     // when
     final var persistedResource =
-        resourceState.findResourceByIdAndVersionTag(wrapString("form-1"), "v1.0", tenantId);
+        resourceState.findResourceByIdAndVersionTag("form-1", "v1.0", tenantId);
 
     // then
     assertThat(persistedResource).isEmpty();
@@ -115,7 +114,7 @@ public class ResourceStateTest {
 
     final Optional<PersistedResource> resourceByKey =
         resourceState.findResourceByIdAndDeploymentKey(
-            resourceRecord.getResourceIdBuffer(), 1L, tenantId);
+            resourceRecord.getResourceId(), 1L, tenantId);
     assertThat(resourceByKey).isPresent();
     assertThat(bufferAsString(resourceByKey.get().getResourceId())).isEqualTo("resource-id");
     assertThat(resourceByKey.get().getVersion()).isEqualTo(0);
@@ -126,7 +125,7 @@ public class ResourceStateTest {
         resourceRecord);
     final Optional<PersistedResource> deleted =
         resourceState.findResourceByIdAndDeploymentKey(
-            resourceRecord.getResourceIdBuffer(), 1L, tenantId);
+            resourceRecord.getResourceId(), 1L, tenantId);
     assertThat(deleted).isEmpty();
   }
 
@@ -138,7 +137,7 @@ public class ResourceStateTest {
 
     final Optional<PersistedResource> resourceByKey =
         resourceState.findResourceByIdAndVersionTag(
-            resourceRecord.getResourceIdBuffer(), "v1.0", tenantId);
+            resourceRecord.getResourceId(), "v1.0", tenantId);
     assertThat(resourceByKey).isPresent();
     assertThat(bufferAsString(resourceByKey.get().getResourceId())).isEqualTo("resource-id");
     assertThat(resourceByKey.get().getVersion()).isEqualTo(0);
@@ -148,7 +147,7 @@ public class ResourceStateTest {
     resourceState.deleteResourceInResourceKeyByResourceIdAndVersionTagColumnFamily(resourceRecord);
     final Optional<PersistedResource> deleted =
         resourceState.findResourceByIdAndVersionTag(
-            resourceRecord.getResourceIdBuffer(), "v1.0", tenantId);
+            resourceRecord.getResourceId(), "v1.0", tenantId);
     assertThat(deleted).isEmpty();
   }
 


### PR DESCRIPTION
Replaces the use of `DirectBuffer` in the resource cache key.
Also refactors `ResourceState` to not make use of `DirectBuffer` at all which should improve safety long term and make the API easier to use.

Fixes #25505