### PR TITLE
ci: add lint rule to check for Caching Strategy best practices and fix problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,12 +411,12 @@ jobs:
         working-directory: identity/client
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'yarn'
-          cache-dependency-path: identity/client/yarn.lock
+          node-version: "20"
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: identity/client
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Check formatting
@@ -541,12 +541,12 @@ jobs:
         uses: YunaBraska/java-info-action@main
         with:
           work-dir: ./optimize
-      - name: Set Node.js
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
-          cache: yarn
-          cache-dependency-path: optimize/client/yarn.lock
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: optimize/client
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Unit tests

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -30,9 +30,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
-          cache: 'yarn'
-          cache-dependency-path: operate/client/yarn.lock
+          node-version: "20"
+      - uses: camunda/infra-global-github-actions/setup-yarn-cache@main
+        with:
+          directory: operate/client
       - run: yarn install --frozen-lockfile
         name: Install dependencies
       - run: yarn ts-check


### PR DESCRIPTION
## Description

Follow-up to #18750 ensuring that we follow the best practices from https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy in all workflows (some occurrences slipped/got reintroduced when #21607 was done).

This PR adds a new rule to automatically check for usages of `setup-node` action with `cache: yarn` option enabled (which doesn't adhere to the Caching Strategy) and fails, then fixes those:

* https://github.com/camunda/camunda/pull/25658/files#annotation_29377704891
* https://github.com/camunda/camunda/pull/25658/files#annotation_29377704899

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #18750 
