### PR TITLE
fix: enable full annotation processing for protocol module

### DIFF
--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -138,6 +138,7 @@
           <compilerArgs combine.children="append">
             <!-- required by javac detection logic in immutables -->
             <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+            <arg>-proc:full</arg>
           </compilerArgs>
           <fork>true</fork>
         </configuration>


### PR DESCRIPTION
This setting is required to enable annotation processing on JDK 23 and up. `full` enables the same behavior that previous JDK versions used. We require annotation processing for our use of the `immutables` library.

See https://inside.java/2024/06/18/quality-heads-up/ for more information.