### PR TITLE
fix: exclude child documents when querying tenants and groups

### DIFF
--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/GroupFilterTransformer.java
@@ -12,6 +12,8 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.GroupFilter;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 import java.util.List;
 
 public class GroupFilterTransformer implements FilterTransformer<GroupFilter> {
@@ -20,6 +22,7 @@ public class GroupFilterTransformer implements FilterTransformer<GroupFilter> {
   public SearchQuery toSearchQuery(final GroupFilter filter) {
 
     return and(
+        term(GroupIndex.JOIN, IdentityJoinRelationshipType.GROUP.getType()),
         filter.groupKey() == null ? null : term("key", filter.groupKey()),
         filter.name() == null ? null : term("name", filter.name()));
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/TenantFilterTransformer.java
@@ -15,6 +15,8 @@ import static io.camunda.webapps.schema.descriptors.usermanagement.index.TenantI
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.TenantFilter;
+import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
+import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 import java.util.List;
 
 public class TenantFilterTransformer implements FilterTransformer<TenantFilter> {
@@ -23,6 +25,7 @@ public class TenantFilterTransformer implements FilterTransformer<TenantFilter> 
   public SearchQuery toSearchQuery(final TenantFilter filter) {
 
     return and(
+        term(TenantIndex.JOIN, IdentityJoinRelationshipType.TENANT.getType()),
         filter.key() == null ? null : term(KEY, filter.key()),
         filter.tenantId() == null ? null : term(TENANT_ID, filter.tenantId()),
         filter.name() == null ? null : term(NAME, filter.name()));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/TenantQueryTransformerTest.java
@@ -9,9 +9,9 @@ package io.camunda.search.clients.transformers.filter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.search.clients.query.SearchBoolQuery;
-import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.FilterBuilders;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TenantQueryTransformerTest extends AbstractTransformerTest {
@@ -25,14 +25,18 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
-        .isInstanceOfSatisfying(
-            SearchTermQuery.class,
-            (termQuery) -> {
-              assertThat(termQuery.field()).isEqualTo("key");
-              assertThat(termQuery.value().longValue()).isEqualTo(12345L);
-            });
+    assertThat(searchRequest)
+        .isEqualTo(
+            SearchQuery.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(
+                                List.of(
+                                    SearchQuery.of(
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
+                                    SearchQuery.of(
+                                        q1 -> q.term(t -> t.field("key").value(12345L))))))));
   }
 
   @Test
@@ -44,14 +48,19 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
-        .isInstanceOfSatisfying(
-            SearchTermQuery.class,
-            (termQuery) -> {
-              assertThat(termQuery.field()).isEqualTo("tenantId");
-              assertThat(termQuery.value().stringValue()).isEqualTo("tenant1");
-            });
+    assertThat(searchRequest)
+        .isEqualTo(
+            SearchQuery.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(
+                                List.of(
+                                    SearchQuery.of(
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
+                                    SearchQuery.of(
+                                        q1 ->
+                                            q.term(t -> t.field("tenantId").value("tenant1"))))))));
   }
 
   @Test
@@ -63,14 +72,19 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
-        .isInstanceOfSatisfying(
-            SearchTermQuery.class,
-            (termQuery) -> {
-              assertThat(termQuery.field()).isEqualTo("name");
-              assertThat(termQuery.value().stringValue()).isEqualTo("TestTenant");
-            });
+    assertThat(searchRequest)
+        .isEqualTo(
+            SearchQuery.of(
+                q ->
+                    q.bool(
+                        b ->
+                            b.must(
+                                List.of(
+                                    SearchQuery.of(
+                                        q1 -> q.term(t -> t.field("join").value("tenant"))),
+                                    SearchQuery.of(
+                                        q1 ->
+                                            q.term(t -> t.field("name").value("TestTenant"))))))));
   }
 
   @Test
@@ -83,39 +97,20 @@ public class TenantQueryTransformerTest extends AbstractTransformerTest {
     final var searchRequest = transformQuery(filter);
 
     // then
-    final var queryVariant = searchRequest.queryOption();
-    assertThat(queryVariant)
-        .isInstanceOfSatisfying(
-            SearchBoolQuery.class,
-            (boolQuery) -> {
-              assertThat(boolQuery.must()).hasSize(3);
-
-              // Verify "key" filter
-              assertThat(boolQuery.must().get(0).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (termQuery) -> {
-                        assertThat(termQuery.field()).isEqualTo("key");
-                        assertThat(termQuery.value().longValue()).isEqualTo(12345L);
-                      });
-
-              // Verify "tenantId" filter
-              assertThat(boolQuery.must().get(1).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (termQuery) -> {
-                        assertThat(termQuery.field()).isEqualTo("tenantId");
-                        assertThat(termQuery.value().stringValue()).isEqualTo("tenant1");
-                      });
-
-              // Verify "name" filter
-              assertThat(boolQuery.must().get(2).queryOption())
-                  .isInstanceOfSatisfying(
-                      SearchTermQuery.class,
-                      (termQuery) -> {
-                        assertThat(termQuery.field()).isEqualTo("name");
-                        assertThat(termQuery.value().stringValue()).isEqualTo("TestTenant");
-                      });
-            });
+    assertThat(searchRequest)
+        .isEqualTo(
+            SearchQuery.of(
+                builder ->
+                    builder.bool(
+                        b ->
+                            b.must(
+                                List.of(
+                                    SearchQuery.of(
+                                        q -> q.term(t -> t.field("join").value("tenant"))),
+                                    SearchQuery.of(q -> q.term(t -> t.field("key").value(12345L))),
+                                    SearchQuery.of(
+                                        q -> q.term(t -> t.field("tenantId").value("tenant1"))),
+                                    SearchQuery.of(
+                                        q -> q.term(t -> t.field("name").value("TestTenant"))))))));
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -15,6 +15,7 @@ public class GroupIndex extends UserManagementIndexDescriptor {
 
   public static final String INDEX_NAME = "groups";
   public static final String INDEX_VERSION = "8.7.0";
+  public static final String JOIN = "join";
 
   public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory(

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -19,6 +19,7 @@ public class TenantIndex extends UserManagementIndexDescriptor {
   public static final String KEY = "key";
   public static final String TENANT_ID = "tenantId";
   public static final String NAME = "name";
+  public static final String JOIN = "join";
 
   public static final EntityJoinRelationFactory JOIN_RELATION_FACTORY =
       new EntityJoinRelationFactory(


### PR DESCRIPTION


## Description

ES returns child documents together with the parents by default, but those cannot be handled by the entity transformers.

Roles queries already include the same filter.
