### PR TITLE
fix: reference the correct env var for enabling multi-tenancy

### DIFF
--- a/dist/src/main/config/gateway.yaml.template
+++ b/dist/src/main/config/gateway.yaml.template
@@ -291,7 +291,7 @@
       # For now, only Identity is supported as tenant authorization provider.
       # It is used when ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE is set to 'identity'.
       #
-      # This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MULTITENANCY_ENABLED.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED.
       enabled: false
 
     # interceptors:

--- a/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
+++ b/zeebe/gateway/src/test/resources/configuration/gateway.default.yaml
@@ -137,5 +137,5 @@
 # For now, only Identity is supported as tenant authorization provider.
 # It is used when ZEEBE_GATEWAY_SECURITY_AUTHENTICATION_MODE is set to 'identity'.
 #
-# This setting can also be overridden using the environment variable ZEEBE_GATEWAY_MULTITENANCY_ENABLED.
+# This setting can also be overridden using the environment variable ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED.
 # enabled: false


### PR DESCRIPTION
## Description

This PR changes the env var referenced from the comments in configuration templates from `ZEEBE_GATEWAY_MULTITENANCY_ENABLED` (which is a typo) to `ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED`, which is the actual [environment variable used for enabling multi-tenancy](https://github.com/search?q=repo%3Acamunda%2Fcamunda%20ZEEBE_BROKER_GATEWAY_MULTITENANCY_ENABLED&type=code).
