### PR TITLE
[Backport stable/8.6] fix: do not close active channels on first response timeout

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -235,6 +235,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Connections that did not receive any message within the specified timeout will be closed.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.
+      # heartbeatTimeout: 15s
+
+      # Sends a heartbeat when no other data is sent over an open connection within the specified timeout.
+      # This is to ensure that the connection is kept open.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATINTERVAL.
+      # heartbeatInterval: 5s
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # If this setting is enabled then the certificate and private key must either be provided separately

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -82,6 +82,15 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE.
       # maxMessageSize: 4MB
 
+      # Connections that did not receive any message within the specified timeout will be closed.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATTIMEOUT.
+      # heartbeatTimeout: 15s
+
+      # Sends a heartbeat when no other data is sent over an open connection within the specified timeout.
+      # This is to ensure that the connection is kept open.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_NETWORK_HEARTBEATINTERVAL.
+      # heartbeatInterval: 5s
+
       # security:
         # Enables TLS authentication between this gateway and other nodes in the cluster
         # If this setting is enabled then the certificate and private key must either be provided separately

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingConfig.java
@@ -35,6 +35,8 @@ public class MessagingConfig implements Config {
   private CompressionAlgorithm compressionAlgorithm = CompressionAlgorithm.NONE;
   private File keyStore;
   private String keyStorePassword;
+  private Duration heartbeatTimeout = Duration.ofSeconds(15);
+  private Duration heartbeatInterval = Duration.ofSeconds(5);
 
   /**
    * Returns the local interfaces to which to bind the node.
@@ -248,6 +250,24 @@ public class MessagingConfig implements Config {
 
   public String getKeyStorePassword() {
     return keyStorePassword;
+  }
+
+  public Duration getHeartbeatTimeout() {
+    return heartbeatTimeout;
+  }
+
+  public MessagingConfig setHeartbeatTimeout(final Duration heartbeatTimeout) {
+    this.heartbeatTimeout = heartbeatTimeout;
+    return this;
+  }
+
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  public MessagingConfig setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+    return this;
   }
 
   public enum CompressionAlgorithm {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -961,9 +961,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
           .addLast(
               "idle",
               new IdleStateHandler(
-                  (int) config.getHeartbeatTimeout().getSeconds(),
-                  (int) config.getHeartbeatInterval().getSeconds(),
-                  0));
+                  config.getHeartbeatTimeout().toMillis(),
+                  config.getHeartbeatInterval().toMillis(),
+                  0,
+                  TimeUnit.MILLISECONDS));
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
 
       switch (config.getCompressionAlgorithm()) {
@@ -1003,10 +1004,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
       channel
           .pipeline()
           .addLast(
+              "idle",
               new IdleStateHandler(
-                  (int) config.getHeartbeatTimeout().getSeconds(),
-                  (int) config.getHeartbeatInterval().getSeconds(),
-                  0));
+                  config.getHeartbeatTimeout().toMillis(),
+                  config.getHeartbeatInterval().toMillis(),
+                  0,
+                  TimeUnit.MILLISECONDS));
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
 
       switch (config.getCompressionAlgorithm()) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -129,15 +129,12 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private final ChannelPool channelPool;
   private final Set<CompletableFuture<?>> openFutures = Sets.newConcurrentHashSet();
   private final MessagingConfig config;
-
   private EventLoopGroup serverGroup;
   private EventLoopGroup clientGroup;
   private Class<? extends ServerChannel> serverChannelClass;
   private Class<? extends SocketChannel> clientChannelClass;
   private Class<? extends DatagramChannel> clientDataGramChannelClass;
-
   private Channel serverChannel;
-
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
   private ScheduledExecutorService timeoutExecutor;
   private volatile LocalClientConnection localConnection;
@@ -166,21 +163,8 @@ public final class NettyMessagingService implements ManagedMessagingService {
   }
 
   @VisibleForTesting
-  // duplicated for tests - to inject channel pool
-  NettyMessagingService(
-      final String cluster,
-      final Address advertisedAddress,
-      final MessagingConfig config,
-      final ProtocolVersion protocolVersion,
-      final Function<Function<Address, CompletableFuture<Channel>>, ChannelPool>
-          channelPoolFactor) {
-    preamble = cluster.hashCode();
-    this.advertisedAddress = advertisedAddress;
-    this.protocolVersion = protocolVersion;
-    this.config = config;
-    channelPool = channelPoolFactor.apply(this::openChannel);
-
-    initAddresses(config);
+  public ChannelPool getChannelPool() {
+    return channelPool;
   }
 
   private void initAddresses(final MessagingConfig config) {
@@ -938,7 +922,10 @@ public final class NettyMessagingService implements ManagedMessagingService {
         return;
       }
       switch (idleStateEvent.state()) {
-        case READER_IDLE -> ctx.close();
+        case READER_IDLE -> {
+          log.warn("Connection {} timed out, closing channel", ctx.channel());
+          ctx.close();
+        }
         case WRITER_IDLE -> ctx.writeAndFlush(createHeartBeat());
         default -> {}
       }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -655,18 +655,6 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .whenComplete(
             (channel, channelError) -> {
               if (channelError == null) {
-                responseFuture.whenComplete(
-                    (response, error) -> {
-                      if (error instanceof TimeoutException) {
-                        // response future has been completed exceptionally by our
-                        // timeout check, we will not receive any response on this channel
-                        // if we talk with the wrong IP or node
-                        // See https://github.com/zeebe-io/zeebe-chaos/issues/294
-                        // In order to no longer reuse a maybe broken/outdated channel we close it
-                        // On next request a new channel will be created
-                        channel.close();
-                      }
-                    });
                 final ClientConnection connection = getOrCreateClientConnection(channel);
                 callback
                     .apply(connection)

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -36,6 +36,7 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -63,10 +64,13 @@ import io.netty.handler.codec.compression.ZlibWrapper;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
 import io.netty.resolver.dns.DnsAddressResolverGroup;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
+import io.netty.util.ReferenceCountUtil;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import io.netty.util.concurrent.Future;
 import java.io.File;
@@ -915,6 +919,52 @@ public final class NettyMessagingService implements ManagedMessagingService {
     }
   }
 
+  private final class HeartBeatHandler extends ChannelDuplexHandler {
+    private static final String HEARTBEAT_SUBJECT = "internal-heartbeat";
+    private static final byte[] HEARTBEAT_PAYLOAD = new byte[0];
+
+    @Override
+    public void channelRead(final ChannelHandlerContext ctx, final Object msg) {
+      if (msg instanceof final ProtocolRequest request
+          && request.subject().equals(HEARTBEAT_SUBJECT)) {
+
+        if (!Arrays.equals(request.payload(), HEARTBEAT_PAYLOAD)) {
+          log.warn(
+              "Received unexpected heartbeat payload from {}, perhaps the message subject {} is accidentally reused",
+              request.sender(),
+              request.subject());
+        }
+
+        // Swallow the heartbeat message by releasing it and not passing it to the next handler
+        ReferenceCountUtil.release(msg);
+        return;
+      }
+
+      // Pass the message to the next handler, it wasn't a heartbeat
+      ctx.fireChannelRead(msg);
+    }
+
+    @Override
+    public void userEventTriggered(final ChannelHandlerContext ctx, final Object evt) {
+      if (!(evt instanceof final IdleStateEvent idleStateEvent)) {
+        return;
+      }
+      switch (idleStateEvent.state()) {
+        case READER_IDLE -> ctx.close();
+        case WRITER_IDLE -> ctx.writeAndFlush(createHeartBeat());
+        default -> {}
+      }
+    }
+
+    private ProtocolRequest createHeartBeat() {
+      return new ProtocolRequest(
+          messageIdGenerator.incrementAndGet(),
+          advertisedAddress,
+          HEARTBEAT_SUBJECT,
+          HEARTBEAT_PAYLOAD);
+    }
+  }
+
   /** Channel initializer for basic connections. */
   private class BasicClientChannelInitializer extends ChannelInitializer<SocketChannel> {
 
@@ -931,6 +981,14 @@ public final class NettyMessagingService implements ManagedMessagingService {
         channel.pipeline().addLast("tls", sslHandler);
       }
 
+      channel
+          .pipeline()
+          .addLast(
+              "idle",
+              new IdleStateHandler(
+                  (int) config.getHeartbeatTimeout().getSeconds(),
+                  (int) config.getHeartbeatInterval().getSeconds(),
+                  0));
       channel.pipeline().addLast("handshake", new ClientHandshakeHandlerAdapter(future));
 
       switch (config.getCompressionAlgorithm()) {
@@ -967,6 +1025,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
         channel.pipeline().addLast("tls", sslHandler);
       }
 
+      channel
+          .pipeline()
+          .addLast(
+              new IdleStateHandler(
+                  (int) config.getHeartbeatTimeout().getSeconds(),
+                  (int) config.getHeartbeatInterval().getSeconds(),
+                  0));
       channel.pipeline().addLast("handshake", new ServerHandshakeHandlerAdapter());
 
       switch (config.getCompressionAlgorithm()) {
@@ -1039,6 +1104,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
       context.pipeline().remove(this);
       context.pipeline().addLast("encoder", protocol.newEncoder());
       context.pipeline().addLast("decoder", protocol.newDecoder());
+      context.pipeline().addLast("heartbeat", new HeartBeatHandler());
       context.pipeline().addLast("handler", new MessageDispatcher<>(connection));
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -156,7 +156,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
     preamble = cluster.hashCode();
     this.advertisedAddress = advertisedAddress;
     this.protocolVersion = protocolVersion;
-    this.config = config;
+    this.config = verifyHeartbeatConfig(config);
     channelPool = new ChannelPool(this::openChannel, config.getConnectionPoolSize());
 
     initAddresses(config);
@@ -165,6 +165,25 @@ public final class NettyMessagingService implements ManagedMessagingService {
   @VisibleForTesting
   public ChannelPool getChannelPool() {
     return channelPool;
+  }
+
+  private static MessagingConfig verifyHeartbeatConfig(final MessagingConfig config) {
+    if (config.getHeartbeatInterval().isZero() && config.getHeartbeatTimeout().isZero()) {
+      // Setting both to zero essentially disables the heartbeat mechanism which is valid.
+      return config;
+    }
+
+    if (config.getHeartbeatInterval().isNegative() || config.getHeartbeatTimeout().isNegative()) {
+      throw new IllegalArgumentException(
+          "Heartbeat interval and timeout must not be negative. Use 0s to disable heartbeats.");
+    }
+
+    if (config.getHeartbeatInterval().compareTo(config.getHeartbeatTimeout()) >= 0) {
+      throw new IllegalArgumentException(
+          "Heartbeat interval %s must be less than heartbeat timeout %s"
+              .formatted(config.getHeartbeatInterval(), config.getHeartbeatTimeout()));
+    }
+    return config;
   }
 
   private void initAddresses(final MessagingConfig config) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -634,49 +634,14 @@ final class NettyMessagingServiceTest {
     }
 
     @Test
-    void shouldCloseChannelAfterTimeout() {
+    void shouldNotCreateNewChannelOnNewRequestAfterTimeout() {
       // given
       final var subject = nextSubject();
       final var timeoutOnCreate = Duration.ofSeconds(10);
 
       final var channelPool = netty1.getChannelPool();
 
-      // grab the original channel, so we can assert it was closed
-      // it's also useful to send a successful request once, so we can ensure the channel exists
-      // and set a lower timeout on the request we want specifically to time out
-      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-      netty1
-          .sendAndReceive(
-              netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
-          .join();
-      final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
-
-      // when - set up handler which will always cause timeouts
-      netty2.unregisterHandler(subject);
-      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-      final CompletableFuture<byte[]> response =
-          netty1.sendAndReceive(
-              netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
-
-      // then
-      assertThat(response)
-          .failsWithin(Duration.ofSeconds(15))
-          .withThrowableThat()
-          .havingRootCause()
-          .isInstanceOf(TimeoutException.class)
-          .withMessageContaining("timed out in");
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
-    }
-
-    @Test
-    void shouldCreateNewChannelOnNewRequestAfterTimeout() {
-      // given
-      final var subject = nextSubject();
-      final var timeoutOnCreate = Duration.ofSeconds(10);
-
-      final var channelPool = netty1.getChannelPool();
-
-      // grab the original channel, so we can assert it was closed
+      // grab the original channel, so we can assert it was not closed
       // it's also useful to send a successful request once, so we can ensure the channel exists
       // and set a lower timeout on the request we want specifically to time out
       netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
@@ -697,8 +662,6 @@ final class NettyMessagingServiceTest {
           .withThrowableThat()
           .havingRootCause()
           .isInstanceOf(TimeoutException.class);
-      // wait until the channel is closed before grabbing the next one
-      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
 
       // when - remote connection finally succeeds
       // give a generous time out on the second request, as creating a new channel can be slow at
@@ -708,8 +671,8 @@ final class NettyMessagingServiceTest {
       netty1.sendAndReceive(netty2.address(), subject, "success".getBytes(), true, timeoutOnCreate);
 
       // then
-      final var newChannel = channelPool.getChannel(netty2.address(), subject).join();
-      assertThat(newChannel).isNotEqualTo(originalChannel);
+      final var currentChannel = channelPool.getChannel(netty2.address(), subject).join();
+      assertThat(currentChannel).isEqualTo(originalChannel);
     }
 
     @EnabledOnOs(OS.LINUX)
@@ -731,6 +694,21 @@ final class NettyMessagingServiceTest {
       // fix this was way, way, way more, so it should be fine to allow a little bit more than the
       // expected max number of connections
       assertThat(udpSocketCount()).isLessThanOrEqualTo(maxConnections * 2L);
+    }
+
+    @Test
+    void shouldGetChannelClosedWhenNotSendingHeartbeats() {
+      // given
+      final var subject = nextSubject();
+      final var channelPool = netty1.getChannelPool();
+      final var channel = channelPool.getChannel(netty2.address(), subject).join();
+
+      // when - removing the `IdleStateHandler` from the pipeline such that `HeartBeatHandler` is
+      // not triggered
+      channel.pipeline().remove("idle");
+
+      // then - the other side notices a lack of heartbeats and closes the channel
+      assertThat(channel.closeFuture()).succeedsWithin(Duration.ofSeconds(5));
     }
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -64,7 +64,10 @@ final class NettyMessagingServiceTest {
   private static final int UID_COLUMN = 7;
 
   private MessagingConfig defaultConfig() {
-    return new MessagingConfig().setShutdownQuietPeriod(Duration.ofMillis(50));
+    return new MessagingConfig()
+        .setShutdownQuietPeriod(Duration.ofMillis(50))
+        .setHeartbeatInterval(Duration.ofMillis(50))
+        .setHeartbeatTimeout(Duration.ofMillis(500));
   }
 
   private String nextSubject() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTest.java
@@ -49,7 +49,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.stream.Stream;
-import org.agrona.collections.MutableReference;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -70,22 +69,6 @@ final class NettyMessagingServiceTest {
 
   private String nextSubject() {
     return UUID.randomUUID().toString();
-  }
-
-  private ManagedMessagingService createMessagingServiceWithPool(
-      final MutableReference<ChannelPool> poolRef) {
-    final var otherAddress = newAddress();
-    final var config = defaultConfig();
-    return new NettyMessagingService(
-        CLUSTER_NAME,
-        otherAddress,
-        config,
-        ProtocolVersion.V2,
-        factory -> {
-          final var pool = new ChannelPool(factory, 8);
-          poolRef.set(pool);
-          return pool;
-        });
   }
 
   private NettyMessagingService newMessagingService() {
@@ -648,91 +631,82 @@ final class NettyMessagingServiceTest {
     }
 
     @Test
-    void shouldCloseChannelAfterTimeout() throws Exception {
+    void shouldCloseChannelAfterTimeout() {
       // given
       final var subject = nextSubject();
-      final MutableReference<ChannelPool> poolRef = new MutableReference<>();
       final var timeoutOnCreate = Duration.ofSeconds(10);
 
-      try (final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef)) {
-        final var channelPool = poolRef.get();
-        nettyWithOwnPool.start().join();
+      final var channelPool = netty1.getChannelPool();
 
-        // grab the original channel, so we can assert it was closed
-        // it's also useful to send a successful request once, so we can ensure the channel exists
-        // and set a lower timeout on the request we want specifically to time out
-        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-        nettyWithOwnPool
-            .sendAndReceive(
-                netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
-            .join();
-        final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
+      // grab the original channel, so we can assert it was closed
+      // it's also useful to send a successful request once, so we can ensure the channel exists
+      // and set a lower timeout on the request we want specifically to time out
+      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+      netty1
+          .sendAndReceive(
+              netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+          .join();
+      final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
 
-        // when - set up handler which will always cause timeouts
-        netty2.unregisterHandler(subject);
-        netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-        final CompletableFuture<byte[]> response =
-            nettyWithOwnPool.sendAndReceive(
-                netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+      // when - set up handler which will always cause timeouts
+      netty2.unregisterHandler(subject);
+      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
 
-        // then
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(15))
-            .withThrowableThat()
-            .havingRootCause()
-            .isInstanceOf(TimeoutException.class)
-            .withMessageContaining("timed out in");
-        assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
-      }
+      // then
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(15))
+          .withThrowableThat()
+          .havingRootCause()
+          .isInstanceOf(TimeoutException.class)
+          .withMessageContaining("timed out in");
+      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
     }
 
     @Test
-    void shouldCreateNewChannelOnNewRequestAfterTimeout() throws Exception {
+    void shouldCreateNewChannelOnNewRequestAfterTimeout() {
       // given
       final var subject = nextSubject();
-      final MutableReference<ChannelPool> poolRef = new MutableReference<>();
       final var timeoutOnCreate = Duration.ofSeconds(10);
 
-      try (final var nettyWithOwnPool = createMessagingServiceWithPool(poolRef)) {
-        final var channelPool = poolRef.get();
-        nettyWithOwnPool.start().join();
+      final var channelPool = netty1.getChannelPool();
 
-        // grab the original channel, so we can assert it was closed
-        // it's also useful to send a successful request once, so we can ensure the channel exists
-        // and set a lower timeout on the request we want specifically to time out
-        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-        nettyWithOwnPool
-            .sendAndReceive(
-                netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
-            .join();
-        final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
+      // grab the original channel, so we can assert it was closed
+      // it's also useful to send a successful request once, so we can ensure the channel exists
+      // and set a lower timeout on the request we want specifically to time out
+      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+      netty1
+          .sendAndReceive(
+              netty2.address(), subject, "get channel".getBytes(), true, timeoutOnCreate)
+          .join();
+      final var originalChannel = channelPool.getChannel(netty2.address(), subject).join();
 
-        // set up handler which will always cause timeouts
-        netty2.unregisterHandler(subject);
-        netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
-        final CompletableFuture<byte[]> response =
-            nettyWithOwnPool.sendAndReceive(
-                netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
-        assertThat(response)
-            .failsWithin(Duration.ofSeconds(15))
-            .withThrowableThat()
-            .havingRootCause()
-            .isInstanceOf(TimeoutException.class);
-        // wait until the channel is closed before grabbing the next one
-        assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
+      // set up handler which will always cause timeouts
+      netty2.unregisterHandler(subject);
+      netty2.registerHandler(subject, (address, bytes) -> new CompletableFuture<>());
+      final CompletableFuture<byte[]> response =
+          netty1.sendAndReceive(
+              netty2.address(), subject, "fail".getBytes(), true, Duration.ofSeconds(1));
+      assertThat(response)
+          .failsWithin(Duration.ofSeconds(15))
+          .withThrowableThat()
+          .havingRootCause()
+          .isInstanceOf(TimeoutException.class);
+      // wait until the channel is closed before grabbing the next one
+      assertThat(originalChannel.closeFuture()).succeedsWithin(Duration.ofSeconds(15));
 
-        // when - remote connection finally succeeds
-        // give a generous time out on the second request, as creating a new channel can be slow at
-        // times
-        netty2.unregisterHandler(subject);
-        netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
-        nettyWithOwnPool.sendAndReceive(
-            netty2.address(), subject, "success".getBytes(), true, timeoutOnCreate);
+      // when - remote connection finally succeeds
+      // give a generous time out on the second request, as creating a new channel can be slow at
+      // times
+      netty2.unregisterHandler(subject);
+      netty2.registerHandler(subject, (address, bytes) -> new byte[0], Runnable::run);
+      netty1.sendAndReceive(netty2.address(), subject, "success".getBytes(), true, timeoutOnCreate);
 
-        // then
-        final var newChannel = channelPool.getChannel(netty2.address(), subject).join();
-        assertThat(newChannel).isNotEqualTo(originalChannel);
-      }
+      // then
+      final var newChannel = channelPool.getChannel(netty2.address(), subject).join();
+      assertThat(newChannel).isNotEqualTo(originalChannel);
     }
 
     @EnabledOnOs(OS.LINUX)

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/clustering/ClusterConfigFactory.java
@@ -79,7 +79,9 @@ public final class ClusterConfigFactory {
         new MessagingConfig()
             .setCompressionAlgorithm(cluster.getMessageCompression())
             .setInterfaces(Collections.singletonList(network.getInternalApi().getHost()))
-            .setPort(network.getInternalApi().getPort());
+            .setPort(network.getInternalApi().getPort())
+            .setHeartbeatTimeout(network.getHeartbeatTimeout())
+            .setHeartbeatInterval(network.getHeartbeatInterval());
 
     if (network.getSecurity().isEnabled()) {
       final var security = network.getSecurity();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/NetworkCfg.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.configuration;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.CommandApiCfg;
 import io.camunda.zeebe.broker.system.configuration.SocketBindingCfg.InternalApiCfg;
+import java.time.Duration;
 import org.springframework.util.unit.DataSize;
 
 public final class NetworkCfg implements ConfigurationEntry {
@@ -26,6 +27,8 @@ public final class NetworkCfg implements ConfigurationEntry {
   private String advertisedHost = null;
   private int portOffset = 0;
   private DataSize maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+  private Duration heartbeatTimeout = Duration.ofSeconds(15);
+  private Duration heartbeatInterval = Duration.ofSeconds(5);
 
   private final CommandApiCfg commandApi = new CommandApiCfg();
   private InternalApiCfg internalApi = new InternalApiCfg();
@@ -86,6 +89,22 @@ public final class NetworkCfg implements ConfigurationEntry {
     this.maxMessageSize = maxMessageSize;
   }
 
+  public Duration getHeartbeatTimeout() {
+    return heartbeatTimeout;
+  }
+
+  public void setHeartbeatTimeout(final Duration heartbeatTimeout) {
+    this.heartbeatTimeout = heartbeatTimeout;
+  }
+
+  public Duration getHeartbeatInterval() {
+    return heartbeatInterval;
+  }
+
+  public void setHeartbeatInterval(final Duration heartbeatInterval) {
+    this.heartbeatInterval = heartbeatInterval;
+  }
+
   public CommandApiCfg getCommandApi() {
     return commandApi;
   }
@@ -117,6 +136,10 @@ public final class NetworkCfg implements ConfigurationEntry {
         + '\''
         + ", maxMessageSize="
         + maxMessageSize
+        + ", heartbeatTimeout="
+        + heartbeatTimeout
+        + ", heartbeatInterval="
+        + heartbeatInterval
         + ", commandApi="
         + commandApi
         + ", internalApi="


### PR DESCRIPTION
# Description
Backport of #25615 to `stable/8.6`.

relates to #25596
original author: @lenaschoenburg