### PR TITLE
ci: build-platform-frontend takes at most ~10 mins, reduced timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-frontend


### PR DESCRIPTION
## Description

In the [Unified CI](https://github.com/camunda/camunda/wiki/CI-&-Automation#unified-ci) we should try to keep things quick to avoid developers waiting. I checked the historic runtimes of the `build-platform-frontend` job and noticed that it never takes more than around 10 minutes, although it was capped to 30 minutes timeout from inception (which is unnecessary):

![image](https://github.com/user-attachments/assets/14211ed4-813d-41af-a485-d9c52fbec9a4)

Find the query in the details:

<details>
```sql
SELECT TIMESTAMP_BUCKET(report_time, INTERVAL 1 DAY) as time_column, job_name, MIN(CEIL(IEEE_DIVIDE(build_duration_milliseconds, 1000 * 60.0))) as min_build_duration_minutes, ROUND(AVG(IEEE_DIVIDE(build_duration_milliseconds, 1000 * 60.0)), 1) as avg_build_duration_minutes, MAX(CEIL(IEEE_DIVIDE(build_duration_milliseconds, 1000 * 60.0))) as max_build_duration_minutes
FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
WHERE ci_url="https://github.com/camunda/camunda" #AND build_trigger="push" AND build_ref="refs/heads/main"
AND job_name="build-platform-frontend"
GROUP BY time_column, job_name
ORDER BY time_column DESC, job_name ASC
LIMIT 100
</details>

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
