### PR TITLE
fix: ignore inherited permissions when adding or removing

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -79,7 +79,7 @@ public class PermissionsBehavior {
     for (final PermissionValue permission : record.getPermissions()) {
       final var addedResourceIds = permission.getResourceIds();
       final var currentResourceIds =
-          authCheckBehavior.getAuthorizedResourceIdentifiers(
+          authCheckBehavior.getAllAuthorizedResourceIdentifiers(
               record.getOwnerKey(),
               record.getOwnerType(),
               record.getResourceType(),
@@ -108,7 +108,7 @@ public class PermissionsBehavior {
       final AuthorizationRecord record) {
     for (final PermissionValue permission : record.getPermissions()) {
       final var currentResourceIdentifiers =
-          authCheckBehavior.getAuthorizedResourceIdentifiers(
+          authCheckBehavior.getAllAuthorizedResourceIdentifiers(
               record.getOwnerKey(),
               record.getOwnerType(),
               record.getResourceType(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -105,11 +105,8 @@ public class PermissionsBehavior {
       final AuthorizationRecord record) {
     for (final PermissionValue permission : record.getPermissions()) {
       final var currentResourceIdentifiers =
-          authCheckBehavior.getAllAuthorizedResourceIdentifiers(
-              record.getOwnerKey(),
-              record.getOwnerType(),
-              record.getResourceType(),
-              permission.getPermissionType());
+          authCheckBehavior.getDirectAuthorizedResourceIdentifiers(
+              record.getOwnerKey(), record.getResourceType(), permission.getPermissionType());
 
       final var removedResourceIds = permission.getResourceIds();
       if (!currentResourceIdentifiers.containsAll(removedResourceIds)) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/PermissionsBehavior.java
@@ -79,11 +79,8 @@ public class PermissionsBehavior {
     for (final PermissionValue permission : record.getPermissions()) {
       final var addedResourceIds = permission.getResourceIds();
       final var currentResourceIds =
-          authCheckBehavior.getAllAuthorizedResourceIdentifiers(
-              record.getOwnerKey(),
-              record.getOwnerType(),
-              record.getResourceType(),
-              permission.getPermissionType());
+          authCheckBehavior.getDirectAuthorizedResourceIdentifiers(
+              record.getOwnerKey(), record.getResourceType(), permission.getPermissionType());
 
       final var duplicates = new HashSet<>(currentResourceIds);
       duplicates.retainAll(addedResourceIds);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchCollector.java
@@ -94,7 +94,7 @@ final class JobBatchCollector {
             : value.getTenantIds();
     final Map<JobKind, Integer> jobCountPerJobKind = new EnumMap<>(JobKind.class);
     final var authorizedProcessIds =
-        authCheckBehavior.getAuthorizedResourceIdentifiers(
+        authCheckBehavior.getAllAuthorizedResourceIdentifiers(
             new AuthorizationRequest(
                 record,
                 AuthorizationResourceType.PROCESS_DEFINITION,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AddPermissionAuthorizationTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
@@ -94,7 +95,7 @@ public class AddPermissionAuthorizationTest {
   }
 
   @Test
-  public void shouldRejectIfPermissionAlreadyExists() {
+  public void shouldRejectIfPermissionAlreadyExistsDirectly() {
     // given
     final var ownerKey =
         engine
@@ -139,5 +140,98 @@ public class AddPermissionAuthorizationTest {
                     ownerKey,
                     "[bar]",
                     "[bar, baz]"));
+  }
+
+  @Test
+  public void shouldNotRejectIfPermissionAlreadyExistsOnRole() {
+    // given -- user is assigned a role that has the permission
+    final var ownerKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var roleKey = engine.role().newRole("role").create().getKey();
+    engine.role().addEntity(roleKey).withEntityKey(ownerKey).withEntityType(EntityType.USER).add();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(roleKey)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermission(PermissionType.CREATE, "foo")
+        .withPermission(PermissionType.DELETE, "bar", "baz")
+        .add()
+        .getValue();
+
+    // when -- assigning the permission directly to the user
+    final var response =
+        engine
+            .authorization()
+            .permission()
+            .withOwnerKey(ownerKey)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermission(PermissionType.DELETE, "foo", "bar")
+            .add();
+
+    // then
+    assertThat(response.getValue())
+        .extracting(
+            AuthorizationRecordValue::getOwnerKey,
+            AuthorizationRecordValue::getOwnerType,
+            AuthorizationRecordValue::getResourceType)
+        .containsExactly(
+            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
+  }
+
+  @Test
+  public void shouldNotRejectIfPermissionAlreadyExistsOnGroup() {
+    // given -- user is assigned a group that has the permission
+    final var ownerKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var groupKey = engine.group().newGroup("group").create().getKey();
+    engine
+        .group()
+        .addEntity(groupKey)
+        .withEntityKey(ownerKey)
+        .withEntityType(EntityType.USER)
+        .add();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(groupKey)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermission(PermissionType.CREATE, "foo")
+        .withPermission(PermissionType.DELETE, "bar", "baz")
+        .add()
+        .getValue();
+
+    // when -- assigning the permission directly to the user
+    final var response =
+        engine
+            .authorization()
+            .permission()
+            .withOwnerKey(ownerKey)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermission(PermissionType.DELETE, "foo", "bar")
+            .add();
+
+    // then
+    assertThat(response.getValue())
+        .extracting(
+            AuthorizationRecordValue::getOwnerKey,
+            AuthorizationRecordValue::getOwnerType,
+            AuthorizationRecordValue::getResourceType)
+        .containsExactly(
+            ownerKey, AuthorizationOwnerType.USER, AuthorizationResourceType.DEPLOYMENT);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -99,7 +99,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
     final var resourceIdentifiers =
-        authorizationCheckBehavior.getAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -116,7 +116,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
     final var resourceIdentifiers =
-        authorizationCheckBehavior.getAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
 
     // then
     assertThat(resourceIdentifiers).isEmpty();
@@ -157,7 +157,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
     final var resourceIdentifiers =
-        authorizationCheckBehavior.getAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);
@@ -198,7 +198,7 @@ public class AuthorizationCheckBehaviorTest {
     // when
     final var request = new AuthorizationRequest(command, resourceType, permissionType);
     final var resourceIdentifiers =
-        authorizationCheckBehavior.getAuthorizedResourceIdentifiers(request);
+        authorizationCheckBehavior.getAllAuthorizedResourceIdentifiers(request);
 
     // then
     assertThat(resourceIdentifiers).containsExactlyInAnyOrder(resourceId1, resourceId2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/RemovePermissionAuthorizationTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Set;
@@ -148,5 +149,107 @@ public class RemovePermissionAuthorizationTest {
                     ownerKey,
                     "[foo]",
                     "[bar]"));
+  }
+
+  @Test
+  public void shouldRejectIfPermissionIsOnlyInheritedFromRole() {
+    // given
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var roleKey = engine.role().newRole("role").create().getKey();
+
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(roleKey)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermission(PermissionType.CREATE, "foo")
+        .withPermission(PermissionType.DELETE, "bar")
+        .add()
+        .getValue();
+    engine.role().addEntity(roleKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .permission()
+            .withOwnerKey(userKey)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermission(PermissionType.DELETE, "foo", "bar")
+            .expectRejection()
+            .remove();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("Permission is not found")
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to remove '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' is not found. Existing resource ids are: '%s'"
+                .formatted(
+                    PermissionType.DELETE,
+                    AuthorizationResourceType.DEPLOYMENT,
+                    "[bar, foo]",
+                    userKey,
+                    "[bar, foo]",
+                    "[]"));
+  }
+
+  @Test
+  public void shouldRejectIfPermissionIsOnlyInheritedFromGroup() {
+    // given
+    final var userKey =
+        engine
+            .user()
+            .newUser("foo")
+            .withEmail("foo@bar")
+            .withName("Foo Bar")
+            .withPassword("zabraboof")
+            .create()
+            .getKey();
+    final var groupKey = engine.group().newGroup("role").create().getKey();
+
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(groupKey)
+        .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+        .withPermission(PermissionType.CREATE, "foo")
+        .withPermission(PermissionType.DELETE, "bar")
+        .add()
+        .getValue();
+    engine.group().addEntity(groupKey).withEntityKey(userKey).withEntityType(EntityType.USER).add();
+
+    // when
+    final var rejection =
+        engine
+            .authorization()
+            .permission()
+            .withOwnerKey(userKey)
+            .withResourceType(AuthorizationResourceType.DEPLOYMENT)
+            .withPermission(PermissionType.DELETE, "foo", "bar")
+            .expectRejection()
+            .remove();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("Permission is not found")
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to remove '%s' permission for resource '%s' and resource identifiers '%s' for owner '%s', but this permission for resource identifiers '%s' is not found. Existing resource ids are: '%s'"
+                .formatted(
+                    PermissionType.DELETE,
+                    AuthorizationResourceType.DEPLOYMENT,
+                    "[bar, foo]",
+                    userKey,
+                    "[bar, foo]",
+                    "[]"));
   }
 }


### PR DESCRIPTION
We only want to reject a request to add a permission if the permission already exists directly on the entity, not if it is already inherited through an assigned role or group.

Similarly, we need to reject deletion of a permission if the the permission does not exist directly.

This exposes a new method in `AuthorizationCheckBehavior` to only get _direct_ authorizations without included inherited ones. This method is then used to check for duplicated permissions.

Depends on #25634 to avoid merge conflicts
Fixes #25652