### PR TITLE
[Backport stable/8.5] fix: don't use mutable keys for forms cache

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -177,7 +177,7 @@ public final class BpmnUserTaskBehavior {
         .flatMap(
             formId -> {
               final Optional<PersistedForm> latestFormById =
-                  formState.findLatestFormById(wrapString(formId), tenantId);
+                  formState.findLatestFormById(formId, tenantId);
               return latestFormById
                   .<Either<Failure, Long>>map(
                       persistedForm -> Either.right(persistedForm.getFormKey()))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -119,7 +117,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
     formRecord.setTenantId(tenantId);
 
     formState
-        .findLatestFormById(wrapString(formRecord.getFormId()), tenantId)
+        .findLatestFormById(formRecord.getFormId(), tenantId)
         .ifPresentOrElse(
             latestForm -> {
               final boolean isDuplicate =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -81,8 +81,7 @@ public class DbFormState implements MutableFormState {
     dbPersistedForm.wrap(record);
     formsByKey.upsert(tenantAwareFormKey, dbPersistedForm);
     formsByTenantIdAndIdCache.put(
-        new TenantIdAndFormId(record.getTenantId(), record.getFormIdBuffer()),
-        dbPersistedForm.copy());
+        new TenantIdAndFormId(record.getTenantId(), record.getFormId()), dbPersistedForm.copy());
   }
 
   @Override
@@ -106,7 +105,7 @@ public class DbFormState implements MutableFormState {
     dbFormKey.wrapLong(record.getFormKey());
     formsByKey.deleteExisting(tenantAwareFormKey);
     formsByTenantIdAndIdCache.invalidate(
-        new TenantIdAndFormId(record.getTenantId(), record.getFormIdBuffer()));
+        new TenantIdAndFormId(record.getTenantId(), record.getFormId()));
   }
 
   @Override
@@ -124,8 +123,7 @@ public class DbFormState implements MutableFormState {
   }
 
   @Override
-  public Optional<PersistedForm> findLatestFormById(
-      final DirectBuffer formId, final String tenantId) {
+  public Optional<PersistedForm> findLatestFormById(final String formId, final String tenantId) {
     tenantIdKey.wrapString(tenantId);
     final Optional<PersistedForm> cachedForm = getFormFromCache(tenantId, formId);
     if (cachedForm.isPresent()) {
@@ -158,8 +156,8 @@ public class DbFormState implements MutableFormState {
     versionManager.clear();
   }
 
-  private PersistedForm getPersistedFormById(final DirectBuffer formId, final String tenantId) {
-    dbFormId.wrapBuffer(formId);
+  private PersistedForm getPersistedFormById(final String formId, final String tenantId) {
+    dbFormId.wrapString(formId);
     final long latestVersion = versionManager.getLatestResourceVersion(formId, tenantId);
     formVersion.wrapLong(latestVersion);
     final PersistedForm persistedForm =
@@ -170,11 +168,10 @@ public class DbFormState implements MutableFormState {
     return persistedForm.copy();
   }
 
-  private Optional<PersistedForm> getFormFromCache(
-      final String tenantId, final DirectBuffer formId) {
+  private Optional<PersistedForm> getFormFromCache(final String tenantId, final String formId) {
     return Optional.ofNullable(
         formsByTenantIdAndIdCache.getIfPresent(new TenantIdAndFormId(tenantId, formId)));
   }
 
-  private record TenantIdAndFormId(String tenantId, DirectBuffer formId) {}
+  private record TenantIdAndFormId(String tenantId, String formId) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public class DbFormState implements MutableFormState {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.deployment.PersistedForm;
 import java.util.Optional;
-import org.agrona.DirectBuffer;
 
 public interface FormState {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/FormState.java
@@ -21,7 +21,7 @@ public interface FormState {
    * @return the latest version of the form, or {@link Optional#empty()} if no form is deployed with
    *     the given id
    */
-  Optional<PersistedForm> findLatestFormById(DirectBuffer formId, final String tenantId);
+  Optional<PersistedForm> findLatestFormById(String formId, final String tenantId);
 
   /**
    * Query forms by the given form key and return the form.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormCreatedApplierTest.java
@@ -71,8 +71,7 @@ public class FormCreatedApplierTest {
     formCreatedApplier.applyState(formRecord2.getFormKey(), formRecord2);
 
     // when
-    final var maybePersistedForm =
-        formState.findLatestFormById(formRecord1.getFormIdBuffer(), TENANT_1);
+    final var maybePersistedForm = formState.findLatestFormById(formRecord1.getFormId(), TENANT_1);
 
     // then
     assertThat(maybePersistedForm).isNotEmpty();
@@ -105,8 +104,8 @@ public class FormCreatedApplierTest {
     assertPersistedForm(form1, formKey, formId, version, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, TENANT_2);
 
-    form1 = formState.findLatestFormById(wrapString(formId), TENANT_1).orElseThrow();
-    form2 = formState.findLatestFormById(wrapString(formId), TENANT_2).orElseThrow();
+    form1 = formState.findLatestFormById(formId, TENANT_1).orElseThrow();
+    form2 = formState.findLatestFormById(formId, TENANT_2).orElseThrow();
     assertPersistedForm(form1, formKey, formId, version, TENANT_1);
     assertPersistedForm(form2, formKey, formId, version, TENANT_2);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
@@ -49,20 +49,20 @@ public class FormDeletedApplierTest {
     formCreatedApplier.applyState(formV1.getFormKey(), formV1);
     formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
-      final var latestFormOpt =
-          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
-      assertThat(latestFormOpt).isNotEmpty();
-      assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
+    final var latestFormOpt =
+        formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+    assertThat(latestFormOpt).isNotEmpty();
+    assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
     // when
     formDeletedApplier.applyState(formV2.getFormKey(), formV2);
 
-      // then
-      final var latestFormV1Opt =
-          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
-      assertThat(latestFormV1Opt).isNotEmpty();
-      assertThat(latestFormV1Opt.get().getVersion()).isEqualTo(1);
-    }
+    // then
+    final var latestFormV1Opt =
+        formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+    assertThat(latestFormV1Opt).isNotEmpty();
+    assertThat(latestFormV1Opt.get().getVersion()).isEqualTo(1);
+  }
 
   @Test
   void shouldFindVersion2AsLatestFormAfterDeletion() {
@@ -72,20 +72,20 @@ public class FormDeletedApplierTest {
     formCreatedApplier.applyState(formV1.getFormKey(), formV1);
     formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
-      final var latestFormOpt =
-          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
-      assertThat(latestFormOpt).isNotEmpty();
-      assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
+    final var latestFormOpt =
+        formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+    assertThat(latestFormOpt).isNotEmpty();
+    assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
     // when
     formDeletedApplier.applyState(formV1.getFormKey(), formV1);
 
-      // then
-      final var latestFormV2Opt =
-          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
-      assertThat(latestFormV2Opt).isNotEmpty();
-      assertThat(latestFormV2Opt.get().getVersion()).isEqualTo(2);
-    }
+    // then
+    final var latestFormV2Opt =
+        formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+    assertThat(latestFormV2Opt).isNotEmpty();
+    assertThat(latestFormV2Opt.get().getVersion()).isEqualTo(2);
+  }
 
   @Test
   void shouldNotReuseADeletedVersionNumber() {
@@ -122,8 +122,8 @@ public class FormDeletedApplierTest {
     formDeletedApplier.applyState(tenant1Form.getFormKey(), tenant1Form);
 
     // then
-    assertThat(formState.findLatestFormById(tenant1Form.getFormIdBuffer(), TENANT_1)).isEmpty();
-    assertThat(formState.findLatestFormById(tenant2Form.getFormIdBuffer(), TENANT_2)).isNotEmpty();
+    assertThat(formState.findLatestFormById(tenant1Form.getFormId(), TENANT_1)).isEmpty();
+    assertThat(formState.findLatestFormById(tenant2Form.getFormId(), TENANT_2)).isNotEmpty();
   }
 
   private FormRecord sampleFormRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/FormDeletedApplierTest.java
@@ -49,20 +49,20 @@ public class FormDeletedApplierTest {
     formCreatedApplier.applyState(formV1.getFormKey(), formV1);
     formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
-    final var latestFormOpt =
-        formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
-    assertThat(latestFormOpt).isNotEmpty();
-    assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
+      final var latestFormOpt =
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+      assertThat(latestFormOpt).isNotEmpty();
+      assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
     // when
     formDeletedApplier.applyState(formV2.getFormKey(), formV2);
 
-    // then
-    final var latestFormV1Opt =
-        formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
-    assertThat(latestFormV1Opt).isNotEmpty();
-    assertThat(latestFormV1Opt.get().getVersion()).isEqualTo(1);
-  }
+      // then
+      final var latestFormV1Opt =
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+      assertThat(latestFormV1Opt).isNotEmpty();
+      assertThat(latestFormV1Opt.get().getVersion()).isEqualTo(1);
+    }
 
   @Test
   void shouldFindVersion2AsLatestFormAfterDeletion() {
@@ -72,20 +72,20 @@ public class FormDeletedApplierTest {
     formCreatedApplier.applyState(formV1.getFormKey(), formV1);
     formCreatedApplier.applyState(formV2.getFormKey(), formV2);
 
-    final var latestFormOpt =
-        formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
-    assertThat(latestFormOpt).isNotEmpty();
-    assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
+      final var latestFormOpt =
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+      assertThat(latestFormOpt).isNotEmpty();
+      assertThat(latestFormOpt.get().getVersion()).isEqualTo(2);
 
     // when
     formDeletedApplier.applyState(formV1.getFormKey(), formV1);
 
-    // then
-    final var latestFormV2Opt =
-        formState.findLatestFormById(formV2.getFormIdBuffer(), formV2.getTenantId());
-    assertThat(latestFormV2Opt).isNotEmpty();
-    assertThat(latestFormV2Opt.get().getVersion()).isEqualTo(2);
-  }
+      // then
+      final var latestFormV2Opt =
+          formState.findLatestFormById(formV2.getFormId(), formV2.getTenantId());
+      assertThat(latestFormV2Opt).isNotEmpty();
+      assertThat(latestFormV2Opt.get().getVersion()).isEqualTo(2);
+    }
 
   @Test
   void shouldNotReuseADeletedVersionNumber() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -32,7 +32,7 @@ public class FormStateTest {
   @Test
   void shouldReturnEmptyIfNoFormIsDeployedForFormId() {
     // when
-    final var persistedForm = formState.findLatestFormById(wrapString("form-1"), tenantId);
+    final var persistedForm = formState.findLatestFormById("form-1", tenantId);
 
     // then
     assertThat(persistedForm).isEmpty();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/FormStateTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.deployment;
 
-import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;


### PR DESCRIPTION
# Description
Backport of #25523 to `stable/8.5`.

relates to #25504
original author: @lenaschoenburg