### PR TITLE
feat: A process instance completes an ad-hoc subprocess when the last child instance is completed

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventCompatibilityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventCompatibilityTest.java
@@ -126,7 +126,17 @@ public class CompensationEventCompatibilityTest {
               BpmnElementType.MULTI_INSTANCE_BODY,
               b ->
                   b.manualTask()
-                      .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2]").sequential())));
+                      .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2]").sequential())),
+          Scenario.of(
+              "ad-hoc subprocess",
+              BpmnElementType.AD_HOC_SUB_PROCESS,
+              b ->
+                  b.adHocSubProcess(
+                      "ad-hoc",
+                      adHocSubProcess -> {
+                        adHocSubProcess.zeebeActiveElementsCollectionExpression("[\"A\"]");
+                        adHocSubProcess.manualTask("A");
+                      })));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =


### PR DESCRIPTION
## Description

- The process instance completes the ad-hoc subprocess when the last child instance of the subprocess is completed.
- On completion of the subprocess, 
    - Apply output mappings 
    - Invoke end execution listeners.
- Enable support for compensation events: 
    - A compensation boundary can be attached to an ad-hoc subprocess
    - An ad-hoc subprocess can be used as a compensation handler

## Related issues

closes #25272 
