### PR TITLE
feat: ElasticsearchBackupRepository uses new ElasticsearchClient instead of RestHighLevelClient

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -288,11 +288,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-high-level-client</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>camunda-search-client-opensearch</artifactId>
     </dependency>

--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupConfig.java
@@ -65,10 +65,10 @@ public class BackupConfig {
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(1);
-    executor.setMaxPoolSize(1);
+    executor.setMaxPoolSize(8);
+    executor.setKeepAliveSeconds(60);
     executor.setThreadNamePrefix("webapps_backup_");
-    // TODO why just 6?
-    executor.setQueueCapacity(6);
+    executor.setQueueCapacity(4096);
     executor.initialize();
     return executor;
   }

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
@@ -7,17 +7,18 @@
  */
 package io.camunda.application.commons.backup;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
-import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 /** Note that the condition used refers to operate ElasticSearchCondition */
 @Conditional(ElasticsearchCondition.class)
@@ -25,22 +26,29 @@ import org.springframework.context.annotation.Profile;
 @Profile("operate")
 public class ElasticsearchBackupRepository {
 
-  private final RestHighLevelClient esClient;
+  private final ElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupRepositoryProps;
+  private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
 
   public ElasticsearchBackupRepository(
-      @Qualifier("esClient") final RestHighLevelClient esClient,
+      @Qualifier("elasticsearchClient") final ElasticsearchClient esClient,
       final ObjectMapper objectMapper,
-      final BackupRepositoryProps backupRepositoryProps) {
+      final BackupRepositoryProps backupRepositoryProps,
+      @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor) {
     this.esClient = esClient;
     this.objectMapper = objectMapper;
     this.backupRepositoryProps = backupRepositoryProps;
+    this.threadPoolTaskExecutor = threadPoolTaskExecutor;
   }
 
   @Bean
   public BackupRepository backupRepository() {
     return new io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository(
-        esClient, objectMapper, backupRepositoryProps, new WebappsSnapshotNameProvider());
+        esClient,
+        objectMapper,
+        backupRepositoryProps,
+        new WebappsSnapshotNameProvider(),
+        threadPoolTaskExecutor);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
@@ -13,6 +13,7 @@ import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
+import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -29,7 +30,7 @@ public class ElasticsearchBackupRepository {
   private final ElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupRepositoryProps;
-  private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
+  private final Executor threadPoolTaskExecutor;
 
   public ElasticsearchBackupRepository(
       @Qualifier("elasticsearchClient") final ElasticsearchClient esClient,

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
@@ -14,6 +14,7 @@ import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.WebappsSnapshotNameProvider;
 import io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository;
+import java.util.concurrent.Executor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -38,7 +39,7 @@ public class ElasticsearchTasklistBackupRepository {
   private final ElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupRepositoryProps;
-  private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
+  private final Executor threadPoolTaskExecutor;
 
   public ElasticsearchTasklistBackupRepository(
       @Qualifier("tasklistElasticsearchClient") final ElasticsearchClient esClient,

--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -35,16 +35,8 @@
     </dependency>
     <!--    Elastic Search-->
     <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-high-level-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.elasticsearch.client</groupId>
-      <artifactId>elasticsearch-rest-client</artifactId>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
     </dependency>
     <!--    Jackson -->
     <dependency>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
@@ -8,22 +8,46 @@
 package io.camunda.webapps.backup;
 
 import java.util.Map;
-import org.opensearch.client.json.JsonData;
-import org.opensearch.client.json.JsonpMapper;
 
 public record Metadata(Long backupId, String version, Integer partNo, Integer partCount) {
 
   // used by open search backend
-  public Map<String, JsonData> asJson(final JsonpMapper jsonpMapper) {
+  public Map<String, co.elastic.clients.json.JsonData> asJsonES(
+      final co.elastic.clients.json.JsonpMapper jsonpMapper) {
     return Map.of(
-        "backupId", JsonData.of(backupId(), jsonpMapper),
-        "version", JsonData.of(version(), jsonpMapper),
-        "partNo", JsonData.of(partNo(), jsonpMapper),
-        "partCount", JsonData.of(partCount(), jsonpMapper));
+        "backupId", co.elastic.clients.json.JsonData.of(backupId(), jsonpMapper),
+        "version", co.elastic.clients.json.JsonData.of(version(), jsonpMapper),
+        "partNo", co.elastic.clients.json.JsonData.of(partNo(), jsonpMapper),
+        "partCount", co.elastic.clients.json.JsonData.of(partCount(), jsonpMapper));
+  }
+
+  public static Metadata fromMetadataES(
+      final Map<String, co.elastic.clients.json.JsonData> metadata,
+      final co.elastic.clients.json.JsonpMapper jsonpMapper) {
+    try {
+      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
+      final var version = metadata.get("version").to(String.class, jsonpMapper);
+      final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
+      final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);
+      return new Metadata(backupId, version, partNo, partCount);
+    } catch (final Exception e) {
+      throw new RuntimeException("Unable to deserialize metadata %s".formatted(metadata), e);
+    }
+  }
+
+  // used by open search backend
+  public Map<String, org.opensearch.client.json.JsonData> asJson(
+      final org.opensearch.client.json.JsonpMapper jsonpMapper) {
+    return Map.of(
+        "backupId", org.opensearch.client.json.JsonData.of(backupId(), jsonpMapper),
+        "version", org.opensearch.client.json.JsonData.of(version(), jsonpMapper),
+        "partNo", org.opensearch.client.json.JsonData.of(partNo(), jsonpMapper),
+        "partCount", org.opensearch.client.json.JsonData.of(partCount(), jsonpMapper));
   }
 
   public static Metadata fromMetadata(
-      final Map<String, JsonData> metadata, final JsonpMapper jsonpMapper) {
+      final Map<String, org.opensearch.client.json.JsonData> metadata,
+      final org.opensearch.client.json.JsonpMapper jsonpMapper) {
     try {
       final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
       final var version = metadata.get("version").to(String.class, jsonpMapper);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/Metadata.java
@@ -7,55 +7,8 @@
  */
 package io.camunda.webapps.backup;
 
-import java.util.Map;
-
 public record Metadata(Long backupId, String version, Integer partNo, Integer partCount) {
 
   // used by open search backend
-  public Map<String, co.elastic.clients.json.JsonData> asJsonES(
-      final co.elastic.clients.json.JsonpMapper jsonpMapper) {
-    return Map.of(
-        "backupId", co.elastic.clients.json.JsonData.of(backupId(), jsonpMapper),
-        "version", co.elastic.clients.json.JsonData.of(version(), jsonpMapper),
-        "partNo", co.elastic.clients.json.JsonData.of(partNo(), jsonpMapper),
-        "partCount", co.elastic.clients.json.JsonData.of(partCount(), jsonpMapper));
-  }
 
-  public static Metadata fromMetadataES(
-      final Map<String, co.elastic.clients.json.JsonData> metadata,
-      final co.elastic.clients.json.JsonpMapper jsonpMapper) {
-    try {
-      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
-      final var version = metadata.get("version").to(String.class, jsonpMapper);
-      final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
-      final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);
-      return new Metadata(backupId, version, partNo, partCount);
-    } catch (final Exception e) {
-      throw new RuntimeException("Unable to deserialize metadata %s".formatted(metadata), e);
-    }
-  }
-
-  // used by open search backend
-  public Map<String, org.opensearch.client.json.JsonData> asJson(
-      final org.opensearch.client.json.JsonpMapper jsonpMapper) {
-    return Map.of(
-        "backupId", org.opensearch.client.json.JsonData.of(backupId(), jsonpMapper),
-        "version", org.opensearch.client.json.JsonData.of(version(), jsonpMapper),
-        "partNo", org.opensearch.client.json.JsonData.of(partNo(), jsonpMapper),
-        "partCount", org.opensearch.client.json.JsonData.of(partCount(), jsonpMapper));
-  }
-
-  public static Metadata fromMetadata(
-      final Map<String, org.opensearch.client.json.JsonData> metadata,
-      final org.opensearch.client.json.JsonpMapper jsonpMapper) {
-    try {
-      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
-      final var version = metadata.get("version").to(String.class, jsonpMapper);
-      final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
-      final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);
-      return new Metadata(backupId, version, partNo, partCount);
-    } catch (final Exception e) {
-      throw new RuntimeException("Unable to deserialize metadata %s".formatted(metadata), e);
-    }
-  }
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -241,7 +241,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                   groupingBy(
                       si -> {
                         final Metadata metadata =
-                            Metadata.fromMetadataES(si.metadata(), esClient._jsonpMapper());
+                            MetadataMarshaller.fromMetadata(si.metadata(), esClient._jsonpMapper());
                         Long backupId = metadata.backupId();
                         // backward compatibility with v. 8.1
                         if (backupId == null) {
@@ -397,7 +397,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final var firstSnapshot = snapshots.getFirst();
     final Metadata metadata =
-        Metadata.fromMetadataES(firstSnapshot.metadata(), esClient._jsonpMapper());
+        MetadataMarshaller.fromMetadata(firstSnapshot.metadata(), esClient._jsonpMapper());
     final Integer expectedSnapshotsCount = metadata.partCount();
 
     if (snapshots.size() == expectedSnapshotsCount

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -7,15 +7,22 @@
  */
 package io.camunda.webapps.backup.repository.elasticsearch;
 
+import static io.camunda.webapps.backup.repository.elasticsearch.SnapshotState.*;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static org.elasticsearch.snapshots.SnapshotState.FAILED;
-import static org.elasticsearch.snapshots.SnapshotState.INCOMPATIBLE;
-import static org.elasticsearch.snapshots.SnapshotState.IN_PROGRESS;
-import static org.elasticsearch.snapshots.SnapshotState.PARTIAL;
-import static org.elasticsearch.snapshots.SnapshotState.SUCCESS;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ElasticsearchException;
+import co.elastic.clients.elasticsearch._types.ShardFailure;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotRequest;
+import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotResponse;
+import co.elastic.clients.elasticsearch.snapshot.DeleteSnapshotResponse;
+import co.elastic.clients.elasticsearch.snapshot.GetSnapshotRequest;
+import co.elastic.clients.elasticsearch.snapshot.GetSnapshotResponse;
+import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
+import co.elastic.clients.elasticsearch.snapshot.SnapshotSort;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.backup.BackupException;
@@ -41,24 +48,8 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
-import org.elasticsearch.ElasticsearchStatusException;
-import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesRequest;
-import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequest;
-import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequest;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
-import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.search.sort.SortOrder;
-import org.elasticsearch.snapshots.SnapshotInfo;
-import org.elasticsearch.snapshots.SnapshotShardFailure;
-import org.elasticsearch.transport.TransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,20 +58,23 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   private static final String REPOSITORY_MISSING_EXCEPTION_TYPE =
       "type=repository_missing_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
-  private final RestHighLevelClient esClient;
+  private final ElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupProps;
   private final SnapshotNameProvider snapshotNameProvider;
+  private final Executor executor;
 
   public ElasticsearchBackupRepository(
-      final RestHighLevelClient esClient,
+      final ElasticsearchClient esClient,
       final ObjectMapper objectMapper,
       final BackupRepositoryProps operateProperties,
-      final SnapshotNameProvider snapshotNameProvider) {
+      final SnapshotNameProvider snapshotNameProvider,
+      final Executor executor) {
     this.esClient = esClient;
     this.objectMapper = objectMapper;
     backupProps = operateProperties;
     this.snapshotNameProvider = snapshotNameProvider;
+    this.executor = executor;
   }
 
   @Override
@@ -89,20 +83,75 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   }
 
   @Override
+  public void executeSnapshotting(
+      final BackupService.SnapshotRequest snapshotRequest,
+      final Runnable onSuccess,
+      final Runnable onFailure) {
+    final var request =
+        CreateSnapshotRequest.of(
+            b ->
+                b.repository(snapshotRequest.repositoryName())
+                    .snapshot(snapshotRequest.snapshotName())
+                    .indices(snapshotRequest.indices())
+                    // ignoreUnavailable = false - indices defined by their exact name MUST be
+                    // present
+                    // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE
+                    // absent
+                    .ignoreUnavailable(false)
+                    // TODO not all migrated
+                    //                    .(IndicesOptions.fromOptions(false, true, true, true))
+                    .includeGlobalState(backupProps.includeGlobalState())
+                    .metadata(
+                        objectMapper.convertValue(
+                            snapshotRequest.metadata(), new TypeReference<>() {}))
+                    .featureStates("none")
+                    .waitForCompletion(true));
+    final var listener = new CreateSnapshotListener(snapshotRequest, onSuccess, onFailure);
+
+    executor.execute(
+        () -> {
+          try {
+            esClient.snapshot().create(request);
+            listener.onSuccess.run();
+          } catch (final Exception e) {
+            listener.onFailure.run();
+          }
+        });
+  }
+
+  @Override
   public void deleteSnapshot(final String repositoryName, final String snapshotName) {
-    final DeleteSnapshotRequest request = new DeleteSnapshotRequest(repositoryName);
-    request.snapshots(snapshotName);
-    esClient.snapshot().deleteAsync(request, RequestOptions.DEFAULT, getDeleteListener());
+    executor.execute(
+        () -> {
+          try {
+            final var response =
+                esClient
+                    .snapshot()
+                    .delete(q -> q.repository(repositoryName).snapshot(snapshotName));
+            LOGGER.debug(
+                "Delete snapshot was acknowledged by Elasticsearch node: {}",
+                response.acknowledged());
+          } catch (final Exception e) {
+            if (isSnapshotMissingException(e)) {
+              // no snapshot with given backupID exists, this is fine, log warning
+              LOGGER.warn("No snapshot found for snapshot deletion: {} ", e.getMessage());
+            } else {
+              LOGGER.error("Exception occurred while deleting the snapshot: {}", e.getMessage(), e);
+            }
+          }
+        });
   }
 
   @Override
   public void validateRepositoryExists(final String repositoryName) {
-    final GetRepositoriesRequest getRepositoriesRequest =
-        new GetRepositoriesRequest().repositories(new String[] {repositoryName});
     try {
-      final GetRepositoriesResponse repository =
-          esClient.snapshot().getRepository(getRepositoriesRequest, RequestOptions.DEFAULT);
-    } catch (final IOException | TransportException ex) {
+      final var repository = esClient.snapshot().getRepository(r -> r.name(repositoryName));
+      if (repository.result().isEmpty()) {
+        final String reason =
+            String.format("No repository with name [%s] could be found.", repositoryName);
+        throw new MissingRepositoryException(reason);
+      }
+    } catch (final IOException ex) {
       final String reason =
           String.format(
               "Encountered an error connecting to Elasticsearch while retrieving repository with name [%s].",
@@ -124,14 +173,16 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
   @Override
   public void validateNoDuplicateBackupId(final String repositoryName, final Long backupId) {
-    final GetSnapshotsRequest snapshotsStatusRequest =
-        new GetSnapshotsRequest()
-            .repository(repositoryName)
-            .snapshots(new String[] {snapshotNameProvider.getSnapshotNamePrefix(backupId) + "*"});
-    final GetSnapshotsResponse response;
+    final GetSnapshotResponse response;
     try {
-      response = esClient.snapshot().get(snapshotsStatusRequest, RequestOptions.DEFAULT);
-    } catch (final IOException | TransportException ex) {
+      response =
+          esClient
+              .snapshot()
+              .get(
+                  r ->
+                      r.repository(repositoryName)
+                          .snapshot(snapshotNameProvider.getSnapshotNamePrefix(backupId) + "*"));
+    } catch (final IOException ex) {
       final String reason =
           String.format(
               "Encountered an error connecting to Elasticsearch while searching for duplicate backup. Repository name: [%s].",
@@ -148,14 +199,12 @@ public class ElasticsearchBackupRepository implements BackupRepository {
               backupId);
       throw new BackupRepositoryConnectionException(reason, e);
     }
-    if (!response.getSnapshots().isEmpty()) {
+    if (!response.snapshots().isEmpty()) {
       final String reason =
           String.format(
               "A backup with ID [%s] already exists. Found snapshots: [%s]",
               backupId,
-              response.getSnapshots().stream()
-                  .map(snapshotInfo -> snapshotInfo.snapshotId().toString())
-                  .collect(joining(", ")));
+              response.snapshots().stream().map(SnapshotInfo::snapshot).collect(joining(", ")));
       throw new InvalidRequestException(reason);
     }
   }
@@ -169,20 +218,21 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
   @Override
   public List<GetBackupStateResponseDto> getBackups(final String repositoryName) {
-    final GetSnapshotsRequest snapshotsStatusRequest =
-        new GetSnapshotsRequest()
-            .repository(repositoryName)
-            .snapshots(new String[] {snapshotNameProvider.snapshotNamePrefix() + "*"})
-            // it looks like sorting as well as size/offset are not working, need to sort
-            // additionally before return
-            .sort(GetSnapshotsRequest.SortBy.START_TIME)
-            .order(SortOrder.DESC);
-    final GetSnapshotsResponse response;
+    final GetSnapshotRequest snapshotsStatusRequest =
+        GetSnapshotRequest.of(
+            b ->
+                b.repository(repositoryName)
+                    .snapshot(snapshotNameProvider.snapshotNamePrefix() + "*")
+                    // it looks like sorting as well as size/offset are not working, need to sort
+                    // additionally before return
+                    .sort(SnapshotSort.StartTime)
+                    .order(SortOrder.Desc));
+    final GetSnapshotResponse response;
     try {
-      response = esClient.snapshot().get(snapshotsStatusRequest, RequestOptions.DEFAULT);
+      response = esClient.snapshot().get(snapshotsStatusRequest);
       final List<SnapshotInfo> snapshots =
-          response.getSnapshots().stream()
-              .sorted(Comparator.comparing(SnapshotInfo::startTime).reversed())
+          response.snapshots().stream()
+              .sorted(Comparator.comparing(SnapshotInfo::startTimeInMillis).reversed())
               .toList();
 
       final LinkedHashMap<Long, List<SnapshotInfo>> groupedSnapshotInfos =
@@ -191,12 +241,11 @@ public class ElasticsearchBackupRepository implements BackupRepository {
                   groupingBy(
                       si -> {
                         final Metadata metadata =
-                            objectMapper.convertValue(si.userMetadata(), Metadata.class);
+                            Metadata.fromMetadataES(si.metadata(), esClient._jsonpMapper());
                         Long backupId = metadata.backupId();
                         // backward compatibility with v. 8.1
                         if (backupId == null) {
-                          backupId =
-                              snapshotNameProvider.extractBackupId(si.snapshotId().getName());
+                          backupId = snapshotNameProvider.extractBackupId(si.snapshot());
                         }
                         return backupId;
                       },
@@ -209,7 +258,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
               .collect(toList());
 
       return responses;
-    } catch (final IOException | TransportException ex) {
+    } catch (final IOException ex) {
       final String reason =
           String.format(
               "Encountered an error connecting to Elasticsearch while searching for snapshots. Repository name: [%s].",
@@ -231,75 +280,33 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     }
   }
 
-  @Override
-  public void executeSnapshotting(
-      final BackupService.SnapshotRequest snapshotRequest,
-      final Runnable onSuccess,
-      final Runnable onFailure) {
-    final var request =
-        new CreateSnapshotRequest()
-            .repository(snapshotRequest.repositoryName())
-            .snapshot(snapshotRequest.snapshotName())
-            .indices(snapshotRequest.indices())
-            // ignoreUnavailable = false - indices defined by their exact name MUST be present
-            // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE absent
-            .indicesOptions(IndicesOptions.fromOptions(false, true, true, true))
-            .includeGlobalState(backupProps.includeGlobalState())
-            .userMetadata(
-                objectMapper.convertValue(snapshotRequest.metadata(), new TypeReference<>() {}))
-            .featureStates(new String[] {"none"})
-            .waitForCompletion(true);
-    final var listener = new CreateSnapshotListener(snapshotRequest, onSuccess, onFailure);
+  public void onDeleteResponse(final DeleteSnapshotResponse response) {}
 
-    esClient.snapshot().createAsync(request, RequestOptions.DEFAULT, listener);
-  }
-
-  private ActionListener<AcknowledgedResponse> getDeleteListener() {
-    return new ActionListener<>() {
-      @Override
-      public void onResponse(final AcknowledgedResponse response) {
-        LOGGER.debug(
-            "Delete snapshot was acknowledged by Elasticsearch node: {}",
-            response.isAcknowledged());
-      }
-
-      @Override
-      public void onFailure(final Exception e) {
-        if (isSnapshotMissingException(e)) {
-          // no snapshot with given backupID exists, this is fine, log warning
-          LOGGER.warn("No snapshot found for snapshot deletion: {} ", e.getMessage());
-        } else {
-          LOGGER.error("Exception occurred while deleting the snapshot: {}", e.getMessage(), e);
-        }
-      }
-    };
-  }
+  public void onDeleteFailure(final Exception e) {}
 
   private boolean isSnapshotMissingException(final Exception e) {
-    return e instanceof ElasticsearchStatusException
-        && ((ElasticsearchStatusException) e)
-            .getDetailedMessage()
-            .contains(SNAPSHOT_MISSING_EXCEPTION_TYPE);
+    return e instanceof ElasticsearchException
+        && e.getMessage().contains(SNAPSHOT_MISSING_EXCEPTION_TYPE);
   }
 
   private boolean isRepositoryMissingException(final Exception e) {
-    return e instanceof ElasticsearchStatusException
-        && ((ElasticsearchStatusException) e)
-            .getDetailedMessage()
-            .contains(REPOSITORY_MISSING_EXCEPTION_TYPE);
+    return e instanceof ElasticsearchException
+        && e.getMessage().contains(REPOSITORY_MISSING_EXCEPTION_TYPE);
   }
 
   // Check: see inner
   public List<SnapshotInfo> findSnapshots(final String repositoryName, final Long backupId) {
-    final GetSnapshotsRequest snapshotsStatusRequest =
-        new GetSnapshotsRequest()
-            .repository(repositoryName)
-            .snapshots(new String[] {snapshotNameProvider.getSnapshotNamePrefix(backupId) + "*"});
-    final GetSnapshotsResponse response;
+    final GetSnapshotRequest snapshotsStatusRequest =
+        GetSnapshotRequest.of(
+            b ->
+                b.repository(repositoryName)
+                    .snapshot(snapshotNameProvider.getSnapshotNamePrefix(backupId) + "*"));
+
+    final GetSnapshotResponse response;
     try {
-      response = esClient.snapshot().get(snapshotsStatusRequest, RequestOptions.DEFAULT);
-      return response.getSnapshots();
-    } catch (final IOException | TransportException ex) {
+      response = esClient.snapshot().get(snapshotsStatusRequest);
+      return response.snapshots();
+    } catch (final IOException ex) {
       final String reason =
           String.format(
               "Encountered an error connecting to Elasticsearch while searching for snapshots. Repository name: [%s].",
@@ -335,7 +342,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       final List<SnapshotInfo> snapshotInfos = findSnapshots(repositoryName, backupId);
       final SnapshotInfo currentSnapshot =
           snapshotInfos.stream()
-              .filter(x -> Objects.equals(x.snapshotId().getName(), snapshotName))
+              .filter(x -> Objects.equals(x.snapshot(), snapshotName))
               .findFirst()
               .orElse(null);
       if (currentSnapshot == null) {
@@ -344,7 +351,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
         // No need to continue
         return false;
       }
-      if (currentSnapshot.state() == IN_PROGRESS) {
+      if (Objects.equals(currentSnapshot.state(), IN_PROGRESS.name())) {
         try {
           Thread.sleep(100);
         } catch (final InterruptedException e) {
@@ -365,19 +372,21 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   }
 
   private boolean snapshotWentWell(final SnapshotInfo snapshotInfo) {
-    if (snapshotInfo.state() == SUCCESS) {
-      LOGGER.info("Snapshot done: {}", snapshotInfo.snapshotId());
+    if (snapshotInfo != null && Objects.equals(snapshotInfo.state(), SUCCESS.name())) {
+      LOGGER.info("Snapshot done: {}", snapshotInfo.snapshot());
       return true;
-    } else if (snapshotInfo.state() == FAILED) {
+    } else if (snapshotInfo != null && Objects.equals(snapshotInfo.state(), FAILED.name())) {
       LOGGER.error(
           "Snapshot taking failed for {}, reason {}",
-          snapshotInfo.snapshotId(),
+          snapshotInfo.snapshot(),
           snapshotInfo.reason());
       // No need to continue
       return false;
     } else {
       LOGGER.warn(
-          "Snapshot state is {} for snapshot {}", snapshotInfo.state(), snapshotInfo.snapshotId());
+          "Snapshot state is {} for snapshot {}",
+          snapshotInfo != null ? snapshotInfo.state() : null,
+          snapshotInfo != null ? snapshotInfo.snapshot() : null);
       return false;
     }
   }
@@ -388,24 +397,26 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final var firstSnapshot = snapshots.getFirst();
     final Metadata metadata =
-        objectMapper.convertValue(firstSnapshot.userMetadata(), Metadata.class);
+        Metadata.fromMetadataES(firstSnapshot.metadata(), esClient._jsonpMapper());
     final Integer expectedSnapshotsCount = metadata.partCount();
 
     if (snapshots.size() == expectedSnapshotsCount
-        && snapshots.stream().map(SnapshotInfo::state).allMatch(SUCCESS::equals)) {
+        && snapshots.stream().map(SnapshotInfo::state).allMatch(SUCCESS.name()::equals)) {
       response.setState(BackupStateDto.COMPLETED);
     } else if (snapshots.stream()
         .map(SnapshotInfo::state)
-        .anyMatch(s -> FAILED.equals(s) || PARTIAL.equals(s))) {
+        .anyMatch(s -> FAILED.name().equals(s) || PARTIAL.name().equals(s))) {
       response.setState(BackupStateDto.FAILED);
-    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(INCOMPATIBLE::equals)) {
+      // INCOMPATIBLE used to be present in the enum, but in the REST api docs we only have the
+      // cases defined in SnapshotState
+    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch("INCOMPATIBLE"::equals)) {
       response.setState(BackupStateDto.INCOMPATIBLE);
-    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(IN_PROGRESS::equals)) {
+    } else if (snapshots.stream().map(SnapshotInfo::state).anyMatch(IN_PROGRESS.name()::equals)) {
       response.setState(BackupStateDto.IN_PROGRESS);
     } else if (snapshots.size() < expectedSnapshotsCount) {
       // Check: if missing in tasklist
       if (isIncompleteCheckTimedOut(
-          backupProps.incompleteCheckTimeoutInSeconds(), snapshots.getLast().endTime())) {
+          backupProps.incompleteCheckTimeoutInSeconds(), snapshots.getLast().endTimeInMillis())) {
         response.setState(BackupStateDto.INCOMPLETE);
       } else {
         response.setState(BackupStateDto.IN_PROGRESS);
@@ -416,17 +427,17 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     final List<GetBackupStateResponseDetailDto> details = new ArrayList<>();
     for (final SnapshotInfo snapshot : snapshots) {
       final GetBackupStateResponseDetailDto detail = new GetBackupStateResponseDetailDto();
-      detail.setSnapshotName(snapshot.snapshotId().getName());
+      detail.setSnapshotName(snapshot.snapshot());
       detail.setStartTime(
           OffsetDateTime.ofInstant(
-              Instant.ofEpochMilli(snapshot.startTime()), ZoneId.systemDefault()));
-      if (snapshot.shardFailures() != null) {
+              Instant.ofEpochMilli(snapshot.startTimeInMillis()), ZoneId.systemDefault()));
+      if (null != snapshot.shards() && null != snapshot.shards().failures()) {
         detail.setFailures(
-            snapshot.shardFailures().stream()
-                .map(SnapshotShardFailure::toString)
+            snapshot.shards().failures().stream()
+                .map(ShardFailure::toString)
                 .toArray(String[]::new));
       }
-      detail.setState(snapshot.state().name());
+      detail.setState(snapshot.state());
       details.add(detail);
     }
     response.setDetails(details);
@@ -434,8 +445,8 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       String failureReason = null;
       final String failedSnapshots =
           snapshots.stream()
-              .filter(s -> s.state().equals(FAILED))
-              .map(s -> s.snapshotId().getName())
+              .filter(s -> Objects.equals(s.state(), FAILED.name()))
+              .map(SnapshotInfo::snapshot)
               .collect(Collectors.joining(", "));
       if (!failedSnapshots.isEmpty()) {
         failureReason =
@@ -443,8 +454,8 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       } else {
         final String partialSnapshot =
             snapshots.stream()
-                .filter(s -> s.state().equals(PARTIAL))
-                .map(s -> s.snapshotId().getName())
+                .filter(s -> Objects.equals(s.state(), PARTIAL.name()))
+                .map(SnapshotInfo::snapshot)
                 .collect(Collectors.joining(", "));
         if (!partialSnapshot.isEmpty()) {
           failureReason = String.format("Some of the snapshots are partial: %s", partialSnapshot);
@@ -460,7 +471,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   }
 
   /** CreateSnapshotListener */
-  public class CreateSnapshotListener implements ActionListener<CreateSnapshotResponse> {
+  public class CreateSnapshotListener {
 
     private final BackupService.SnapshotRequest snapshotRequest;
     private final long backupId;
@@ -477,9 +488,8 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       this.onFailure = onFailure;
     }
 
-    @Override
     public void onResponse(final CreateSnapshotResponse response) {
-      if (snapshotWentWell(response.getSnapshotInfo())) {
+      if (snapshotWentWell(response.snapshot())) {
         onSuccess.run();
       } else {
         onFailure.run();
@@ -487,7 +497,6 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     }
 
     // Check: tasklist does not wait for the snapshot to finish
-    @Override
     public void onFailure(final Exception ex) {
       if (ex instanceof SocketTimeoutException) {
         // This is thrown even if the backup is still running

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/MetadataMarshaller.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/MetadataMarshaller.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.backup.repository.elasticsearch;
+
+import co.elastic.clients.json.JsonData;
+import co.elastic.clients.json.JsonpMapper;
+import io.camunda.webapps.backup.Metadata;
+import java.util.Map;
+
+public class MetadataMarshaller {
+
+  // used by open search backend
+  public static Map<String, JsonData> asJson(
+      final Metadata metadata, final JsonpMapper jsonpMapper) {
+    return Map.of(
+        "backupId", JsonData.of(metadata.backupId(), jsonpMapper),
+        "version", JsonData.of(metadata.version(), jsonpMapper),
+        "partNo", JsonData.of(metadata.partNo(), jsonpMapper),
+        "partCount", JsonData.of(metadata.partCount(), jsonpMapper));
+  }
+
+  public static Metadata fromMetadata(
+      final Map<String, JsonData> metadata, final JsonpMapper jsonpMapper) {
+    try {
+      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
+      final var version = metadata.get("version").to(String.class, jsonpMapper);
+      final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
+      final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);
+      return new Metadata(backupId, version, partNo, partCount);
+    } catch (final Exception e) {
+      throw new RuntimeException("Unable to deserialize metadata %s".formatted(metadata), e);
+    }
+  }
+}

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/SnapshotState.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/SnapshotState.java
@@ -5,11 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.webapps.backup.repository.opensearch;
+package io.camunda.webapps.backup.repository.elasticsearch;
 
 public enum SnapshotState {
   FAILED,
   PARTIAL,
-  STARTED,
-  SUCCESS;
+  IN_PROGRESS,
+  SUCCESS
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/MetadataMarshaller.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/MetadataMarshaller.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.backup.repository.opensearch;
+
+import io.camunda.webapps.backup.Metadata;
+import java.util.Map;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.json.JsonpMapper;
+
+public class MetadataMarshaller {
+
+  public static Map<String, JsonData> asJson(
+      final Metadata metadata, final JsonpMapper jsonpMapper) {
+    return Map.of(
+        "backupId", JsonData.of(metadata.backupId(), jsonpMapper),
+        "version", JsonData.of(metadata.version(), jsonpMapper),
+        "partNo", JsonData.of(metadata.partNo(), jsonpMapper),
+        "partCount", JsonData.of(metadata.partCount(), jsonpMapper));
+  }
+
+  public static Metadata fromMetadata(
+      final Map<String, JsonData> metadata, final JsonpMapper jsonpMapper) {
+    try {
+      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
+      final var version = metadata.get("version").to(String.class, jsonpMapper);
+      final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
+      final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);
+      return new Metadata(backupId, version, partNo, partCount);
+    } catch (final Exception e) {
+      throw new RuntimeException("Unable to deserialize metadata %s".formatted(metadata), e);
+    }
+  }
+}

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -184,7 +184,7 @@ public class OpensearchBackupRepository implements BackupRepository {
                   groupingBy(
                       si -> {
                         final Metadata metadata =
-                            Metadata.fromMetadata(
+                            MetadataMarshaller.fromMetadata(
                                 si.getMetadata(), openSearchClient._transport().jsonpMapper());
                         Long backupId = metadata.backupId();
                         // backward compatibility with v. 8.1
@@ -222,7 +222,8 @@ public class OpensearchBackupRepository implements BackupRepository {
       final Runnable onFailure) {
     final Long backupId = backupId(snapshotRequest);
     final Map<String, JsonData> metadataJson =
-        snapshotRequest.metadata().asJson(openSearchClient._transport().jsonpMapper());
+        MetadataMarshaller.asJson(
+            snapshotRequest.metadata(), openSearchClient._transport().jsonpMapper());
 
     final var requestBuilder =
         createSnapshotRequestBuilder(
@@ -402,7 +403,7 @@ public class OpensearchBackupRepository implements BackupRepository {
       final Long backupId, final List<OpenSearchSnapshotInfo> snapshots) {
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final Metadata metadata =
-        Metadata.fromMetadata(
+        MetadataMarshaller.fromMetadata(
             snapshots.getFirst().getMetadata(), openSearchClient._transport().jsonpMapper());
     final Integer expectedSnapshotsCount = metadata.partCount();
 

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -164,7 +164,8 @@ public class ElasticsearchBackupRepositoryTest {
     // Set up Snapshot client
     when(esClient.snapshot()).thenReturn(snapshotClient);
     // Set up Snapshot details
-    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 1).asJsonES(null);
+    final Map<String, JsonData> metadata =
+        MetadataMarshaller.asJson(new Metadata(1L, "1", 1, 1), null);
     when(firstSnapshotInfo.metadata()).thenReturn(metadata);
     when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
     //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
@@ -193,7 +194,8 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up first Snapshot details
-    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    final Map<String, JsonData> metadata =
+        MetadataMarshaller.asJson(new Metadata(1L, "1", 1, 3), null);
     when(firstSnapshotInfo.metadata()).thenReturn(metadata);
     when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
     //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
@@ -231,7 +233,8 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up first Snapshot details
-    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    final Map<String, JsonData> metadata =
+        MetadataMarshaller.asJson(new Metadata(1L, "1", 1, 3), null);
     when(firstSnapshotInfo.metadata()).thenReturn(metadata);
     when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
     //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
@@ -271,7 +274,8 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up Snapshot details
-    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    final Map<String, JsonData> metadata =
+        MetadataMarshaller.asJson(new Metadata(1L, "1", 1, 3), null);
     when(firstSnapshotInfo.metadata()).thenReturn(metadata);
     when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
     //    when(firstSnapshotInfo.uuid()).thenReturn("uuid-first");

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -12,6 +12,12 @@ import static org.assertj.core.api.AssertionsForClassTypes.fail;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.snapshot.ElasticsearchSnapshotClient;
+import co.elastic.clients.elasticsearch.snapshot.GetSnapshotRequest;
+import co.elastic.clients.elasticsearch.snapshot.GetSnapshotResponse;
+import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
+import co.elastic.clients.json.JsonData;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.Metadata;
@@ -21,17 +27,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.client.SnapshotClient;
-import org.elasticsearch.snapshots.SnapshotId;
-import org.elasticsearch.snapshots.SnapshotInfo;
-import org.elasticsearch.snapshots.SnapshotState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,13 +46,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class ElasticsearchBackupRepositoryTest {
 
+  private final Executor executor = Runnable::run;
   private final String repositoryName = "repo1";
   private final long backupId = 555;
   private final String snapshotName = "camunda_operate_" + backupId + "_8.6_part_1_of_6";
   private final long incompleteCheckTimeoutLengthSeconds = 5 * 60L; // 5 minutes
   private final long incompleteCheckTimeoutLength = incompleteCheckTimeoutLengthSeconds * 1000;
-  @Mock private RestHighLevelClient esClient;
-  @Mock private SnapshotClient snapshotClient;
+  @Mock private ElasticsearchClient esClient;
   @Spy private ObjectMapper objectMapper = new ObjectMapper();
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
@@ -64,18 +65,18 @@ public class ElasticsearchBackupRepositoryTest {
     backupRepository =
         Mockito.spy(
             new ElasticsearchBackupRepository(
-                esClient, objectMapper, backupProps, new TestSnapshotProvider()));
+                esClient, objectMapper, backupProps, new TestSnapshotProvider(), executor));
   }
 
   @Test
   public void testWaitingForSnapshotWithTimeout() {
     final int timeout = 1;
-    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
+    final var snapshotState = SnapshotState.IN_PROGRESS.name();
 
     // mock calls to `findSnapshot` and `operateProperties`
-    final SnapshotInfo snapshotInfo = Mockito.mock(SnapshotInfo.class, Mockito.RETURNS_DEEP_STUBS);
+    final var snapshotInfo = Mockito.mock(SnapshotInfo.class, Mockito.RETURNS_DEEP_STUBS);
     when(snapshotInfo.state()).thenReturn(snapshotState);
-    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+    when(snapshotInfo.snapshot()).thenReturn(snapshotName);
     when(backupProps.snapshotTimeout()).thenReturn(timeout);
     doReturn(List.of(snapshotInfo))
         .when(backupRepository)
@@ -95,10 +96,10 @@ public class ElasticsearchBackupRepositoryTest {
     // mock calls to `findSnapshot` and `operateProperties`
     final SnapshotInfo snapshotInfo = Mockito.mock(SnapshotInfo.class, Mockito.RETURNS_DEEP_STUBS);
     when(snapshotInfo.state())
-        .thenReturn(SnapshotState.IN_PROGRESS)
-        .thenReturn(SnapshotState.IN_PROGRESS)
-        .thenReturn(SnapshotState.SUCCESS);
-    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+        .thenReturn(SnapshotState.IN_PROGRESS.name())
+        .thenReturn(SnapshotState.IN_PROGRESS.name())
+        .thenReturn(SnapshotState.SUCCESS.name());
+    when(snapshotInfo.snapshot()).thenReturn(snapshotName);
     when(backupProps.snapshotTimeout()).thenReturn(timeout);
     doReturn(List.of(snapshotInfo))
         .when(backupRepository)
@@ -114,12 +115,12 @@ public class ElasticsearchBackupRepositoryTest {
   @Test
   public void testWaitingForSnapshotWithoutTimeout() {
     final int timeout = 0;
-    final SnapshotState snapshotState = SnapshotState.IN_PROGRESS;
+    final var snapshotState = SnapshotState.IN_PROGRESS.name();
 
     // mock calls to `findSnapshot` and `operateProperties`
     final SnapshotInfo snapshotInfo = Mockito.mock(SnapshotInfo.class, Mockito.RETURNS_DEEP_STUBS);
     when(snapshotInfo.state()).thenReturn(snapshotState);
-    when(snapshotInfo.snapshotId().getName()).thenReturn(snapshotName);
+    when(snapshotInfo.snapshot()).thenReturn(snapshotName);
     when(backupProps.snapshotTimeout()).thenReturn(timeout);
     doReturn(List.of(snapshotInfo))
         .when(backupRepository)
@@ -156,22 +157,22 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   void shouldReturnBackupStateCompleted() throws IOException {
-    final var snapshotClient = Mockito.mock(SnapshotClient.class);
+    final var snapshotClient = Mockito.mock(ElasticsearchSnapshotClient.class);
     final var firstSnapshotInfo = Mockito.mock(SnapshotInfo.class);
-    final var snapshotResponse = Mockito.mock(GetSnapshotsResponse.class);
+    final var snapshotResponse = Mockito.mock(GetSnapshotResponse.class);
 
     // Set up Snapshot client
     when(esClient.snapshot()).thenReturn(snapshotClient);
     // Set up Snapshot details
-    final Map<String, Object> metadata =
-        objectMapper.convertValue(new Metadata(1L, "1", 1, 1), Map.class);
-    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
-    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 1).asJsonES(null);
+    when(firstSnapshotInfo.metadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
 
     // Set up Snapshot response
-    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
-    when(snapshotClient.get(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(snapshotResponse.snapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotClient.get((GetSnapshotRequest) ArgumentMatchers.any()))
         .thenReturn(snapshotResponse);
 
     // Test
@@ -181,9 +182,9 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   void shouldReturnBackupStateIncomplete() throws IOException {
-    final var snapshotClient = Mockito.mock(SnapshotClient.class);
+    final var snapshotClient = Mockito.mock(ElasticsearchSnapshotClient.class);
     final var firstSnapshotInfo = Mockito.mock(SnapshotInfo.class);
-    final var snapshotResponse = Mockito.mock(GetSnapshotsResponse.class);
+    final var snapshotResponse = Mockito.mock(GetSnapshotResponse.class);
     final var lastSnapshotInfo = Mockito.mock(SnapshotInfo.class);
 
     // Set up Snapshot client
@@ -192,21 +193,22 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up first Snapshot details
-    final Map<String, Object> metadata =
-        objectMapper.convertValue(new Metadata(1L, "1", 1, 3), Map.class);
-    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
-    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
-    when(firstSnapshotInfo.startTime()).thenReturn(23L);
+    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    when(firstSnapshotInfo.metadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
+    when(firstSnapshotInfo.startTimeInMillis()).thenReturn(23L);
 
     // Set up last Snapshot details
-    when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(lastSnapshotInfo.endTime()).thenReturn(23L + 6 * 60 * 1_000);
-    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(lastSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(lastSnapshotInfo.uuid()).thenReturn("uuid");
+    when(lastSnapshotInfo.endTimeInMillis()).thenReturn(23L + 6 * 60 * 1_000);
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
 
     // Set up Snapshot response
-    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
-    when(snapshotClient.get(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(snapshotResponse.snapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get((GetSnapshotRequest) ArgumentMatchers.any()))
         .thenReturn(snapshotResponse);
 
     // Test
@@ -217,9 +219,9 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   void shouldReturnBackupStateIncompleteWhenLastSnapshotEndTimeIsTimedOut() throws IOException {
-    final var snapshotClient = Mockito.mock(SnapshotClient.class);
+    final var snapshotClient = Mockito.mock(ElasticsearchSnapshotClient.class);
     final var firstSnapshotInfo = Mockito.mock(SnapshotInfo.class);
-    final var snapshotResponse = Mockito.mock(GetSnapshotsResponse.class);
+    final var snapshotResponse = Mockito.mock(GetSnapshotResponse.class);
     final var lastSnapshotInfo = Mockito.mock(SnapshotInfo.class);
     final long now = Instant.now().toEpochMilli();
 
@@ -229,22 +231,25 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up first Snapshot details
-    final Map<String, Object> metadata =
-        objectMapper.convertValue(new Metadata(1L, "1", 1, 3), Map.class);
-    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
-    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
-    when(firstSnapshotInfo.startTime()).thenReturn(now - 4_000);
+    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    when(firstSnapshotInfo.metadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(firstSnapshotInfo.uuid()).thenReturn("uuid");
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
+    when(firstSnapshotInfo.startTimeInMillis()).thenReturn(now - 4_000);
 
     // Set up last Snapshot details
-    when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
-    when(lastSnapshotInfo.startTime()).thenReturn(now - (incompleteCheckTimeoutLength + 4_000));
-    when(lastSnapshotInfo.endTime()).thenReturn(now - (incompleteCheckTimeoutLength + 2_000));
+    when(lastSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(lastSnapshotInfo.uuid()).thenReturn("uuid");
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
+    when(lastSnapshotInfo.startTimeInMillis())
+        .thenReturn(now - (incompleteCheckTimeoutLength + 4_000));
+    when(lastSnapshotInfo.endTimeInMillis())
+        .thenReturn(now - (incompleteCheckTimeoutLength + 2_000));
 
     // Set up Snapshot response
-    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
-    when(snapshotClient.get(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(snapshotResponse.snapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get((GetSnapshotRequest) ArgumentMatchers.any()))
         .thenReturn(snapshotResponse);
 
     // Test
@@ -254,10 +259,10 @@ public class ElasticsearchBackupRepositoryTest {
 
   @Test
   void shouldReturnBackupStateProgress() throws IOException {
-    final var snapshotClient = Mockito.mock(SnapshotClient.class);
+    final var snapshotClient = Mockito.mock(ElasticsearchSnapshotClient.class);
     final var firstSnapshotInfo = Mockito.mock(SnapshotInfo.class);
+    final var snapshotResponse = Mockito.mock(GetSnapshotResponse.class);
     final var lastSnapshotInfo = Mockito.mock(SnapshotInfo.class);
-    final var snapshotResponse = Mockito.mock(GetSnapshotsResponse.class);
     final long now = Instant.now().toEpochMilli();
 
     // Set up Snapshot client
@@ -266,21 +271,20 @@ public class ElasticsearchBackupRepositoryTest {
     when(backupProps.incompleteCheckTimeoutInSeconds())
         .thenReturn(incompleteCheckTimeoutLengthSeconds);
     // Set up Snapshot details
-    final Map<String, Object> metadata =
-        objectMapper.convertValue(new Metadata(1L, "1", 1, 3), Map.class);
-    when(firstSnapshotInfo.userMetadata()).thenReturn(metadata);
-    when(firstSnapshotInfo.snapshotId())
-        .thenReturn(new SnapshotId("first-snapshot-name", "uuid-first"));
-    when(lastSnapshotInfo.snapshotId())
-        .thenReturn(new SnapshotId("last-snapshot-name", "uuid-last"));
-    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
-    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
-    when(firstSnapshotInfo.startTime()).thenReturn(now - 4_000);
-    when(lastSnapshotInfo.startTime()).thenReturn(now - 200);
-    when(lastSnapshotInfo.endTime()).thenReturn(now - 5);
+    final Map<String, JsonData> metadata = new Metadata(1L, "1", 1, 3).asJsonES(null);
+    when(firstSnapshotInfo.metadata()).thenReturn(metadata);
+    when(firstSnapshotInfo.snapshot()).thenReturn("snapshot-name");
+    //    when(firstSnapshotInfo.uuid()).thenReturn("uuid-first");
+    when(lastSnapshotInfo.snapshot()).thenReturn("last-snapshot-name");
+    //    when(firstSnapshotInfo.uuid()).thenReturn("uuid-last");
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS.name());
+    when(firstSnapshotInfo.startTimeInMillis()).thenReturn(now - 4_000);
+    when(lastSnapshotInfo.startTimeInMillis()).thenReturn(now - 200);
+    when(lastSnapshotInfo.endTimeInMillis()).thenReturn(now - 5);
     // Set up Snapshot response
-    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
-    when(snapshotClient.get(ArgumentMatchers.any(), ArgumentMatchers.any()))
+    when(snapshotResponse.snapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
+    when(snapshotClient.get((GetSnapshotRequest) ArgumentMatchers.any()))
         .thenReturn(snapshotResponse);
 
     // Test

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -419,7 +419,7 @@ class OpensearchBackupRepositoryTest {
         .indices(List.of())
         .snapshot("snapshot")
         .uuid("uuid")
-        .metadata(metadata.asJson(new JacksonJsonpMapper()));
+        .metadata(MetadataMarshaller.asJson(metadata, new JacksonJsonpMapper()));
   }
 
   private GetSnapshotResponse.Builder defaultFields(final GetSnapshotResponse.Builder b) {


### PR DESCRIPTION
## Description
Main differences:
- SnapshotState is now a string and not an enum (which is the state of a single part of the snapshot)
  - INCOMPATIBLE does not exist anymore in the [api](https://www.elastic.co/guide/en/elasticsearch/reference/current/create-snapshot-api.html#create-snapshot-api-request-body)
- The new snapshot client is sync and not async
- :red_circle: Some option in the snaphot creation are not available in the client (even though they can be set from REST apis) (see my comment)
- I added an executor to make each method return immediately as before

## Related issues
closes #25676
