### PR TITLE
Set camunda.database.type in tasklist integration tests

### DIFF
--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -50,8 +50,10 @@ jobs:
         include:
           - database: elasticsearch
             testProfile: docker-es
+            url: http://localhost:9200
           - database: opensearch
             testProfile: docker-os
+            url: http://localhost:9205
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch
@@ -77,7 +79,7 @@ jobs:
       # Run integration tests in parallel
       - name: Run Integration Tests
         run: |
-          ./mvnw -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
+          ./mvnw -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }} -Dcamunda.database.url=${{ matrix.url }}
 
       # Sanitize the branch name to replace non alphanumeric characters with `-`
       - id: sanitize

--- a/tasklist/qa/integration-tests/pom.xml
+++ b/tasklist/qa/integration-tests/pom.xml
@@ -547,6 +547,8 @@
           <systemPropertyVariables>
             <spring.profiles.active>test</spring.profiles.active>
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
+            <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
+            <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
           </systemPropertyVariables>
         </configuration>
       </plugin>
@@ -560,6 +562,8 @@
           <systemPropertyVariables>
             <spring.profiles.active>test</spring.profiles.active>
             <camunda.tasklist.database>${camunda.tasklist.database}</camunda.tasklist.database>
+            <camunda.database.type>${camunda.tasklist.database}</camunda.database.type>
+            <camunda.database.url>${camunda.database.url:http://localhost:9200}</camunda.database.url>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
OS Integration tests are failing in `main` branch
`camunda.database` properties are not correctly configured for opensearch

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
