### PR TITLE
Properly copy Identity related records

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -64,8 +64,8 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
     final var record = command.getValue();
 
     final var tenantKey = record.getTenantKey();
-    final var persistedRecord = tenantState.getTenantByKey(tenantKey);
-    if (persistedRecord.isEmpty()) {
+    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    if (persistedTenant.isEmpty()) {
       rejectCommand(
           command,
           RejectionType.NOT_FOUND,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -64,9 +64,9 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
   public void processNewCommand(final TypedRecord<TenantRecord> command) {
     final var record = command.getValue();
     final var tenantKey = record.getTenantKey();
-    final var persistedTenantRecord = tenantState.getTenantByKey(tenantKey);
+    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
 
-    if (persistedTenantRecord.isEmpty()) {
+    if (persistedTenant.isEmpty()) {
       rejectCommand(
           command,
           RejectionType.NOT_FOUND,
@@ -77,10 +77,10 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
 
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
-            .addResourceId(persistedTenantRecord.get().getTenantId());
+            .addResourceId(persistedTenant.get().getTenantId());
     if (!authCheckBehavior.isAuthorized(authorizationRequest)) {
       rejectCommandWithUnauthorizedError(
-          command, authorizationRequest, persistedTenantRecord.get().getTenantId());
+          command, authorizationRequest, persistedTenant.get().getTenantId());
       return;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantUpdateProcessor.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
+import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
@@ -57,8 +58,8 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
     final var record = command.getValue();
     final var tenantKey = record.getTenantKey();
 
-    final var persistedRecord = tenantState.getTenantByKey(tenantKey);
-    if (persistedRecord.isEmpty()) {
+    final var persistedTenant = tenantState.getTenantByKey(tenantKey);
+    if (persistedTenant.isEmpty()) {
       rejectCommand(
           command,
           RejectionType.NOT_FOUND,
@@ -76,12 +77,12 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
       return;
     }
 
-    if (!isAuthorizedToUpdate(command, persistedRecord.get())) {
+    if (!isAuthorizedToUpdate(command, persistedTenant.get())) {
       return;
     }
 
-    updateExistingTenant(persistedRecord.get(), record);
-    updateStateAndDistribute(command, persistedRecord.get());
+    updateExistingTenant(persistedTenant.get(), record);
+    updateStateAndDistribute(command, persistedTenant.get());
   }
 
   @Override
@@ -92,20 +93,20 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
   }
 
   private boolean isAuthorizedToUpdate(
-      final TypedRecord<TenantRecord> command, final TenantRecord persistedRecord) {
+      final TypedRecord<TenantRecord> command, final PersistedTenant persistedTenant) {
     final var authorizationRequest =
         new AuthorizationRequest(command, AuthorizationResourceType.TENANT, PermissionType.UPDATE)
-            .addResourceId(persistedRecord.getTenantId());
+            .addResourceId(persistedTenant.getTenantId());
     if (!authCheckBehavior.isAuthorized(authorizationRequest)) {
       rejectCommandWithUnauthorizedError(
-          command, authorizationRequest, persistedRecord.getTenantId());
+          command, authorizationRequest, persistedTenant.getTenantId());
       return false;
     }
     return true;
   }
 
   private void updateExistingTenant(
-      final TenantRecord existingTenant, final TenantRecord updateRecord) {
+      final PersistedTenant existingTenant, final TenantRecord updateRecord) {
     final var updatedName = updateRecord.getName();
     if (!updatedName.isEmpty()) {
       existingTenant.setName(updatedName);
@@ -113,11 +114,17 @@ public class TenantUpdateProcessor implements DistributedTypedRecordProcessor<Te
   }
 
   private void updateStateAndDistribute(
-      final TypedRecord<TenantRecord> command, final TenantRecord tenantRecord) {
+      final TypedRecord<TenantRecord> command, final PersistedTenant persistedTenant) {
+    final var updatedRecord =
+        new TenantRecord()
+            .setTenantKey(persistedTenant.getTenantKey())
+            .setTenantId(persistedTenant.getTenantId())
+            .setName(persistedTenant.getName());
+
     stateWriter.appendFollowUpEvent(
-        tenantRecord.getTenantKey(), TenantIntent.UPDATED, tenantRecord);
+        persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord);
     responseWriter.writeEventOnCommand(
-        tenantRecord.getTenantKey(), TenantIntent.UPDATED, tenantRecord, command);
+        persistedTenant.getTenantKey(), TenantIntent.UPDATED, updatedRecord, command);
     distributeCommand(command);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedRole.java
@@ -43,6 +43,8 @@ public class PersistedRole extends UnpackedObject implements DbValue {
   }
 
   public PersistedRole copy() {
-    return new PersistedRole();
+    final var copy = new PersistedRole();
+    copy.copyFrom(this);
+    return copy;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -69,7 +69,7 @@ public class DbGroupState implements MutableGroupState {
   public void create(final long groupKey, final GroupRecord group) {
     this.groupKey.wrapLong(groupKey);
     groupName.wrapString(group.getName());
-    persistedGroup.copy(group);
+    persistedGroup.copyFrom(group);
 
     groupColumnFamily.insert(this.groupKey, persistedGroup);
     groupByNameColumnFamily.insert(groupName, fkGroupKey);
@@ -88,7 +88,7 @@ public class DbGroupState implements MutableGroupState {
       groupName.wrapString(group.getName());
       groupByNameColumnFamily.insert(groupName, fkGroupKey);
 
-      persistedGroup.copy(group);
+      persistedGroup.copyFrom(group);
       groupColumnFamily.update(this.groupKey, persistedGroup);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -69,7 +69,7 @@ public class DbGroupState implements MutableGroupState {
   public void create(final long groupKey, final GroupRecord group) {
     this.groupKey.wrapLong(groupKey);
     groupName.wrapString(group.getName());
-    persistedGroup.wrap(group);
+    persistedGroup.copy(group);
 
     groupColumnFamily.insert(this.groupKey, persistedGroup);
     groupByNameColumnFamily.insert(groupName, fkGroupKey);
@@ -88,7 +88,7 @@ public class DbGroupState implements MutableGroupState {
       groupName.wrapString(group.getName());
       groupByNameColumnFamily.insert(groupName, fkGroupKey);
 
-      persistedGroup.wrap(group);
+      persistedGroup.copy(group);
       groupColumnFamily.update(this.groupKey, persistedGroup);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
-import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 
 public class PersistedGroup extends UnpackedObject implements DbValue {
@@ -40,9 +39,5 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
   public PersistedGroup setName(final String name) {
     nameProp.setValue(name);
     return this;
-  }
-
-  public void copy(final GroupRecord group) {
-    copyFrom(group);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -42,8 +42,7 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public void wrap(final GroupRecord group) {
-    groupKeyProp.setValue(group.getGroupKey());
-    nameProp.setValue(group.getName());
+  public void copy(final GroupRecord group) {
+    copyFrom(group);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TenantState.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
-import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +21,7 @@ public interface TenantState {
    * @param tenantKey the key of the tenant to retrieve
    * @return an Optional containing the tenant record if it exists, otherwise an empty Optional
    */
-  Optional<TenantRecord> getTenantByKey(final long tenantKey);
+  Optional<PersistedTenant> getTenantByKey(final long tenantKey);
 
   /**
    * Retrieves the tenant key associated with the given tenant ID.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -63,7 +63,7 @@ public class DbTenantState implements MutableTenantState {
   public void createTenant(final TenantRecord tenantRecord) {
     tenantKey.wrapLong(tenantRecord.getTenantKey());
     tenantId.wrapString(tenantRecord.getTenantId());
-    persistedTenant.wrap(tenantRecord);
+    persistedTenant.copy(tenantRecord);
     tenantsColumnFamily.insert(tenantKey, persistedTenant);
     tenantByIdColumnFamily.insert(tenantId, fkTenantKey);
   }
@@ -108,29 +108,10 @@ public class DbTenantState implements MutableTenantState {
   }
 
   @Override
-  public Optional<TenantRecord> getTenantByKey(final long tenantKey) {
+  public Optional<PersistedTenant> getTenantByKey(final long tenantKey) {
     this.tenantKey.wrapLong(tenantKey);
     final PersistedTenant persistedTenant = tenantsColumnFamily.get(this.tenantKey);
-
-    if (persistedTenant != null) {
-      final TenantRecord tenantRecord = new TenantRecord();
-      tenantRecord
-          .setTenantKey(persistedTenant.getTenantKey())
-          .setTenantId(persistedTenant.getTenantId())
-          .setName(persistedTenant.getName());
-
-      // Retrieve entityKey if it exists for the tenant
-      final EntityTypeValue entityTypeValue =
-          entityByTenantColumnFamily.get(new DbCompositeKey<>(fkTenantKey, entityKey));
-
-      if (entityTypeValue != null) {
-        tenantRecord.setEntityKey(entityKey.getValue());
-      }
-
-      return Optional.of(tenantRecord);
-    }
-
-    return Optional.empty();
+    return Optional.ofNullable(persistedTenant);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/DbTenantState.java
@@ -63,7 +63,7 @@ public class DbTenantState implements MutableTenantState {
   public void createTenant(final TenantRecord tenantRecord) {
     tenantKey.wrapLong(tenantRecord.getTenantKey());
     tenantId.wrapString(tenantRecord.getTenantId());
-    persistedTenant.copy(tenantRecord);
+    persistedTenant.from(tenantRecord);
     tenantsColumnFamily.insert(tenantKey, persistedTenant);
     tenantByIdColumnFamily.insert(tenantId, fkTenantKey);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
@@ -100,7 +100,7 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
    *
    * @param tenantRecord the TenantRecord from which to copy the data
    */
-  public void copy(final TenantRecord tenantRecord) {
+  public void from(final TenantRecord tenantRecord) {
     tenantKeyProp.setValue(tenantRecord.getTenantKey());
     tenantIdProp.setValue(tenantRecord.getTenantId());
     nameProp.setValue(tenantRecord.getName());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
@@ -101,6 +101,8 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
    * @param tenantRecord the TenantRecord from which to copy the data
    */
   public void copy(final TenantRecord tenantRecord) {
-    copyFrom(tenantRecord);
+    tenantKeyProp.setValue(tenantRecord.getTenantKey());
+    tenantIdProp.setValue(tenantRecord.getTenantId());
+    nameProp.setValue(tenantRecord.getName());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/tenant/PersistedTenant.java
@@ -27,6 +27,12 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
     declareProperty(nameProp);
   }
 
+  public PersistedTenant copy() {
+    final var copy = new PersistedTenant();
+    copy.copyFrom(this);
+    return copy;
+  }
+
   /**
    * Gets the tenant key.
    *
@@ -94,9 +100,7 @@ public class PersistedTenant extends UnpackedObject implements DbValue {
    *
    * @param tenantRecord the TenantRecord from which to copy the data
    */
-  public void wrap(final TenantRecord tenantRecord) {
-    tenantKeyProp.setValue(tenantRecord.getTenantKey());
-    tenantIdProp.setValue(tenantRecord.getTenantId());
-    nameProp.setValue(tenantRecord.getName());
+  public void copy(final TenantRecord tenantRecord) {
+    copyFrom(tenantRecord);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
@@ -41,10 +41,7 @@ public class PersistedUser extends UnpackedObject implements DbValue {
 
   public PersistedUser copy() {
     final var copy = new PersistedUser();
-    copy.setUser(getUser());
-    copy.setRoleKeysList(getRoleKeysList());
-    copy.setTenantIdsList(getTenantIdsList());
-    copy.setGroupKeysList(getGroupKeysList());
+    copy.copyFrom(this);
     return copy;
   }
 
@@ -53,7 +50,7 @@ public class PersistedUser extends UnpackedObject implements DbValue {
   }
 
   public void setUser(final UserRecord record) {
-    userProp.getValue().wrap(record);
+    userProp.getValue().copy(record);
   }
 
   public long getUserKey() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/user/PersistedUser.java
@@ -50,7 +50,7 @@ public class PersistedUser extends UnpackedObject implements DbValue {
   }
 
   public void setUser(final UserRecord record) {
-    userProp.getValue().copy(record);
+    userProp.getValue().copyFrom(record);
   }
 
   public long getUserKey() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -32,7 +32,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   public IdentitySetupRecord setDefaultRole(final RoleRecord role) {
-    defaultRoleProp.getValue().wrap(role);
+    defaultRoleProp.getValue().copy(role);
     return this;
   }
 
@@ -42,7 +42,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   public IdentitySetupRecord setDefaultUser(final UserRecord user) {
-    defaultUserProp.getValue().wrap(user);
+    defaultUserProp.getValue().copy(user);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -32,7 +32,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   public IdentitySetupRecord setDefaultRole(final RoleRecord role) {
-    defaultRoleProp.getValue().copy(role);
+    defaultRoleProp.getValue().copyFrom(role);
     return this;
   }
 
@@ -42,7 +42,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   public IdentitySetupRecord setDefaultUser(final UserRecord user) {
-    defaultUserProp.getValue().copy(user);
+    defaultUserProp.getValue().copyFrom(user);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -24,10 +24,8 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
     declareProperty(mappingKeyProp).declareProperty(claimNameProp).declareProperty(claimValueProp);
   }
 
-  public void wrap(final MappingRecord record) {
-    mappingKeyProp.setValue(record.getMappingKey());
-    claimNameProp.setValue(record.getClaimName());
-    claimValueProp.setValue(record.getClaimValue());
+  public void copy(final MappingRecord record) {
+    copyFrom(record);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/MappingRecord.java
@@ -24,10 +24,6 @@ public class MappingRecord extends UnifiedRecordValue implements MappingRecordVa
     declareProperty(mappingKeyProp).declareProperty(claimNameProp).declareProperty(claimValueProp);
   }
 
-  public void copy(final MappingRecord record) {
-    copyFrom(record);
-  }
-
   @Override
   public long getMappingKey() {
     return mappingKeyProp.getValue();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -31,11 +31,8 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
         .declareProperty(entityTypeProp);
   }
 
-  public void wrap(final RoleRecord record) {
-    roleKeyProp.setValue(record.getRoleKey());
-    nameProp.setValue(record.getName());
-    entityKeyProp.setValue(record.getEntityKey());
-    entityTypeProp.setValue(record.getEntityType());
+  public void copy(final RoleRecord record) {
+    copyFrom(record);
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/RoleRecord.java
@@ -31,10 +31,6 @@ public class RoleRecord extends UnifiedRecordValue implements RoleRecordValue {
         .declareProperty(entityTypeProp);
   }
 
-  public void copy(final RoleRecord record) {
-    copyFrom(record);
-  }
-
   @Override
   public long getRoleKey() {
     return roleKeyProp.getValue();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -71,10 +71,7 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
     return this;
   }
 
-  public void wrap(final GroupRecord groupRecord) {
-    groupKeyProp.setValue(groupRecord.getGroupKey());
-    nameProp.setValue(groupRecord.getName());
-    entityKeyProp.setValue(groupRecord.getEntityKey());
-    entityTypeProp.setValue(groupRecord.getEntityType());
+  public void copy(final GroupRecord groupRecord) {
+    copyFrom(groupRecord);
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -70,8 +70,4 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
     entityTypeProp.setValue(entityType);
     return this;
   }
-
-  public void copy(final GroupRecord groupRecord) {
-    copyFrom(groupRecord);
-  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/tenant/TenantRecord.java
@@ -35,20 +35,9 @@ public final class TenantRecord extends UnifiedRecordValue implements TenantReco
         .declareProperty(entityTypeProp);
   }
 
-  public void wrap(final TenantRecord record) {
-    tenantKeyProp.setValue(record.getTenantKey());
-    tenantIdProp.setValue(record.getTenantIdBuffer());
-    nameProp.setValue(record.getNameBuffer());
-    entityKeyProp.setValue(record.getEntityKey());
-    entityTypeProp.setValue(record.getEntityType());
-  }
-
   public TenantRecord copy() {
     final TenantRecord copy = new TenantRecord();
-    copy.tenantKeyProp.setValue(getTenantKey());
-    copy.tenantIdProp.setValue(tenantIdProp.getValue());
-    copy.nameProp.setValue(nameProp.getValue());
-    copy.entityKeyProp.setValue(getEntityKey());
+    copy.copyFrom(this);
     return copy;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -37,10 +37,6 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
         .declareProperty(userTypeProp);
   }
 
-  public void copy(final UserRecord record) {
-    copyFrom(record);
-  }
-
   @Override
   public Long getUserKey() {
     return userKeyProp.getValue();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -37,13 +37,8 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
         .declareProperty(userTypeProp);
   }
 
-  public void wrap(final UserRecord record) {
-    userKeyProp.setValue(record.getUserKey());
-    usernameProp.setValue(record.getUsernameBuffer());
-    nameProp.setValue(record.getNameBuffer());
-    emailProp.setValue(record.getEmailBuffer());
-    passwordProp.setValue(record.getPasswordBuffer());
-    userTypeProp.setValue(record.getUserType());
+  public void copy(final UserRecord record) {
+    copyFrom(record);
   }
 
   @Override


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Replaces the wrap methods with a proper copy. This means the internal buffers actually points to different parts of memory.
I've also found a "bug" in retrieving the tenant from the state. I've fixed this in the second commit.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25620 
