### PR TITLE
feat: search tasks by process instance variable

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/filter/UserTaskFilter.java
@@ -146,12 +146,13 @@ public interface UserTaskFilter extends SearchRequestFilter {
   UserTaskFilter bpmnProcessId(final String bpmnProcessId);
 
   /**
-   * Filters user tasks by the specified Process Definition Id.
+   * Filters user tasks by specified Process Instance Variables.
    *
    * @param variableValueFilters from the task
    * @return the updated filter
    */
-  UserTaskFilter variables(final List<UserTaskVariableFilterRequest> variableValueFilters);
+  UserTaskFilter processInstanceVariables(
+      final List<UserTaskVariableFilterRequest> variableValueFilters);
 
   /**
    * Filters user tasks by the specified element instance key.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/filter/UserTaskFilterImpl.java
@@ -134,8 +134,9 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   }
 
   @Override
-  public UserTaskFilter variables(final List<UserTaskVariableFilterRequest> variableValueFilters) {
-    filter.setVariables(variableValueFilters);
+  public UserTaskFilter processInstanceVariables(
+      final List<UserTaskVariableFilterRequest> variableValueFilters) {
+    filter.setProcessInstanceVariables(variableValueFilters);
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/SearchUserTaskTest.java
@@ -186,12 +186,12 @@ public final class SearchUserTaskTest extends ClientRestTest {
 
     listFilter.add(userTaskVariableFilterRequest);
 
-    client.newUserTaskQuery().filter(f -> f.variables(listFilter)).send().join();
+    client.newUserTaskQuery().filter(f -> f.processInstanceVariables(listFilter)).send().join();
 
     // then
     final UserTaskSearchQueryRequest request =
         gatewayService.getLastRequest(UserTaskSearchQueryRequest.class);
-    assertThat(request.getFilter().getVariables()).isEqualTo(listFilter);
+    assertThat(request.getFilter().getProcessInstanceVariables()).isEqualTo(listFilter);
   }
 
   @Test

--- a/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/UserTaskMapper.xml
@@ -236,10 +236,10 @@
     </if>
 
     <!-- Variables Basic Filter -->
-    <if test="filter.variableFilters != null and !filter.variableFilters.isEmpty()">
+    <if test="filter.processInstanceVariableFilter != null and !filter.processInstanceVariableFilter.isEmpty()">
       AND EXISTS (Select * from VARIABLE v where v.PROCESS_INSTANCE_KEY = ut.PROCESS_INSTANCE_KEY
       AND ( 1 = 1
-      <foreach collection="filter.variableFilters" item="operation">
+      <foreach collection="filter.processInstanceVariableFilter" item="operation">
         OR ( v.VAR_NAME = #{operation.name}
         /**
         FIXME waiting for the new API implementation of the variableFilter which uses the new

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -68,7 +68,7 @@ class UserTaskQueryTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/25287")
+  @Disabled("To be re-enabled in the scope of https://github.com/camunda/camunda/issues/25292")
   public void shouldRetrieveTaskByTaskVariable() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("task02").value("1");
@@ -76,7 +76,7 @@ class UserTaskQueryTest {
     final var result =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter)))
+            .filter(f -> f.processInstanceVariables(List.of(variableValueFilter)))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(1);
@@ -103,7 +103,7 @@ class UserTaskQueryTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/25287")
+  @Disabled("To be re-enabled in the scope of https://github.com/camunda/camunda/issues/25292")
   public void shouldRetrieveVariablesFromUserTask() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("task02").value("1");
@@ -111,7 +111,7 @@ class UserTaskQueryTest {
     final var resultUserTaskQuery =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter)))
+            .filter(f -> f.processInstanceVariables(List.of(variableValueFilter)))
             .send()
             .join();
 
@@ -132,10 +132,10 @@ class UserTaskQueryTest {
     final var result =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter)))
+            .filter(f -> f.processInstanceVariables(List.of(variableValueFilter)))
             .send()
             .join();
-    assertThat(result.items().size()).isEqualTo(1);
+    assertThat(result.items().size()).isEqualTo(2);
   }
 
   @Test
@@ -198,7 +198,7 @@ class UserTaskQueryTest {
     final var result =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter)))
+            .filter(f -> f.processInstanceVariables(List.of(variableValueFilter)))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(2);
@@ -212,14 +212,14 @@ class UserTaskQueryTest {
     final var result =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter)))
+            .filter(f -> f.processInstanceVariables(List.of(variableValueFilter)))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(0);
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/25287")
+  @Disabled("To be re-enabled in the scope of https://github.com/camunda/camunda/issues/25292")
   public void shouldRetrieveTaskByOrVariableCondition() {
     final UserTaskVariableFilterRequest variableValueFilter1 =
         new UserTaskVariableFilterRequest().name("task02").value("1");
@@ -230,7 +230,9 @@ class UserTaskQueryTest {
     final var result =
         camundaClient
             .newUserTaskQuery()
-            .filter(f -> f.variables(List.of(variableValueFilter1, variableValueFilter2)))
+            .filter(
+                f ->
+                    f.processInstanceVariables(List.of(variableValueFilter1, variableValueFilter2)))
             .send()
             .join();
     assertThat(result.items().size()).isEqualTo(2);

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -124,8 +124,7 @@ class UserTaskQueryTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/25287")
-  public void shouldRetrieveTaskByProcessVariable() {
+  public void shouldRetrieveTaskByProcessInstanceVariable() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("process01").value("\"pVar\"");
 
@@ -190,7 +189,6 @@ class UserTaskQueryTest {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/25287")
   public void shouldRetrieveTaskByVariableNameSearch() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("process01");
@@ -205,7 +203,7 @@ class UserTaskQueryTest {
   }
 
   @Test
-  public void shouldNoteRetrieveTaskByInvalidVariableValue() {
+  public void shouldNotRetrieveTaskByInvalidVariableValue() {
     final UserTaskVariableFilterRequest variableValueFilter =
         new UserTaskVariableFilterRequest().name("process01").value("\"pVariable\"");
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/UserTaskExporterIT.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -120,12 +119,9 @@ public class UserTaskExporterIT {
   @Nested
   class UserTaskVariableIT {
 
-    // TODO Re-enable
-    @Disabled("Should be re enabled when Search clients are aligned with schema changes")
     @TestTemplate
     void shouldExportUserTaskVariable(final TestStandaloneBroker testBroker) {
       final var client = testBroker.newClientBuilder().build();
-
       // when
       ExporterTestUtil.createAndDeployUserTaskProcess(
           client, "test-process-id", "zeebe-task", AbstractUserTaskBuilder::zeebeUserTask);
@@ -152,7 +148,7 @@ public class UserTaskExporterIT {
               .newUserTaskQuery()
               .filter(
                   f ->
-                      f.variables(
+                      f.processInstanceVariables(
                           List.of(new UserTaskVariableFilterRequest().name("stringVariable"))))
               .send()
               .join()
@@ -165,7 +161,8 @@ public class UserTaskExporterIT {
               .newUserTaskQuery()
               .filter(
                   f ->
-                      f.variables(List.of(new UserTaskVariableFilterRequest().name("intVariable"))))
+                      f.processInstanceVariables(
+                          List.of(new UserTaskVariableFilterRequest().name("intVariable"))))
               .send()
               .join()
               .items();
@@ -177,7 +174,7 @@ public class UserTaskExporterIT {
               .newUserTaskQuery()
               .filter(
                   f ->
-                      f.variables(
+                      f.processInstanceVariables(
                           List.of(new UserTaskVariableFilterRequest().name("boolVariable"))))
               .send()
               .join()
@@ -190,7 +187,8 @@ public class UserTaskExporterIT {
               .newUserTaskQuery()
               .filter(
                   f ->
-                      f.variables(List.of(new UserTaskVariableFilterRequest().name("bigVariable"))))
+                      f.processInstanceVariables(
+                          List.of(new UserTaskVariableFilterRequest().name("bigVariable"))))
               .send()
               .join()
               .items();
@@ -202,7 +200,7 @@ public class UserTaskExporterIT {
               .newUserTaskQuery()
               .filter(
                   f ->
-                      f.variables(
+                      f.processInstanceVariables(
                           List.of(
                               new UserTaskVariableFilterRequest()
                                   .name("stringVariable")

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/usertask/UserTaskIT.java
@@ -193,7 +193,7 @@ public class UserTaskIT {
             .search(
                 new UserTaskDbQuery(
                     new UserTaskFilter.Builder()
-                        .variable(
+                        .processInstanceVariables(
                             List.of(
                                 new VariableValueFilter.Builder()
                                     .name(randomizedVariable.name())

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UserTaskFilterTransformer.java
@@ -69,7 +69,7 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
     // Process Instance Variable Query: Check if processVariable  with specified varName and
     // varValue exists
     ofNullable(getProcessVariablesQuery(filter.processInstanceVariableFilter()))
-        .ifPresent(f -> queries.add(hasParentQuery("process", f)));
+        .ifPresent(f -> queries.add(hasParentQuery(TaskJoinRelationshipType.PROCESS.getType(), f)));
 
     queries.add(exists("flowNodeInstanceId")); // Default to task
 

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -302,7 +302,8 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
 
     final VariableValueFilter variableFilterValue = variableValueFilterBuilder.build();
 
-    final var filter = FilterBuilders.userTask((f) -> f.variable(List.of(variableFilterValue)));
+    final var filter =
+        FilterBuilders.userTask((f) -> f.processInstanceVariables(List.of(variableFilterValue)));
     final var searchQuery = SearchQueryBuilders.userTaskSearchQuery((b) -> b.filter(filter));
 
     // when

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UserTaskQueryTransformerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchExistsQuery;
 import io.camunda.search.clients.query.SearchHasChildQuery;
+import io.camunda.search.clients.query.SearchHasParentQuery;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryOption;
 import io.camunda.search.clients.query.SearchTermQuery;
@@ -294,7 +295,7 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
   }
 
   @Test
-  public void shouldQueryByVariableValueFilter() {
+  public void shouldQueryByProcessInstanceVariableValueFilter() {
     // given
     final VariableValueFilter.Builder variableValueFilterBuilder =
         new VariableValueFilter.Builder();
@@ -319,26 +320,23 @@ public class UserTaskQueryTransformerTest extends AbstractTransformerTest {
               assertThat(outerBoolQuery.must()).isNotEmpty();
 
               final SearchQuery outerMustQuery = outerBoolQuery.must().get(0);
-              assertThat(outerMustQuery.queryOption()).isInstanceOf(SearchBoolQuery.class);
+              assertThat(outerMustQuery.queryOption()).isInstanceOf(SearchHasParentQuery.class);
 
               // Drill down into the nested SearchBoolQuery
-              final SearchBoolQuery nestedBoolQuery =
-                  (SearchBoolQuery) outerMustQuery.queryOption();
-              assertThat(nestedBoolQuery.should()).isNotEmpty();
+              final SearchHasParentQuery nestedHasParentQuery =
+                  (SearchHasParentQuery) outerMustQuery.queryOption();
+              assertThat(nestedHasParentQuery.parentType())
+                  .isEqualTo(TaskJoinRelationshipType.PROCESS.getType());
 
-              final SearchQuery shouldQuery = nestedBoolQuery.should().get(0);
-              assertThat(shouldQuery.queryOption()).isInstanceOf(SearchHasChildQuery.class);
-
+              // Drill down into the nested SearchHasChildQuery of the hasParentQuery
               final SearchHasChildQuery childQuery =
-                  (SearchHasChildQuery) shouldQuery.queryOption();
+                  (SearchHasChildQuery) nestedHasParentQuery.query().queryOption();
               assertThat(childQuery.type())
-                  .isEqualTo(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
+                  .isEqualTo(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
 
-              // Check the inner bool query inside the child query
-              final SearchQuery innerQuery = childQuery.query();
-              assertThat(innerQuery.queryOption()).isInstanceOf(SearchBoolQuery.class);
-
-              final SearchBoolQuery innerBoolQuery = (SearchBoolQuery) innerQuery.queryOption();
+              // Drill down into the nested SearchBoolQuery of the hasChildQuery
+              final SearchBoolQuery innerBoolQuery =
+                  (SearchBoolQuery) childQuery.query().queryOption();
               assertThat(innerBoolQuery.must()).hasSize(2);
 
               assertThat(innerBoolQuery.must().get(0).queryOption())

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UserTaskFilter.java
@@ -29,7 +29,7 @@ public record UserTaskFilter(
     List<Operation<String>> candidateUserOperations,
     List<Operation<String>> candidateGroupOperations,
     List<String> tenantIds,
-    List<VariableValueFilter> variableFilters,
+    List<VariableValueFilter> processInstanceVariableFilter,
     List<Long> elementInstanceKeys,
     String type)
     implements FilterBase {
@@ -46,7 +46,7 @@ public record UserTaskFilter(
     private List<Operation<String>> candidateUserOperations;
     private List<Operation<String>> candidateGroupOperations;
     private List<String> tenantIds;
-    private List<VariableValueFilter> variableFilters;
+    private List<VariableValueFilter> processInstanceVariableFilters;
     private List<Long> elementInstanceKeys;
     private String type;
 
@@ -173,8 +173,8 @@ public record UserTaskFilter(
       return this;
     }
 
-    public Builder variable(final List<VariableValueFilter> values) {
-      variableFilters = addValuesToList(variableFilters, values);
+    public Builder processInstanceVariables(final List<VariableValueFilter> values) {
+      processInstanceVariableFilters = addValuesToList(processInstanceVariableFilters, values);
       return this;
     }
 
@@ -206,7 +206,7 @@ public record UserTaskFilter(
           Objects.requireNonNullElse(candidateUserOperations, Collections.emptyList()),
           Objects.requireNonNullElse(candidateGroupOperations, Collections.emptyList()),
           Objects.requireNonNullElse(tenantIds, Collections.emptyList()),
-          Objects.requireNonNullElse(variableFilters, Collections.emptyList()),
+          Objects.requireNonNullElse(processInstanceVariableFilters, Collections.emptyList()),
           Objects.requireNonNullElse(elementInstanceKeys, Collections.emptyList()),
           type);
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3434,7 +3434,7 @@ components:
           format: int64
         processInstanceVariables:
           type: array
-          description: Process variables associated with the user task.
+          description: Process Instance variables associated with the user task.
           items:
             $ref: "#/components/schemas/UserTaskVariableFilterRequest"
     UserTaskVariableFilterRequest:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3432,9 +3432,9 @@ components:
           type: integer
           description: The key of the element instance.
           format: int64
-        variables:
+        processInstanceVariables:
           type: array
-          description: Variables associated with the user task.
+          description: Process variables associated with the user task.
           items:
             $ref: "#/components/schemas/UserTaskVariableFilterRequest"
     UserTaskVariableFilterRequest:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -549,9 +549,10 @@ public final class SearchQueryRequestMapper {
               Optional.ofNullable(f.getTenantId()).ifPresent(builder::tenantIds);
               Optional.ofNullable(f.getElementInstanceKey())
                   .ifPresent(builder::elementInstanceKeys);
-              Optional.ofNullable(f.getVariables())
+              Optional.ofNullable(f.getProcessInstanceVariables())
                   .filter(variables -> !variables.isEmpty())
-                  .ifPresent(vars -> builder.variable(toVariableValueFilters(vars)));
+                  .ifPresent(
+                      vars -> builder.processInstanceVariables(toVariableValueFilters(vars)));
             });
 
     return builder.build();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Search Task by Process Instance Variables(iteration 1) implementation.

- Disabled tests to be re enabled on the iteration 2
- Replaced static join type strings with the Enum ones for consistency
- Renamed `variables` filter to `processInstanceVariables` to discern with the upcoming `localVariable`
- Search now checks for all process variables regardless of the scope, since `localVariables` are now duplicated as `process` variables to handle the case of sub-processes
- Adapted tests for ES/OS along with RDBMS ones

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25291
