### PR TITLE
refactor: export snapshot variable on user task completion

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/IndexTemplateDescriptorsConfigurator.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/IndexTemplateDescriptorsConfigurator.java
@@ -26,6 +26,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -294,6 +295,17 @@ public class IndexTemplateDescriptorsConfigurator {
     return new BatchOperationTemplate(
         operateProperties.getIndexPrefix(DatabaseInfo.getCurrent()),
         databaseInfo.isElasticsearchDb()) {
+      @Override
+      public String getIndexPrefix() {
+        return indexPrefixHolder.getIndexPrefix();
+      }
+    };
+  }
+
+  @Bean("operateSnapshotTaskVariableTemplate")
+  public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
+      final DatabaseInfo databaseInfo, final IndexPrefixHolder indexPrefixHolder) {
+    return new SnapshotTaskVariableTemplate("", databaseInfo.isElasticsearchDb()) {
       @Override
       public String getIndexPrefix() {
         return indexPrefixHolder.getIndexPrefix();

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexTemplateDescriptorsConfigurator.java
@@ -26,6 +26,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.PostImporterQueueTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.SequenceFlowTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
+import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -172,6 +173,14 @@ public class IndexTemplateDescriptorsConfigurator {
   public BatchOperationTemplate getBatchOperationTemplate(
       final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
     return new BatchOperationTemplate(
+        operateProperties.getIndexPrefix(DatabaseInfo.getCurrent()),
+        databaseInfo.isElasticsearchDb());
+  }
+
+  @Bean("operateSnapshotTaskVariableTemplate")
+  public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
+      final OperateProperties operateProperties, final DatabaseInfo databaseInfo) {
+    return new SnapshotTaskVariableTemplate(
         operateProperties.getIndexPrefix(DatabaseInfo.getCurrent()),
         databaseInfo.isElasticsearchDb());
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/UserTaskReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/UserTaskReader.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.operate.webapp.reader;
 
+import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
-import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,5 +18,5 @@ public interface UserTaskReader {
 
   Optional<TaskEntity> getUserTaskByFlowNodeInstanceKey(long flowNodeInstanceKey);
 
-  List<TaskVariableEntity> getUserTaskVariables(long flowNodeInstanceKey);
+  List<SnapshotTaskVariableEntity> getUserTaskVariables(long taskKey);
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilder.java
@@ -20,7 +20,6 @@ import io.camunda.operate.webapp.rest.dto.metadata.UserTaskInstanceMetadataDto;
 import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeType;
-import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -116,7 +115,6 @@ public class FlowNodeInstanceMetadataBuilder {
       final FlowNodeInstanceEntity flowNodeInstance) {
     final var userTask = userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey());
     final var event = eventReader.getEventEntityByFlowNodeInstanceId(flowNodeInstance.getId());
-    final var variables = userTaskReader.getUserTaskVariables(flowNodeInstance.getKey());
     final var result =
         new UserTaskInstanceMetadataDto(
             flowNodeInstance.getFlowNodeId(),
@@ -126,8 +124,9 @@ public class FlowNodeInstanceMetadataBuilder {
             flowNodeInstance.getEndDate(),
             event);
     if (userTask.isPresent()) {
+      final var variables = userTaskReader.getUserTaskVariables(userTask.get().getKey());
       final Map<String, Object> variablesMap = new HashMap<>();
-      for (final TaskVariableEntity v : variables) {
+      for (final var v : variables) {
         variablesMap.put(v.getName(), v.getValue());
       }
 

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/FlowNodeInstanceMetadataBuilderTest.java
@@ -26,8 +26,8 @@ import io.camunda.webapps.schema.entities.operate.EventEntity;
 import io.camunda.webapps.schema.entities.operate.EventMetadataEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.FlowNodeType;
+import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskEntity;
-import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
@@ -112,11 +112,11 @@ class FlowNodeInstanceMetadataBuilderTest {
                         .setCorrelationKey("23-05")));
     when(userTaskReader.getUserTaskByFlowNodeInstanceKey(flowNodeInstance.getKey()))
         .thenReturn(userTask);
-    when(userTaskReader.getUserTaskVariables(flowNodeInstance.getKey()))
+    when(userTaskReader.getUserTaskVariables(userTask.get().getKey()))
         .thenReturn(
             List.of(
-                new TaskVariableEntity().setName("name").setValue("Homer Simpson"),
-                new TaskVariableEntity().setName("City").setValue("Springfield")));
+                new SnapshotTaskVariableEntity().setName("name").setValue("Homer Simpson"),
+                new SnapshotTaskVariableEntity().setName("City").setValue("Springfield")));
     final var metadata = (UserTaskInstanceMetadataDto) builder.buildFrom(flowNodeInstance);
     assertThat(metadata.getFlowNodeType()).isEqualTo(FlowNodeType.USER_TASK);
     assertStandardValues(metadata);

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/IndexTemplateDescriptorsConfigurator.java
@@ -158,8 +158,15 @@ public class IndexTemplateDescriptorsConfigurator {
     return new TasklistMetricIndex("", databaseInfo.isElasticsearchDb());
   }
 
-  @Bean
-  public SnapshotTaskVariableTemplate getSnapshotTaskVariableTemplate(
+  @Bean("operateSnapshotTaskVariableTemplate")
+  public SnapshotTaskVariableTemplate getOperateSnapshotTaskVariableTemplate(
+      final DatabaseInfo databaseInfo) {
+    // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
+    return new SnapshotTaskVariableTemplate("", databaseInfo.isElasticsearchDb());
+  }
+
+  @Bean("tasklistSnapshotTaskVariableTemplate")
+  public SnapshotTaskVariableTemplate getTasklistSnapshotTaskVariableTemplate(
       final DatabaseInfo databaseInfo) {
     // Just take the provided DatabaseInfo, no need to distinguish between Tasklist or Operate
     return new SnapshotTaskVariableTemplate("", databaseInfo.isElasticsearchDb());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/TasklistIndexTemplateDescriptorsConfigurator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/TasklistIndexTemplateDescriptorsConfigurator.java
@@ -48,7 +48,7 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
         getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));
   }
 
-  @Bean
+  @Bean("tasklistSnapshotTaskVariableTemplate")
   public SnapshotTaskVariableTemplate snapshotTaskVariableTemplate() {
     return new SnapshotTaskVariableTemplate(
         getIndexPrefix(tasklistProperties), isElasticsearch(tasklistProperties));

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -101,7 +101,9 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   @Autowired private VariableStore variableStoreElasticSearch;
 
-  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -98,7 +98,9 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   @Autowired private VariableStore variableStoreElasticSearch;
 
-  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired private TaskVariableSearchUtil taskVariableSearchUtil;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -50,7 +50,9 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
 
   @Autowired private UserTaskRecordToVariableEntityMapper userTaskRecordToVariableEntityMapper;
 
-  @Autowired private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -47,7 +47,9 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -50,7 +50,9 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
 
   @Autowired private UserTaskRecordToVariableEntityMapper userTaskRecordToVariableEntityMapper;
 
-  @Autowired private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -47,7 +47,9 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired private SnapshotTaskVariableTemplate variableIndex;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate variableIndex;
 
   @Autowired private UserTaskRecordToTaskEntityMapper userTaskRecordToTaskEntityMapper;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchChecks.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -47,7 +48,9 @@ public class ElasticsearchChecks {
 
   @Autowired private ProcessStore processStore;
 
-  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   /** Checks whether the process of given args[0] processId (Long) is deployed. */
   @Bean(name = PROCESS_IS_DEPLOYED_CHECK)

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
@@ -55,7 +55,9 @@ public class ElasticsearchHelper implements NoSqlHelper {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   @Autowired
   @Qualifier("tasklistVariableTemplate")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchChecks.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
@@ -46,7 +47,9 @@ public class OpenSearchChecks {
 
   @Autowired private ProcessStore processStore;
 
-  @Autowired private SnapshotTaskVariableTemplate taskVariableTemplate;
+  @Autowired
+  @Qualifier("tasklistSnapshotTaskVariableTemplate")
+  private SnapshotTaskVariableTemplate taskVariableTemplate;
 
   /** Checks whether the process of given args[0] processId (Long) is deployed. */
   @Bean(name = PROCESS_IS_DEPLOYED_CHECK)

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexTemplateDescriptorsConfigurator.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TasklistIndexTemplateDescriptorsConfigurator.java
@@ -66,7 +66,7 @@ public class TasklistIndexTemplateDescriptorsConfigurator {
     };
   }
 
-  @Bean
+  @Bean("tasklistSnapshotTaskVariableTemplate")
   public SnapshotTaskVariableTemplate snapshotTaskVariableTemplate(
       final TasklistProperties tasklistProperties,
       final TasklistIndexPrefixHolder indexPrefixHolder) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -282,7 +282,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
                 templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new UserTaskCompletionVariableHandler(
-                templateDescriptorsMap.get(TaskTemplate.class).getFullQualifiedName(),
+                templateDescriptorsMap
+                    .get(SnapshotTaskVariableTemplate.class)
+                    .getFullQualifiedName(),
                 configuration.getIndex().getVariableSizeThreshold()),
             new OperationFromProcessInstanceHandler(
                 templateDescriptorsMap.get(OperationTemplate.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandler.java
@@ -9,11 +9,11 @@ package io.camunda.exporter.handlers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
-import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
-import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
+import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
+import io.camunda.webapps.schema.entities.ExporterEntity;
+import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -21,17 +21,17 @@ import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskCompletionVariableHandler
-    implements ExportHandler<TaskVariableEntity, UserTaskRecordValue> {
+    implements ExportHandler<SnapshotTaskVariableBatch, UserTaskRecordValue> {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskCompletionVariableHandler.class);
 
-  private static final String ID_PATTERN = "%s-%s" + TaskTemplate.LOCAL_VARIABLE_SUFFIX;
+  private static final String ID_PATTERN = "%s-%s";
   private static final ObjectMapper MAPPER = new ObjectMapper();
   protected final int variableSizeThreshold;
   private final String indexName;
@@ -48,8 +48,8 @@ public class UserTaskCompletionVariableHandler
   }
 
   @Override
-  public Class<TaskVariableEntity> getEntityType() {
-    return TaskVariableEntity.class;
+  public Class<SnapshotTaskVariableBatch> getEntityType() {
+    return SnapshotTaskVariableBatch.class;
   }
 
   @Override
@@ -61,82 +61,95 @@ public class UserTaskCompletionVariableHandler
 
   @Override
   public List<String> generateIds(final Record<UserTaskRecordValue> record) {
-    final List<String> variableIds = new ArrayList<>();
-    record
-        .getValue()
-        .getVariables()
-        .keySet()
-        .forEach(
-            variableName ->
-                variableIds.add(
-                    ID_PATTERN.formatted(record.getValue().getElementInstanceKey(), variableName)));
-    return variableIds;
+    return List.of(String.valueOf(record.getValue().getUserTaskKey()));
   }
 
   @Override
-  public TaskVariableEntity createNewEntity(final String id) {
-    return new TaskVariableEntity().setId(id);
+  public SnapshotTaskVariableBatch createNewEntity(final String id) {
+    return new SnapshotTaskVariableBatch(id, new ArrayList<>());
   }
 
   @Override
   public void updateEntity(
-      final Record<UserTaskRecordValue> record, final TaskVariableEntity entity) {
-    final String variableName = entity.getId().split("-")[1];
-    entity
-        .setPartitionId(record.getPartitionId())
-        .setPosition(record.getPosition())
-        .setName(variableName)
-        .setTenantId(record.getValue().getTenantId())
-        .setKey(record.getKey())
-        .setProcessInstanceId(record.getValue().getProcessInstanceKey())
-        .setScopeKey(record.getValue().getElementInstanceKey());
-
-    String variableStringValue = "";
-    final Object variableValue = record.getValue().getVariables().get(variableName);
-    try {
-      variableStringValue = MAPPER.writeValueAsString(variableValue);
-    } catch (final JsonProcessingException e) {
-      LOGGER.error(
-          String.format(
-              "Failed to parse variable '%s' value as string '%s'", variableName, variableValue),
-          e);
-    }
-
-    if (variableStringValue.length() > variableSizeThreshold) {
-      entity.setValue(variableStringValue.substring(0, variableSizeThreshold));
-      entity.setFullValue(variableStringValue);
-      entity.setIsTruncated(true);
-    } else {
-      entity.setValue(variableStringValue);
-      entity.setFullValue(null);
-      entity.setIsTruncated(false);
-    }
-
-    final TaskJoinRelationship joinRelationship = new TaskJoinRelationship();
-    joinRelationship.setParent(entity.getScopeKey());
-    joinRelationship.setName(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
-    entity.setJoin(joinRelationship);
+      final Record<UserTaskRecordValue> record, final SnapshotTaskVariableBatch entity) {
+    final var snapshotVariableCollection = entity.variables();
+    final var recordValue = record.getValue();
+    final var recordVariables = recordValue.getVariables();
+    recordVariables.entrySet().stream()
+        .map(e -> createSnapshotVariableEntity(e, record))
+        .forEach(snapshotVariableCollection::add);
   }
 
   @Override
-  public void flush(final TaskVariableEntity entity, final BatchRequest batchRequest) {
-    final Map<String, Object> updateFields = new HashMap<>();
-
-    updateFields.put(TaskTemplate.VARIABLE_VALUE, entity.getValue());
-    updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, entity.getFullValue());
-    updateFields.put(TaskTemplate.IS_TRUNCATED, entity.getIsTruncated());
-    updateFields.put(TaskTemplate.JOIN_FIELD_NAME, entity.getJoin());
-
-    batchRequest.upsertWithRouting(
-        indexName,
-        entity.getId(),
-        entity,
-        updateFields,
-        String.valueOf(entity.getProcessInstanceId()));
+  public void flush(final SnapshotTaskVariableBatch entity, final BatchRequest batchRequest) {
+    entity.variables().forEach(v -> flushSnapshotTaskVariableEntity(v, batchRequest));
   }
 
   @Override
   public String getIndexName() {
     return indexName;
+  }
+
+  private void flushSnapshotTaskVariableEntity(
+      final SnapshotTaskVariableEntity entity, final BatchRequest batchRequest) {
+    final var updateFields = new HashMap<String, Object>();
+    updateFields.put(SnapshotTaskVariableTemplate.VALUE, entity.getValue());
+    updateFields.put(SnapshotTaskVariableTemplate.FULL_VALUE, entity.getFullValue());
+    updateFields.put(SnapshotTaskVariableTemplate.IS_PREVIEW, entity.getIsPreview());
+    batchRequest.upsert(indexName, entity.getId(), entity, updateFields);
+  }
+
+  private SnapshotTaskVariableEntity createSnapshotVariableEntity(
+      final Entry<String, Object> e, final Record<UserTaskRecordValue> record) {
+    final var recordValue = record.getValue();
+    final var userTaskKey = recordValue.getUserTaskKey();
+
+    final var variableName = e.getKey();
+    final var variableValue = e.getValue();
+
+    final var variableValueAsString = toJsonString(variableValue);
+    final var snapshotVariableEntity =
+        new SnapshotTaskVariableEntity()
+            .setId(String.format(ID_PATTERN, userTaskKey, variableName))
+            .setKey(record.getKey())
+            .setPartitionId(record.getPartitionId())
+            .setName(e.getKey())
+            .setTenantId(recordValue.getTenantId())
+            .setProcessInstanceKey(recordValue.getProcessInstanceKey())
+            .setTaskId(String.valueOf(record.getValue().getUserTaskKey()))
+            .setFullValue(variableValueAsString);
+
+    if (variableValueAsString.length() > variableSizeThreshold) {
+      // store preview
+      snapshotVariableEntity
+          .setValue(variableValueAsString.substring(0, variableSizeThreshold))
+          .setIsPreview(true);
+    } else {
+      snapshotVariableEntity.setValue(variableValueAsString).setIsPreview(false);
+    }
+    return snapshotVariableEntity;
+  }
+
+  private String toJsonString(final Object value) {
+    try {
+      return MAPPER.writeValueAsString(value);
+    } catch (final JsonProcessingException e) {
+      LOGGER.error("Failed to parse variable value '{}'", value, e);
+      return "";
+    }
+  }
+
+  public record SnapshotTaskVariableBatch(String id, List<SnapshotTaskVariableEntity> variables)
+      implements ExporterEntity<SnapshotTaskVariableBatch> {
+
+    @Override
+    public String getId() {
+      return id;
+    }
+
+    @Override
+    public SnapshotTaskVariableBatch setId(final String id) {
+      throw new UnsupportedOperationException("Not allowed to set an id");
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskCompletionVariableHandlerTest.java
@@ -12,19 +12,20 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.handlers.UserTaskCompletionVariableHandler.SnapshotTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
-import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
-import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
-import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
-import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
+import io.camunda.webapps.schema.descriptors.tasklist.template.SnapshotTaskVariableTemplate;
+import io.camunda.webapps.schema.entities.tasklist.SnapshotTaskVariableEntity;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableUserTaskRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
@@ -42,7 +43,7 @@ public class UserTaskCompletionVariableHandlerTest {
 
   @Test
   void testGetEntityType() {
-    assertThat(underTest.getEntityType()).isEqualTo(TaskVariableEntity.class);
+    assertThat(underTest.getEntityType()).isEqualTo(SnapshotTaskVariableBatch.class);
   }
 
   @Test
@@ -113,10 +114,7 @@ public class UserTaskCompletionVariableHandlerTest {
     final var idList = underTest.generateIds(variableRecord);
 
     // then
-    assertThat(idList)
-        .containsExactlyInAnyOrder(
-            elementInstanceKey + "-" + "var1" + TaskTemplate.LOCAL_VARIABLE_SUFFIX,
-            elementInstanceKey + "-" + "var2" + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
+    assertThat(idList).containsExactlyInAnyOrder(String.valueOf(elementInstanceKey));
   }
 
   @Test
@@ -132,35 +130,21 @@ public class UserTaskCompletionVariableHandlerTest {
   @Test
   void shouldAddEntityOnFlush() {
     // given
-    final var join = new TaskJoinRelationship();
-    join.setName(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
-    join.setParent(123L);
-    final TaskVariableEntity inputEntity =
-        new TaskVariableEntity()
-            .setId("111")
-            .setValue("value")
-            .setIsTruncated(false)
-            .setScopeKey(123L)
-            .setJoin(join);
+    final SnapshotTaskVariableEntity inputEntity =
+        new SnapshotTaskVariableEntity().setId("111").setValue("value").setIsPreview(false);
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(new SnapshotTaskVariableBatch("123", List.of(inputEntity)), mockRequest);
 
     // then
     final Map<String, Object> updateFieldsMap = new HashMap<>();
-    updateFieldsMap.put(TaskTemplate.VARIABLE_FULL_VALUE, null);
-    updateFieldsMap.put(TaskTemplate.VARIABLE_VALUE, "value");
-    updateFieldsMap.put(TaskTemplate.IS_TRUNCATED, false);
-    updateFieldsMap.put(TaskTemplate.JOIN_FIELD_NAME, join);
+    updateFieldsMap.put(SnapshotTaskVariableTemplate.VALUE, inputEntity.getValue());
+    updateFieldsMap.put(SnapshotTaskVariableTemplate.FULL_VALUE, inputEntity.getFullValue());
+    updateFieldsMap.put(SnapshotTaskVariableTemplate.IS_PREVIEW, inputEntity.getIsPreview());
 
     verify(mockRequest, times(1))
-        .upsertWithRouting(
-            indexName,
-            inputEntity.getId(),
-            inputEntity,
-            updateFieldsMap,
-            String.valueOf(inputEntity.getProcessInstanceId()));
+        .upsert(indexName, inputEntity.getId(), inputEntity, updateFieldsMap);
   }
 
   @Test
@@ -170,26 +154,20 @@ public class UserTaskCompletionVariableHandlerTest {
     final var taskRecord = generateRecordWithVariables(scopeKey, Map.of("var1", "val1"));
 
     // when
-    final TaskVariableEntity variableEntity =
-        new TaskVariableEntity().setId(scopeKey + "-" + "var1");
-    underTest.updateEntity(taskRecord, variableEntity);
+    final var batch = new SnapshotTaskVariableBatch(String.valueOf(scopeKey), new ArrayList<>());
+    underTest.updateEntity(taskRecord, batch);
 
     // then
+    final var variableEntity = batch.variables().getFirst();
     assertThat(variableEntity.getId()).isEqualTo(scopeKey + "-" + "var1");
     assertThat(variableEntity.getKey()).isEqualTo(taskRecord.getKey());
     assertThat(variableEntity.getName()).isEqualTo("var1");
-    assertThat(variableEntity.getScopeKey()).isEqualTo(scopeKey);
     assertThat(variableEntity.getTenantId()).isEqualTo(taskRecord.getValue().getTenantId());
-    assertThat(variableEntity.getPosition()).isEqualTo(taskRecord.getPosition());
     assertThat(variableEntity.getValue()).isEqualTo("\"val1\"");
-    assertThat(variableEntity.getProcessInstanceId())
+    assertThat(variableEntity.getProcessInstanceKey())
         .isEqualTo(taskRecord.getValue().getProcessInstanceKey());
-    assertThat(variableEntity.getIsTruncated()).isFalse();
-    assertThat(variableEntity.getFullValue()).isNull();
-    assertThat(variableEntity.getJoin()).isNotNull();
-    assertThat(variableEntity.getJoin().getParent()).isEqualTo(scopeKey);
-    assertThat(variableEntity.getJoin().getName())
-        .isEqualTo(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
+    assertThat(variableEntity.getIsPreview()).isFalse();
+    assertThat(variableEntity.getFullValue()).isEqualTo("\"val1\"");
   }
 
   @Test
@@ -201,16 +179,16 @@ public class UserTaskCompletionVariableHandlerTest {
             scopeKey, Map.of("var1", "v".repeat(underTest.variableSizeThreshold + 1)));
 
     // when
-    final TaskVariableEntity variableEntity =
-        new TaskVariableEntity().setId(scopeKey + "-" + "var1");
-    underTest.updateEntity(taskRecord, variableEntity);
+    final var batch = new SnapshotTaskVariableBatch(String.valueOf(scopeKey), new ArrayList<>());
+    underTest.updateEntity(taskRecord, batch);
 
     // then
+    final var variableEntity = batch.variables().getFirst();
     assertThat(variableEntity.getValue())
         .isEqualTo("\"" + "v".repeat(underTest.variableSizeThreshold - 1));
     assertThat(variableEntity.getFullValue())
         .isEqualTo("\"" + "v".repeat(underTest.variableSizeThreshold + 1) + "\"");
-    assertThat(variableEntity.getIsTruncated()).isTrue();
+    assertThat(variableEntity.getIsPreview()).isTrue();
   }
 
   private Record<UserTaskRecordValue> generateRecordWithVariables(
@@ -222,6 +200,7 @@ public class UserTaskCompletionVariableHandlerTest {
                 .withValue(
                     ImmutableUserTaskRecordValue.builder()
                         .from(factory.generateObject(UserTaskRecordValue.class))
+                        .withUserTaskKey(elementInstanceKey)
                         .withElementInstanceKey(elementInstanceKey)
                         .withVariables(variables)
                         .build()));


### PR DESCRIPTION
## Description

* Export Snapshot Task Variables on User Task completion.
* This is necessary to support the Tasklist v1 API.
* Refactors the UserTaskReader in Operate to retrieve (snapshot) Task Variables from the snapshot task variable index.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24665 
