### PR TITLE
feat: store reconstructed deployment in state and update references

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+
+public final class DeploymentReconstructedApplier
+    implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
+  private final MutableDeploymentState deploymentState;
+
+  public DeploymentReconstructedApplier(final MutableProcessingState processingState) {
+    deploymentState = processingState.getDeploymentState();
+  }
+
+  @Override
+  public void applyState(final long key, final DeploymentRecord value) {
+    deploymentState.storeDeploymentRecord(key, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
+import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -18,10 +19,12 @@ public final class DeploymentReconstructedApplier
     implements TypedEventApplier<DeploymentIntent, DeploymentRecord> {
   private final MutableDeploymentState deploymentState;
   private final MutableProcessState processState;
+  private final MutableFormState formState;
 
   public DeploymentReconstructedApplier(final MutableProcessingState processingState) {
     deploymentState = processingState.getDeploymentState();
     processState = processingState.getProcessState();
+    formState = processingState.getFormState();
   }
 
   @Override
@@ -30,6 +33,11 @@ public final class DeploymentReconstructedApplier
     for (final var processMetadata : value.processesMetadata()) {
       processState.setMissingDeploymentKey(
           processMetadata.getTenantId(), processMetadata.getKey(), deploymentKey);
+    }
+
+    for (final var formMetadata : value.formMetadata()) {
+      formState.setMissingDeploymentKey(
+          formMetadata.getTenantId(), formMetadata.getFormKey(), deploymentKey);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/DeploymentReconstructedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.engine.state.mutable.MutableFormState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
@@ -20,11 +21,13 @@ public final class DeploymentReconstructedApplier
   private final MutableDeploymentState deploymentState;
   private final MutableProcessState processState;
   private final MutableFormState formState;
+  private final MutableDecisionState decisionState;
 
   public DeploymentReconstructedApplier(final MutableProcessingState processingState) {
     deploymentState = processingState.getDeploymentState();
     processState = processingState.getProcessState();
     formState = processingState.getFormState();
+    decisionState = processingState.getDecisionState();
   }
 
   @Override
@@ -38,6 +41,11 @@ public final class DeploymentReconstructedApplier
     for (final var formMetadata : value.formMetadata()) {
       formState.setMissingDeploymentKey(
           formMetadata.getTenantId(), formMetadata.getFormKey(), deploymentKey);
+    }
+
+    for (final var decisionMetadata : value.decisionsMetadata()) {
+      decisionState.setMissingDeploymentKey(
+          decisionMetadata.getTenantId(), decisionMetadata.getDecisionKey(), deploymentKey);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -167,7 +167,7 @@ public final class EventAppliers implements EventApplier {
     register(
         DeploymentIntent.FULLY_DISTRIBUTED,
         new DeploymentFullyDistributedApplier(state.getDeploymentState()));
-    register(DeploymentIntent.RECONSTRUCTED, NOOP_EVENT_APPLIER);
+    register(DeploymentIntent.RECONSTRUCTED, new DeploymentReconstructedApplier(state));
     register(
         DeploymentIntent.RECONSTRUCTED_ALL,
         new DeploymentReconstructedAllApplier(state.getDeploymentState()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
@@ -21,20 +21,19 @@ import org.agrona.DirectBuffer;
 
 public final class PersistedDecision extends UnpackedObject implements DbValue {
 
+  private static final long NO_DEPLOYMENT_KEY = -1L;
   private final StringProperty decisionIdProp = new StringProperty("decisionId");
   private final StringProperty decisionNameProp = new StringProperty("decisionName");
   private final IntegerProperty versionProp = new IntegerProperty("version");
   private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
-
   private final StringProperty decisionRequirementsIdProp =
       new StringProperty("decisionRequirementsId");
   private final LongProperty decisionRequirementsKeyProp =
       new LongProperty("decisionRequirementsKey");
-
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-
-  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1L);
+  private final LongProperty deploymentKeyProp =
+      new LongProperty("deploymentKey", NO_DEPLOYMENT_KEY);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public PersistedDecision() {
@@ -110,6 +109,14 @@ public final class PersistedDecision extends UnpackedObject implements DbValue {
 
   public long getDeploymentKey() {
     return deploymentKeyProp.getValue();
+  }
+
+  public void setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
+  }
+
+  public boolean hasDeploymentKey() {
+    return deploymentKeyProp.getValue() != NO_DEPLOYMENT_KEY;
   }
 
   public String getVersionTag() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -22,6 +22,8 @@ import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
 public final class PersistedForm extends UnpackedObject implements DbValue {
+  private static final long NO_DEPLOYMENT_KEY = -1L;
+
   private final StringProperty formIdProp = new StringProperty("formId");
   private final IntegerProperty versionProp = new IntegerProperty("version");
   private final LongProperty formKeyProp = new LongProperty("formKey");
@@ -30,7 +32,8 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
   private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1L);
+  private final LongProperty deploymentKeyProp =
+      new LongProperty("deploymentKey", NO_DEPLOYMENT_KEY);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public PersistedForm() {
@@ -92,8 +95,17 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
     return bufferAsString(tenantIdProp.getValue());
   }
 
+  public boolean hasDeploymentKey() {
+    return deploymentKeyProp.getValue() != NO_DEPLOYMENT_KEY;
+  }
+
   public long getDeploymentKey() {
     return deploymentKeyProp.getValue();
+  }
+
+  public PersistedForm setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
+    return this;
   }
 
   public void wrap(final FormRecord record) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import org.agrona.DirectBuffer;
 
 public final class PersistedProcess extends UnpackedObject implements DbValue {
+  private static final long NO_DEPLOYMENT_KEY = -1L;
   private final IntegerProperty versionProp = new IntegerProperty("version", -1);
   private final LongProperty keyProp = new LongProperty("key", -1L);
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId");
@@ -30,7 +31,8 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
       new EnumProperty<>("state", PersistedProcessState.class, PersistedProcessState.ACTIVE);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1L);
+  private final LongProperty deploymentKeyProp =
+      new LongProperty("deploymentKey", NO_DEPLOYMENT_KEY);
   private final StringProperty versionTagProp = new StringProperty("versionTag", "");
 
   public PersistedProcess() {
@@ -100,8 +102,17 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
     return this;
   }
 
+  public boolean hasDeploymentKey() {
+    return deploymentKeyProp.getValue() != NO_DEPLOYMENT_KEY;
+  }
+
   public long getDeploymentKey() {
     return deploymentKeyProp.getValue();
+  }
+
+  public PersistedProcess setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
+    return this;
   }
 
   public enum PersistedProcessState {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableDecisionState.java
@@ -59,4 +59,6 @@ public interface MutableDecisionState extends DecisionState {
    * @param record the record of the decision requirements
    */
   void deleteDecisionRequirements(DecisionRequirementsRecord record);
+
+  void setMissingDeploymentKey(String tenantId, long decisionKey, long deploymentKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableFormState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableFormState.java
@@ -81,4 +81,15 @@ public interface MutableFormState extends FormState {
    * @param record the record of the form that is deleted
    */
   void deleteFormInFormKeyByFormIdAndVersionTagColumnFamily(FormRecord record);
+
+  /**
+   * Sets the deployment key of a form that was not previously associated with a deployment. This
+   * method updates both the ColumnFamily and the in memory cache. Throws an exception if the form
+   * is already associated with another deployment.
+   *
+   * @param tenantId tenant id of the form that is updated
+   * @param formKey the key of the form that is updated
+   * @param deploymentKey the new deployment key
+   */
+  void setMissingDeploymentKey(String tenantId, long formKey, long deploymentKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
@@ -34,6 +34,18 @@ public interface MutableProcessState extends ProcessState {
   void updateProcessState(final ProcessRecord processRecord, final PersistedProcessState state);
 
   /**
+   * Sets the deployment key of a process that was not previously associated with a deployment. This
+   * method updates both the ColumnFamily and the in memory cache. Throws an exception if the
+   * process is already associated with another deployment.
+   *
+   * @param tenantId tenant id of the process that is updated
+   * @param processDefinitionKey the key of the process definition that is updated
+   * @param deploymentKey the new deployment key
+   */
+  void setMissingDeploymentKey(
+      final String tenantId, final long processDefinitionKey, final long deploymentKey);
+
+  /**
    * Deletes a process from the state and cache
    *
    * @param processRecord the record of the process that is deleted

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DeploymentReconstructProcessorTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.appliers.EventAppliers;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
+import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -29,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -113,6 +115,9 @@ final class DeploymentReconstructProcessorTest {
             new ProcessRecord()
                 .setBpmnProcessId("process")
                 .setResourceName("process.bpmn")
+                .setResource(
+                    BufferUtil.wrapString(
+                        Bpmn.convertToString(Bpmn.createExecutableProcess("process").done())))
                 .setVersion(1));
 
     // when


### PR DESCRIPTION
This adds an applier for the Deployment/Reconstructed event that:
1. Stores the deployment with all its metadata in the deployment state
2. Updates persisted processes, lookup tables and in-memory caches to point to the new deployment key
2. Updates persisted forms, lookup tables and in-memory caches to point to the new deployment key
2. Updates persisted decisions, lookup tables and in-memory caches to point to the new deployment key

Depends on #25487 
Closes #24817