### PR TITLE
test: await processor to reach the end to account for internal processing

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
@@ -22,13 +22,10 @@ public class ReachEndOfLogTest {
 
   @Test
   public void shouldReturnTrueIfNothingProcessed() {
-    // given
-
-    // when
-    final var reachedEnd = engineRule.hasReachedEnd();
-
-    // then
-    assertThat(reachedEnd).isTrue();
+    // then -- eventually reaches the end. Needs to wait to account for internal processing.
+    Awaitility.await("Processor should reach the end")
+        .timeout(Duration.ofSeconds(5))
+        .until(engineRule::hasReachedEnd);
   }
 
   @Test


### PR DESCRIPTION
With deployment reconstruction always producing some records right after startup, we need to relax this test such that it gives the stream processor a couple of seconds to reach the end.