### PR TITLE
feat: create default tenant on startup

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -10,13 +10,16 @@ package io.camunda.zeebe.engine.processing.user;
 import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
+import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.UserType;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
@@ -33,12 +36,15 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   public static final String DEFAULT_USER_PASSWORD = "demo";
   public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
   public static final String DEFAULT_ROLE_NAME = "Admin";
+  public static final String DEFAULT_TENANT_ID = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
+  public static final String DEFAULT_TENANT_NAME = "Default";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private final KeyGenerator keyGenerator;
   private final EngineConfiguration config;
   private final PasswordEncoder passwordEncoder;
   private final RoleState roleState;
   private final UserState userState;
+  private final TenantState tenantState;
 
   public IdentitySetupInitializer(
       final KeyGenerator keyGenerator,
@@ -49,6 +55,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
     userState = processingState.getUserState();
     roleState = processingState.getRoleState();
+    tenantState = processingState.getTenantState();
   }
 
   @Override
@@ -70,8 +77,9 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
 
     final var roleExists = roleState.getRoleKeyByName(DEFAULT_ROLE_NAME).isPresent();
     final var userExists = userState.getUser(DEFAULT_USER_USERNAME).isPresent();
-    if (roleExists && userExists) {
-      LOG.debug("Skipping identity setup as default user and role already exist");
+    final var tenantExists = tenantState.getTenantKeyById(DEFAULT_TENANT_ID).isPresent();
+    if (roleExists && userExists && tenantExists) {
+      LOG.debug("Skipping identity setup as default user, role, and tenant already exist");
       return;
     }
 
@@ -92,9 +100,17 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
             .setEmail(DEFAULT_USER_EMAIL)
             .setPassword(passwordEncoder.encode(DEFAULT_USER_PASSWORD))
             .setUserType(UserType.DEFAULT);
+    final var defaultTenant =
+        new TenantRecord()
+            .setTenantKey(keyGenerator.nextKey())
+            .setTenantId(DEFAULT_TENANT_ID)
+            .setName(DEFAULT_TENANT_NAME);
 
     final var setupRecord =
-        new IdentitySetupRecord().setDefaultRole(defaultRole).setDefaultUser(defaultUser);
+        new IdentitySetupRecord()
+            .setDefaultRole(defaultRole)
+            .setDefaultUser(defaultUser)
+            .setDefaultTenant(defaultTenant);
 
     taskResultBuilder.appendCommandRecord(IdentitySetupIntent.INITIALIZE, setupRecord);
     return taskResultBuilder.build();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeMultiPartitionTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -48,8 +49,16 @@ public class IdentitySetupInitializeMultiPartitionTest {
             .setName("name")
             .setPassword("password")
             .setEmail("email");
+    final var tenant =
+        new TenantRecord().setTenantKey(3).setTenantId("tenant-id").setName("tenant-name");
 
-    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+    engine
+        .identitySetup()
+        .initialize()
+        .withRole(role)
+        .withUser(user)
+        .withTenant(tenant)
+        .initialize();
 
     // then
     assertThat(
@@ -103,8 +112,16 @@ public class IdentitySetupInitializeMultiPartitionTest {
             .setName("name")
             .setPassword("password")
             .setEmail("email");
+    final var tenant =
+        new TenantRecord().setTenantKey(3).setTenantId("tenant-id").setName("tenant-name");
 
-    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+    engine
+        .identitySetup()
+        .initialize()
+        .withRole(role)
+        .withUser(user)
+        .withTenant(tenant)
+        .initialize();
 
     // then
     assertThat(
@@ -133,8 +150,16 @@ public class IdentitySetupInitializeMultiPartitionTest {
             .setName("name")
             .setPassword("password")
             .setEmail("email");
+    final var tenant =
+        new TenantRecord().setTenantKey(3).setTenantId("tenant-id").setName("tenant-name");
 
-    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+    engine
+        .identitySetup()
+        .initialize()
+        .withRole(role)
+        .withUser(user)
+        .withTenant(tenant)
+        .initialize();
 
     // Increase time to trigger a redistribution
     engine.increaseTime(Duration.ofMinutes(1));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -173,7 +173,13 @@ public class IdentitySetupInitializeTest {
 
     // when
     final var initializeRecord =
-        engine.identitySetup().initialize().withTenant(tenant).initialize();
+        engine
+            .identitySetup()
+            .initialize()
+            .withUser(new UserRecord().setUserKey(2))
+            .withRole(new RoleRecord().setRoleKey(3))
+            .withTenant(tenant)
+            .initialize();
 
     // then
     assertTenantIsNotCreated(initializeRecord.getSourceRecordPosition());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -12,11 +12,13 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
@@ -40,7 +42,7 @@ public class IdentitySetupInitializeTest {
   @Rule public final TestWatcher recordingExporterTestWatcher = new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldCreateRoleAndUser() {
+  public void shouldCreateRoleUserAndTenant() {
     // given
     final var roleKey = 1;
     final var roleName = "roleName";
@@ -57,9 +59,20 @@ public class IdentitySetupInitializeTest {
             .setName(userName)
             .setPassword(password)
             .setEmail(mail);
+    final var tenantKey = 3;
+    final var tenantId = "tenant-id";
+    final var tenantName = "tenant-name";
+    final var tenant =
+        new TenantRecord().setTenantKey(tenantKey).setName(tenantName).setTenantId(tenantId);
 
     // when
-    engine.identitySetup().initialize().withRole(role).withUser(user).initialize();
+    engine
+        .identitySetup()
+        .initialize()
+        .withRole(role)
+        .withUser(user)
+        .withTenant(tenant)
+        .initialize();
 
     // then
     assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue())
@@ -71,6 +84,10 @@ public class IdentitySetupInitializeTest {
         .hasName(userName)
         .hasPassword(password)
         .hasEmail(mail);
+    assertThat(RecordingExporter.tenantRecords(TenantIntent.CREATED).getFirst().getValue())
+        .hasTenantKey(tenantKey)
+        .hasName(tenantName)
+        .hasTenantId(tenantId);
     assertUserIsAssignedToRole(roleKey, userKey);
     assertThatAllPermissionsAreAddedToRole(roleKey);
   }
@@ -144,6 +161,22 @@ public class IdentitySetupInitializeTest {
                 .asList())
         .describedAs("No permissions should be added. The role should not be modified.")
         .isEmpty();
+  }
+
+  @Test
+  public void shouldNotCreateTenantIfAlreadyExists() {
+    // given
+    final var tenantId = "tenant-id";
+    final var tenantName = "tenant-name";
+    final var tenant = new TenantRecord().setTenantKey(1).setTenantId(tenantId).setName(tenantName);
+    engine.tenant().newTenant().withTenantId(tenantId).withName(tenantName).create().getKey();
+
+    // when
+    final var initializeRecord =
+        engine.identitySetup().initialize().withTenant(tenant).initialize();
+
+    // then
+    assertTenantIsNotCreated(initializeRecord.getSourceRecordPosition());
   }
 
   @Test
@@ -270,6 +303,15 @@ public class IdentitySetupInitializeTest {
                 .roleRecords()
                 .withIntent(RoleIntent.CREATED)
                 .toList())
+        .isEmpty();
+  }
+
+  private static void assertTenantIsNotCreated(final long initializePosition) {
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .after(initializePosition)
+                .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
+                .withIntent(TenantIntent.CREATED))
         .isEmpty();
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
@@ -533,6 +534,11 @@ public class CommandDistributionIdempotencyTest {
                                 .setEmail("email")
                                 .setPassword("password")
                                 .setName("name"))
+                        .withTenant(
+                            new TenantRecord()
+                                .setTenantKey(3L)
+                                .setTenantId("tenant-id")
+                                .setName("tenant-name"))
                         .initialize(),
                 1),
             IdentitySetupInitializeProcessor.class

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
@@ -59,6 +60,11 @@ public final class IdentitySetupClient {
 
     public IdentitySetupInitializeClient withUser(final UserRecord user) {
       record.setDefaultUser(user);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withTenant(final TenantRecord tenant) {
+      record.setDefaultTenant(tenant);
       return this;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.protocol.impl.record.value.authorization;
 
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 
 public class IdentitySetupRecord extends UnifiedRecordValue implements IdentitySetupRecordValue {
@@ -20,10 +22,14 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
       new ObjectProperty<>("defaultRole", new RoleRecord());
   private final ObjectProperty<UserRecord> defaultUserProp =
       new ObjectProperty<>("defaultUser", new UserRecord());
+  private final ObjectProperty<TenantRecord> defaultTenantProp =
+      new ObjectProperty<>("defaultTenant", new TenantRecord());
 
   public IdentitySetupRecord() {
-    super(2);
-    declareProperty(defaultRoleProp).declareProperty(defaultUserProp);
+    super(3);
+    declareProperty(defaultRoleProp)
+        .declareProperty(defaultUserProp)
+        .declareProperty(defaultTenantProp);
   }
 
   @Override
@@ -43,6 +49,16 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
 
   public IdentitySetupRecord setDefaultUser(final UserRecord user) {
     defaultUserProp.getValue().wrap(user);
+    return this;
+  }
+
+  @Override
+  public TenantRecordValue getDefaultTenant() {
+    return defaultTenantProp.getValue();
+  }
+
+  public IdentitySetupRecord setDefaultTenant(final TenantRecord tenant) {
+    defaultTenantProp.getValue().copyFrom(tenant);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3007,7 +3007,9 @@ final class JsonSerializableToJsonTest {
                             .setName("name")
                             .setEmail("email")
                             .setPassword("password")
-                            .setUserType(UserType.REGULAR)),
+                            .setUserType(UserType.REGULAR))
+                    .setDefaultTenant(
+                        new TenantRecord().setTenantKey(4).setTenantId("id").setName("name")),
         """
       {
         "defaultRole": {
@@ -3023,6 +3025,13 @@ final class JsonSerializableToJsonTest {
           "email": "email",
           "password": "password",
           "userType": "REGULAR"
+        },
+        "defaultTenant": {
+          "tenantKey": 4,
+          "tenantId": "id",
+          "name": "name",
+          "entityKey": -1,
+          "entityType": "UNSPECIFIED"
         }
       }
       """
@@ -3048,6 +3057,13 @@ final class JsonSerializableToJsonTest {
               "password": "",
               "email": "",
               "userType": "REGULAR"
+          },
+          "defaultTenant": {
+              "tenantKey": -1,
+              "tenantId": "",
+              "name": "",
+              "entityKey": -1,
+              "entityType": "UNSPECIFIED"
           }
       }
       """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -26,4 +26,6 @@ public interface IdentitySetupRecordValue extends RecordValue {
   RoleRecordValue getDefaultRole();
 
   UserRecordValue getDefaultUser();
+
+  TenantRecordValue getDefaultTenant();
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -72,6 +72,11 @@ final class IdentitySetupInitializerIT {
 
     final var createdRole = record.getDefaultRole();
     Assertions.assertThat(createdRole).hasName(IdentitySetupInitializer.DEFAULT_ROLE_NAME);
+
+    final var createdTenant = record.getDefaultTenant();
+    Assertions.assertThat(createdTenant)
+        .hasTenantId(IdentitySetupInitializer.DEFAULT_TENANT_ID)
+        .hasName(IdentitySetupInitializer.DEFAULT_TENANT_NAME);
   }
 
   @Test


### PR DESCRIPTION
Adds the default tenant `<default>` to the identity setup.
The default user and role are not associated with that tenant in any way, that's pending clarification: https://github.com/camunda/camunda/issues/25610#issuecomment-2517344335

Closes #25610