### PR TITLE
feat: add Optimize indices with priority Prio6Backup

### DIFF
--- a/optimize/util/optimize-commons/pom.xml
+++ b/optimize/util/optimize-commons/pom.xml
@@ -296,6 +296,12 @@
       <scope>compile</scope>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>webapps-schema</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexMappingCreator.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/IndexMappingCreator.java
@@ -9,11 +9,17 @@ package io.camunda.optimize.service.db.schema;
 
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.service.util.configuration.ConfigurationService;
+import io.camunda.webapps.schema.descriptors.backup.BackupPriority;
 import java.io.IOException;
 
-public interface IndexMappingCreator<TBuilder> {
+public interface IndexMappingCreator<TBuilder> extends BackupPriority {
 
   String getIndexName();
+
+  @Override
+  default String getFullQualifiedName() {
+    return getIndexName();
+  }
 
   default String getIndexNameInitialSuffix() {
     return "";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/AlertIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/AlertIndex.java
@@ -16,8 +16,10 @@ import io.camunda.optimize.dto.optimize.query.alert.AlertDefinitionDto;
 import io.camunda.optimize.dto.optimize.query.alert.AlertInterval;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class AlertIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class AlertIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 4;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessKeyIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/BusinessKeyIndex.java
@@ -12,8 +12,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.persistence.BusinessKeyDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class BusinessKeyIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class BusinessKeyIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 2;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/CollectionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/CollectionIndex.java
@@ -18,8 +18,10 @@ import io.camunda.optimize.dto.optimize.query.collection.CollectionDataDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionRoleRequestDto;
 import io.camunda.optimize.dto.optimize.query.collection.CollectionScopeEntryDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class CollectionIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class CollectionIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 5;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardIndex.java
@@ -18,8 +18,10 @@ import io.camunda.optimize.dto.optimize.query.dashboard.tile.DashboardReportTile
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.DimensionDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.PositionDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class DashboardIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 8;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardShareIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DashboardShareIndex.java
@@ -13,8 +13,10 @@ import io.camunda.optimize.dto.optimize.query.dashboard.tile.DimensionDto;
 import io.camunda.optimize.dto.optimize.query.dashboard.tile.PositionDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class DashboardShareIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class DashboardShareIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 4;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DecisionDefinitionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/DecisionDefinitionIndex.java
@@ -9,8 +9,10 @@ package io.camunda.optimize.service.db.schema.index;
 
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class DecisionDefinitionIndex<TBuilder> extends AbstractDefinitionIndex<TBuilder> {
+public abstract class DecisionDefinitionIndex<TBuilder> extends AbstractDefinitionIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 5;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ExternalProcessVariableIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ExternalProcessVariableIndex.java
@@ -13,9 +13,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.variable.ExternalProcessVariableDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
 public abstract class ExternalProcessVariableIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio6Backup {
 
   public static final String VARIABLE_ID = ExternalProcessVariableDto.Fields.variableId;
   public static final String VARIABLE_NAME = ExternalProcessVariableDto.Fields.variableName;
@@ -38,11 +39,6 @@ public abstract class ExternalProcessVariableIndex<TBuilder>
   }
 
   @Override
-  public int getVersion() {
-    return VERSION;
-  }
-
-  @Override
   public String getIndexNameInitialSuffix() {
     return DatabaseConstants.INDEX_SUFFIX_PRE_ROLLOVER;
   }
@@ -50,6 +46,11 @@ public abstract class ExternalProcessVariableIndex<TBuilder>
   @Override
   public boolean isCreateFromTemplate() {
     return true;
+  }
+
+  @Override
+  public int getVersion() {
+    return VERSION;
   }
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/InstantPreviewDashboardMetadataIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/InstantPreviewDashboardMetadataIndex.java
@@ -12,9 +12,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.INSTANT_DASHBOARD
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.dashboard.InstantDashboardDataDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
 public abstract class InstantPreviewDashboardMetadataIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio6Backup {
 
   public static final int VERSION = 1;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/MetadataIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/MetadataIndex.java
@@ -11,8 +11,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.MetadataDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class MetadataIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class MetadataIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 3;
   public static final String ID = "1";

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessDefinitionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessDefinitionIndex.java
@@ -10,8 +10,10 @@ package io.camunda.optimize.service.db.schema.index;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.ProcessDefinitionOptimizeDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class ProcessDefinitionIndex<TBuilder> extends AbstractDefinitionIndex<TBuilder> {
+public abstract class ProcessDefinitionIndex<TBuilder> extends AbstractDefinitionIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 6;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessInstanceIndex.java
@@ -19,9 +19,11 @@ import io.camunda.optimize.dto.optimize.persistence.CandidateGroupOperationDto;
 import io.camunda.optimize.dto.optimize.persistence.incident.IncidentDto;
 import io.camunda.optimize.dto.optimize.query.process.FlowNodeInstanceDto;
 import io.camunda.optimize.dto.optimize.query.variable.SimpleProcessVariableDto;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 import java.util.Locale;
 
-public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceIndex<TBuilder> {
+public abstract class ProcessInstanceIndex<TBuilder> extends AbstractInstanceIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 8;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessOverviewIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ProcessOverviewIndex.java
@@ -14,8 +14,10 @@ import io.camunda.optimize.dto.optimize.query.processoverview.ProcessDigestRespo
 import io.camunda.optimize.dto.optimize.query.processoverview.ProcessOverviewDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class ProcessOverviewIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class ProcessOverviewIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 2;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ReportShareIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/ReportShareIndex.java
@@ -10,8 +10,10 @@ package io.camunda.optimize.service.db.schema.index;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class ReportShareIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class ReportShareIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 3;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/SettingsIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/SettingsIndex.java
@@ -13,8 +13,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.SETTINGS_INDEX_NA
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.SettingsDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class SettingsIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class SettingsIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
   public static final int VERSION = 3;
   public static final String ID = "1";
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/TenantIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/TenantIndex.java
@@ -11,8 +11,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.TenantDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class TenantIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class TenantIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
   public static final int VERSION = 3;
 
   @Override

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/TerminatedUserSessionIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/TerminatedUserSessionIndex.java
@@ -12,9 +12,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FOR
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
 public abstract class TerminatedUserSessionIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio6Backup {
 
   public static final int VERSION = 3;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/VariableLabelIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/VariableLabelIndex.java
@@ -12,8 +12,10 @@ import io.camunda.optimize.dto.optimize.query.variable.DefinitionVariableLabelsD
 import io.camunda.optimize.dto.optimize.query.variable.LabelDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class VariableLabelIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder> {
+public abstract class VariableLabelIndex<TBuilder> extends DefaultIndexMappingCreator<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 1;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/VariableUpdateInstanceIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/VariableUpdateInstanceIndex.java
@@ -14,9 +14,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.variable.VariableUpdateInstanceDto;
 import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
 public abstract class VariableUpdateInstanceIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio6Backup {
 
   public static final String INSTANCE_ID = VariableUpdateInstanceDto.Fields.instanceId;
   public static final String NAME = VariableUpdateInstanceDto.Fields.name;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/PositionBasedImportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/PositionBasedImportIndex.java
@@ -15,9 +15,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.index.ImportIndexDto;
 import io.camunda.optimize.dto.optimize.index.PositionBasedImportIndexDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 
 public abstract class PositionBasedImportIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio1Backup {
 
   public static final int VERSION = 3;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/TimestampBasedImportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/index/TimestampBasedImportIndex.java
@@ -15,9 +15,10 @@ import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.index.ImportIndexDto;
 import io.camunda.optimize.dto.optimize.index.TimestampBasedImportIndexDto;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
 public abstract class TimestampBasedImportIndex<TBuilder>
-    extends DefaultIndexMappingCreator<TBuilder> {
+    extends DefaultIndexMappingCreator<TBuilder> implements Prio6Backup {
 
   public static final int VERSION = 5;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/CombinedReportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/CombinedReportIndex.java
@@ -11,8 +11,10 @@ import static io.camunda.optimize.service.db.DatabaseConstants.COMBINED_REPORT_I
 
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class CombinedReportIndex<TBuilder> extends AbstractReportIndex<TBuilder> {
+public abstract class CombinedReportIndex<TBuilder> extends AbstractReportIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 5;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleDecisionReportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleDecisionReportIndex.java
@@ -13,8 +13,10 @@ import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.report.single.decision.DecisionReportDataDto;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class SingleDecisionReportIndex<TBuilder> extends AbstractReportIndex<TBuilder> {
+public abstract class SingleDecisionReportIndex<TBuilder> extends AbstractReportIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final int VERSION = 10;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/db/schema/index/report/SingleProcessReportIndex.java
@@ -13,8 +13,10 @@ import co.elastic.clients.elasticsearch._types.mapping.DynamicMapping;
 import co.elastic.clients.elasticsearch._types.mapping.Property;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
 import io.camunda.optimize.dto.optimize.query.report.single.process.ProcessReportDataDto;
+import io.camunda.webapps.schema.descriptors.backup.Prio6Backup;
 
-public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportIndex<TBuilder> {
+public abstract class SingleProcessReportIndex<TBuilder> extends AbstractReportIndex<TBuilder>
+    implements Prio6Backup {
 
   public static final String MANAGEMENT_REPORT = ProcessReportDataDto.Fields.managementReport;
   public static final String INSTANT_PREVIEW_REPORT =

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio6Backup.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/Prio6Backup.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.backup;
+
+public interface Prio6Backup extends BackupPriority {}


### PR DESCRIPTION
## Description
A new Priority has been created with priority=6 that all optimize indices will use.

>[!WARNING]
Indices are not yet in use by the common Backup components

## Related issues
closes #24464
