### PR TITLE
fix: parse unexpected REST responses in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.async.NonBlockingByteBufferJsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -91,13 +93,23 @@ public interface TypedApiEntityConsumer<T> {
 
     @Override
     public ApiEntity<T> generateContent() throws IOException {
-      buffer.asParserOnFirstToken();
-
-      if (isResponse) {
-        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
+      try {
+        if (isResponse) {
+          return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
+        }
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
+      } catch (final IOException ioe) {
+        // write the original JSON response into an error response
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final JsonGenerator generator = json.createGenerator(output);
+        buffer.serialize(generator);
+        generator.flush();
+        return ApiEntity.of(
+            new ProblemDetail()
+                .title("Unexpected server response")
+                .status(500)
+                .detail(output.toString(StandardCharsets.UTF_8.name())));
       }
-
-      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
     }
 
     @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -100,15 +100,9 @@ public interface TypedApiEntityConsumer<T> {
         return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
       } catch (final IOException ioe) {
         // write the original JSON response into an error response
-        final ByteArrayOutputStream output = new ByteArrayOutputStream();
-        final JsonGenerator generator = json.createGenerator(output);
-        buffer.serialize(generator);
-        generator.flush();
+        final String jsonString = getJsonString();
         return ApiEntity.of(
-            new ProblemDetail()
-                .title("Unexpected server response")
-                .status(500)
-                .detail(output.toString(StandardCharsets.UTF_8.name())));
+            new ProblemDetail().title("Unexpected server response").status(500).detail(jsonString));
       }
     }
 
@@ -147,6 +141,17 @@ public interface TypedApiEntityConsumer<T> {
     @Override
     public int getBufferedBytes() {
       return bufferedBytes;
+    }
+
+    private String getJsonString() {
+      try (final ByteArrayOutputStream output = new ByteArrayOutputStream();
+          final JsonGenerator generator = json.createGenerator(output)) {
+        buffer.serialize(generator);
+        generator.flush();
+        return output.toString(StandardCharsets.UTF_8.name());
+      } catch (final Exception ex) {
+        return "Original response cannot be constructed";
+      }
     }
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -150,6 +150,7 @@ public interface TypedApiEntityConsumer<T> {
         generator.flush();
         return output.toString(StandardCharsets.UTF_8.name());
       } catch (final Exception ex) {
+        LOGGER.warn("Failed to serialize JSON string", ex);
         return "Original response cannot be constructed";
       }
     }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -56,6 +56,54 @@ class ApiEntityConsumerTest {
   }
 
   @Test
+  void testJsonApiEntityConsumerWithValidJsonOtherTypeResponse() throws IOException {
+    // given
+    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with the correct content type
+    consumer.streamStart(ContentType.APPLICATION_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Error.class);
+    final ProblemDetail response = entity.problem();
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
+    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+  }
+
+  @Test
+  void testJsonApiEntityConsumerWithValidJsonOtherTypeErrorResponse() throws IOException {
+    // given
+    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with the correct content type
+    consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Error.class);
+    final ProblemDetail response = entity.problem();
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
+    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+  }
+
+  @Test
   void testJsonApiEntityConsumerWithProblemDetailResponse() throws IOException {
     // given
     final String problemDetailResponse =


### PR DESCRIPTION
## Description

If an unexpected response is returned for REST calls, the Java client needs to handle this in a meaningful way. The client tries to parse "application/json" responses as the defined target type. If this fails, it returns a ProblemDetail instead, containing the original payload JSON as detail information.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25087 
