### PR TITLE
fix: include start.sh and shutdown.sh in c8run

### DIFF
--- a/c8run/package.go
+++ b/c8run/package.go
@@ -129,6 +129,8 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string) error {
 		filepath.Join("c8run", "endpoints.txt"),
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
+		filepath.Join("c8run", "start.sh"),
+		filepath.Join("c8run", "shutdown.sh"),
 	}
 	outputArchive, err := os.Create(filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-"+runtime.GOOS+"-"+architecture+".tar.gz"))
 	if err != nil {


### PR DESCRIPTION
## Description


start.sh and shutdown.sh were intended to be included as part of c8run to preserve the existing start and shutdown commands from 8.6 . These files for the most part just contain the command `./c8run start` and `./c8run stop`, and  have been inside the git repo, but these were missing when creating the actual package.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25633 