### PR TITLE
Assign priority of indices based on new requirements

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/HistoryBackupComponent.java
@@ -16,6 +16,7 @@ import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +36,8 @@ public class HistoryBackupComponent {
   private final List<Prio1Backup> prio1BackupIndices;
   private final List<Prio2Backup> prio2BackupTemplates;
   private final List<Prio3Backup> prio3BackupTemplates;
-  private final List<Prio4Backup> prio4BackupIndices;
+  private final List<Prio4Backup> prio4BackupTemplates;
+  private final List<Prio5Backup> prio5BackupIndices;
   private final BackupRepositoryProps backupRepositoryProps;
   private final BackupRepository backupRepository;
 
@@ -44,18 +46,21 @@ public class HistoryBackupComponent {
       final List<Prio1Backup> prio1BackupIndices,
       final List<Prio2Backup> prio2BackupTemplates,
       final List<Prio3Backup> prio3BackupTemplates,
-      final List<Prio4Backup> prio4BackupIndices,
+      final List<Prio4Backup> prio4BackupTemplates,
+      final List<Prio5Backup> prio5BackupIndices,
       final BackupRepositoryProps backupRepositoryProps,
       final BackupRepository backupRepository) {
     LOG.debug("Prio1BackupIndices are {}", prio1BackupIndices);
     LOG.debug("Prio2BackupTemplates are {}", prio2BackupTemplates);
     LOG.debug("Prio3BackupTemplates are {}", prio3BackupTemplates);
-    LOG.debug("Prio4BackupIndices are {}", prio4BackupIndices);
+    LOG.debug("Prio4BackupIndices are {}", prio4BackupTemplates);
+    LOG.debug("Prio4BackupIndices are {}", prio5BackupIndices);
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.prio1BackupIndices = prio1BackupIndices;
     this.prio2BackupTemplates = prio2BackupTemplates;
     this.prio3BackupTemplates = prio3BackupTemplates;
-    this.prio4BackupIndices = prio4BackupIndices;
+    this.prio4BackupTemplates = prio4BackupTemplates;
+    this.prio5BackupIndices = prio5BackupIndices;
     this.backupRepositoryProps = backupRepositoryProps;
     this.backupRepository = backupRepository;
   }
@@ -67,7 +72,8 @@ public class HistoryBackupComponent {
         prio1BackupIndices,
         prio2BackupTemplates,
         prio3BackupTemplates,
-        prio4BackupIndices,
+        prio4BackupTemplates,
+        prio5BackupIndices,
         backupRepositoryProps,
         backupRepository);
   }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/indices/UserIndex.java
