### PR TITLE
fix: Enable WebSessionRepositoryConfiguration only when RestGateway is enabled

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.java
@@ -19,6 +19,7 @@ import io.camunda.search.clients.PersistentWebSessionClient;
 import io.camunda.search.clients.PersistentWebSessionSearchImpl;
 import io.camunda.search.connect.configuration.ConnectConfiguration;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.PersistentWebSessionIndexDescriptor;
+import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import io.camunda.zeebe.util.error.FatalErrorHandler;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -31,6 +32,7 @@ import org.springframework.session.config.annotation.web.http.EnableSpringHttpSe
 @Configuration
 @EnableSpringHttpSession
 @ConditionalOnPersistentWebSessionEnabled
+@ConditionalOnRestGatewayEnabled
 public class WebSessionRepositoryConfiguration {
 
   private final GenericConversionService conversionService;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Slack discussion https://camunda.slack.com/archives/C043W5V88M7/p1733212711536189
Tasklist and Operate importers are crashlooping in SaaS with:
```
Error creating bean with name 'webSessionRepositoryConfiguration' defined in URL [jar:file:/usr/local/tasklist/lib/camunda-zeebe-8.7.0-SNAPSHOT.jar!/io/camunda/application/commons/identity/WebSessionRepositoryConfiguration.class]:
Unsatisfied dependency expressed through constructor parameter 1: No qualifying bean of type 'io.camunda.search.connect.configuration.ConnectConfiguration' available: expected at least 1 bean which qualifies as autowire candidate. Dependency annotations: {}
```
In this pull request, I make `WebSessionRepositoryConfiguration` conditional on Rest gateway enabled

`WebSessionRepositoryConfiguration` got triggered by `CAMUNDA_TASKLIST_PERSISTENTSESSIONSENABLED` set to true by the controller in the importer deployement. I think no need to fix it in the controller as this will trigger a restart of all importer pods, and the importer pods are also meant to be deleted in the long term.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
