### PR TITLE
build: migrate local Operate dev setup to new exporter

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -2,10 +2,14 @@
 
 .PHONY: env-up
 env-up:
-	docker compose -f docker-compose.yml up -d elasticsearch zeebe \
-	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
-	&& CAMUNDA_OPERATE_TASKLIST_URL=http://localhost:8081 \
-	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,auth
+	docker compose -f docker-compose.yml up -d elasticsearch \
+    && mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks -DskipQaBuild \
+	&& CAMUNDA_OPERATE_IMPORTERENABLED=false \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE=elasticsearch \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200 \
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneCamunda" -Dspring.profiles.active=operate,broker,dev,dev-data,auth
 
 env-os-up:
 	docker compose -f docker-compose.yml up -d opensearch zeebe-opensearch \


### PR DESCRIPTION
## Description

Migrate from Operate importer to Camunda exporter in local Operate dev setup (`env-up` target in Makefile)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
