### PR TITLE
fix: Tasklist redirections are not working properly after login

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -600,11 +600,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.operate.webapp.controllers;
 
-import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;

--- a/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
+++ b/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.tasklist.webapp.controllers;
 
-import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;

--- a/dist/src/main/java/io/camunda/webapps/controllers/IndexController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/IndexController.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.webapps.controllers;
 
-import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 
 import io.camunda.webapps.WebappsModuleConfiguration.WebappsProperties;
 import jakarta.servlet.http.HttpServletRequest;

--- a/dist/src/main/java/io/camunda/webapps/controllers/WebappsRequestForwardManager.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/WebappsRequestForwardManager.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.webapps.controllers;
 
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
+
 import io.camunda.webapps.WebappsModuleConfiguration.WebappsProperties;
 import jakarta.servlet.http.HttpServletRequest;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,7 +26,6 @@ public class WebappsRequestForwardManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(WebappsRequestForwardManager.class);
 
   private static final String LOGIN_RESOURCE = "/api/login";
-  private static final String REQUESTED_URL = "requestedUrl";
 
   @Autowired private WebappsProperties webappsProperties;
 
@@ -44,15 +45,6 @@ public class WebappsRequestForwardManager {
         request.getRequestURI().substring(request.getContextPath().length()),
         LOGIN_RESOURCE);
     return "forward:" + LOGIN_RESOURCE;
