### PR TITLE
fix: include package.sh in c8run for backwards compatibility

### DIFF
--- a/c8run/package.bat
+++ b/c8run/package.bat
@@ -1,0 +1,2 @@
+@echo on
+.\c8run.exe package

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -76,6 +76,7 @@ func PackageWindows(camundaVersion string, elasticsearchVersion string) error {
 		filepath.Join("c8run", "endpoints.txt"),
 		filepath.Join("c8run", "log"),
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
+		filepath.Join("c8run", "package.bat"),
 	}
 	err = archive.ZipSource(filesToArchive, filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-windows-x86_64.zip"))
 	if err != nil {

--- a/c8run/package.go
+++ b/c8run/package.go
@@ -131,6 +131,7 @@ func PackageUnix(camundaVersion string, elasticsearchVersion string) error {
 		filepath.Join("c8run", "camunda-zeebe-"+camundaVersion),
 		filepath.Join("c8run", "start.sh"),
 		filepath.Join("c8run", "shutdown.sh"),
+		filepath.Join("c8run", "package.sh"),
 	}
 	outputArchive, err := os.Create(filepath.Join("c8run", "camunda8-run-"+camundaVersion+"-"+runtime.GOOS+"-"+architecture+".tar.gz"))
 	if err != nil {

--- a/c8run/package.sh
+++ b/c8run/package.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+./c8run package


### PR DESCRIPTION
## Description

Similar to why we include start.sh and shutdown.sh ,  we include package.sh so that users used to the 8.6 way of running c8run are not broken when using the golang version.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
