### PR TITLE
feat: save Tasklist OS notifications close on localStorage

### DIFF
--- a/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.module.scss
+++ b/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.module.scss
@@ -1,0 +1,11 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+.actionableNotification {
+  max-inline-size: initial;
+}

--- a/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.test.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.test.tsx
@@ -8,8 +8,7 @@
 
 import {render, screen, within} from 'modules/testing-library';
 import {TurnOnNotificationPermission} from './TurnOnNotificationPermission';
-
-vi.mock('modules/featureFlags');
+import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
 
 describe('<TurnOnNotificationPermission/>', () => {
   it('when no decision is made, should show a dialog about enabling notifications', () => {
@@ -46,6 +45,40 @@ describe('<TurnOnNotificationPermission/>', () => {
 
   it('when notifications are not allowed, should not show a dialog about enabling notifications', () => {
     vi.stubGlobal('Notification', {permission: 'denied'});
+
+    render(<TurnOnNotificationPermission />);
+
+    expect(
+      screen.queryByRole('alertdialog', {
+        name: /^Don't miss new assignments$/i,
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should save user selection on localStorage', async () => {
+    vi.stubGlobal('Notification', {permission: 'default'});
+
+    const {user} = render(<TurnOnNotificationPermission />);
+
+    expect(
+      screen.getByRole('alertdialog', {
+        name: /^Don't miss new assignments$/i,
+      }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /close notification/i}));
+
+    expect(
+      screen.queryByRole('alertdialog', {
+        name: /^Don't miss new assignments$/i,
+      }),
+    ).not.toBeInTheDocument();
+    expect(getStateLocally('areNativeNotificationsEnabled')).toBe(false);
+  });
+
+  it('should respect localStorage selection', () => {
+    vi.stubGlobal('Notification', {permission: 'default'});
+    storeStateLocally('areNativeNotificationsEnabled', false);
 
     render(<TurnOnNotificationPermission />);
 

--- a/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/TurnOnNotificationPermission.tsx
@@ -8,21 +8,26 @@
 
 import {ActionableNotification} from '@carbon/react';
 import {requestPermission} from 'modules/os-notifications/requestPermission';
+import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
 import {useState} from 'react';
 import {useTranslation} from 'react-i18next';
+import styles from './TurnOnNotificationPermission.module.scss';
 
 const TurnOnNotificationPermission: React.FC = () => {
   const {t} = useTranslation();
-  const [enabled, setEnabled] = useState(true);
-  if (
-    !(
-      enabled &&
-      'Notification' in window &&
-      Notification.permission === 'default'
-    )
-  ) {
+  const areNativeNotificationsEnabled = getStateLocally(
+    'areNativeNotificationsEnabled',
+  );
+  const [isEnabled, setIsEnabled] = useState(
+    'Notification' in window &&
+      Notification.permission === 'default' &&
+      !(areNativeNotificationsEnabled === false),
+  );
+
+  if (!isEnabled) {
     return null;
   }
+
   return (
     <div>
       <ActionableNotification
@@ -34,13 +39,15 @@ const TurnOnNotificationPermission: React.FC = () => {
         onActionButtonClick={async () => {
           const result = await requestPermission();
           if (result !== 'default') {
-            setEnabled(false);
+            setIsEnabled(false);
           }
         }}
-        onClose={() => setEnabled(false)}
-        style={{maxInlineSize: 'initial'}}
+        onClose={() => {
+          setIsEnabled(false);
+          storeStateLocally('areNativeNotificationsEnabled', false);
+        }}
+        className={styles.actionableNotification}
         lowContrast
-        hasFocus={false}
       />
     </div>
   );

--- a/tasklist/client/src/modules/utils/localStorage/index.tsx
+++ b/tasklist/client/src/modules/utils/localStorage/index.tsx
@@ -17,6 +17,7 @@ const validators = {
   theme: z.enum(['light', 'dark', 'system']),
   autoSelectNextTask: z.boolean(),
   customFilters: z.record(z.string(), namedCustomFiltersSchema),
+  areNativeNotificationsEnabled: z.boolean(),
 } as const;
 
 type Validators = typeof validators;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This was discussed with Volodymyr via Slack. When we introduced these native OS notifications on Tasklist we didn't persist the user selection when they simply closed the notification dialog. With this PR we will persist it on localStorage to avoid reopening it after the user selected it.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)


