### PR TITLE
[Backport stable/8.3] fix: do not close active channels on first response timeout

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -33,6 +33,8 @@ public class MessagingConfig implements Config {
   private File certificateChain;
   private File privateKey;
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
+  private Duration heartbeatTimeout = Duration.ofSeconds(15);
+  private Duration heartbeatInterval = Duration.ofSeconds(5);
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -222,6 +224,24 @@ public class MessagingConfig implements Config {
     }
 
     this.privateKey = privateKey;
+    return this;
+  }
+
+  public Duration getHeartbeatTimeout() {
+    return heartbeatTimeout;
+  }
+
+  public MessagingConfig setHeartbeatTimeout(final Duration heartbeatTimeout) {
+    this.heartbeatTimeout = heartbeatTimeout;
+    return this;
+  }
+
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  public MessagingConfig setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
     return this;
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -562,18 +562,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .whenComplete(
             (channel, channelError) -> {
               if (channelError == null) {
-                responseFuture.whenComplete(
-                    (response, error) -> {
-                      if (error instanceof TimeoutException) {
-                        // response future has been completed exceptionally by our
-                        // timeout check, we will not receive any response on this channel
-                        // if we talk with the wrong IP or node
-                        // See https://github.com/zeebe-io/zeebe-chaos/issues/294
-                        // In order to no longer reuse a maybe broken/outdated channel we close it
-                        // On next request a new channel will be created
-                        channel.close();
-                      }
-                    });
                 final ClientConnection connection = getOrCreateClientConnection(channel);
                 callback
                     .apply(connection)

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -877,9 +877,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
           .addLast(
               "idle",
               new IdleStateHandler(
-                  (int) config.getHeartbeatTimeout().getSeconds(),
-                  (int) config.getHeartbeatInterval().getSeconds(),
-                  0));
+                  config.getHeartbeatTimeout().toMillis(),
+                  config.getHeartbeatInterval().toMillis(),
+                  0,
+                  TimeUnit.MILLISECONDS));
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
 
       switch (config.getCompressionAlgorithm()) {
@@ -919,10 +920,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
       channel
           .pipeline()
           .addLast(
+              "idle",
               new IdleStateHandler(
-                  (int) config.getHeartbeatTimeout().getSeconds(),
-                  (int) config.getHeartbeatInterval().getSeconds(),
-                  0));
+                  config.getHeartbeatTimeout().toMillis(),
+                  config.getHeartbeatInterval().toMillis(),
+                  0,
+                  TimeUnit.MILLISECONDS));
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
 
       switch (config.getCompressionAlgorithm()) {

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
-import org.agrona.collections.MutableReference;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -62,8 +61,8 @@ public class NettyMessagingServiceTest {
 
   private static final Logger LOGGER = getLogger(NettyMessagingServiceTest.class);
   private static final String IP_STRING = "127.0.0.1";
-  ManagedMessagingService netty1;
-  ManagedMessagingService netty2;
+  NettyMessagingService netty1;
+  NettyMessagingService netty2;
   ManagedMessagingService nettyv11;
   ManagedMessagingService nettyv12;
   ManagedMessagingService nettyv21;
@@ -83,13 +82,11 @@ public class NettyMessagingServiceTest {
     final var config = new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
 
     netty1 =
-        (ManagedMessagingService)
-            new NettyMessagingService("test", address1, config).start().join();
+        (NettyMessagingService) new NettyMessagingService("test", address1, config).start().join();
 
     address2 = Address.from(SocketUtil.getNextAddress().getPort());
     netty2 =
-        (ManagedMessagingService)
-            new NettyMessagingService("test", address2, config).start().join();
+        (NettyMessagingService) new NettyMessagingService("test", address2, config).start().join();
 
     addressv11 = Address.from(SocketUtil.getNextAddress().getPort());
     nettyv11 =
@@ -587,108 +584,77 @@ public class NettyMessagingServiceTest {
   public void shouldCloseChannelAfterTimeout() {
     // given
     final var subject = nextSubject();
-    final MutableReference<ChannelPool> poolRef = new MutableReference<>();
     final var timeoutOnCreate = Duration.ofSeconds(10);
-    final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef);
-    final var channelPool = poolRef.get();
 
-    try {
-      nettyWithOwnPool.start().join();
+    final var channelPool = netty2.getChannelPool();
 
-      // grab the original channel, so we can assert it was closed
-      // it's also useful to send a successful request once, so we can ensure the channel exists and
-      // set a lower timeout on the request we want specifically to time out
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool
-          .sendAndReceive(address2, subject, "get channel".getBytes(), true, timeoutOnCreate)
-          .join();
-      final var originalChannel = channelPool.getChannel(address2, subject).join();
+    // grab the original channel, so we can assert it was closed
+    // it's also useful to send a successful request once, so we can ensure the channel exists
+    // and set a lower timeout on the request we want specifically to time out
+    netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+    netty1
+        .sendAndReceive(netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+        .join();
+    final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
 
-      // when - set up handler which will always cause timeouts
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-      final CompletableFuture<byte[]> response =
-          nettyWithOwnPool.sendAndReceive(
-              address2, subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+    // when - set up handler which will always cause timeouts
+    netty2.unregisterHandler(subject);
+    netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+    final CompletableFuture<byte[]> response =
+        netty1.sendAndReceive(
+            netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
 
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(15))
-          .withThrowableThat()
-          .havingRootCause()
-          .isInstanceOf(TimeoutException.class)
-          .withMessageContaining("timed out in");
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
-    } finally {
-      nettyWithOwnPool.stop().join();
-    }
+    // then
+    assertThat(response)
+        .failsWithin(Duration.ofSeconds(15))
+        .withThrowableThat()
+        .havingRootCause()
+        .isInstanceOf(TimeoutException.class)
+        .withMessageContaining("timed out in");
+    assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
   }
 
   @Test
   public void shouldCreateNewChannelOnNewRequestAfterTimeout() {
     // given
     final var subject = nextSubject();
-    final MutableReference<ChannelPool> poolRef = new MutableReference<>();
     final var timeoutOnCreate = Duration.ofSeconds(10);
-    final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef);
-    final var channelPool = poolRef.get();
 
-    try {
-      nettyWithOwnPool.start().join();
+    final var channelPool = netty1.getChannelPool();
 
-      // grab the original channel, so we can assert it was closed
-      // it's also useful to send a successful request once, so we can ensure the channel exists and
-      // set a lower timeout on the request we want specifically to time out
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool
-          .sendAndReceive(address2, subject, "get channel".getBytes(), true, timeoutOnCreate)
-          .join();
-      final var originalChannel = channelPool.getChannel(address2, subject).join();
+    // grab the original channel, so we can assert it was closed
+    // it's also useful to send a successful request once, so we can ensure the channel exists
+    // and set a lower timeout on the request we want specifically to time out
+    netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+    netty1
+        .sendAndReceive(netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+        .join();
+    final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
 
-      // set up handler which will always cause timeouts
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-      final CompletableFuture<byte[]> response =
-          nettyWithOwnPool.sendAndReceive(
-              address2, subject, "fail".getBytes(), true, Duration.ofSeconds(1));
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(15))
-          .withThrowableThat()
-          .havingRootCause()
-          .isInstanceOf(TimeoutException.class);
-      // wait until the channel is closed before grabbing the next one
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
+    // set up handler which will always cause timeouts
+    netty2.unregisterHandler(subject);
+    netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+    final CompletableFuture<byte[]> response =
+        netty1.sendAndReceive(
+            netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+    assertThat(response)
+        .failsWithin(Duration.ofSeconds(15))
+        .withThrowableThat()
+        .havingRootCause()
+        .isInstanceOf(TimeoutException.class);
+    // wait until the channel is closed before grabbing the next one
+    assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
 
-      // when - remote connection finally succeeds
-      // give a generous time out on the second request, as creating a new channel can be slow at
-      // times
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      nettyWithOwnPool.sendAndReceive(
-          address2, subject, "success".getBytes(), true, timeoutOnCreate);
+    // when - remote connection finally succeeds
+    // give a generous time out on the second request, as creating a new channel can be slow at
+    // times
+    netty2.unregisterHandler(subject);
+    netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+    netty1.sendAndReceive(netty2.address(), subject, "success".getBytes(), true, timeoutOnCreate);
 
-      // then
-      final var newChannel = channelPool.getChannel(address2, subject).join();
-      assertThat(newChannel).isNotEqualTo(originalChannel);
-    } finally {
-      nettyWithOwnPool.stop().join();
-    }
-  }
-
-  private ManagedMessagingService createMessagingServiceWithPool(
-      final MutableReference<ChannelPool> poolRef) {
-    final var otherAddress = Address.from(SocketUtil.getNextAddress().getPort());
-    final var config = new MessagingConfig();
-    return new NettyMessagingService(
-        "test",
-        otherAddress,
-        config,
-        ProtocolVersion.V2,
-        factory -> {
-          final var pool = new ChannelPool(factory, 8);
-          poolRef.set(pool);
-          return pool;
-        });
+    // then
+    final var newChannel = channelPool.getChannel(netty2.address(), subject).join();
+    assertThat(newChannel).isNotEqualTo(originalChannel);
   }
 
   @Test

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -79,7 +79,11 @@ public class NettyMessagingServiceTest {
   @Before
   public void setUp() throws Exception {
     address1 = Address.from(SocketUtil.getNextAddress().getPort());
-    final var config = new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
+    final var config =
+        new MessagingConfig()
+            .setShutdownQuietPeriod(Duration.ofMillis(50))
+            .setHeartbeatInterval(Duration.ofMillis(50))
+            .setHeartbeatTimeout(Duration.ofMillis(500));
 
     netty1 =
         (NettyMessagingService) new NettyMessagingService("test", address1, config).start().join();

--- a/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -79,7 +79,9 @@ public final class ClusterConfigFactory {
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
-            .setPort(network.getInternalApi().getPort());
+            .setPort(network.getInternalApi().getPort())
+            .setHeartbeatTimeout(network.getHeartbeatTimeout())
+            .setHeartbeatInterval(network.getHeartbeatInterval());
 
     if (network.getSecurity().isEnabled()) {
       messaging

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
+import java.time.Duration;
 import java.util.Optional;
 import org.springframework.util.unit.DataSize;
 
@@ -23,6 +24,8 @@ public final class NetworkCfg implements ConfigurationEntry {
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
   private String advertisedHost;
+  private Duration heartbeatTimeout = Duration.ofSeconds(15);
+  private Duration heartbeatInterval = Duration.ofSeconds(5);
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -75,6 +78,22 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
+  public Duration getHeartbeatTimeout() {
+    return heartbeatTimeout;
+  }
+
+  public void setHeartbeatTimeout(final Duration heartbeatTimeout) {
+    this.heartbeatTimeout = heartbeatTimeout;
+  }
+
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  public void setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+  }
+
   public CommandApiCfg getCommandApi() {
     return commandApi;
   }
@@ -106,6 +125,10 @@ public final class NetworkCfg implements ConfigurationEntry {
         + '\''
         + ", maxMessageSize="
         + maxMessageSize
+        + ", heartbeatTimeout="
+        + heartbeatTimeout
+        + ", heartbeatInterval="
+        + heartbeatInterval
         + ", commandApi="
         + commandApi
         + ", internalApi="

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -174,6 +174,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Connections that did not receive any message within the specified timeout will be closed.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.
+      # heartbeatTimeout: 15s
+
+      # Sends a heartbeat when no other data is sent over an open connection within the specified timeout.
+      # This is to ensure that the connection is kept open.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATINTERVAL.
+      # heartbeatInterval: 5s
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_ENABLED.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -68,6 +68,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Connections that did not receive any message within the specified timeout will be closed.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.
+      # heartbeatTimeout: 15s
+
+      # Sends a heartbeat when no other data is sent over an open connection within the specified timeout.
+      # This is to ensure that the connection is kept open.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATINTERVAL.
+      # heartbeatInterval: 5s
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_SECURITY_ENABLED.


### PR DESCRIPTION
# Description
Backport of #25615 to `stable/8.3`.

relates to #25596
original author: @lenaschoenburg