### PR TITLE
feat: add user task listener event types to operate

### DIFF
--- a/operate/client/src/modules/types/operate.d.ts
+++ b/operate/client/src/modules/types/operate.d.ts
@@ -106,7 +106,13 @@ interface ListenerEntity {
   listenerKey: string;
   state: 'ACTIVE' | 'COMPLETED' | 'FAILED';
   jobType: string;
-  event: 'UNSPECIFIED' | 'START' | 'END';
+  event:
+    | 'START'
+    | 'END'
+    | 'COMPLETE'
+    | 'ASSIGNMENT'
+    | 'UNKNOWN'
+    | 'UNSPECIFIED';
   time: string;
   sortValues: ReadonlyArray<string>;
 }

--- a/operate/client/src/modules/types/operate.d.ts
+++ b/operate/client/src/modules/types/operate.d.ts
@@ -109,8 +109,8 @@ interface ListenerEntity {
   event:
     | 'START'
     | 'END'
-    | 'COMPLETE'
-    | 'ASSIGNMENT'
+    | 'COMPLETING'
+    | 'ASSIGNING'
     | 'UNKNOWN'
     | 'UNSPECIFIED';
   time: string;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -67,7 +67,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual4 = resultListeners.get(0);
     assertEquals("22", actual4.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual4.getListenerType());
-    assertEquals(ListenerEventType.COMPLETE, actual4.getEvent());
+    assertEquals(ListenerEventType.COMPLETING, actual4.getEvent());
     assertEquals(ListenerState.FAILED, actual4.getState());
     assertNull(actual4.getTime());
 
@@ -96,7 +96,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual2 = resultListeners.get(4);
     assertEquals("31", actual2.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual2.getListenerType());
-    assertEquals(ListenerEventType.ASSIGNMENT, actual2.getEvent());
+    assertEquals(ListenerEventType.ASSIGNING, actual2.getEvent());
     assertEquals(ListenerState.UNKNOWN, actual2.getState());
     assertNotNull(actual2.getTime());
   }
@@ -267,7 +267,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
             .setFlowNodeInstanceId(1L)
             .setState("CREATED")
             .setJobKind("TASK_LISTENER")
-            .setListenerEventType("UPDATE");
+            .setListenerEventType("UPDATING");
 
     final JobEntity e4 =
         createJob()
@@ -277,7 +277,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
             .setFlowNodeInstanceId(2L)
             .setState("FAILED")
             .setJobKind("TASK_LISTENER")
-            .setListenerEventType("COMPLETE")
+            .setListenerEventType("COMPLETING")
             .setErrorCode("0")
             .setErrorMessage("Internal Error");
 
@@ -290,7 +290,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
             .setState("invalid")
             .setEndTime(OffsetDateTime.now().minusMinutes(5))
             .setJobKind("TASK_LISTENER")
-            .setListenerEventType("ASSIGNMENT");
+            .setListenerEventType("ASSIGNING");
 
     // Execution Listener of other process instance that should *not* get returned
     final JobEntity e6 =

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/it/ListenerReaderIT.java
@@ -67,14 +67,14 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual4 = resultListeners.get(0);
     assertEquals("22", actual4.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual4.getListenerType());
-    assertEquals(ListenerEventType.UNSPECIFIED, actual4.getEvent());
+    assertEquals(ListenerEventType.COMPLETE, actual4.getEvent());
     assertEquals(ListenerState.FAILED, actual4.getState());
     assertNull(actual4.getTime());
 
     final ListenerDto actual3 = resultListeners.get(1);
     assertEquals("21", actual3.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual3.getListenerType());
-    assertEquals(ListenerEventType.UNSPECIFIED, actual3.getEvent());
+    assertEquals(ListenerEventType.UNKNOWN, actual3.getEvent());
     assertEquals(ListenerState.ACTIVE, actual3.getState());
     assertNull(actual3.getTime());
 
@@ -96,7 +96,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual2 = resultListeners.get(4);
     assertEquals("31", actual2.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual2.getListenerType());
-    assertEquals(ListenerEventType.UNSPECIFIED, actual2.getEvent());
+    assertEquals(ListenerEventType.ASSIGNMENT, actual2.getEvent());
     assertEquals(ListenerState.UNKNOWN, actual2.getState());
     assertNotNull(actual2.getTime());
   }
@@ -116,7 +116,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
     final ListenerDto actual0 = resultListeners.get(0);
     assertEquals("21", actual0.getListenerKey());
     assertEquals(ListenerType.TASK_LISTENER, actual0.getListenerType());
-    assertEquals(ListenerEventType.UNSPECIFIED, actual0.getEvent());
+    assertEquals(ListenerEventType.UNKNOWN, actual0.getEvent());
     assertEquals(ListenerState.ACTIVE, actual0.getState());
     assertNull(actual0.getTime());
 
@@ -290,7 +290,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
             .setState("invalid")
             .setEndTime(OffsetDateTime.now().minusMinutes(5))
             .setJobKind("TASK_LISTENER")