@@ -9,14 +9,14 @@ package io.camunda.operate.schema.indices;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.property.OperateProperties;
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class UserIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class UserIndex extends OperateIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "user";
   public static final String ID = "id";

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/UserIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/UserIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.tasklist.schema.indices;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 
-public class UserIndex extends TasklistIndexDescriptor implements Prio4Backup {
+public class UserIndex extends TasklistIndexDescriptor implements Prio5Backup {
 
   public static final String ID = "id";
   public static final String USER_ID = "userId";

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupServiceImpl.java
@@ -14,6 +14,7 @@ import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -37,7 +38,9 @@ public class BackupServiceImpl implements BackupService {
 
   private final List<Prio3Backup> prio3BackupTemplates;
 
-  private final List<Prio4Backup> prio4BackupIndices;
+  private final List<Prio4Backup> prio4BackupTemplates;
+
+  private final List<Prio5Backup> prio5BackupIndices;
 
   private final BackupRepositoryProps backupProps;
 
@@ -50,14 +53,16 @@ public class BackupServiceImpl implements BackupService {
       final List<Prio1Backup> prio1BackupIndices,
       final List<Prio2Backup> prio2BackupTemplates,
       final List<Prio3Backup> prio3BackupTemplates,
-      final List<Prio4Backup> prio4BackupIndices,
+      final List<Prio4Backup> prio4BackupTemplates,
+      final List<Prio5Backup> prio5BackupIndices,
       final BackupRepositoryProps operateProperties,
       final BackupRepository repository) {
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
     this.prio1BackupIndices = prio1BackupIndices;
     this.prio2BackupTemplates = prio2BackupTemplates;
     this.prio3BackupTemplates = prio3BackupTemplates;
-    this.prio4BackupIndices = prio4BackupIndices;
+    this.prio4BackupTemplates = prio4BackupTemplates;
+    this.prio5BackupIndices = prio5BackupIndices;
     this.repository = repository;
     backupProps = operateProperties;
   }
@@ -143,9 +148,10 @@ public class BackupServiceImpl implements BackupService {
             // dated indices
             fullQualifiedNameWithMatcher(prio2BackupTemplates),
             fullQualifiedName(prio3BackupTemplates),
+            fullQualifiedName(prio4BackupTemplates),
             // dated indices
-            fullQualifiedNameWithMatcher(prio3BackupTemplates),
-            fullQualifiedName(prio4BackupIndices)
+            fullQualifiedNameWithMatcher(prio4BackupTemplates),
+            fullQualifiedName(prio5BackupIndices)
           };
     }
     return indexPatternsOrdered;

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio5Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio5Backup.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.backup;
+
+public interface Prio5Backup extends BackupPriority {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class DecisionIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class DecisionIndex extends OperateIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "decision";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionRequirementsIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionRequirementsIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class DecisionRequirementsIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class DecisionRequirementsIndex extends OperateIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "decision-requirements";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ImportPositionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ImportPositionIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class ImportPositionIndex extends OperateIndexDescriptor implements Prio3Backup {
+public class ImportPositionIndex extends OperateIndexDescriptor implements Prio1Backup {
 
   public static final String INDEX_NAME = "import-position";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/MetricIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/MetricIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class MetricIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class MetricIndex extends OperateIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "metric";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ProcessIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/ProcessIndex.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 
-public class ProcessIndex extends OperateIndexDescriptor implements Prio4Backup {
+public class ProcessIndex extends OperateIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "process";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/DecisionInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/DecisionInstanceTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class DecisionInstanceTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "decision-instance";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/EventTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/EventTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class EventTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "event";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/FlowNodeInstanceTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class FlowNodeInstanceTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "flownode-instance";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/IncidentTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/IncidentTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class IncidentTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "incident";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/JobTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class JobTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "job";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/MessageTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/MessageTemplate.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 
-public class MessageTemplate extends OperateTemplateDescriptor implements Prio3Backup {
+public class MessageTemplate extends OperateTemplateDescriptor implements Prio4Backup {
 
   public static final String INDEX_NAME = "message";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/PostImporterQueueTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/PostImporterQueueTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class PostImporterQueueTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "post-importer-queue";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/SequenceFlowTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/SequenceFlowTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class SequenceFlowTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "sequence-flow";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/UserTaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/UserTaskTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class UserTaskTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "user-task";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/VariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/VariableTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 
 public class VariableTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "variable";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/FormIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/FormIndex.java
@@ -8,10 +8,10 @@
 package io.camunda.webapps.schema.descriptors.tasklist.index;
 
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 
-public class FormIndex extends TasklistIndexDescriptor implements Prio4Backup {
+public class FormIndex extends TasklistIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "form";
   public static final String INDEX_VERSION = "8.4.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistMetricIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/index/TasklistMetricIndex.java
@@ -8,10 +8,10 @@
 package io.camunda.webapps.schema.descriptors.tasklist.index;
 
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistIndexDescriptor;
 
-public class TasklistMetricIndex extends TasklistIndexDescriptor implements Prio4Backup {
+public class TasklistMetricIndex extends TasklistIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "metric";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/DraftTaskVariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/DraftTaskVariableTemplate.java
@@ -7,10 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 
-public class DraftTaskVariableTemplate extends TasklistTemplateDescriptor implements Prio3Backup {
+public class DraftTaskVariableTemplate extends TasklistTemplateDescriptor implements Prio4Backup {
 
   public static final String INDEX_NAME = "draft-task-variable";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/SnapshotTaskVariableTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/SnapshotTaskVariableTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 
 public class SnapshotTaskVariableTemplate extends TasklistTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "task-variable";
   public static final String INDEX_VERSION = "8.3.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/tasklist/template/TaskTemplate.java
@@ -7,12 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.tasklist.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import io.camunda.webapps.schema.descriptors.tasklist.TasklistTemplateDescriptor;
 
 public class TaskTemplate extends TasklistTemplateDescriptor
-    implements Prio3Backup, ProcessInstanceDependant {
+    implements Prio2Backup, ProcessInstanceDependant {
 
   public static final String INDEX_NAME = "task";
   public static final String INDEX_VERSION = "8.5.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/AuthorizationIndex.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class AuthorizationIndex extends UserManagementIndexDescriptor {
+public class AuthorizationIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "authorizations";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/GroupIndex.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 
-public class GroupIndex extends UserManagementIndexDescriptor {
+public class GroupIndex extends UserManagementIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "groups";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/MappingIndex.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class MappingIndex extends UserManagementIndexDescriptor {
+public class MappingIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "mappings";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/PersistentWebSessionIndexDescriptor.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
 public class PersistentWebSessionIndexDescriptor extends UserManagementIndexDescriptor
-    implements Prio4Backup {
+    implements Prio5Backup {
 
   public static final String INDEX_NAME = "web-session";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/RoleIndex.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.RoleIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.IdentityJoinRelationshipType;
 
-public class RoleIndex extends RoleIndexDescriptor {
+public class RoleIndex extends RoleIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "role";
   public static final String INDEX_VERSION = "8.7.0";
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/TenantIndex.java
@@ -7,11 +7,12 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation;
 import io.camunda.webapps.schema.entities.usermanagement.EntityJoinRelation.EntityJoinRelationFactory;
 
-public class TenantIndex extends UserManagementIndexDescriptor {
+public class TenantIndex extends UserManagementIndexDescriptor implements Prio5Backup {
 
   public static final String INDEX_NAME = "tenants";
   public static final String INDEX_VERSION = "8.7.0";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/usermanagement/index/UserIndex.java
@@ -7,9 +7,10 @@
  */
 package io.camunda.webapps.schema.descriptors.usermanagement.index;
 
+import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
 import io.camunda.webapps.schema.descriptors.usermanagement.UserManagementIndexDescriptor;
 
-public class UserIndex extends UserManagementIndexDescriptor {
+public class UserIndex extends UserManagementIndexDescriptor implements Prio5Backup {
   public static final String INDEX_NAME = "users";
   public static final String INDEX_VERSION = "8.7.0";
 


### PR DESCRIPTION
## Description
Recap the changes that has been done:

Name | Indexes | Priority
-- | -- | -- 
camunda_8.6.0-snapshot_part_1_of_7 | Operate-import-position-8.3.0_, tasklist-import-position-8.2.0_optimize-position-based-import-index_v3 | 1
camunda_8.6.0-snapshot_part_2_of_7 | Operate-list-view-8.3.0_, tasklist-task-8.5.0_ | 2
camunda_8.6.0-snapshot_part_3_of_7 | operate-list-view-8.3.0_*, -operate-list-view-8.3.0_tasklist-task-8.5.0_*, -tasklist-task-8.5.0_ | 2 w/ matchers
camunda_8.6.0-snapshot_part_4_of_7 | operate-batch-operation-1.0.0_ , operate-operation-8.4.1_  | 3
camunda_8.6.0-snapshot_part_5_of_7 | operate-decision-8.3.0_operate-decision-instance-8.3.0_operate-event-8.3.0_operate-flownode-instance-8.3.1_operate-incident-8.3.1_ operate-message-8.5.0_operate-post-importer-queue-8.3.0_Operate-sequence-flow-8.3.0_operate-user-task-8.5.0_operate-variable-8.3.0_, tasklist-draft-task-variable-8.3.0_*, -tasklist-draft-task-variable-8.3.0_, tasklist-task-variable-8.3.0_*, -tasklist-task-variable-8.3.0_ | 4 & 4 w/ matchers
camunda_8.6.0-snapshot_part_6_of_7 | Operate-migration-steps-repository-1.1.0_,operate-web-session-1.1.0_,Operate-user-1.2.0_operate-decision-instance-8.3.0_operate-decision-requirements-8.3.0_operate-metric-8.3.0_operate-process-8.3.0_ tasklist-process-8.4.0_Tasklist-form-8.4.0, Identity-Authorizations, Identity-Users, Identity-Web-Session, Identity-Tenants, Identity-Roles, Identity-Groups, Identity-Mapping | 5
camunda_8.6.0-snapshot_part_7_of_7 | optimize-process-instance-process_05rl6n5_v8, optimize-single-decision-report_v10, optimize-process-overview_v2, optimize-instant-dashboard_v1, optimize-timestamp-based-import-index_v5, optimize-business-key_v2optimize-single-process-report_v11, optimize-combined-report_v5, optimize-dashboard_v8, optimize-dashboard-share_v4, optimize-variable-update-instance_v2-000001, optimize-variable-label_v1, optimize-process-instance-process_1jkjnqs_v8, optimize-terminated-user-session_v3, optimize-settings_v3, optimize-collection_v5, optimize-process-instance-customer_onboarding_en_v8, optimize-report-share_v3, optimize-decision-definition_v5, optimize-tenant_v3, optimize-metadata_v3, optimize-external-process-variable_v2-000001, optimize-process-definition_v6, optimize-alert_v4, optimize-process-instance-variables-test_v8 | 6 (or 5, as optimize can be done in parallel?)



Changes to be performed:
- create a new BackupPriority: 
  -  `operate-batch-operation-1.0.0_ , operate-operation-8.4.1_ ` will have priority 3
  - all prio3 indices will have prio4
  - all prio4 indices will have prio5  
- Operate ImportIndex had prio3, now has prio1
- Tasklist TaskTemplate had prio3, now has prio2
- Operate DecisionIndex was done in the last group (prio4), now it will be done in prio4, but with all the others that were previously prio3
- Identity indices have been added with prio5 


>[!WARNING]
> Optimize indices are not added to the BackupService yet

## Checklist

## Related issues

closes #24464
