### PR TITLE
test: fix Tasklist integration tests

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/modules/ModuleIntegrationTest.java
@@ -7,12 +7,14 @@
  */
 package io.camunda.tasklist.modules;
 
+import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.modules.ModulesTestApplication;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
@@ -27,7 +29,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({"tasklist", "test"})
+@Import(CommonsModuleConfiguration.class)
+@ActiveProfiles({"tasklist", "test", "standalone"})
 public abstract class ModuleIntegrationTest {
 
   @Autowired protected ApplicationContext applicationContext;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistIntegrationTest.java
@@ -33,7 +33,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       "camunda.webapps.default-app = tasklist",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({"tasklist", "test"})
+@ActiveProfiles({"tasklist", "test", "standalone"})
 public abstract class TasklistIntegrationTest {
 
   protected OffsetDateTime testStartTime;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.util;
 
+import io.camunda.application.commons.CommonsModuleConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
@@ -34,7 +35,7 @@ import org.springframework.context.annotation.Profile;
           value = TasklistModuleConfiguration.class),
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import({WebappsModuleConfiguration.class})
+@Import({WebappsModuleConfiguration.class, CommonsModuleConfiguration.class})
 public class TestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/AuthenticationWithPersistentSessionsIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/AuthenticationWithPersistentSessionsIT.java
@@ -52,7 +52,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       "camunda.tasklist.archiver.rolloverEnabled = false",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({TasklistProfileService.IDENTITY_AUTH_PROFILE, "tasklist", "test"})
+@ActiveProfiles({TasklistProfileService.IDENTITY_AUTH_PROFILE, "tasklist", "test", "standalone"})
 public class AuthenticationWithPersistentSessionsIT implements AuthenticationTestable {
 
   @LocalServerPort private int randomServerPort;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationIT.java
@@ -95,7 +95,7 @@ import org.springframework.web.client.RestTemplate;
       TasklistProperties.PREFIX + ".archiver.rolloverEnabled = false",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({SSO_AUTH_PROFILE, "tasklist", "test"})
+@ActiveProfiles({SSO_AUTH_PROFILE, "tasklist", "test", "standalone"})
 public class AuthenticationIT implements AuthenticationTestable {
 
   public static final SalesPlan TASKLIST_TEST_SALESPLAN = new SalesPlan("test");

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
@@ -89,7 +89,7 @@ import org.springframework.web.client.RestTemplate;
       "camunda.tasklist.archiver.rolloverEnabled = false",
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({SSO_AUTH_PROFILE, "tasklist", "test"})
+@ActiveProfiles({SSO_AUTH_PROFILE, "tasklist", "test", "standalone"})
 public class AuthenticationWithPersistentSessionsIT implements AuthenticationTestable {
 
   private static final String COOKIE_KEY = "Cookie";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Tasklist Integration tests are failing with
```
Parameter 1 of constructor in io.camunda.webapps.controllers.BackupController required a bean of type 'io.camunda.webapps.backup.repository.BackupRepositoryProps' that could not be found.
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
