### PR TITLE
feat: backup filename starts with camunda_webapps instead of camunda_operate

### DIFF
--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProvider.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/WebappsSnapshotNameProvider.java
@@ -13,7 +13,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class WebappsSnapshotNameProvider implements SnapshotNameProvider {
-  public static final String SNAPSHOT_NAME_PREFIX = "camunda_operate_";
+  public static final String SNAPSHOT_NAME_PREFIX = "camunda_webapps_";
   private static final String SNAPSHOT_NAME_PATTERN = "{prefix}{version}_part_{index}_of_{count}";
   private static final String SNAPSHOT_NAME_PREFIX_PATTERN = SNAPSHOT_NAME_PREFIX + "{backupId}_";
   private static final Pattern BACKUPID_PATTERN =


### PR DESCRIPTION
## Description
Rename file pattern to camunda_webapps instead of camunda_operate
## Related issues
closes #25481