-            .setListenerEventType("CREATE");
+            .setListenerEventType("ASSIGNMENT");
 
     // Execution Listener of other process instance that should *not* get returned
     final JobEntity e6 =
@@ -301,8 +301,7 @@ public class ListenerReaderIT extends OperateSearchAbstractIT {
             .setFlowNodeId("other_ID")
             .setState("COMPLETE")
             .setEndTime(OffsetDateTime.now().minusMinutes(4))
-            .setJobKind("EXECUTION_LISTENER")
-            .setListenerEventType("START");
+            .setJobKind("EXECUTION_LISTENER");
 
     // non Listener jobs to check that they do *not* get returned
     final JobEntity e7 =

--- a/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
@@ -20,10 +20,10 @@ public class ListenerEventTypeTest {
     assertEquals(actual1, ListenerEventType.START);
     final ListenerEventType actual2 = ListenerEventType.fromZeebeListenerEventType("END");
     assertEquals(actual2, ListenerEventType.END);
-    final ListenerEventType actual3 = ListenerEventType.fromZeebeListenerEventType("COMPLETE");
-    assertEquals(actual3, ListenerEventType.COMPLETE);
-    final ListenerEventType actual4 = ListenerEventType.fromZeebeListenerEventType("ASSIGNMENT");
-    assertEquals(actual4, ListenerEventType.ASSIGNMENT);
+    final ListenerEventType actual3 = ListenerEventType.fromZeebeListenerEventType("COMPLETING");
+    assertEquals(actual3, ListenerEventType.COMPLETING);
+    final ListenerEventType actual4 = ListenerEventType.fromZeebeListenerEventType("ASSIGNING");
+    assertEquals(actual4, ListenerEventType.ASSIGNING);
     final ListenerEventType actual5 = ListenerEventType.fromZeebeListenerEventType("TEST");
     assertEquals(actual5, ListenerEventType.UNKNOWN);
     final ListenerEventType actual6 = ListenerEventType.fromZeebeListenerEventType(null);

--- a/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/ListenerEventTypeTest.java
@@ -18,9 +18,15 @@ public class ListenerEventTypeTest {
   public void convertStatesFromZeebeJobs() {
     final ListenerEventType actual1 = ListenerEventType.fromZeebeListenerEventType("START");
     assertEquals(actual1, ListenerEventType.START);
-    final ListenerEventType actual2 = ListenerEventType.fromZeebeListenerEventType("TEST");
-    assertEquals(actual2, ListenerEventType.UNSPECIFIED);
-    final ListenerEventType actual3 = ListenerEventType.fromZeebeListenerEventType(null);
-    assertEquals(actual3, ListenerEventType.UNSPECIFIED);
+    final ListenerEventType actual2 = ListenerEventType.fromZeebeListenerEventType("END");
+    assertEquals(actual2, ListenerEventType.END);
+    final ListenerEventType actual3 = ListenerEventType.fromZeebeListenerEventType("COMPLETE");
+    assertEquals(actual3, ListenerEventType.COMPLETE);
+    final ListenerEventType actual4 = ListenerEventType.fromZeebeListenerEventType("ASSIGNMENT");
+    assertEquals(actual4, ListenerEventType.ASSIGNMENT);
+    final ListenerEventType actual5 = ListenerEventType.fromZeebeListenerEventType("TEST");
+    assertEquals(actual5, ListenerEventType.UNKNOWN);
+    final ListenerEventType actual6 = ListenerEventType.fromZeebeListenerEventType(null);
+    assertEquals(actual6, ListenerEventType.UNSPECIFIED);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
@@ -13,8 +13,8 @@ import org.slf4j.LoggerFactory;
 public enum ListenerEventType {
   START,
   END,
-  COMPLETE,
-  ASSIGNMENT,
+  COMPLETING,
+  ASSIGNING,
   UNKNOWN,
   UNSPECIFIED;
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/ListenerEventType.java
@@ -13,21 +13,24 @@ import org.slf4j.LoggerFactory;
 public enum ListenerEventType {
   START,
   END,
+  COMPLETE,
+  ASSIGNMENT,
+  UNKNOWN,
   UNSPECIFIED;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ListenerEventType.class);
 
   public static ListenerEventType fromZeebeListenerEventType(final String listenerEventType) {
     if (listenerEventType == null) {
-      LOGGER.warn("Listener event type is null. Setting it as {}.", UNSPECIFIED);
+      LOGGER.debug("Listener event type is null. Setting it as {}.", UNSPECIFIED);
       return UNSPECIFIED;
     }
     try {
       return ListenerEventType.valueOf(listenerEventType);
     } catch (final IllegalArgumentException e) {
-      LOGGER.warn(
-          "Unknown listener event type [{}]. Setting it as {}.", listenerEventType, UNSPECIFIED);
+      LOGGER.debug(
+          "Unknown listener event type [{}]. Setting it as {}.", listenerEventType, UNKNOWN);
     }
-    return UNSPECIFIED;
+    return UNKNOWN;
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Display user tasks with their correct event type name in Operate.

## Related issues

closes https://github.com/camunda/camunda/issues/23728