-  }
-
-  public static String getRequestedUrl(final HttpServletRequest request) {
-    final String requestedPath =
-        request.getRequestURI().substring(request.getContextPath().length());
-    final String queryString = request.getQueryString();
-    final String requestedUrl =
-        StringUtils.isEmpty(queryString) ? requestedPath : requestedPath + "?" + queryString;
-    return requestedUrl;
   }
 
   private boolean isNotLoggedIn() {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -8,6 +8,8 @@
 package io.camunda.operate.webapp.security;
 
 import static io.camunda.operate.webapp.security.OperateURIs.*;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 import static org.apache.http.entity.ContentType.APPLICATION_JSON;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
@@ -208,8 +210,7 @@ public abstract class BaseWebConfigurer {
       final HttpServletResponse response,
       final AuthenticationException ex)
       throws IOException {
-    final String requestedUrl =
-        request.getRequestURI().substring(request.getContextPath().length());
+    final String requestedUrl = getRequestedUrl(request);
     if (requestedUrl.contains("/api/")
         || requestedUrl.contains("/v1/")
         || requestedUrl.contains("/v2/")) {
@@ -220,11 +221,10 @@ public abstract class BaseWebConfigurer {
   }
 
   private void storeRequestedUrlAndRedirectToLogin(
-      final HttpServletRequest request, final HttpServletResponse response, String requestedUrl)
+      final HttpServletRequest request,
+      final HttpServletResponse response,
+      final String requestedUrl)
       throws IOException {
-    if (request.getQueryString() != null && !request.getQueryString().isEmpty()) {
-      requestedUrl = requestedUrl + "?" + request.getQueryString();
-    }
     logger.warn("Try to access protected resource {}. Save it for later redirect", requestedUrl);
     request.getSession(true).setAttribute(REQUESTED_URL, requestedUrl);
     response.sendRedirect(request.getContextPath() + LOGIN_RESOURCE);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
@@ -20,8 +20,6 @@ public final class OperateURIs {
   public static final String SSO_CALLBACK_URI = "/sso-callback";
   public static final String NO_PERMISSION = "/noPermission";
   public static final String IDENTITY_CALLBACK_URI = "/identity-callback";
-  public static final String // For redirects after login
-      REQUESTED_URL = "requestedUrl";
   public static final String[] AUTH_WHITELIST = {
     "/swagger-resources",
     "/swagger-resources/**",

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/identity/IdentityController.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.security.identity;
 
 import static io.camunda.operate.OperateProfileService.IDENTITY_AUTH_PROFILE;
 import static io.camunda.operate.webapp.security.OperateURIs.*;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
 
 import io.camunda.identity.sdk.authentication.dto.AuthCodeDto;
 import jakarta.servlet.http.HttpServletRequest;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/sso/SSOController.java
@@ -11,9 +11,9 @@ import static io.camunda.operate.OperateProfileService.SSO_AUTH_PROFILE;
 import static io.camunda.operate.webapp.security.OperateURIs.LOGIN_RESOURCE;
 import static io.camunda.operate.webapp.security.OperateURIs.LOGOUT_RESOURCE;
 import static io.camunda.operate.webapp.security.OperateURIs.NO_PERMISSION;
-import static io.camunda.operate.webapp.security.OperateURIs.REQUESTED_URL;
 import static io.camunda.operate.webapp.security.OperateURIs.ROOT;
 import static io.camunda.operate.webapp.security.OperateURIs.SSO_CALLBACK_URI;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
 
 import com.auth0.IdentityVerificationException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -20,6 +20,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>webapps-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>tasklist-common</artifactId>
     </dependency>
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
@@ -37,7 +37,6 @@ public final class TasklistURIs {
   public static final String SSO_CALLBACK = "/sso-callback";
   public static final String NO_PERMISSION = "/noPermission";
   public static final String IDENTITY_CALLBACK_URI = "/identity-callback";
-  public static final String REQUESTED_URL = "requestedUrl";
   public static final String COOKIE_JSESSIONID = "TASKLIST-SESSION";
   public static final String START_PUBLIC_PROCESS = ROOT_URL + "/new/";
   public static final String RESPONSE_CHARACTER_ENCODING = "UTF-8";

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityController.java
@@ -12,8 +12,8 @@ import static io.camunda.tasklist.webapp.security.TasklistURIs.IDENTITY_CALLBACK
 import static io.camunda.tasklist.webapp.security.TasklistURIs.LOGIN_RESOURCE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.LOGOUT_RESOURCE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.NO_PERMISSION;
-import static io.camunda.tasklist.webapp.security.TasklistURIs.REQUESTED_URL;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.ROOT;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
 
 import io.camunda.identity.sdk.authentication.dto.AuthCodeDto;
 import jakarta.servlet.http.HttpServletRequest;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityWebSecurityConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityWebSecurityConfig.java
@@ -9,6 +9,8 @@ package io.camunda.tasklist.webapp.security.identity;
 
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.IDENTITY_AUTH_PROFILE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.*;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 
 import io.camunda.tasklist.webapp.security.BaseWebConfigurer;
@@ -72,10 +74,7 @@ public class IdentityWebSecurityConfig extends BaseWebConfigurer {
   protected void authenticationEntry(
       final HttpServletRequest req, final HttpServletResponse res, final AuthenticationException ex)
       throws IOException {
-    String requestedUrl = req.getRequestURI();
-    if (req.getQueryString() != null && !req.getQueryString().isEmpty()) {
-      requestedUrl = requestedUrl + "?" + req.getQueryString();
-    }
+    final String requestedUrl = getRequestedUrl(req);
 
     if (containsAny(requestedUrl.toLowerCase(), GRAPHQL_URL, REST_V1_API)) {
       req.getSession().invalidate();

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOController.java
@@ -11,9 +11,9 @@ import static io.camunda.tasklist.webapp.security.TasklistProfileService.SSO_AUT
 import static io.camunda.tasklist.webapp.security.TasklistURIs.LOGIN_RESOURCE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.LOGOUT_RESOURCE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.NO_PERMISSION;
-import static io.camunda.tasklist.webapp.security.TasklistURIs.REQUESTED_URL;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.ROOT;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.SSO_CALLBACK;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOWebSecurityConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOWebSecurityConfig.java
@@ -9,6 +9,8 @@ package io.camunda.tasklist.webapp.security.sso;
 
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.SSO_AUTH_PROFILE;
 import static io.camunda.tasklist.webapp.security.TasklistURIs.*;
+import static io.camunda.webapps.util.HttpUtils.REQUESTED_URL;
+import static io.camunda.webapps.util.HttpUtils.getRequestedUrl;
 import static org.apache.commons.lang3.StringUtils.containsAny;
 
 import com.auth0.AuthenticationController;
@@ -86,11 +88,7 @@ public class SSOWebSecurityConfig extends BaseWebConfigurer {
       final HttpServletRequest req, final HttpServletResponse res, final AuthenticationException ex)
       throws IOException {
 
-    String requestedUrl = req.getRequestURI();
-
-    if (req.getQueryString() != null && !req.getQueryString().isEmpty()) {
-      requestedUrl = requestedUrl + "?" + req.getQueryString();
-    }
+    final String requestedUrl = getRequestedUrl(req);
 
     if (containsAny(requestedUrl.toLowerCase(), GRAPHQL_URL, REST_V1_API)) {
       req.getSession().invalidate();

--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/webapps-common/src/main/java/io/camunda/webapps/util/HttpUtils.java
+++ b/webapps-common/src/main/java/io/camunda/webapps/util/HttpUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public final class HttpUtils {
+  // session attribute key used to store the requested URL for redirects after login
+  public static final String REQUESTED_URL = "requestedUrl";
+
+  private HttpUtils() {}
+
+  /**
+   * Builds the full requested URL from an {@link HttpServletRequest}.
+   *
+   * <p>Combines the request URI (excluding the context path) and the query string to form the
+   * complete URL requested by the client.
+   *
+   * @param request the {@link HttpServletRequest} to extract the URL from
+   */
+  public static String getRequestedUrl(final HttpServletRequest request) {
+    final String requestedPath =
+        request.getRequestURI().substring(request.getContextPath().length());
+    final String queryString = request.getQueryString();
+    return queryString == null || queryString.isEmpty()
+        ? requestedPath
+        : requestedPath + "?" + queryString;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
This fixes a regression introduced by https://github.com/camunda/camunda/issues/25534
The problem comes from the requested url that is stored in the session and used for redirection after login.
In tasklist, it was including the context path, while in the common index controller (and also in Operate) it is excluding the context path.

In this pull request, I am extracting a common method to be used by Tasklist, Operate and the common controllers, to set the requested url in the session without the context path.

Tested in a DEV SaaS cluster https://console.cloud.dev.ultrawombat.com/org/2f48fdc5-883d-454c-8288-c32289b319bb/cluster/460af586-0993-417c-a783-1e636320174d

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25638 
