### PR TITLE
Support corrections for `complete` task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -122,6 +122,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           commandWriter.appendFollowUpCommand(
               userTask.getUserTaskKey(), UserTaskIntent.DENY_TASK_LISTENER, userTask);
         } else {
+          userTask.correctAttributes(
+              value.getResult().getCorrectedAttributes(), value.getResult().getCorrections());
           commandWriter.appendFollowUpCommand(
               userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
         }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -91,7 +91,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
             elementInstanceKey,
             ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER,
             elementInstance.getValue());
-        return;
       }
       case TASK_LISTENER -> {
         /*
@@ -117,8 +116,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           commandWriter.appendFollowUpCommand(
               userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
         }
-
-        return;
       }
       default -> {
         final long scopeKey = elementInstance.getValue().getFlowScopeKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -40,7 +40,12 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           + "Support will be enabled with the resolution of issue #23702";
   private static final Set<String> CORRECTABLE_PROPERTIES =
       Set.of(
-          "assignee", "candidateGroups", "candidateUsers", "dueDate", "followUpDate", "priority");
+          "assignee",
+          "candidateGroupsList",
+          "candidateUsersList",
+          "dueDate",
+          "followUpDate",
+          "priority");
 
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -68,7 +68,7 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
             this::acceptCommand,
             authCheckBehavior,
             List.of(
-                this::checkVariablesNotProvidedForTaskListenerJob,
+                this::checkTaskListenerJobForProvidingVariables,
                 this::checkTaskListenerJobForDenyingWithCorrections,
                 this::checkTaskListenerJobForUnknownPropertyCorrections));
     this.jobMetrics = jobMetrics;
@@ -149,7 +149,8 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     }
   }
 
-  private Either<Rejection, JobRecord> checkVariablesNotProvidedForTaskListenerJob(
+  /** We currently don't support completing task listener jobs with variables. */
+  private Either<Rejection, JobRecord> checkTaskListenerJobForProvidingVariables(
       final TypedRecord<JobRecord> command, final JobRecord job) {
 
     if (job.getJobKind() == JobKind.TASK_LISTENER && hasVariables(command)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -115,11 +115,11 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           if (value.getResult().isDenied()) {
             commandWriter.appendFollowUpCommand(
                 userTask.getUserTaskKey(), UserTaskIntent.DENY_TASK_LISTENER, userTask);
-            return;
+          } else {
+            commandWriter.appendFollowUpCommand(
+                userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
           }
 
-          commandWriter.appendFollowUpCommand(
-              userTask.getUserTaskKey(), UserTaskIntent.COMPLETE_TASK_LISTENER, userTask);
           return;
         }
       default:

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -40,12 +41,12 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
           + "Support will be enabled with the resolution of issue #23702";
   private static final Set<String> CORRECTABLE_PROPERTIES =
       Set.of(
-          "assignee",
-          "candidateGroupsList",
-          "candidateUsersList",
-          "dueDate",
-          "followUpDate",
-          "priority");
+          UserTaskRecord.ASSIGNEE,
+          UserTaskRecord.CANDIDATE_GROUPS,
+          UserTaskRecord.CANDIDATE_USERS,
+          UserTaskRecord.DUE_DATE,
+          UserTaskRecord.FOLLOW_UP_DATE,
+          UserTaskRecord.PRIORITY);
 
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -99,6 +99,36 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var userTaskElementInstance = getUserTaskElementInstance(intermediateUserTaskRecord);
     final var context = buildContext(userTaskElementInstance);
 
+    if (!command.getValue().getChangedAttributes().isEmpty()) {
+      // todo: replace with call to UserTask.wrapChangedAttributes
+      command
+          .getValue()
+          .getChangedAttributes()
+          .forEach(
+              attribute -> {
+                switch (attribute) {
+                  case "assignee" ->
+                      intermediateUserTaskRecord.setAssignee(command.getValue().getAssignee());
+                  case "candidateGroups" ->
+                      intermediateUserTaskRecord.setCandidateGroupsList(
+                          command.getValue().getCandidateGroupsList());
+                  case "candidateUsers" ->
+                      intermediateUserTaskRecord.setCandidateUsersList(
+                          command.getValue().getCandidateUsersList());
+                  case "dueDate" ->
+                      intermediateUserTaskRecord.setDueDate(command.getValue().getDueDate());
+                  case "followUpDate" ->
+                      intermediateUserTaskRecord.setFollowUpDate(
+                          command.getValue().getFollowUpDate());
+                  case "priority" ->
+                      intermediateUserTaskRecord.setPriority(command.getValue().getPriority());
+                }
+              });
+      intermediateUserTaskRecord.setChangedAttributes(command.getValue().getChangedAttributes());
+      stateWriter.appendFollowUpEvent(
+          command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
+    }
+
     findNextTaskListener(listenerEventType, userTaskElement, userTaskElementInstance)
         .ifPresentOrElse(
             listener ->

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -118,22 +118,22 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final UserTaskRecord userTaskRecord) {
     final var currentUserTask = userTaskState.getUserTask(command.getKey());
     if (!currentUserTask.getAssigneeBuffer().equals(userTaskRecord.getAssigneeBuffer())) {
-      userTaskRecord.addChangedAttribute("assignee");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.ASSIGNEE);
     }
     if (!currentUserTask.getCandidateGroupsList().equals(userTaskRecord.getCandidateGroupsList())) {
-      userTaskRecord.addChangedAttribute("candidateGroupsList");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.CANDIDATE_GROUPS);
     }
     if (!currentUserTask.getCandidateUsersList().equals(userTaskRecord.getCandidateUsersList())) {
-      userTaskRecord.addChangedAttribute("candidateUsersList");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.CANDIDATE_USERS);
     }
     if (!currentUserTask.getDueDateBuffer().equals(userTaskRecord.getDueDateBuffer())) {
-      userTaskRecord.addChangedAttribute("dueDate");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.DUE_DATE);
     }
     if (!currentUserTask.getFollowUpDateBuffer().equals(userTaskRecord.getFollowUpDateBuffer())) {
-      userTaskRecord.addChangedAttribute("followUpDate");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.FOLLOW_UP_DATE);
     }
     if (currentUserTask.getPriority() != userTaskRecord.getPriority()) {
-      userTaskRecord.addChangedAttribute("priority");
+      userTaskRecord.addChangedAttribute(UserTaskRecord.PRIORITY);
     }
 
     final var commandProcessor = determineProcessorFromUserTaskLifecycleState(lifecycleState);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -140,6 +140,28 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final TypedRecord<UserTaskRecord> command,
       final LifecycleState lifecycleState,
       final UserTaskRecord userTaskRecord) {
+    final var currentUserTask = userTaskState.getUserTask(command.getKey());
+    if (!currentUserTask.getAssigneeBuffer().equals(userTaskRecord.getAssigneeBuffer())) {
+      userTaskRecord.addChangedAttribute("assignee");
+    }
+    if (!currentUserTask.getCandidateGroupsList().equals(userTaskRecord.getCandidateGroupsList())) {
+      // todo: change to candidateGroupsList
+      userTaskRecord.addChangedAttribute("candidateGroups");
+    }
+    if (!currentUserTask.getCandidateUsersList().equals(userTaskRecord.getCandidateUsersList())) {
+      // todo: change to candidateUsersList
+      userTaskRecord.addChangedAttribute("candidateUsers");
+    }
+    if (!currentUserTask.getDueDateBuffer().equals(userTaskRecord.getDueDateBuffer())) {
+      userTaskRecord.addChangedAttribute("dueDate");
+    }
+    if (!currentUserTask.getFollowUpDateBuffer().equals(userTaskRecord.getFollowUpDateBuffer())) {
+      userTaskRecord.addChangedAttribute("followUpDate");
+    }
+    if (currentUserTask.getPriority() != userTaskRecord.getPriority()) {
+      userTaskRecord.addChangedAttribute("priority");
+    }
+
     final var commandProcessor = determineProcessorFromUserTaskLifecycleState(lifecycleState);
     commandProcessor.onFinalizeCommand(command, userTaskRecord);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -100,31 +100,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
     final var context = buildContext(userTaskElementInstance);
 
     if (!command.getValue().getChangedAttributes().isEmpty()) {
-      // todo: replace with call to UserTask.wrapChangedAttributes
-      command
-          .getValue()
-          .getChangedAttributes()
-          .forEach(
-              attribute -> {
-                switch (attribute) {
-                  case "assignee" ->
-                      intermediateUserTaskRecord.setAssignee(command.getValue().getAssignee());
-                  case "candidateGroupsList" ->
-                      intermediateUserTaskRecord.setCandidateGroupsList(
-                          command.getValue().getCandidateGroupsList());
-                  case "candidateUsersList" ->
-                      intermediateUserTaskRecord.setCandidateUsersList(
-                          command.getValue().getCandidateUsersList());
-                  case "dueDate" ->
-                      intermediateUserTaskRecord.setDueDate(command.getValue().getDueDate());
-                  case "followUpDate" ->
-                      intermediateUserTaskRecord.setFollowUpDate(
-                          command.getValue().getFollowUpDate());
-                  case "priority" ->
-                      intermediateUserTaskRecord.setPriority(command.getValue().getPriority());
-                }
-              });
-      intermediateUserTaskRecord.setChangedAttributes(command.getValue().getChangedAttributes());
+      intermediateUserTaskRecord.wrapChangedAttributes(command.getValue(), true);
       stateWriter.appendFollowUpEvent(
           command.getKey(), UserTaskIntent.CORRECTED, intermediateUserTaskRecord);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -117,24 +117,7 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       final LifecycleState lifecycleState,
       final UserTaskRecord userTaskRecord) {
     final var currentUserTask = userTaskState.getUserTask(command.getKey());
-    if (!currentUserTask.getAssigneeBuffer().equals(userTaskRecord.getAssigneeBuffer())) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.ASSIGNEE);
-    }
-    if (!currentUserTask.getCandidateGroupsList().equals(userTaskRecord.getCandidateGroupsList())) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.CANDIDATE_GROUPS);
-    }
-    if (!currentUserTask.getCandidateUsersList().equals(userTaskRecord.getCandidateUsersList())) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.CANDIDATE_USERS);
-    }
-    if (!currentUserTask.getDueDateBuffer().equals(userTaskRecord.getDueDateBuffer())) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.DUE_DATE);
-    }
-    if (!currentUserTask.getFollowUpDateBuffer().equals(userTaskRecord.getFollowUpDateBuffer())) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.FOLLOW_UP_DATE);
-    }
-    if (currentUserTask.getPriority() != userTaskRecord.getPriority()) {
-      userTaskRecord.addChangedAttribute(UserTaskRecord.PRIORITY);
-    }
+    userTaskRecord.setDiffAsChangedAttributes(currentUserTask);
 
     final var commandProcessor = determineProcessorFromUserTaskLifecycleState(lifecycleState);
     commandProcessor.onFinalizeCommand(command, userTaskRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -109,10 +109,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
                 switch (attribute) {
                   case "assignee" ->
                       intermediateUserTaskRecord.setAssignee(command.getValue().getAssignee());
-                  case "candidateGroups" ->
+                  case "candidateGroupsList" ->
                       intermediateUserTaskRecord.setCandidateGroupsList(
                           command.getValue().getCandidateGroupsList());
-                  case "candidateUsers" ->
+                  case "candidateUsersList" ->
                       intermediateUserTaskRecord.setCandidateUsersList(
                           command.getValue().getCandidateUsersList());
                   case "dueDate" ->
@@ -145,12 +145,10 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
       userTaskRecord.addChangedAttribute("assignee");
     }
     if (!currentUserTask.getCandidateGroupsList().equals(userTaskRecord.getCandidateGroupsList())) {
-      // todo: change to candidateGroupsList
-      userTaskRecord.addChangedAttribute("candidateGroups");
+      userTaskRecord.addChangedAttribute("candidateGroupsList");
     }
     if (!currentUserTask.getCandidateUsersList().equals(userTaskRecord.getCandidateUsersList())) {
-      // todo: change to candidateUsersList
-      userTaskRecord.addChangedAttribute("candidateUsers");
+      userTaskRecord.addChangedAttribute("candidateUsersList");
     }
     if (!currentUserTask.getDueDateBuffer().equals(userTaskRecord.getDueDateBuffer())) {
       userTaskRecord.addChangedAttribute("dueDate");

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCompleteProcessor.java
@@ -81,9 +81,6 @@ public final class UserTaskCompleteProcessor implements UserTaskCommandProcessor
       final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
     final long userTaskKey = command.getKey();
 
-    userTaskRecord.setVariables(command.getValue().getVariablesBuffer());
-    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
-
     if (command.hasRequestMetadata()) {
       stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);
       completeElementInstance(userTaskRecord);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -49,6 +49,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
@@ -78,7 +79,7 @@ public class TaskListenerTest {
 
   @Before
   public void setup() {
-    listenerType = "my_listener";
+    listenerType = "my_listener_" + UUID.randomUUID();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -980,8 +980,8 @@ public class TaskListenerTest {
                 .setCorrectedAttributes(
                     List.of(
                         "assignee",
-                        "candidateUsers",
-                        "candidateGroups",
+                        "candidateUsersList",
+                        "candidateGroupsList",
                         "dueDate",
                         "followUpDate",
                         "priority")))
@@ -994,7 +994,12 @@ public class TaskListenerTest {
                 .getFirst()
                 .getValue())
         .hasChangedAttributes(
-            "assignee", "candidateUsers", "candidateGroups", "dueDate", "followUpDate", "priority")
+            "assignee",
+            "candidateUsersList",
+            "candidateGroupsList",
+            "dueDate",
+            "followUpDate",
+            "priority")
         .hasAssignee("new_assignee")
         .hasCandidateUsersList(List.of("new_candidate_user"))
         .hasCandidateGroupsList(List.of("new_candidate_group"))
@@ -1087,8 +1092,8 @@ public class TaskListenerTest {
                 .setCorrectedAttributes(
                     List.of(
                         "assignee",
-                        "candidateUsers",
-                        "candidateGroups",
+                        "candidateUsersList",
+                        "candidateGroupsList",
                         "dueDate",
                         "followUpDate",
                         "priority")))
@@ -1148,8 +1153,8 @@ public class TaskListenerTest {
                 .setCorrectedAttributes(
                     List.of(
                         "assignee",
-                        "candidateUsers",
-                        "candidateGroups",
+                        "candidateUsersList",
+                        "candidateGroupsList",
                         "dueDate",
                         "followUpDate",
                         "priority")))
@@ -1173,8 +1178,8 @@ public class TaskListenerTest {
                 .describedAs("Expect that user task completed with corrected data")
                 .hasChangedAttributes(
                     "assignee",
-                    "candidateUsers",
-                    "candidateGroups",
+                    "candidateUsersList",
+                    "candidateGroupsList",
                     "dueDate",
                     "followUpDate",
                     "priority")
@@ -1214,8 +1219,8 @@ public class TaskListenerTest {
                 .setCorrectedAttributes(
                     List.of(
                         "assignee",
-                        "candidateUsers",
-                        "candidateGroups",
+                        "candidateUsersList",
+                        "candidateGroupsList",
                         "dueDate",
                         "followUpDate",
                         "priority")))
@@ -1306,7 +1311,7 @@ public class TaskListenerTest {
             Expected to complete task listener job with a corrections result, \
             but property 'unknown_property' cannot be corrected. \
             Only the following properties can be corrected: \
-            [assignee, candidateGroups, candidateUsers, dueDate, followUpDate, priority].""");
+            [assignee, candidateGroupsList, candidateUsersList, dueDate, followUpDate, priority].""");
   }
 
   private static void completeRecreatedJobWithType(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -972,8 +972,8 @@ public class TaskListenerTest {
                 .setCorrections(
                     new JobResultCorrections()
                         .setAssignee("new_assignee")
-                        .setCandidateUsers(List.of("new_candidate_user"))
-                        .setCandidateGroups(List.of("new_candidate_group"))
+                        .setCandidateUsersList(List.of("new_candidate_user"))
+                        .setCandidateGroupsList(List.of("new_candidate_group"))
                         .setDueDate("new_due_date")
                         .setFollowUpDate("new_follow_up_date")
                         .setPriority(100))
@@ -1084,8 +1084,8 @@ public class TaskListenerTest {
                 .setCorrections(
                     new JobResultCorrections()
                         .setAssignee("new_assignee")
-                        .setCandidateUsers(List.of("new_candidate_user"))
-                        .setCandidateGroups(List.of("new_candidate_group"))
+                        .setCandidateUsersList(List.of("new_candidate_user"))
+                        .setCandidateGroupsList(List.of("new_candidate_group"))
                         .setDueDate("new_due_date")
                         .setFollowUpDate("new_follow_up_date")
                         .setPriority(100))
@@ -1145,8 +1145,8 @@ public class TaskListenerTest {
                 .setCorrections(
                     new JobResultCorrections()
                         .setAssignee("new_assignee")
-                        .setCandidateUsers(List.of("new_candidate_user"))
-                        .setCandidateGroups(List.of("new_candidate_group"))
+                        .setCandidateUsersList(List.of("new_candidate_user"))
+                        .setCandidateGroupsList(List.of("new_candidate_group"))
                         .setDueDate("new_due_date")
                         .setFollowUpDate("new_follow_up_date")
                         .setPriority(100))
@@ -1211,8 +1211,8 @@ public class TaskListenerTest {
                 .setCorrections(
                     new JobResultCorrections()
                         .setAssignee("new_assignee")
-                        .setCandidateUsers(List.of("new_candidate_user"))
-                        .setCandidateGroups(List.of("new_candidate_group"))
+                        .setCandidateUsersList(List.of("new_candidate_user"))
+                        .setCandidateGroupsList(List.of("new_candidate_group"))
                         .setDueDate("new_due_date")
                         .setFollowUpDate("new_follow_up_date")
                         .setPriority(100))

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -120,10 +120,10 @@
                         "followUpDate": {
                           "type": "keyword"
                         },
-                        "candidateGroups": {
+                        "candidateGroupsList": {
                           "type": "text"
                         },
-                        "candidateUsers": {
+                        "candidateUsersList": {
                           "type": "text"
                         },
                         "priority": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -101,10 +101,10 @@
                     "followUpDate": {
                       "type": "keyword"
                     },
-                    "candidateGroups": {
+                    "candidateGroupsList": {
                       "type": "text"
                     },
-                    "candidateUsers": {
+                    "candidateUsersList": {
                       "type": "text"
                     },
                     "priority": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -120,10 +120,10 @@
                         "followUpDate": {
                           "type": "keyword"
                         },
-                        "candidateGroups": {
+                        "candidateGroupsList": {
                           "type": "text"
                         },
-                        "candidateUsers": {
+                        "candidateUsersList": {
                           "type": "text"
                         },
                         "priority": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -101,10 +101,10 @@
                     "followUpDate": {
                       "type": "keyword"
                     },
-                    "candidateGroups": {
+                    "candidateGroupsList": {
                       "type": "text"
                     },
-                    "candidateUsers": {
+                    "candidateUsersList": {
                       "type": "text"
                     },
                     "priority": {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
@@ -32,10 +32,10 @@ public final class JobResultCorrections extends UnpackedObject
   private final StringProperty assigneeProp = new StringProperty("assignee", "");
   private final StringProperty dueDateProp = new StringProperty("dueDate", "");
   private final StringProperty followUpDateProp = new StringProperty("followUpDate", "");
-  private final ArrayProperty<StringValue> candidateUsersProp =
-      new ArrayProperty<>("candidateUsers", StringValue::new);
-  private final ArrayProperty<StringValue> candidateGroupsProp =
-      new ArrayProperty<>("candidateGroups", StringValue::new);
+  private final ArrayProperty<StringValue> candidateUsersListProp =
+      new ArrayProperty<>("candidateUsersList", StringValue::new);
+  private final ArrayProperty<StringValue> candidateGroupsListProp =
+      new ArrayProperty<>("candidateGroupsList", StringValue::new);
   private final IntegerProperty priorityProp = new IntegerProperty("priority", -1);
 
   public JobResultCorrections() {
@@ -43,8 +43,8 @@ public final class JobResultCorrections extends UnpackedObject
     declareProperty(assigneeProp)
         .declareProperty(dueDateProp)
         .declareProperty(followUpDateProp)
-        .declareProperty(candidateUsersProp)
-        .declareProperty(candidateGroupsProp)
+        .declareProperty(candidateUsersListProp)
+        .declareProperty(candidateGroupsListProp)
         .declareProperty(priorityProp);
   }
 
@@ -97,31 +97,32 @@ public final class JobResultCorrections extends UnpackedObject
 
   @Override
   public List<String> getCandidateGroups() {
-    return StreamSupport.stream(candidateGroupsProp.spliterator(), false)
+    return StreamSupport.stream(candidateGroupsListProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .toList();
   }
 
   public JobResultCorrections setCandidateGroups(final List<String> candidateGroups) {
-    candidateGroupsProp.reset();
+    candidateGroupsListProp.reset();
     candidateGroups.forEach(
-        candidateGroup -> candidateGroupsProp.add().wrap(BufferUtil.wrapString(candidateGroup)));
+        candidateGroup ->
+            candidateGroupsListProp.add().wrap(BufferUtil.wrapString(candidateGroup)));
     return this;
   }
 
   @Override
   public List<String> getCandidateUsers() {
-    return StreamSupport.stream(candidateUsersProp.spliterator(), false)
+    return StreamSupport.stream(candidateUsersListProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .toList();
   }
 
   public JobResultCorrections setCandidateUsers(final List<String> candidateUsers) {
-    candidateUsersProp.reset();
+    candidateUsersListProp.reset();
     candidateUsers.forEach(
-        candidateUser -> candidateUsersProp.add().wrap(BufferUtil.wrapString(candidateUser)));
+        candidateUser -> candidateUsersListProp.add().wrap(BufferUtil.wrapString(candidateUser)));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobResultCorrections.java
@@ -52,8 +52,8 @@ public final class JobResultCorrections extends UnpackedObject
     setAssignee(other.getAssignee());
     setDueDate(other.getDueDate());
     setFollowUpDate(other.getFollowUpDate());
-    setCandidateUsers(other.getCandidateUsers());
-    setCandidateGroups(other.getCandidateGroups());
+    setCandidateUsersList(other.getCandidateUsersList());
+    setCandidateGroupsList(other.getCandidateGroupsList());
     setPriority(other.getPriority());
   }
 
@@ -96,14 +96,14 @@ public final class JobResultCorrections extends UnpackedObject
   }
 
   @Override
-  public List<String> getCandidateGroups() {
+  public List<String> getCandidateGroupsList() {
     return StreamSupport.stream(candidateGroupsListProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .toList();
   }
 
-  public JobResultCorrections setCandidateGroups(final List<String> candidateGroups) {
+  public JobResultCorrections setCandidateGroupsList(final List<String> candidateGroups) {
     candidateGroupsListProp.reset();
     candidateGroups.forEach(
         candidateGroup ->
@@ -112,14 +112,14 @@ public final class JobResultCorrections extends UnpackedObject
   }
 
   @Override
-  public List<String> getCandidateUsers() {
+  public List<String> getCandidateUsersList() {
     return StreamSupport.stream(candidateUsersListProp.spliterator(), false)
         .map(StringValue::getValue)
         .map(BufferUtil::bufferAsString)
         .toList();
   }
 
-  public JobResultCorrections setCandidateUsers(final List<String> candidateUsers) {
+  public JobResultCorrections setCandidateUsersList(final List<String> candidateUsers) {
     candidateUsersListProp.reset();
     candidateUsers.forEach(
         candidateUser -> candidateUsersListProp.add().wrap(BufferUtil.wrapString(candidateUser)));

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -206,6 +206,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
             case DUE_DATE -> setDueDate(corrections.getDueDate());
             case FOLLOW_UP_DATE -> setFollowUpDate(corrections.getFollowUpDate());
             case PRIORITY -> setPriority(corrections.getPriority());
+            default ->
+                throw new IllegalArgumentException("Unknown corrected attribute: " + attribute);
           }
           addChangedAttribute(attribute);
         });

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -201,8 +201,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         attribute -> {
           switch (attribute) {
             case ASSIGNEE -> setAssignee(corrections.getAssignee());
-            case CANDIDATE_GROUPS -> setCandidateGroupsList(corrections.getCandidateGroups());
-            case CANDIDATE_USERS -> setCandidateUsersList(corrections.getCandidateUsers());
+            case CANDIDATE_GROUPS -> setCandidateGroupsList(corrections.getCandidateGroupsList());
+            case CANDIDATE_USERS -> setCandidateUsersList(corrections.getCandidateUsersList());
             case DUE_DATE -> setDueDate(corrections.getDueDate());
             case FOLLOW_UP_DATE -> setFollowUpDate(corrections.getFollowUpDate());
             case PRIORITY -> setPriority(corrections.getPriority());

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -199,14 +199,13 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       final List<String> correctedAttributes, final JobResultCorrections corrections) {
     correctedAttributes.forEach(
         attribute -> {
-          // todo: replace attributes with constants
           switch (attribute) {
-            case "assignee" -> setAssignee(corrections.getAssignee());
-            case "candidateGroupsList" -> setCandidateGroupsList(corrections.getCandidateGroups());
-            case "candidateUsersList" -> setCandidateUsersList(corrections.getCandidateUsers());
-            case "dueDate" -> setDueDate(corrections.getDueDate());
-            case "followUpDate" -> setFollowUpDate(corrections.getFollowUpDate());
-            case "priority" -> setPriority(corrections.getPriority());
+            case ASSIGNEE -> setAssignee(corrections.getAssignee());
+            case CANDIDATE_GROUPS -> setCandidateGroupsList(corrections.getCandidateGroups());
+            case CANDIDATE_USERS -> setCandidateUsersList(corrections.getCandidateUsers());
+            case DUE_DATE -> setDueDate(corrections.getDueDate());
+            case FOLLOW_UP_DATE -> setFollowUpDate(corrections.getFollowUpDate());
+            case PRIORITY -> setPriority(corrections.getPriority());
           }
           addChangedAttribute(attribute);
         });

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -37,6 +37,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public static final DirectBuffer NO_HEADERS = new UnsafeBuffer(MsgPackHelper.EMTPY_OBJECT);
 
+  public static final String ASSIGNEE = "assignee";
   public static final String CANDIDATE_GROUPS = "candidateGroupsList";
   public static final String CANDIDATE_USERS = "candidateUsersList";
   public static final String DUE_DATE = "dueDate";
@@ -44,6 +45,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   public static final String PRIORITY = "priority";
 
   private static final String EMPTY_STRING = "";
+  private static final StringValue ASSIGNEE_VALUE = new StringValue(ASSIGNEE);
   private static final StringValue CANDIDATE_GROUPS_VALUE = new StringValue(CANDIDATE_GROUPS);
   private static final StringValue CANDIDATE_USERS_VALUE = new StringValue(CANDIDATE_USERS);
   private static final StringValue DUE_DATE_VALUE = new StringValue(DUE_DATE);
@@ -51,7 +53,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private static final StringValue PRIORITY_VALUE = new StringValue(PRIORITY);
 
   private final LongProperty userTaskKeyProp = new LongProperty("userTaskKey", -1);
-  private final StringProperty assigneeProp = new StringProperty("assignee", EMPTY_STRING);
+  private final StringProperty assigneeProp = new StringProperty(ASSIGNEE, EMPTY_STRING);
   private final ArrayProperty<StringValue> candidateGroupsListProp =
       new ArrayProperty<>(CANDIDATE_GROUPS, StringValue::new);
   private final ArrayProperty<StringValue> candidateUsersListProp =
@@ -162,6 +164,9 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   private void updateAttribute(final StringValue attribute, final UserTaskRecord record) {
     switch (bufferAsString(attribute.getValue())) {
+      case ASSIGNEE:
+        setAssignee(record.getAssigneeBuffer());
+        break;
       case CANDIDATE_GROUPS:
         setCandidateGroupsList(record.getCandidateGroupsList());
         break;
@@ -194,6 +199,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       final List<String> correctedAttributes, final JobResultCorrections corrections) {
     correctedAttributes.forEach(
         attribute -> {
+          // todo: replace attributes with constants
           switch (attribute) {
             case "assignee" -> setAssignee(corrections.getAssignee());
             case "candidateGroups" -> setCandidateGroupsList(corrections.getCandidateGroups());
@@ -432,6 +438,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+    return this;
+  }
+
+  public UserTaskRecord setAssigneeChanged() {
+    changedAttributesProp.add().wrap(ASSIGNEE_VALUE);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -512,6 +512,28 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
+  public void setDiffAsChangedAttributes(final UserTaskRecord other) {
+    changedAttributesProp.reset();
+    if (!getAssigneeBuffer().equals(other.getAssigneeBuffer())) {
+      addChangedAttribute(ASSIGNEE);
+    }
+    if (!getCandidateGroupsList().equals(other.getCandidateGroupsList())) {
+      addChangedAttribute(CANDIDATE_GROUPS);
+    }
+    if (!getCandidateUsersList().equals(other.getCandidateUsersList())) {
+      addChangedAttribute(CANDIDATE_USERS);
+    }
+    if (!getDueDateBuffer().equals(other.getDueDateBuffer())) {
+      addChangedAttribute(DUE_DATE);
+    }
+    if (!getFollowUpDateBuffer().equals(other.getFollowUpDateBuffer())) {
+      addChangedAttribute(FOLLOW_UP_DATE);
+    }
+    if (getPriority() != other.getPriority()) {
+      addChangedAttribute(PRIORITY);
+    }
+  }
+
   @JsonIgnore
   public DirectBuffer getAssigneeBuffer() {
     return assigneeProp.getValue();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -202,8 +202,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
           // todo: replace attributes with constants
           switch (attribute) {
             case "assignee" -> setAssignee(corrections.getAssignee());
-            case "candidateGroups" -> setCandidateGroupsList(corrections.getCandidateGroups());
-            case "candidateUsers" -> setCandidateUsersList(corrections.getCandidateUsers());
+            case "candidateGroupsList" -> setCandidateGroupsList(corrections.getCandidateGroups());
+            case "candidateUsersList" -> setCandidateUsersList(corrections.getCandidateUsers());
             case "dueDate" -> setDueDate(corrections.getDueDate());
             case "followUpDate" -> setFollowUpDate(corrections.getFollowUpDate());
             case "priority" -> setPriority(corrections.getPriority());

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -28,6 +28,8 @@ import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.agrona.DirectBuffer;
@@ -516,23 +518,22 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public void setDiffAsChangedAttributes(final UserTaskRecord other) {
     changedAttributesProp.reset();
-    if (!getAssigneeBuffer().equals(other.getAssigneeBuffer())) {
-      addChangedAttribute(ASSIGNEE);
-    }
-    if (!getCandidateGroupsList().equals(other.getCandidateGroupsList())) {
-      addChangedAttribute(CANDIDATE_GROUPS);
-    }
-    if (!getCandidateUsersList().equals(other.getCandidateUsersList())) {
-      addChangedAttribute(CANDIDATE_USERS);
-    }
-    if (!getDueDateBuffer().equals(other.getDueDateBuffer())) {
-      addChangedAttribute(DUE_DATE);
-    }
-    if (!getFollowUpDateBuffer().equals(other.getFollowUpDateBuffer())) {
-      addChangedAttribute(FOLLOW_UP_DATE);
-    }
-    if (getPriority() != other.getPriority()) {
-      addChangedAttribute(PRIORITY);
+    addIfAttributeChanged(ASSIGNEE, UserTaskRecord::getAssigneeBuffer, other);
+    addIfAttributeChanged(CANDIDATE_GROUPS, UserTaskRecord::getCandidateGroupsList, other);
+    addIfAttributeChanged(CANDIDATE_USERS, UserTaskRecord::getCandidateUsersList, other);
+    addIfAttributeChanged(DUE_DATE, UserTaskRecord::getDueDateBuffer, other);
+    addIfAttributeChanged(FOLLOW_UP_DATE, UserTaskRecord::getFollowUpDateBuffer, other);
+    addIfAttributeChanged(PRIORITY, UserTaskRecord::getPriority, other);
+  }
+
+  private <T> void addIfAttributeChanged(
+      final String attribute,
+      final Function<UserTaskRecord, T> attributeGetter,
+      final UserTaskRecord other) {
+    final T thisAttribute = attributeGetter.apply(this);
+    final T otherAttribute = attributeGetter.apply(other);
+    if (!Objects.equals(thisAttribute, otherAttribute)) {
+      addChangedAttribute(attribute);
     }
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -107,6 +107,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(priorityProp);
   }
 
+  /** Like {@link #wrap(UserTaskRecord)} but does not set the variables. */
   public void wrapWithoutVariables(final UserTaskRecord record) {
     userTaskKeyProp.setValue(record.getUserTaskKey());
     assigneeProp.setValue(record.getAssigneeBuffer());
@@ -131,9 +132,22 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     priorityProp.setValue(record.getPriority());
   }
 
+  /**
+   * Wraps the given record's properties, typically used to quickly set the same properties.
+   *
+   * @implNote This method uses variable assignment. So changing a non-primitive in one record also
+   *     affects the other. If you need to separate the records, use {@link #copy()} instead.
+   */
   public void wrap(final UserTaskRecord record) {
     wrapWithoutVariables(record);
     variableProp.setValue(record.getVariablesBuffer());
+  }
+
+  /** Returns a full copy of the record. */
+  public UserTaskRecord copy() {
+    final UserTaskRecord copy = new UserTaskRecord();
+    copy.copyFrom(this);
+    return copy;
   }
 
   public void wrapChangedAttributes(

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -700,16 +700,16 @@ final class JsonSerializableToJsonTest {
                               .setAssignee("frodo")
                               .setDueDate("today")
                               .setFollowUpDate("tomorrow")
-                              .setCandidateGroups(List.of("fellowship", "eagles"))
-                              .setCandidateUsers(List.of("frodo", "sam", "gollum"))
+                              .setCandidateGroupsList(List.of("fellowship", "eagles"))
+                              .setCandidateUsersList(List.of("frodo", "sam", "gollum"))
                               .setPriority(1))
                       .setCorrectedAttributes(
                           List.of(
                               "assignee",
                               "dueDate",
                               "followUpDate",
-                              "candidateGroups",
-                              "candidateUsers",
+                              "candidateGroupsList",
+                              "candidateUsersList",
                               "priority"));
 
               jobRecord
@@ -773,16 +773,16 @@ final class JsonSerializableToJsonTest {
                   "assignee",
                   "dueDate",
                   "followUpDate",
-                  "candidateGroups",
-                  "candidateUsers",
+                  "candidateGroupsList",
+                  "candidateUsersList",
                   "priority"
                 ],
                 "corrections": {
                   "assignee": "frodo",
                   "dueDate": "today",
                   "followUpDate": "tomorrow",
-                  "candidateGroups": ["fellowship", "eagles"],
-                  "candidateUsers": ["frodo", "sam", "gollum"],
+                  "candidateGroupsList": ["fellowship", "eagles"],
+                  "candidateUsersList": ["frodo", "sam", "gollum"],
                   "priority": 1
                 }
               }
@@ -844,16 +844,16 @@ final class JsonSerializableToJsonTest {
                               .setAssignee("frodo")
                               .setDueDate("today")
                               .setFollowUpDate("tomorrow")
-                              .setCandidateGroups(List.of("fellowship", "eagles"))
-                              .setCandidateUsers(List.of("frodo", "sam", "gollum"))
+                              .setCandidateGroupsList(List.of("fellowship", "eagles"))
+                              .setCandidateUsersList(List.of("frodo", "sam", "gollum"))
                               .setPriority(1))
                       .setCorrectedAttributes(
                           List.of(
                               "assignee",
                               "dueDate",
                               "followUpDate",
-                              "candidateGroups",
-                              "candidateUsers",
+                              "candidateGroupsList",
+                              "candidateUsersList",
                               "priority"));
 
               final Map<String, String> customHeaders =
@@ -916,16 +916,16 @@ final class JsonSerializableToJsonTest {
               "assignee",
               "dueDate",
               "followUpDate",
-              "candidateGroups",
-              "candidateUsers",
+              "candidateGroupsList",
+              "candidateUsersList",
               "priority"
             ],
             "corrections": {
               "assignee": "frodo",
               "dueDate": "today",
               "followUpDate": "tomorrow",
-              "candidateGroups": ["fellowship", "eagles"],
-              "candidateUsers": ["frodo", "sam", "gollum"],
+              "candidateGroupsList": ["fellowship", "eagles"],
+              "candidateUsersList": ["frodo", "sam", "gollum"],
               "priority": 1
             }
           }
@@ -969,8 +969,8 @@ final class JsonSerializableToJsonTest {
               "assignee": "",
               "dueDate": "",
               "followUpDate": "",
-              "candidateGroups": [],
-              "candidateUsers": [],
+              "candidateGroupsList": [],
+              "candidateUsersList": [],
               "priority": -1
             }
           }
@@ -1019,8 +1019,8 @@ final class JsonSerializableToJsonTest {
               "assignee": "",
               "dueDate": "",
               "followUpDate": "",
-              "candidateGroups": [],
-              "candidateUsers": [],
+              "candidateGroupsList": [],
+              "candidateUsersList": [],
               "priority": -1
             }
           }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -187,12 +187,12 @@ public interface JobRecordValue
     /**
      * @return the corrected candidate users
      */
-    List<String> getCandidateGroups();
+    List<String> getCandidateGroupsList();
 
     /**
      * @return the corrected candidate groups
      */
-    List<String> getCandidateUsers();
+    List<String> getCandidateUsersList();
 
     /**
      * @return the corrected priority

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -803,6 +803,7 @@ public class CompactRecordLogger {
           summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
     }
 
+    addIfNotEmpty(result, value.getChangedAttributes(), " changedAttributes");
     addIfNotEmpty(result, value.getAssignee(), " assignee");
     addIfNotEmpty(result, value.getCandidateUsersList(), " candidateUsersList");
     addIfNotEmpty(result, value.getCandidateGroupsList(), " candidateGroupsList");


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

> [!NOTE]
> This pull request is rather comprehensive, but splitting was difficult. Let me know if you see any options to make reviewing this easier. I've tried to split it in small commits with explanation.

This adds the ability to the `complete` task listener to correct the user task data:
- `assignee`
- `candidateGroupsList`
- `candidateUsersList`
- `dueDate`
- `followUpDate`
- `priority`

Corrected user task data is available to subsequent task listeners, and eventually persisted on the terminal event (`COMPLETED`). All corrections are discarded when the action is denied.

> [!NOTE]
> Early on I thought that the attributes to correct were called `candidateGroups` and `candidateUsers`, but later I discovered that this should be `candidateGroupsList` and `candidateUsersList`. So, you will encounter the wrong name a lot in earlier commits.

## Related issues

closes #24889
