### PR TITLE
Create fully working incident update task (old post-importer)

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentUpdateIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/exporter/IncidentUpdateIT.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.it.exporter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.it.utils.BrokerWithCamundaExporterITInvocationProvider;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.search.filter.IncidentFilter;
+import io.camunda.zeebe.client.api.search.response.FlowNodeInstance;
+import io.camunda.zeebe.client.api.search.response.Incident;
+import io.camunda.zeebe.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(BrokerWithCamundaExporterITInvocationProvider.class)
+final class IncidentUpdateIT {
+
+  private static final String CALL_ACTIVITY_ID = "child";
+  private static final String TASK_ID = "task";
+  private final String parentProcessId = Strings.newRandomValidBpmnId();
+  private final String childProcessId = Strings.newRandomValidBpmnId();
+  private final String jobType = Strings.newRandomValidBpmnId();
+
+  @TestTemplate
+  void shouldMarkAllInstancesWithIncident(final ZeebeClient client) {
+    // given
+    final var parentInstanceKey = createUndeployedProcessInstance(client);
+    final var childInstanceKey = getChildProcessInstanceKey(client);
+    triggerIncidentOnJob(client);
+
+    // when
+    final var incidents =
+        waitForIncident(client, f -> f.processInstanceKey(childInstanceKey).state("ACTIVE"));
+
+    // then
+    assertIncidentState(client, incidents.getIncidentKey(), "ACTIVE");
+    assertProcessInstanceIncidentState(client, parentInstanceKey, true);
+    assertProcessInstanceIncidentState(client, childInstanceKey, true);
+    assertFlowNodeInstanceIncidentState(client, parentInstanceKey, CALL_ACTIVITY_ID, true);
+    assertFlowNodeInstanceIncidentState(client, childInstanceKey, TASK_ID, true);
+  }
+
+  @TestTemplate
+  void shouldUnmarkAllInstancesWithIncident(final ZeebeClient client) {
+    // given
+    final var parentInstanceKey = createUndeployedProcessInstance(client);
+    final var childInstanceKey = getChildProcessInstanceKey(client);
+    triggerIncidentOnJob(client);
+
+    // when
+    final var incident =
+        waitForIncident(client, f -> f.processInstanceKey(childInstanceKey).state("ACTIVE"));
+    client.newResolveIncidentCommand(incident.getIncidentKey()).send().join();
+
+    // then
+    assertIncidentState(client, incident.getIncidentKey(), "RESOLVED");
+    assertProcessInstanceIncidentState(client, parentInstanceKey, false);
+    assertProcessInstanceIncidentState(client, childInstanceKey, false);
+    assertFlowNodeInstanceIncidentState(client, parentInstanceKey, CALL_ACTIVITY_ID, false);
+    assertFlowNodeInstanceIncidentState(client, childInstanceKey, TASK_ID, false);
+  }
+
+  private void assertIncidentState(
+      final ZeebeClient client, final long key, final String expected) {
+    Awaitility.await("until incident %d state is = %s".formatted(key, expected))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var incident =
+                  client.newIncidentQuery().filter(f -> f.incidentKey(key)).send().join().items();
+              assertThat(incident).hasSize(1).first().returns(expected, Incident::getState);
+            });
+  }
+
+  private void assertProcessInstanceIncidentState(
+      final ZeebeClient client, final long key, final boolean expected) {
+    Awaitility.await("until process instance %d incident state = %s".formatted(key, expected))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var parentProcessInstance = getProcessInstance(client, key);
+              assertThat(parentProcessInstance)
+                  .as("has incident = %s".formatted(expected))
+                  .returns(expected, ProcessInstance::getHasIncident);
+            });
+  }
+
+  private void assertFlowNodeInstanceIncidentState(
+      final ZeebeClient client,
+      final long processInstanceKey,
+      final String flowNodeId,
+      final boolean expected) {
+    Awaitility.await(
+            "until flow node %s in process instance %d incident state = %s"
+                .formatted(flowNodeId, processInstanceKey, expected))
+        .ignoreExceptions()
+        .untilAsserted(
+            () -> {
+              final var taskFlowNode = getFlowNodeInstance(client, processInstanceKey, flowNodeId);
+              assertThat(taskFlowNode)
+                  .as("has incident = %s".formatted(expected))
+                  .returns(expected, FlowNodeInstance::getIncident);
+            });
+  }
+
+  private FlowNodeInstance getFlowNodeInstance(
+      final ZeebeClient client, final long parentInstanceKey, final String callActivityId) {
+    return client
+        .newFlownodeInstanceQuery()
+        .filter(f -> f.processInstanceKey(parentInstanceKey).flowNodeId(callActivityId))
+        .send()
+        .join()
+        .items()
+        .getFirst();
+  }
+
+  private ProcessInstance getProcessInstance(
+      final ZeebeClient client, final long childInstanceKey) {
+    return client
+        .newProcessInstanceQuery()
+        .filter(p -> p.processInstanceKey(childInstanceKey))
+        .send()
+        .join()
+        .items()
+        .getFirst();
+  }
+
+  private long getChildProcessInstanceKey(final ZeebeClient client) {
+    return Awaitility.await("until one flow node exists in the child process instance")
+        .atMost(Duration.ofSeconds(30))
+        .ignoreExceptions()
+        .until(
+            () ->
+                client
+                    .newFlownodeInstanceQuery()
+                    .filter(f -> f.processDefinitionId(childProcessId))
+                    .send()
+                    .join()
+                    .items(),
+            Predicate.not(List::isEmpty))
+        .getFirst()
+        .getProcessInstanceKey();
+  }
+
+  private void triggerIncidentOnJob(final ZeebeClient client) {
+    final var job =
+        client
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .send()
+            .join()
+            .getJobs()
+            .getFirst();
+    client.newThrowErrorCommand(job).errorCode("unknown").send().join();
+  }
+
+  private long createUndeployedProcessInstance(final ZeebeClient client) {
+    deployProcesses(client);
+    return createProcessInstance(client);
+  }
+
+  private long createProcessInstance(final ZeebeClient client) {
+    return client
+        .newCreateInstanceCommand()
+        .bpmnProcessId(parentProcessId)
+        .latestVersion()
+        .send()
+        .join()
+        .getProcessInstanceKey();
+  }
+
+  private void deployProcesses(final ZeebeClient client) {
+    final var parentProcess =
+        Bpmn.createExecutableProcess(parentProcessId)
+            .startEvent()
+            .callActivity(CALL_ACTIVITY_ID, b -> b.zeebeProcessId(childProcessId))
+            .endEvent()
+            .done();
+    final var childProcess =
+        Bpmn.createExecutableProcess(childProcessId)
+            .startEvent()
+            .serviceTask(TASK_ID, b -> b.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(parentProcess, "parent.bpmn")
+        .addProcessModel(childProcess, "child.bpmn")
+        .send()
+        .join();
+  }
+
+  private Incident waitForIncident(
+      final ZeebeClient client, final Consumer<IncidentFilter> filterFn) {
+    return Awaitility.await()
+        .ignoreExceptions()
+        .timeout(Duration.ofSeconds(30))
+        .until(
+            () -> client.newIncidentQuery().filter(filterFn).send().join().items(),
+            Predicate.not(List::isEmpty))
+        .getFirst();
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -40,7 +40,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
     this.archiverRepository =
         Objects.requireNonNull(archiverRepository, "must specify an archiver repository");
     this.incidentRepository =
-        Objects.requireNonNull(incidentRepository, "must specify an archiver repository");
+        Objects.requireNonNull(incidentRepository, "must specify an incident repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/ReschedulingTask.java
@@ -71,7 +71,10 @@ public final class ReschedulingTask implements Runnable {
   private long onError(final Throwable error) {
     errorDelayMs = errorStrategy.applyAsLong(errorDelayMs);
 
-    logger.error(
+    // TODO: it's likely in some cases, we do want to log things as errors, but we need to
+    //  distinguish this from "normal" cases (e.g. missing data in ES, or ES temporarily
+    //  unavailable, etc.)
+    logger.warn(
         "Error occurred while performing a background task; operation will be retried", error);
     return errorDelayMs;
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -51,6 +51,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
 
 public final class ElasticsearchIncidentUpdateRepository implements IncidentUpdateRepository {
@@ -79,7 +80,7 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
       final String listViewAlias,
       final String flowNodeAlias,
       final String operationAlias,
-      final ElasticsearchAsyncClient client,
+      @WillCloseWhenClosed final ElasticsearchAsyncClient client,
       final Executor executor,
       final Logger logger) {
     this.partitionId = partitionId;
@@ -91,6 +92,11 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
     this.client = client;
     this.executor = executor;
     this.logger = logger;
+  }
+
+  @Override
+  public void close() throws Exception {
+    client._transport().close();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepository.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  * Encapsulates all accesses to the underlying storage for the {@link IncidentUpdateTask}, allowing
  * it to work with various databases.
  */
-public interface IncidentUpdateRepository {
+public interface IncidentUpdateRepository extends AutoCloseable {
 
   /**
    * Returns the next batch of sorted pending incident updates.
@@ -223,6 +223,9 @@ public interface IncidentUpdateRepository {
         final Collection<String> treePathTerms) {
       return CompletableFuture.completedFuture(List.of());
     }
+
+    @Override
+    public void close() throws Exception {}
   }
 
   /**

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.annotation.WillCloseWhenClosed;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch._types.ErrorCause;
@@ -79,7 +80,7 @@ public final class OpenSearchIncidentUpdateRepository implements IncidentUpdateR
       final String listViewAlias,
       final String flowNodeAlias,
       final String operationAlias,
-      final OpenSearchAsyncClient client,
+      @WillCloseWhenClosed final OpenSearchAsyncClient client,
       final Executor executor,
       final Logger logger) {
     this.partitionId = partitionId;
@@ -91,6 +92,11 @@ public final class OpenSearchIncidentUpdateRepository implements IncidentUpdateR
     this.client = client;
     this.executor = executor;
     this.logger = logger;
+  }
+
+  @Override
+  public void close() throws Exception {
+    client._transport().close();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/BackgroundTaskManagerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.camunda.exporter.tasks.archiver.ArchiverRepository.NoopArchiverRepository;
+import io.camunda.exporter.tasks.incident.IncidentUpdateRepository.NoopIncidentUpdateRepository;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.util.List;
@@ -34,6 +35,7 @@ final class BackgroundTaskManagerTest {
         new BackgroundTaskManager(
             1,
             new NoopArchiverRepository(),
+            new NoopIncidentUpdateRepository(),
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
             // return unfinished futures to have a deterministic count of submitted tasks
@@ -86,11 +88,15 @@ final class BackgroundTaskManagerTest {
 
   @Nested
   final class CloseTest {
-    private final CloseableRepository repository = new CloseableRepository();
-    private final BackgroundTaskManager archiver =
+    private final CloseableArchiverRepository archiverRepository =
+        new CloseableArchiverRepository();
+    private final CloseableIncidentRepository incidentRepository =
+        new CloseableIncidentRepository();
+    private final BackgroundTaskManager taskManager =
         new BackgroundTaskManager(
             1,
-            repository,
+            archiverRepository,
+            incidentRepository,
             LoggerFactory.getLogger(BackgroundTaskManagerTest.class),
             executor,
             List.of());
@@ -98,31 +104,55 @@ final class BackgroundTaskManagerTest {
     @Test
     void shouldCloseExecutorOnClose() {
       // when
-      archiver.close();
+      taskManager.close();
 
       // then
       assertThat(executor.isTerminated()).isTrue();
     }
 
     @Test
-    void shouldCloseRepositoryOnClose() {
+    void shouldCloseRepositoriesOnClose() {
       // when
-      archiver.close();
+      taskManager.close();
 
       // then
-      assertThat(repository.isClosed).isTrue();
+      assertThat(archiverRepository.isClosed).isTrue();
+      assertThat(incidentRepository.isClosed).isTrue();
     }
 
     @Test
-    void shouldNotThrowOnRepositoryCloseError() {
+    void shouldNotThrowOnArchiverRepositoryCloseError() {
       // given
-      repository.exception = new RuntimeException("foo");
+      archiverRepository.exception = new RuntimeException("foo");
 
       // when
-      assertThatCode(archiver::close).doesNotThrowAnyException();
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
     }
 
-    private static final class CloseableRepository extends NoopArchiverRepository {
+    @Test
+    void shouldNotThrowOnIncidentRepositoryCloseError() {
+      // given
+      incidentRepository.exception = new RuntimeException("foo");
+
+      // when
+      assertThatCode(taskManager::close).doesNotThrowAnyException();
+    }
+
+    private static final class CloseableArchiverRepository extends NoopArchiverRepository {
+      private boolean isClosed;
+      private Exception exception;
+
+      @Override
+      public void close() throws Exception {
+        if (exception != null) {
+          throw exception;
+        }
+
+        isClosed = true;
+      }
+    }
+
+    private static final class CloseableIncidentRepository extends NoopIncidentUpdateRepository {
       private boolean isClosed;
       private Exception exception;
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/incident/IncidentUpdateRepositoryIT.java
@@ -79,6 +79,7 @@ import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+@SuppressWarnings("resource")
 @Testcontainers
 @AutoCloseResources
 abstract sealed class IncidentUpdateRepositoryIT {


### PR DESCRIPTION
## Description

This PR integrates the new post-importer fully into the project. There is some duplication around the repositories:

- We create more than one ES/OS client
- This cascades into keeping track of them in the background task manager, so we can close them
- Some test duplication

In the future, one of the tasks we want is to abstract the client itself away to have a single repository implementation for the archiver, and a single implementation for the incident update task. At the same time, we only have to track one closeable resource in the task manager: the client. So there'll be a lot of stuff cut down later, but I think it's OK to accept this as is for now.

I added only basic E2E tests, as more will be covered as part of https://github.com/camunda/camunda/issues/25595. Here, I mostly wanted to add tests for the very basic functionality to make sure it's working as intended.

One thing: the extension used everywhere (`BrokerWithCamundaExporterITInvocationProvider`) is not actually wiring OS. I'll follow up on that with the rest of the project team.

## Related issues

related to #24932
