### PR TITLE
feat: add usage metrics endpoint 

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -22,6 +22,7 @@ import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.clients.TenantSearchClient;
+import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
@@ -47,6 +48,7 @@ import io.camunda.service.ResourceServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.SignalServices;
 import io.camunda.service.TenantServices;
+import io.camunda.service.UsageMetricsServices;
 import io.camunda.service.UserServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.VariableServices;
@@ -62,6 +64,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnRestGatewayEnabled
 public class CamundaServicesConfiguration {
+
+  @Bean
+  public UsageMetricsServices usageMetricsServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final UsageMetricsSearchClient usageMetricsSearchClient) {
+    return new UsageMetricsServices(
+        brokerClient, securityContextProvider, usageMetricsSearchClient, null);
+  }
 
   @Bean
   public JobServices<JobActivationResponse> jobServices(

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
@@ -172,7 +172,8 @@ public class ElasticsearchSearchClient
 
   private <T> ScrollResponse<T> scroll(final String scrollId, final Class<T> documentClass)
       throws IOException {
-    return client.scroll(r -> r.scrollId(scrollId), documentClass);
+    return client.scroll(
+        r -> r.scrollId(scrollId).scroll(t -> t.time(SCROLL_KEEP_ALIVE_TIME)), documentClass);
   }
 
   private void clearScroll(final String scrollId) {

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
@@ -171,7 +171,8 @@ public class OpensearchSearchClient implements DocumentBasedSearchClient, Docume
 
   private <T> ScrollResponse<T> scroll(final String scrollId, final Class<T> documentClass)
       throws IOException {
-    return client.scroll(r -> r.scrollId(scrollId), documentClass);
+    return client.scroll(
+        r -> r.scrollId(scrollId).scroll(s -> s.time(SCROLL_KEEP_ALIVE_TIME)), documentClass);
   }
 
   private void clearScroll(final String scrollId) {

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -262,7 +262,7 @@ public class SearchClients
                 new UsageMetricsFilter.Builder()
                     .startTime(query.filter().startTime())
                     .endTime(query.filter().endTime())
-                    .events(event)
+                    .event(event)
                     .build())
             .build();
     final List<UsageMetricsEntity> metrics =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -262,7 +262,7 @@ public class SearchClients
                 new UsageMetricsFilter.Builder()
                     .startTime(query.filter().startTime())
                     .endTime(query.filter().endTime())
-                    .event(event)
+                    .events(event)
                     .build())
             .build();
     final List<UsageMetricsEntity> metrics =

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -254,6 +254,9 @@ public class SearchClients
     return distinctCountUsageMetricsFor("EVENT_DECISION_INSTANCE_EVALUATED", query);
   }
 
+  /*
+   * The distinct count is implemented here by using Java Stream API until aggregations are in place.
+   */
   private Long distinctCountUsageMetricsFor(final String event, final UsageMetricsQuery query) {
     final var filter =
         new UsageMetricsQuery.Builder()

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -48,9 +48,7 @@ import io.camunda.search.query.VariableQuery;
 import io.camunda.security.auth.SecurityContext;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.zeebe.util.CloseableSilently;
-import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SearchClients
     implements AuthorizationSearchClient,

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -27,7 +27,6 @@ import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
 import io.camunda.search.filter.UsageMetricsFilter;
-import io.camunda.search.page.SearchQueryPage;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.DecisionDefinitionQuery;
 import io.camunda.search.query.DecisionInstanceQuery;
@@ -242,17 +241,17 @@ public class SearchClients
 
   @Override
   public Long countAssignees(final UsageMetricsQuery query) {
-    return distinctCountUsageMetricsFor2("task_completed_by_assignee", query);
+    return distinctCountUsageMetricsFor("task_completed_by_assignee", query);
   }
 
   @Override
   public Long countProcessInstances(final UsageMetricsQuery query) {
-    return distinctCountUsageMetricsFor2("EVENT_PROCESS_INSTANCE_STARTED", query);
+    return distinctCountUsageMetricsFor("EVENT_PROCESS_INSTANCE_STARTED", query);
   }
 
   @Override
   public Long countDecisionInstances(final UsageMetricsQuery query) {
-    return distinctCountUsageMetricsFor2("EVENT_DECISION_INSTANCE_EVALUATED", query);
+    return distinctCountUsageMetricsFor("EVENT_DECISION_INSTANCE_EVALUATED", query);
   }
 
   private Long distinctCountUsageMetricsFor(final String event, final UsageMetricsQuery query) {
@@ -273,56 +272,5 @@ public class SearchClients
                 securityContext)
             .findAll(filter, io.camunda.webapps.schema.entities.operate.UsageMetricsEntity.class);
     return metrics.stream().map(UsageMetricsEntity::value).distinct().count();
-  }
-
-  private Long distinctCountUsageMetricsFor2(final String event, final UsageMetricsQuery query) {
-    final var results = new HashSet<String>();
-    final var page = SearchQueryPage.of(p -> p.size(1000));
-    final var searchExecutor =
-        new SearchClientBasedQueryExecutor(
-            searchClient,
-            transformers,
-            new DocumentAuthorizationQueryStrategy(this),
-            securityContext);
-    final var filter =
-        new UsageMetricsQuery.Builder()
-            .filter(
-                new UsageMetricsFilter.Builder()
-                    .startTime(query.filter().startTime())
-                    .endTime(query.filter().endTime())
-                    .events(event)
-                    .build())
-            .page(page)
-            .build();
-    SearchQueryResult<UsageMetricsEntity> searchQueryResult =
-        searchExecutor.search(
-            filter, io.camunda.webapps.schema.entities.operate.UsageMetricsEntity.class);
-    results.addAll(
-        searchQueryResult.items().stream()
-            .map(UsageMetricsEntity::value)
-            .collect(Collectors.toSet()));
-    var current = searchQueryResult.items().size();
-    final var max = searchQueryResult.total();
-    while (current < max) {
-      final var sizedFilter =
-          new UsageMetricsQuery.Builder()
-              .filter(
-                  new UsageMetricsFilter.Builder()
-                      .startTime(query.filter().startTime())
-                      .endTime(query.filter().endTime())
-                      .events(event)
-                      .build())
-              .page(new SearchQueryPage.Builder().from(current).size(1000).build())
-              .build();
-      searchQueryResult =
-          searchExecutor.search(
-              sizedFilter, io.camunda.webapps.schema.entities.operate.UsageMetricsEntity.class);
-      results.addAll(
-          searchQueryResult.items().stream()
-              .map(UsageMetricsEntity::value)
-              .collect(Collectors.toSet()));
-      current += searchQueryResult.items().size();
-    }
-    return (long) results.size();
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClients.java
@@ -22,6 +22,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.UsageMetricsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -39,6 +40,7 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
+import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -64,6 +66,7 @@ public class SearchClients
         VariableSearchClient,
         MappingSearchClient,
         GroupSearchClient,
+        UsageMetricsSearchClient,
         CloseableSilently {
 
   private final DocumentBasedSearchClient searchClient;
@@ -231,5 +234,11 @@ public class SearchClients
   @Override
   public void close() {
     searchClient.close();
+  }
+
+  @Override
+  public UsageMetricsEntity searchUsageMetrics(final UsageMetricsQuery query) {
+    // TODO: Search Operate and Tasklist
+    return new UsageMetricsEntity(1L, 2L, 3L);
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -130,6 +130,7 @@ import io.camunda.search.sort.VariableSort;
 import io.camunda.webapps.schema.descriptors.IndexDescriptors;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.DecisionRequirementsIndex;
+import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.operate.index.ProcessIndex;
 import io.camunda.webapps.schema.descriptors.operate.template.DecisionInstanceTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.FlowNodeInstanceTemplate;
@@ -137,6 +138,7 @@ import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.VariableTemplate;
 import io.camunda.webapps.schema.descriptors.tasklist.index.FormIndex;
+import io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.AuthorizationIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.GroupIndex;
@@ -227,26 +229,9 @@ public final class ServiceTransformers {
             TenantQuery.class,
             UserTaskQuery.class,
             UserQuery.class,
-            VariableQuery.class)
+            VariableQuery.class,
+            UsageMetricsQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
-    mappers.put(ProcessInstanceQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(UserTaskQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(VariableQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(DecisionDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(DecisionRequirementsQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(DecisionInstanceQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(UserQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(RoleQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(FormQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(AuthorizationQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(IncidentQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(
-        FlowNodeInstanceQuery.class,
-        new TypedSearchQueryTransformer<FlowNodeInstanceFilter, FlowNodeInstanceSort>(mappers));
-    mappers.put(ProcessDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(TenantQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(MappingQuery.class, new TypedSearchQueryTransformer<>(mappers));
-    mappers.put(UsageMetricsQuery.class, new TypedSearchQueryTransformer<>(mappers));
 
     // document entity -> domain entity
     mappers.put(DecisionDefinitionEntity.class, new DecisionDefinitionEntityTransformer());
@@ -335,13 +320,11 @@ public final class ServiceTransformers {
     mappers.put(RoleFilter.class, new RoleFilterTransformer(indexDescriptors.get(RoleIndex.class)));
     mappers.put(
         TenantFilter.class, new TenantFilterTransformer(indexDescriptors.get(TenantIndex.class)));
-    mappers.put(FlowNodeInstanceFilter.class, new FlownodeInstanceFilterTransformer());
-    mappers.put(IncidentFilter.class, new IncidentFilterTransformer(mappers));
-    mappers.put(FormFilter.class, new FormFilterTransformer(mappers));
-    mappers.put(ProcessDefinitionFilter.class, new ProcessDefinitionFilterTransformer(mappers));
-    mappers.put(TenantFilter.class, new TenantFilterTransformer());
-    mappers.put(MappingFilter.class, new MappingFilterTransformer());
-    mappers.put(UsageMetricsFilter.class, new UsageMetricsFilterTransformer());
+    mappers.put(
+        UsageMetricsFilter.class,
+        new UsageMetricsFilterTransformer(
+            indexDescriptors.get(TasklistMetricIndex.class),
+            indexDescriptors.get(MetricIndex.class)));
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/ServiceTransformers.java
@@ -22,6 +22,7 @@ import io.camunda.search.clients.transformers.entity.ProcessDefinitionEntityTran
 import io.camunda.search.clients.transformers.entity.ProcessInstanceEntityTransformer;
 import io.camunda.search.clients.transformers.entity.RoleEntityTransformer;
 import io.camunda.search.clients.transformers.entity.TenantEntityTransformer;
+import io.camunda.search.clients.transformers.entity.UsageMetricsEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserEntityTransformer;
 import io.camunda.search.clients.transformers.entity.UserTaskEntityTransformer;
 import io.camunda.search.clients.transformers.entity.VariableEntityTransformer;
@@ -40,6 +41,7 @@ import io.camunda.search.clients.transformers.filter.ProcessDefinitionFilterTran
 import io.camunda.search.clients.transformers.filter.ProcessInstanceFilterTransformer;
 import io.camunda.search.clients.transformers.filter.RoleFilterTransformer;
 import io.camunda.search.clients.transformers.filter.TenantFilterTransformer;
+import io.camunda.search.clients.transformers.filter.UsageMetricsFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserFilterTransformer;
 import io.camunda.search.clients.transformers.filter.UserTaskFilterTransformer;
 import io.camunda.search.clients.transformers.filter.VariableFilterTransformer;
@@ -62,6 +64,7 @@ import io.camunda.search.clients.transformers.sort.ProcessDefinitionFieldSorting
 import io.camunda.search.clients.transformers.sort.ProcessInstanceFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.RoleFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.TenantFieldSortingTransformer;
+import io.camunda.search.clients.transformers.sort.UsageMetricsFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.UserTaskFieldSortingTransformer;
 import io.camunda.search.clients.transformers.sort.VariableFieldSortingTransformer;
@@ -80,6 +83,7 @@ import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.RoleFilter;
 import io.camunda.search.filter.TenantFilter;
+import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
@@ -98,6 +102,7 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQuery;
+import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -118,6 +123,7 @@ import io.camunda.search.sort.ProcessInstanceSort;
 import io.camunda.search.sort.RoleSort;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.TenantSort;
+import io.camunda.search.sort.UsageMetricsSort;
 import io.camunda.search.sort.UserSort;
 import io.camunda.search.sort.UserTaskSort;
 import io.camunda.search.sort.VariableSort;
@@ -141,6 +147,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
 import io.camunda.webapps.schema.entities.operate.FlowNodeInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.IncidentEntity;
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
+import io.camunda.webapps.schema.entities.operate.UsageMetricsEntity;
 import io.camunda.webapps.schema.entities.operate.VariableEntity;
 import io.camunda.webapps.schema.entities.operate.dmn.DecisionInstanceEntity;
 import io.camunda.webapps.schema.entities.operate.dmn.definition.DecisionDefinitionEntity;
@@ -222,6 +229,24 @@ public final class ServiceTransformers {
             UserQuery.class,
             VariableQuery.class)
         .forEach(cls -> mappers.put(cls, searchQueryTransformer));
+    mappers.put(ProcessInstanceQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(UserTaskQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(VariableQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(DecisionDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(DecisionRequirementsQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(DecisionInstanceQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(UserQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(RoleQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(FormQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(AuthorizationQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(IncidentQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(
+        FlowNodeInstanceQuery.class,
+        new TypedSearchQueryTransformer<FlowNodeInstanceFilter, FlowNodeInstanceSort>(mappers));
+    mappers.put(ProcessDefinitionQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(TenantQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(MappingQuery.class, new TypedSearchQueryTransformer<>(mappers));
+    mappers.put(UsageMetricsQuery.class, new TypedSearchQueryTransformer<>(mappers));
 
     // document entity -> domain entity
     mappers.put(DecisionDefinitionEntity.class, new DecisionDefinitionEntityTransformer());
@@ -240,6 +265,7 @@ public final class ServiceTransformers {
     mappers.put(GroupEntity.class, new GroupEntityTransformer());
     mappers.put(UserEntity.class, new UserEntityTransformer());
     mappers.put(MappingEntity.class, new MappingEntityTransformer());
+    mappers.put(UsageMetricsEntity.class, new UsageMetricsEntityTransformer());
 
     // domain field sorting -> database field sorting
     mappers.put(DecisionDefinitionSort.class, new DecisionDefinitionFieldSortingTransformer());
@@ -259,6 +285,7 @@ public final class ServiceTransformers {
     mappers.put(GroupSort.class, new GroupFieldSortingTransformer());
     mappers.put(UserSort.class, new UserFieldSortingTransformer());
     mappers.put(MappingSort.class, new MappingFieldSortingTransformer());
+    mappers.put(UsageMetricsSort.class, new UsageMetricsFieldSortingTransformer());
 
     // filters -> search query
     mappers.put(
@@ -308,6 +335,13 @@ public final class ServiceTransformers {
     mappers.put(RoleFilter.class, new RoleFilterTransformer(indexDescriptors.get(RoleIndex.class)));
     mappers.put(
         TenantFilter.class, new TenantFilterTransformer(indexDescriptors.get(TenantIndex.class)));
+    mappers.put(FlowNodeInstanceFilter.class, new FlownodeInstanceFilterTransformer());
+    mappers.put(IncidentFilter.class, new IncidentFilterTransformer(mappers));
+    mappers.put(FormFilter.class, new FormFilterTransformer(mappers));
+    mappers.put(ProcessDefinitionFilter.class, new ProcessDefinitionFilterTransformer(mappers));
+    mappers.put(TenantFilter.class, new TenantFilterTransformer());
+    mappers.put(MappingFilter.class, new MappingFilterTransformer());
+    mappers.put(UsageMetricsFilter.class, new UsageMetricsFilterTransformer());
 
     // result config -> source config
     mappers.put(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UsageMetricsEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/UsageMetricsEntityTransformer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.entity;
+
+import io.camunda.search.clients.transformers.ServiceTransformer;
+import io.camunda.search.entities.UsageMetricsEntity;
+
+public class UsageMetricsEntityTransformer
+    implements ServiceTransformer<
+        io.camunda.webapps.schema.entities.operate.UsageMetricsEntity, UsageMetricsEntity> {
+
+  @Override
+  public UsageMetricsEntity apply(
+      final io.camunda.webapps.schema.entities.operate.UsageMetricsEntity value) {
+    return new UsageMetricsEntity(
+        value.getId(), value.getEventTime(), value.getEvent(), value.getValue());
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
-import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.Operation;
@@ -36,7 +36,7 @@ public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMet
   public SearchQuery toSearchQuery(final UsageMetricsFilter filter) {
     this.filter = filter;
     final var queries = new ArrayList<SearchQuery>();
-    queries.add(term("event", filter.event()));
+    queries.add(stringTerms("event", filter.events()));
     queries.addAll(
         dateTimeOperations(
             "eventTime",
@@ -54,6 +54,6 @@ public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMet
   }
 
   private boolean shouldUseTasklistIndex(final UsageMetricsFilter filter) {
-    return filter != null && "task_completed_by_assignee".equals(filter.event());
+    return filter != null && filter.events().contains("task_completed_by_assignee");
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
@@ -9,7 +9,7 @@ package io.camunda.search.clients.transformers.filter;
 
 import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
-import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
 
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.filter.Operation;
@@ -18,6 +18,7 @@ import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex;
 import java.util.ArrayList;
+import java.util.List;
 
 public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMetricsFilter> {
 
@@ -35,9 +36,11 @@ public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMet
   public SearchQuery toSearchQuery(final UsageMetricsFilter filter) {
     this.filter = filter;
     final var queries = new ArrayList<SearchQuery>();
-    queries.add(stringTerms("event", filter.events()));
-    queries.addAll(dateTimeOperations("eventTime", Operation.gte(filter.startTime()).values()));
-    queries.addAll(dateTimeOperations("eventTime", Operation.lte(filter.endTime()).values()));
+    queries.add(term("event", filter.event()));
+    queries.addAll(
+        dateTimeOperations(
+            "eventTime",
+            List.of(Operation.gte(filter.startTime()), Operation.lte(filter.endTime()))));
     return and(queries);
   }
 
@@ -51,6 +54,6 @@ public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMet
   }
 
   private boolean shouldUseTasklistIndex(final UsageMetricsFilter filter) {
-    return filter != null && filter.events().contains("task_completed_by_assignee");
+    return filter != null && "task_completed_by_assignee".equals(filter.event());
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/filter/UsageMetricsFilterTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.dateTimeOperations;
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UsageMetricsFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+public class UsageMetricsFilterTransformer implements FilterTransformer<UsageMetricsFilter> {
+
+  @Override
+  public SearchQuery toSearchQuery(final UsageMetricsFilter filter) {
+    final var queries = new ArrayList<SearchQuery>();
+    queries.add(stringTerms("event", filter.events()));
+    queries.addAll(dateTimeOperations("eventTime", Operation.gte(filter.startTime()).values()));
+    queries.addAll(dateTimeOperations("eventTime", Operation.lte(filter.endTime()).values()));
+    return and(queries);
+  }
+
+  @Override
+  public List<String> toIndices(final UsageMetricsFilter filter) {
+    if (shouldUseTasklistIndex(filter)) {
+      return List.of("tasklist-metric-8.3.0_");
+    } else {
+      return List.of("operate-metric-8.3.0_");
+    }
+  }
+
+  private boolean shouldUseTasklistIndex(final UsageMetricsFilter filter) {
+    return filter.events().contains("task_completed_by_assignee");
+  }
+}

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UsageMetricsFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UsageMetricsFieldSortingTransformer.java
@@ -11,6 +11,17 @@ public class UsageMetricsFieldSortingTransformer implements FieldSortingTransfor
 
   @Override
   public String apply(final String domainField) {
+    return switch (domainField) {
+      case "id" -> "id";
+      case "event" -> "event";
+      case "eventTime" -> "eventTime";
+      case "value" -> "value";
+      default -> throw new IllegalArgumentException("Unknown field: " + domainField);
+    };
+  }
+
+  @Override
+  public String defaultSortField() {
     return "id";
   }
 }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UsageMetricsFieldSortingTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/sort/UsageMetricsFieldSortingTransformer.java
@@ -5,8 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.entities;
+package io.camunda.search.clients.transformers.sort;
 
-import java.time.OffsetDateTime;
+public class UsageMetricsFieldSortingTransformer implements FieldSortingTransformer {
 
-public record UsageMetricsEntity(String id, OffsetDateTime eventTime, String event, String value) {}
+  @Override
+  public String apply(final String domainField) {
+    return "id";
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
@@ -14,7 +14,6 @@ import io.camunda.search.clients.query.SearchBoolQuery;
 import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.filter.FilterBuilders;
-import io.camunda.search.filter.Operation;
 import io.camunda.webapps.schema.descriptors.operate.index.MetricIndex;
 import io.camunda.webapps.schema.descriptors.tasklist.index.TasklistMetricIndex;
 import java.time.OffsetDateTime;
@@ -29,10 +28,7 @@ public final class UsageMetricsQueryTransformerTest extends AbstractTransformerT
     final var endTime = OffsetDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     final var filter =
         FilterBuilders.usageMetrics(
-            f ->
-                f.startTime(Operation.gte(startTime))
-                    .endTime(Operation.lte(endTime))
-                    .events("EVENT_PROCESS_INSTANCE_START"));
+            f -> f.startTime(startTime).endTime(endTime).events("EVENT_PROCESS_INSTANCE_START"));
 
     // when
     final var searchRequest = transformQuery(filter);
@@ -83,8 +79,8 @@ public final class UsageMetricsQueryTransformerTest extends AbstractTransformerT
     var filter =
         FilterBuilders.usageMetrics(
             f ->
-                f.startTime(Operation.gte(startTime))
-                    .endTime(Operation.lte(endTime))
+                f.startTime(startTime)
+                    .endTime(endTime)
                     .events("EVENT_PROCESS_INSTANCE_START", "EVENT_PROCESS_INSTANCE_END"));
 
     // when
@@ -94,10 +90,7 @@ public final class UsageMetricsQueryTransformerTest extends AbstractTransformerT
     // should use Tasklist
     filter =
         FilterBuilders.usageMetrics(
-            f ->
-                f.startTime(Operation.gte(startTime))
-                    .endTime(Operation.lte(endTime))
-                    .events("task_completed_by_assignee"));
+            f -> f.startTime(startTime).endTime(endTime).events("task_completed_by_assignee"));
     // when
     transformer.toSearchQuery(filter);
     assertThat(transformer.getIndex()).isEqualTo(tasklistMetricIndex);

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/filter/UsageMetricsQueryTransformerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchRangeQuery;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.Operation;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Test;
+
+public final class UsageMetricsQueryTransformerTest extends AbstractTransformerTest {
+
+  @Test
+  public void shouldQueryByStartTimeAndEndTimeAndEvent() {
+    final var startTime = OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    final var endTime = OffsetDateTime.of(2023, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    final var filter =
+        FilterBuilders.usageMetrics(
+            f ->
+                f.startTime(Operation.gte(startTime))
+                    .endTime(Operation.lte(endTime))
+                    .events("EVENT_PROCESS_INSTANCE_START"));
+
+    // when
+    final var searchRequest = transformQuery(filter);
+
+    // then
+    final var queryVariant = searchRequest.queryOption();
+    assertThat(queryVariant)
+        .isInstanceOfSatisfying(
+            SearchBoolQuery.class,
+            t -> {
+              final var musts = t.must();
+              assertThat(musts).hasSize(3);
+              final var eventSearchTermQuery =
+                  new SearchTermQuery.Builder()
+                      .field("event")
+                      .value("EVENT_PROCESS_INSTANCE_START")
+                      .build()
+                      .toSearchQuery();
+              assertThat(musts).contains(eventSearchTermQuery);
+              final var rangeQueries =
+                  musts.stream()
+                      .filter(
+                          q ->
+                              q.queryOption() instanceof SearchRangeQuery
+                                  && ((SearchRangeQuery) q.queryOption())
+                                      .field()
+                                      .equals("eventTime"))
+                      .map(q -> (SearchRangeQuery) q.queryOption())
+                      .toList();
+              assertThat(rangeQueries).hasSize(2);
+              assertThat(rangeQueries)
+                  .anySatisfy(
+                      q -> {
+                        assertThat(q.gte()).isEqualTo("2021-01-01T00:00:00.000+0000");
+                      });
+              assertThat(rangeQueries)
+                  .anySatisfy(
+                      q -> {
+                        assertThat(q.lte()).isEqualTo("2023-01-01T00:00:00.000+0000");
+                      });
+            });
+  }
+
+  @Test
+  public void shouldQueryDifferentIndicesDependingOnEvent() {
+    // should use Operate
+    var filter =
+        FilterBuilders.usageMetrics(
+            f -> f.events("EVENT_PROCESS_INSTANCE_START", "EVENT_PROCESS_INSTANCE_END"));
+
+    // when
+    var indices = new UsageMetricsFilterTransformer().toIndices(filter);
+    assertThat(indices).containsExactly("operate-metric-8.3.0_");
+
+    // should use Tasklist
+    filter = FilterBuilders.usageMetrics(f -> f.events("task_completed_by_assignee"));
+
+    // when
+    indices = new UsageMetricsFilterTransformer().toIndices(filter);
+    assertThat(indices).containsExactly("tasklist-metric-8.3.0_");
+  }
+}

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UsageMetricsSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UsageMetricsSortTest.java
@@ -9,7 +9,6 @@ package io.camunda.search.clients.transformers.sort;
 
 import static java.time.ZoneOffset.UTC;
 
-import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.sort.SearchSortOptions;
@@ -45,8 +44,8 @@ public class UsageMetricsSortTest extends AbstractSortTransformerTest {
     final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, UTC);
     final var filter =
         new UsageMetricsFilter.Builder()
-            .startTime(Operation.gte(startTime))
-            .endTime(Operation.lte(endTime))
+            .startTime(startTime)
+            .endTime(endTime)
             .events("sort-event")
             .build();
     final var request = SearchQueryBuilders.usageMetricsSearchQuery(q -> q.filter(filter).sort(fn));

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UsageMetricsSortTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/transformers/sort/UsageMetricsSortTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.transformers.sort;
+
+import static java.time.ZoneOffset.UTC;
+
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.sort.SearchSortOptions;
+import io.camunda.search.sort.SortOrder;
+import io.camunda.search.sort.UsageMetricsSort;
+import io.camunda.search.sort.UsageMetricsSort.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class UsageMetricsSortTest extends AbstractSortTransformerTest {
+  private static Stream<Arguments> provideSortParameters() {
+    return Stream.of(
+        new TestArguments("id", SortOrder.ASC, s -> s.id().asc()),
+        new TestArguments("event", SortOrder.ASC, s -> s.event().asc()),
+        new TestArguments("eventTime", SortOrder.ASC, s -> s.eventTime().asc()),
+        new TestArguments("value", SortOrder.ASC, s -> s.value().asc()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideSortParameters")
+  public void shouldSortByField(
+      final String field,
+      final SortOrder sortOrder,
+      final Function<Builder, ObjectBuilder<UsageMetricsSort>> fn) {
+    // when
+    final var startTime = OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, UTC);
+    final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, UTC);
+    final var filter =
+        new UsageMetricsFilter.Builder()
+            .startTime(Operation.gte(startTime))
+            .endTime(Operation.lte(endTime))
+            .events("sort-event")
+            .build();
+    final var request = SearchQueryBuilders.usageMetricsSearchQuery(q -> q.filter(filter).sort(fn));
+    final var sort = transformRequest(request);
+
+    // then
+    Assertions.assertThat(sort).hasSize(2);
+    Assertions.assertThat(sort.get(0))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              Assertions.assertThat(t.field().field()).isEqualTo(field);
+              Assertions.assertThat(t.field().order()).isEqualTo(sortOrder);
+            });
+    Assertions.assertThat(sort.get(1))
+        .isInstanceOfSatisfying(
+            SearchSortOptions.class,
+            t -> {
+              Assertions.assertThat(t.field().field()).isEqualTo("id");
+              Assertions.assertThat(t.field().order()).isEqualTo(SortOrder.ASC);
+            });
+  }
+
+  private record TestArguments(
+      String field,
+      SortOrder sortOrder,
+      Function<UsageMetricsSort.Builder, ObjectBuilder<UsageMetricsSort>> fn)
+      implements Arguments {
+
+    @Override
+    public Object[] get() {
+      return new Object[] {field, sortOrder, fn};
+    }
+  }
+}

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -22,6 +22,7 @@ import io.camunda.search.clients.ProcessDefinitionSearchClient;
 import io.camunda.search.clients.ProcessInstanceSearchClient;
 import io.camunda.search.clients.RoleSearchClient;
 import io.camunda.search.clients.TenantSearchClient;
+import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.clients.UserSearchClient;
 import io.camunda.search.clients.UserTaskSearchClient;
 import io.camunda.search.clients.VariableSearchClient;
@@ -55,6 +56,7 @@ import io.camunda.search.query.ProcessInstanceQuery;
 import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.TenantQuery;
+import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -79,7 +81,8 @@ public class RdbmsSearchClient
         RoleSearchClient,
         TenantSearchClient,
         MappingSearchClient,
-        GroupSearchClient {
+        GroupSearchClient,
+        UsageMetricsSearchClient {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsSearchClient.class);
 
@@ -124,6 +127,24 @@ public class RdbmsSearchClient
   @Override
   public RdbmsSearchClient withSecurityContext(final SecurityContext securityContext) {
     return this;
+  }
+
+  @Override
+  public Long countAssignees(final UsageMetricsQuery query) {
+    throw new UnsupportedOperationException(
+        "UsageMetricsClient countAssignees not implemented yet.");
+  }
+
+  @Override
+  public Long countProcessInstances(final UsageMetricsQuery query) {
+    throw new UnsupportedOperationException(
+        "UsageMetricsClient countProcessInstances not implemented yet.");
+  }
+
+  @Override
+  public Long countDecisionInstances(final UsageMetricsQuery query) {
+    throw new UnsupportedOperationException(
+        "UsageMetricsClient countDecisionInstances not implemented yet.");
   }
 
   @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -7,14 +7,16 @@
  */
 package io.camunda.search.clients;
 
-import io.camunda.search.entities.UsageMetricsEntity;
-import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.SecurityContext;
 
 public interface UsageMetricsSearchClient {
 
-  SearchQueryResult<UsageMetricsEntity> searchUsageMetrics(UsageMetricsQuery query);
-
   UsageMetricsSearchClient withSecurityContext(SecurityContext securityContext);
+
+  Long countAssignees(UsageMetricsQuery query);
+
+  Long countProcessInstances(UsageMetricsQuery query);
+
+  Long countDecisionInstances(UsageMetricsQuery query);
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients;
+
+import io.camunda.search.entities.UsageMetricsEntity;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.security.auth.SecurityContext;
+
+public interface UsageMetricsSearchClient {
+
+  UsageMetricsEntity searchUsageMetrics(UsageMetricsQuery query);
+
+  UsageMetricsSearchClient withSecurityContext(SecurityContext securityContext);
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/UsageMetricsSearchClient.java
@@ -8,12 +8,13 @@
 package io.camunda.search.clients;
 
 import io.camunda.search.entities.UsageMetricsEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.SecurityContext;
 
 public interface UsageMetricsSearchClient {
 
-  UsageMetricsEntity searchUsageMetrics(UsageMetricsQuery query);
+  SearchQueryResult<UsageMetricsEntity> searchUsageMetrics(UsageMetricsQuery query);
 
   UsageMetricsSearchClient withSecurityContext(SecurityContext securityContext);
 }

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricsCount.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricsCount.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public record UsageMetricsCount(Long assignees, Long processInstances, Long decisionInstances) {}

--- a/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricsEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/UsageMetricsEntity.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.entities;
+
+public record UsageMetricsEntity(Long assignees, Long processInstances, Long decisionInstances) {}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/FilterBuilders.java
@@ -14,6 +14,15 @@ public final class FilterBuilders {
 
   private FilterBuilders() {}
 
+  public static UsageMetricsFilter.Builder usageMetrics() {
+    return new UsageMetricsFilter.Builder();
+  }
+
+  public static UsageMetricsFilter usageMetrics(
+      final Function<UsageMetricsFilter.Builder, ObjectBuilder<UsageMetricsFilter>> fn) {
+    return fn.apply(usageMetrics()).build();
+  }
+
   public static ProcessDefinitionFilter.Builder processDefinition() {
     return new ProcessDefinitionFilter.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public record UsageMetricsFilter(
+    List<String> events, Operation<OffsetDateTime> startTime, Operation<OffsetDateTime> endTime)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<UsageMetricsFilter> {
+    private List<String> events;
+    private Operation<OffsetDateTime> startTime;
+    private Operation<OffsetDateTime> endTime;
+
+    public Builder events(final List<String> events) {
+      this.events = addValuesToList(this.events, events);
+      return this;
+    }
+
+    public Builder events(final String event, final String... events) {
+      events(collectValues(event, events));
+      return this;
+    }
+
+    public Builder startTime(final Operation<OffsetDateTime> value) {
+      startTime = value;
+      return this;
+    }
+
+    public Builder endTime(final Operation<OffsetDateTime> value) {
+      endTime = value;
+      return this;
+    }
+
+    @Override
+    public UsageMetricsFilter build() {
+      return new UsageMetricsFilter(events, startTime, endTime);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
@@ -7,19 +7,28 @@
  */
 package io.camunda.search.filter;
 
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
+import java.util.List;
 
-public record UsageMetricsFilter(String event, OffsetDateTime startTime, OffsetDateTime endTime)
-    implements FilterBase {
+public record UsageMetricsFilter(
+    List<String> events, OffsetDateTime startTime, OffsetDateTime endTime) implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<UsageMetricsFilter> {
-    private String event;
+    private List<String> events;
     private OffsetDateTime startTime;
     private OffsetDateTime endTime;
 
-    public Builder event(final String event) {
-      this.event = event;
+    public Builder events(final List<String> events) {
+      this.events = addValuesToList(this.events, events);
+      return this;
+    }
+
+    public Builder events(final String event, final String... events) {
+      events(collectValues(event, events));
       return this;
     }
 
@@ -35,7 +44,7 @@ public record UsageMetricsFilter(String event, OffsetDateTime startTime, OffsetD
 
     @Override
     public UsageMetricsFilter build() {
-      return new UsageMetricsFilter(event, startTime, endTime);
+      return new UsageMetricsFilter(events, startTime, endTime);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
+++ b/search/search-domain/src/main/java/io/camunda/search/filter/UsageMetricsFilter.java
@@ -7,45 +7,35 @@
  */
 package io.camunda.search.filter;
 
-import static io.camunda.util.CollectionUtil.addValuesToList;
-import static io.camunda.util.CollectionUtil.collectValues;
-
 import io.camunda.util.ObjectBuilder;
 import java.time.OffsetDateTime;
-import java.util.List;
 
-public record UsageMetricsFilter(
-    List<String> events, Operation<OffsetDateTime> startTime, Operation<OffsetDateTime> endTime)
+public record UsageMetricsFilter(String event, OffsetDateTime startTime, OffsetDateTime endTime)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<UsageMetricsFilter> {
-    private List<String> events;
-    private Operation<OffsetDateTime> startTime;
-    private Operation<OffsetDateTime> endTime;
+    private String event;
+    private OffsetDateTime startTime;
+    private OffsetDateTime endTime;
 
-    public Builder events(final List<String> events) {
-      this.events = addValuesToList(this.events, events);
+    public Builder event(final String event) {
+      this.event = event;
       return this;
     }
 
-    public Builder events(final String event, final String... events) {
-      events(collectValues(event, events));
-      return this;
-    }
-
-    public Builder startTime(final Operation<OffsetDateTime> value) {
+    public Builder startTime(final OffsetDateTime value) {
       startTime = value;
       return this;
     }
 
-    public Builder endTime(final Operation<OffsetDateTime> value) {
+    public Builder endTime(final OffsetDateTime value) {
       endTime = value;
       return this;
     }
 
     @Override
     public UsageMetricsFilter build() {
-      return new UsageMetricsFilter(events, startTime, endTime);
+      return new UsageMetricsFilter(event, startTime, endTime);
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryBuilders.java
@@ -14,6 +14,15 @@ public final class SearchQueryBuilders {
 
   private SearchQueryBuilders() {}
 
+  public static UsageMetricsQuery.Builder usageMetricsSearchQuery() {
+    return new UsageMetricsQuery.Builder();
+  }
+
+  public static UsageMetricsQuery usageMetricsSearchQuery(
+      final Function<UsageMetricsQuery.Builder, ObjectBuilder<UsageMetricsQuery>> fn) {
+    return fn.apply(usageMetricsSearchQuery()).build();
+  }
+
   public static ProcessDefinitionQuery.Builder processDefinitionSearchQuery() {
     return new ProcessDefinitionQuery.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
@@ -50,6 +50,16 @@ public record UsageMetricsQuery(
       return this;
     }
 
+    public UsageMetricsQuery.Builder filter(
+        final Function<UsageMetricsFilter.Builder, ObjectBuilder<UsageMetricsFilter>> fn) {
+      return filter(FilterBuilders.usageMetrics(fn));
+    }
+
+    public UsageMetricsQuery.Builder sort(
+        final Function<UsageMetricsSort.Builder, ObjectBuilder<UsageMetricsSort>> fn) {
+      return sort(SortOptionBuilders.usageMetrics(fn));
+    }
+
     @Override
     public UsageMetricsQuery build() {
       filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
@@ -7,33 +7,54 @@
  */
 package io.camunda.search.query;
 
-public record UsageMetricsQuery(String startTime, String endTime) {
-  public static UsageMetricsQuery of(final String startTime, final String endTime) {
-    return new UsageMetricsQuery(startTime, endTime);
+import io.camunda.search.filter.FilterBuilders;
+import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.sort.SortOptionBuilders;
+import io.camunda.search.sort.UsageMetricsSort;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public record UsageMetricsQuery(
+    UsageMetricsFilter filter, UsageMetricsSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<UsageMetricsFilter, UsageMetricsSort> {
+
+  public static UsageMetricsQuery of(final Function<Builder, ObjectBuilder<UsageMetricsQuery>> fn) {
+    return fn.apply(new Builder()).build();
   }
 
-  public static final class Builder
-      extends SearchQueryBase.AbstractQueryBuilder<UsageMetricsQuery.Builder> {
-    private String startTime;
-    private String endTime;
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements TypedSearchQueryBuilder<
+          UsageMetricsQuery, Builder, UsageMetricsFilter, UsageMetricsSort> {
+    private static final UsageMetricsFilter EMPTY_FILTER = FilterBuilders.usageMetrics().build();
+    private static final UsageMetricsSort EMPTY_SORT = SortOptionBuilders.usageMetrics().build();
+
+    private UsageMetricsFilter filter;
+    private UsageMetricsSort sort;
 
     @Override
-    protected UsageMetricsQuery.Builder self() {
+    protected Builder self() {
       return this;
     }
 
-    public UsageMetricsQuery.Builder startTime(final String value) {
-      startTime = value;
+    @Override
+    public Builder filter(final UsageMetricsFilter value) {
+      filter = value;
       return this;
     }
 
-    public UsageMetricsQuery.Builder endTime(final String value) {
-      endTime = value;
+    @Override
+    public Builder sort(final UsageMetricsSort value) {
+      sort = value;
       return this;
     }
 
+    @Override
     public UsageMetricsQuery build() {
-      return new UsageMetricsQuery(startTime, endTime);
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new UsageMetricsQuery(filter, sort, page());
     }
   }
 }

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
@@ -50,12 +50,12 @@ public record UsageMetricsQuery(
       return this;
     }
 
-    public UsageMetricsQuery.Builder filter(
+    public Builder filter(
         final Function<UsageMetricsFilter.Builder, ObjectBuilder<UsageMetricsFilter>> fn) {
       return filter(FilterBuilders.usageMetrics(fn));
     }
 
-    public UsageMetricsQuery.Builder sort(
+    public Builder sort(
         final Function<UsageMetricsSort.Builder, ObjectBuilder<UsageMetricsSort>> fn) {
       return sort(SortOptionBuilders.usageMetrics(fn));
     }

--- a/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/UsageMetricsQuery.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.query;
+
+public record UsageMetricsQuery(String startTime, String endTime) {
+  public static UsageMetricsQuery of(final String startTime, final String endTime) {
+    return new UsageMetricsQuery(startTime, endTime);
+  }
+
+  public static final class Builder
+      extends SearchQueryBase.AbstractQueryBuilder<UsageMetricsQuery.Builder> {
+    private String startTime;
+    private String endTime;
+
+    @Override
+    protected UsageMetricsQuery.Builder self() {
+      return this;
+    }
+
+    public UsageMetricsQuery.Builder startTime(final String value) {
+      startTime = value;
+      return this;
+    }
+
+    public UsageMetricsQuery.Builder endTime(final String value) {
+      endTime = value;
+      return this;
+    }
+
+    public UsageMetricsQuery build() {
+      return new UsageMetricsQuery(startTime, endTime);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/SortOptionBuilders.java
@@ -14,6 +14,15 @@ public final class SortOptionBuilders {
 
   private SortOptionBuilders() {}
 
+  public static UsageMetricsSort.Builder usageMetrics() {
+    return new UsageMetricsSort.Builder();
+  }
+
+  public static UsageMetricsSort usageMetrics(
+      final Function<UsageMetricsSort.Builder, ObjectBuilder<UsageMetricsSort>> fn) {
+    return fn.apply(usageMetrics()).build();
+  }
+
   public static ProcessDefinitionSort.Builder processDefinition() {
     return new ProcessDefinitionSort.Builder();
   }

--- a/search/search-domain/src/main/java/io/camunda/search/sort/UsageMetricsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/UsageMetricsSort.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public record UsageMetricsSort(List<FieldSorting> orderings) implements SortOption {
+
+  public static UsageMetricsSort of(final Function<Builder, ObjectBuilder<UsageMetricsSort>> fn) {
+    return SortOptionBuilders.usageMetrics(fn);
+  }
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static final class Builder extends SortOption.AbstractBuilder<Builder>
+      implements ObjectBuilder<UsageMetricsSort> {
+
+    public Builder id() {
+      currentOrdering = new FieldSorting("id", null);
+      return this;
+    }
+
+    public Builder event() {
+      currentOrdering = new FieldSorting("event", null);
+      return this;
+    }
+
+    public Builder eventTime() {
+      currentOrdering = new FieldSorting("eventTime", null);
+      return this;
+    }
+
+    public Builder value() {
+      currentOrdering = new FieldSorting("value", null);
+      return this;
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public UsageMetricsSort build() {
+      return new UsageMetricsSort(orderings);
+    }
+  }
+}

--- a/search/search-domain/src/main/java/io/camunda/search/sort/UsageMetricsSort.java
+++ b/search/search-domain/src/main/java/io/camunda/search/sort/UsageMetricsSort.java
@@ -13,13 +13,13 @@ import java.util.function.Function;
 
 public record UsageMetricsSort(List<FieldSorting> orderings) implements SortOption {
 
-  public static UsageMetricsSort of(final Function<Builder, ObjectBuilder<UsageMetricsSort>> fn) {
-    return SortOptionBuilders.usageMetrics(fn);
-  }
-
   @Override
   public List<FieldSorting> getFieldSortings() {
     return orderings;
+  }
+
+  public static UsageMetricsSort of(final Function<Builder, ObjectBuilder<UsageMetricsSort>> fn) {
+    return SortOptionBuilders.usageMetrics(fn);
   }
 
   public static final class Builder extends SortOption.AbstractBuilder<Builder>

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -8,8 +8,7 @@
 package io.camunda.service;
 
 import io.camunda.search.clients.UsageMetricsSearchClient;
-import io.camunda.search.entities.UsageMetricsEntity;
-import io.camunda.search.query.SearchQueryResult;
+import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.security.SecurityContextProvider;
@@ -28,10 +27,11 @@ public class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
     this.usageMetricsSearchClient = usageMetricsSearchClient;
   }
 
-  public SearchQueryResult<UsageMetricsEntity> search(final UsageMetricsQuery query) {
-    return usageMetricsSearchClient
-        .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
-        .searchUsageMetrics(query);
+  public UsageMetricsCount search(final UsageMetricsQuery query) {
+    final var assignees = usageMetricsSearchClient.countAssignees(query);
+    final var processInstances = usageMetricsSearchClient.countProcessInstances(query);
+    final var decisionInstances = usageMetricsSearchClient.countDecisionInstances(query);
+    return new UsageMetricsCount(assignees, processInstances, decisionInstances);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -28,10 +28,32 @@ public class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
   }
 
   public UsageMetricsCount search(final UsageMetricsQuery query) {
+    if (query == null) {
+      throw new IllegalArgumentException("Query must not be null");
+    }
+    validateStartAndEndTime(query);
     final var assignees = usageMetricsSearchClient.countAssignees(query);
     final var processInstances = usageMetricsSearchClient.countProcessInstances(query);
     final var decisionInstances = usageMetricsSearchClient.countDecisionInstances(query);
     return new UsageMetricsCount(assignees, processInstances, decisionInstances);
+  }
+
+  private void validateStartAndEndTime(final UsageMetricsQuery query) {
+    final var filter = query.filter();
+    if (filter.startTime() == null
+        || filter.startTime().value() == null
+        || filter.endTime() == null
+        || filter.endTime().value() == null) {
+      throw new IllegalArgumentException("Query must have a start AND end time");
+    }
+    final var startTime = filter.startTime().value();
+    final var endTime = filter.endTime().value();
+    if (endTime.isBefore(startTime)) {
+      throw new IllegalArgumentException("End time must be after start time");
+    }
+    if (startTime.isAfter(endTime)) {
+      throw new IllegalArgumentException("Start time must be before end time");
+    }
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -14,7 +14,7 @@ import io.camunda.security.auth.Authentication;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 
-public class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
+public final class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
 
   private final UsageMetricsSearchClient usageMetricsSearchClient;
 

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -9,6 +9,7 @@ package io.camunda.service;
 
 import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.entities.UsageMetricsEntity;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.service.security.SecurityContextProvider;
@@ -27,7 +28,7 @@ public class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
     this.usageMetricsSearchClient = usageMetricsSearchClient;
   }
 
-  public UsageMetricsEntity search(final UsageMetricsQuery query) {
+  public SearchQueryResult<UsageMetricsEntity> search(final UsageMetricsQuery query) {
     return usageMetricsSearchClient
         .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
         .searchUsageMetrics(query);

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -40,14 +40,11 @@ public final class UsageMetricsServices extends ApiServices<UsageMetricsServices
 
   private void validateStartAndEndTime(final UsageMetricsQuery query) {
     final var filter = query.filter();
-    if (filter.startTime() == null
-        || filter.startTime().value() == null
-        || filter.endTime() == null
-        || filter.endTime().value() == null) {
+    if (filter.startTime() == null || filter.endTime() == null) {
       throw new IllegalArgumentException("Query must have a start AND end time");
     }
-    final var startTime = filter.startTime().value();
-    final var endTime = filter.endTime().value();
+    final var startTime = filter.startTime();
+    final var endTime = filter.endTime();
     if (endTime.isBefore(startTime)) {
       throw new IllegalArgumentException("End time must be after start time");
     }

--- a/service/src/main/java/io/camunda/service/UsageMetricsServices.java
+++ b/service/src/main/java/io/camunda/service/UsageMetricsServices.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.UsageMetricsSearchClient;
+import io.camunda.search.entities.UsageMetricsEntity;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+
+public class UsageMetricsServices extends ApiServices<UsageMetricsServices> {
+
+  private final UsageMetricsSearchClient usageMetricsSearchClient;
+
+  public UsageMetricsServices(
+      final BrokerClient brokerClient,
+      final SecurityContextProvider securityContextProvider,
+      final UsageMetricsSearchClient usageMetricsSearchClient,
+      final Authentication authentication) {
+    super(brokerClient, securityContextProvider, authentication);
+    this.usageMetricsSearchClient = usageMetricsSearchClient;
+  }
+
+  public UsageMetricsEntity search(final UsageMetricsQuery query) {
+    return usageMetricsSearchClient
+        .withSecurityContext(securityContextProvider.provideSecurityContext(authentication))
+        .searchUsageMetrics(query);
+  }
+
+  @Override
+  public UsageMetricsServices withAuthentication(final Authentication authentication) {
+    return new UsageMetricsServices(
+        brokerClient, securityContextProvider, usageMetricsSearchClient, authentication);
+  }
+}

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.search.clients.UsageMetricsSearchClient;
 import io.camunda.search.entities.UsageMetricsCount;
-import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.UsageMetricsQuery;
@@ -54,11 +53,7 @@ public final class UsageMetricsServiceTest {
     final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
     final UsageMetricsQuery searchQuery =
         SearchQueryBuilders.usageMetricsSearchQuery()
-            .filter(
-                new UsageMetricsFilter.Builder()
-                    .startTime(Operation.gte(startTime))
-                    .endTime(Operation.lte(endTime))
-                    .build())
+            .filter(new UsageMetricsFilter.Builder().startTime(startTime).endTime(endTime).build())
             .build();
 
     // when

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -43,7 +43,7 @@ public final class UsageMetricsServiceTest {
   }
 
   @Test
-  public void shouldReturnProcessInstance() {
+  public void shouldReturnUsageMetricsCount() {
     // given
     when(client.countProcessInstances(any())).thenReturn(5L);
     when(client.countDecisionInstances(any())).thenReturn(23L);

--- a/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UsageMetricsServiceTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.clients.UsageMetricsSearchClient;
+import io.camunda.search.entities.UsageMetricsCount;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.query.SearchQueryBuilders;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.security.auth.Authentication;
+import io.camunda.service.security.SecurityContextProvider;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class UsageMetricsServiceTest {
+
+  private UsageMetricsServices services;
+  private UsageMetricsSearchClient client;
+  private SecurityContextProvider securityContextProvider;
+  private Authentication authentication;
+
+  @BeforeEach
+  public void before() {
+    client = mock(UsageMetricsSearchClient.class);
+    when(client.withSecurityContext(any())).thenReturn(client);
+    securityContextProvider = mock(SecurityContextProvider.class);
+    services =
+        new UsageMetricsServices(
+            mock(BrokerClient.class), securityContextProvider, client, authentication);
+  }
+
+  @Test
+  public void shouldReturnProcessInstance() {
+    // given
+    when(client.countProcessInstances(any())).thenReturn(5L);
+    when(client.countDecisionInstances(any())).thenReturn(23L);
+    when(client.countAssignees(any())).thenReturn(42L);
+
+    final var startTime =
+        OffsetDateTime.of(2021, 1, 1, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
+    final var endTime = OffsetDateTime.of(2023, 1, 2, 0, 0, 0, 0, OffsetDateTime.now().getOffset());
+    final UsageMetricsQuery searchQuery =
+        SearchQueryBuilders.usageMetricsSearchQuery()
+            .filter(
+                new UsageMetricsFilter.Builder()
+                    .startTime(Operation.gte(startTime))
+                    .endTime(Operation.lte(endTime))
+                    .build())
+            .build();
+
+    // when
+    final UsageMetricsCount searchQueryResult = services.search(searchQuery);
+
+    // then
+    assertThat(searchQueryResult).isEqualTo(new UsageMetricsCount(42L, 5L, 23L));
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/UsageMetricsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/UsageMetricsEntity.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.entities.operate;
+
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public class UsageMetricsEntity {
+
+  private String id;
+  private OffsetDateTime eventTime;
+  private String event;
+  private String value;
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, eventTime, event, value);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final UsageMetricsEntity that = (UsageMetricsEntity) o;
+    return Objects.equals(id, that.id) && Objects.equals(eventTime, that.eventTime)
+        && Objects.equals(event, that.event) && Objects.equals(value, that.value);
+  }
+
+  @Override
+  public String toString() {
+    return "UsageMetricsEntity{" +
+        "id='" + id + '\'' +
+        ", eventTime=" + eventTime +
+        ", event='" + event + '\'' +
+        ", value='" + value + '\'' +
+        '}';
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  public OffsetDateTime getEventTime() {
+    return eventTime;
+  }
+
+  public void setEventTime(final OffsetDateTime eventTime) {
+    this.eventTime = eventTime;
+  }
+
+  public String getEvent() {
+    return event;
+  }
+
+  public void setEvent(final String event) {
+    this.event = event;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/UsageMetricsEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/operate/UsageMetricsEntity.java
@@ -28,18 +28,27 @@ public class UsageMetricsEntity {
       return false;
     }
     final UsageMetricsEntity that = (UsageMetricsEntity) o;
-    return Objects.equals(id, that.id) && Objects.equals(eventTime, that.eventTime)
-        && Objects.equals(event, that.event) && Objects.equals(value, that.value);
+    return Objects.equals(id, that.id)
+        && Objects.equals(eventTime, that.eventTime)
+        && Objects.equals(event, that.event)
+        && Objects.equals(value, that.value);
   }
 
   @Override
   public String toString() {
-    return "UsageMetricsEntity{" +
-        "id='" + id + '\'' +
-        ", eventTime=" + eventTime +
-        ", event='" + event + '\'' +
-        ", value='" + value + '\'' +
-        '}';
+    return "UsageMetricsEntity{"
+        + "id='"
+        + id
+        + '\''
+        + ", eventTime="
+        + eventTime
+        + ", event='"
+        + event
+        + '\''
+        + ", value='"
+        + value
+        + '\''
+        + '}';
   }
 
   public String getId() {

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/template/operate-list-view.json
@@ -1,4 +1,4 @@
-{
+ {
 	"settings": {
 		"index": {
 			"refresh_interval": "2s",

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -47,9 +47,9 @@ tags:
   - name: Signal
   - name: Tenant
   - name: User
+  - name: Usage metrics
   - name: User task
   - name: Variable
-  - name: Usage metrics
 
 paths:
   /topology:
@@ -3605,15 +3605,9 @@ paths:
       tags:
         - Usage metrics
       operationId: searchUsageMetrics
-      summary: Query usage metrics (alpha)
+      summary: Query usage metrics
       description: |
         Search for usage metrics by given start date and end date
-
-        Note that this endpoint is an alpha feature and not enabled on Camunda clusters out of the box.
-        The Camunda 8 API (REST) Overview page provides further details.
-
-        This endpoint is an alpha feature and may be subject to change
-        in future releases.
       requestBody:
         required: true
         content:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3599,7 +3599,48 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /usage-metrics/search:
+    post:
+      tags:
+        - Usage metrics
+      operationId: searchUsageMetrics
+      summary: Query usage metrics (alpha)
+      description: |
+        Search for usage metrics by given start date and end date
 
+        Note that this endpoint is an alpha feature and not enabled on Camunda clusters out of the box.
+        The Camunda 8 API (REST) Overview page provides further details.
+
+        This endpoint is an alpha feature and may be subject to change
+        in future releases.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UsageMetricsSearchQueryRequest"
+      responses:
+        "200":
+          description: >
+            The usage metrics search result.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UsageMetricsSearchQueryResponse"
+        "400":
+          description: >
+            The usage metrics search query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /deployments:
     post:
       tags:
@@ -5260,6 +5301,35 @@ components:
         decisionRequirementsKey:
           type: string
           description: The assigned key of the decision requirements graph that the decision definition is part of.
+    UsageMetricsSearchQueryRequest:
+      type: object
+      properties:
+        startTime:
+          description: The start date and time for usage metrics.
+          type: string
+          format: date-time
+        endTime:
+          description: The end date and time for usage metrics.
+          type: string
+          format: date-time
+      required:
+        - startTime
+        - endTime
+    UsageMetricsSearchQueryResponse:
+      type: object
+      properties:
+        assignees:
+          description: The amount of unique active users.
+          type: integer
+          format: int64
+        processInstances:
+          description: The amount of created process instances.
+          type: integer
+          format: int64
+        decisionInstances:
+          description: The amount of executed decision instances.
+          type: integer
+          format: int64
     PermissionTypeEnum:
       description: Specifies the type of permissions.
       enum:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -49,6 +49,7 @@ tags:
   - name: User
   - name: User task
   - name: Variable
+  - name: Usage metrics
 
 paths:
   /topology:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3600,20 +3600,28 @@ paths:
                 $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /usage-metrics/search:
-    post:
+  /usage-metrics:
+    get:
       tags:
         - Usage metrics
-      operationId: searchUsageMetrics
-      summary: Query usage metrics
-      description: |
-        Search for usage metrics by given start date and end date.
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/UsageMetricsSearchQueryRequest"
+      operationId: getUsageMetrics
+      summary: Get usage metrics
+      description: Retrieve the usage metrics by given start and end date.
+      parameters:
+        - name: startTime
+          in: query
+          required: true
+          description: The start date for usage metrics, including this date.
+          schema:
+            type: string
+            format: date-time
+        - name: endTime
+          in: query
+          required: true
+          description: The end date for usage metrics, including this date.
+          schema:
+            type: string
+            format: date-time
       responses:
         "200":
           description: >
@@ -3621,10 +3629,10 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsageMetricsSearchQueryResponse"
+                $ref: "#/components/schemas/UsageMetricsResponse"
         "400":
           description: >
-            The usage metrics search query failed.
+            The usage metrics request failed.
             More details are provided in the response body.
           content:
             application/problem+json:
@@ -5296,21 +5304,7 @@ components:
         decisionRequirementsKey:
           type: string
           description: The assigned key of the decision requirements graph that the decision definition is part of.
-    UsageMetricsSearchQueryRequest:
-      type: object
-      properties:
-        startTime:
-          description: The start date for usage metrics, including this date.
-          type: string
-          format: date-time
-        endTime:
-          description: The end date for usage metrics, including this date.
-          type: string
-          format: date-time
-      required:
-        - startTime
-        - endTime
-    UsageMetricsSearchQueryResponse:
+    UsageMetricsResponse:
       type: object
       properties:
         assignees:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5318,7 +5318,7 @@ components:
           type: integer
           format: int64
         processInstances:
-          description: The amount of created process instances.
+          description: The amount of created root process instances.
           type: integer
           format: int64
         decisionInstances:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -3607,7 +3607,7 @@ paths:
       operationId: searchUsageMetrics
       summary: Query usage metrics
       description: |
-        Search for usage metrics by given start date and end date
+        Search for usage metrics by given start date and end date.
       requestBody:
         required: true
         content:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -5300,11 +5300,11 @@ components:
       type: object
       properties:
         startTime:
-          description: The start date and time for usage metrics.
+          description: The start date for usage metrics, including this date.
           type: string
           format: date-time
         endTime:
-          description: The end date and time for usage metrics.
+          description: The end date for usage metrics, including this date.
           type: string
           format: date-time
       required:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -54,6 +54,7 @@ import io.camunda.search.query.RoleQuery;
 import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.TenantQuery;
 import io.camunda.search.query.TypedSearchQueryBuilder;
+import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.search.query.UserQuery;
 import io.camunda.search.query.UserTaskQuery;
 import io.camunda.search.query.VariableQuery;
@@ -91,6 +92,16 @@ import org.springframework.http.ProblemDetail;
 public final class SearchQueryRequestMapper {
 
   private SearchQueryRequestMapper() {}
+
+  public static Either<ProblemDetail, UsageMetricsQuery> toUsageMetricsQuery(
+      final UsageMetricsSearchQueryRequest request) {
+    if (request.getStartTime() == null || request.getEndTime() == null) {
+      return Either.left(
+          RequestValidator.createProblemDetail(List.of("startTime and endTime must not be null"))
+              .orElseThrow());
+    }
+    return Either.right(UsageMetricsQuery.of(request.getStartTime(), request.getEndTime()));
+  }
 
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(
       final ProcessDefinitionSearchQueryRequest request) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -31,7 +31,6 @@ import io.camunda.search.filter.FilterBuilders;
 import io.camunda.search.filter.FlowNodeInstanceFilter;
 import io.camunda.search.filter.IncidentFilter;
 import io.camunda.search.filter.MappingFilter;
-import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.TenantFilter;
@@ -104,8 +103,8 @@ public final class SearchQueryRequestMapper {
     }
     final UsageMetricsFilter filter =
         new UsageMetricsFilter.Builder()
-            .startTime(Operation.gte(toOffsetDateTime(request.getStartTime())))
-            .endTime(Operation.lte(toOffsetDateTime(request.getEndTime())))
+            .startTime(toOffsetDateTime(request.getStartTime()))
+            .endTime(toOffsetDateTime(request.getEndTime()))
             .build();
     return Either.right(new UsageMetricsQuery.Builder().filter(filter).build());
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -98,13 +98,17 @@ public final class SearchQueryRequestMapper {
 
   public static Either<ProblemDetail, UsageMetricsQuery> toUsageMetricsQuery(
       final UsageMetricsSearchQueryRequest request) {
+    if (request == null || (request.getStartTime() == null && request.getEndTime() == null)) {
+      final var problemDetail =
+          RequestValidator.createProblemDetail(List.of("startTime and endTime must be specified"));
+      return Either.left(problemDetail.orElseThrow());
+    }
     final UsageMetricsFilter filter =
         new UsageMetricsFilter.Builder()
             .startTime(Operation.gte(toOffsetDateTime(request.getStartTime())))
             .endTime(Operation.lte(toOffsetDateTime(request.getEndTime())))
             .build();
-    final var page = new SearchQueryPage.Builder().size(0).build();
-    return Either.right(new UsageMetricsQuery.Builder().filter(filter).page(page).build());
+    return Either.right(new UsageMetricsQuery.Builder().filter(filter).build());
   }
 
   public static Either<ProblemDetail, ProcessDefinitionQuery> toProcessDefinitionQuery(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -35,8 +35,8 @@ import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.ProcessDefinitionFilter;
 import io.camunda.search.filter.ProcessInstanceFilter;
 import io.camunda.search.filter.TenantFilter;
-import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.filter.UntypedOperation;
+import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.filter.UserFilter;
 import io.camunda.search.filter.UserTaskFilter;
 import io.camunda.search.filter.VariableFilter;
@@ -83,7 +83,6 @@ import io.camunda.zeebe.gateway.rest.validator.RequestValidator;
 import io.camunda.zeebe.util.Either;
 import jakarta.validation.constraints.NotNull;
 import java.time.OffsetDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -98,7 +97,7 @@ public final class SearchQueryRequestMapper {
 
   public static Either<ProblemDetail, UsageMetricsQuery> toUsageMetricsQuery(
       final UsageMetricsSearchQueryRequest request) {
-    if (request == null || (request.getStartTime() == null && request.getEndTime() == null)) {
+    if (request == null || request.getStartTime() == null || request.getEndTime() == null) {
       final var problemDetail =
           RequestValidator.createProblemDetail(List.of("startTime and endTime must be specified"));
       return Either.left(problemDetail.orElseThrow());
@@ -446,12 +445,7 @@ public final class SearchQueryRequestMapper {
   }
 
   private static OffsetDateTime toOffsetDateTime(final String text) {
-    try {
-      return StringUtils.isEmpty(text) ? null : OffsetDateTime.parse(text);
-    } catch (final Exception e) {
-      final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSX");
-      return OffsetDateTime.parse(text, formatter);
-    }
+    return StringUtils.isEmpty(text) ? null : OffsetDateTime.parse(text);
   }
 
   private static ProcessInstanceFilter toProcessInstanceFilter(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -70,7 +70,7 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.TenantItem;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
-import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
@@ -88,9 +88,9 @@ public final class SearchQueryResponseMapper {
 
   private SearchQueryResponseMapper() {}
 
-  public static UsageMetricsSearchQueryResponse toUsageMetricsSearchQueryResponse(
+  public static UsageMetricsResponse toUsageMetricsResponse(
       final UsageMetricsCount usageMetricsCount) {
-    return new UsageMetricsSearchQueryResponse()
+    return new UsageMetricsResponse()
         .assignees(usageMetricsCount.assignees())
         .processInstances(usageMetricsCount.processInstances())
         .decisionInstances(usageMetricsCount.decisionInstances());

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -28,6 +28,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
+import io.camunda.search.entities.UsageMetricsEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -69,6 +70,7 @@ import io.camunda.zeebe.gateway.protocol.rest.RoleSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
 import io.camunda.zeebe.gateway.protocol.rest.TenantItem;
 import io.camunda.zeebe.gateway.protocol.rest.TenantSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserSearchResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
@@ -85,6 +87,14 @@ import java.util.stream.Collectors;
 public final class SearchQueryResponseMapper {
 
   private SearchQueryResponseMapper() {}
+
+  public static UsageMetricsSearchQueryResponse toUsageMetricsSearchQueryResponse(
+      final UsageMetricsEntity result) {
+    return new UsageMetricsSearchQueryResponse()
+        .assignees(result.assignees())
+        .processInstances(result.processInstances())
+        .decisionInstances(result.decisionInstances());
+  }
 
   public static ProcessDefinitionSearchQueryResponse toProcessDefinitionSearchQueryResponse(
       final SearchQueryResult<ProcessDefinitionEntity> result) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -28,7 +28,7 @@ import io.camunda.search.entities.ProcessDefinitionEntity;
 import io.camunda.search.entities.ProcessInstanceEntity;
 import io.camunda.search.entities.RoleEntity;
 import io.camunda.search.entities.TenantEntity;
-import io.camunda.search.entities.UsageMetricsEntity;
+import io.camunda.search.entities.UsageMetricsCount;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.entities.UserTaskEntity;
 import io.camunda.search.entities.VariableEntity;
@@ -89,12 +89,11 @@ public final class SearchQueryResponseMapper {
   private SearchQueryResponseMapper() {}
 
   public static UsageMetricsSearchQueryResponse toUsageMetricsSearchQueryResponse(
-      final SearchQueryResult<UsageMetricsEntity> results) {
-    // final var result = results.aggregates();
+      final UsageMetricsCount usageMetricsCount) {
     return new UsageMetricsSearchQueryResponse()
-        .assignees(1L)
-        .processInstances(2L)
-        .decisionInstances(3L);
+        .assignees(usageMetricsCount.assignees())
+        .processInstances(usageMetricsCount.processInstances())
+        .decisionInstances(usageMetricsCount.decisionInstances());
   }
 
   public static ProcessDefinitionSearchQueryResponse toProcessDefinitionSearchQueryResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -89,11 +89,12 @@ public final class SearchQueryResponseMapper {
   private SearchQueryResponseMapper() {}
 
   public static UsageMetricsSearchQueryResponse toUsageMetricsSearchQueryResponse(
-      final UsageMetricsEntity result) {
+      final SearchQueryResult<UsageMetricsEntity> results) {
+    // final var result = results.aggregates();
     return new UsageMetricsSearchQueryResponse()
-        .assignees(result.assignees())
-        .processInstances(result.processInstances())
-        .decisionInstances(result.decisionInstances());
+        .assignees(1L)
+        .processInstances(2L)
+        .decisionInstances(3L);
   }
 
   public static ProcessDefinitionSearchQueryResponse toProcessDefinitionSearchQueryResponse(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
@@ -11,7 +11,6 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.service.UsageMetricsServices;
-import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
@@ -19,9 +18,9 @@ import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @CamundaRestController
 @RequestMapping("/v2/usage-metrics")
@@ -33,18 +32,18 @@ public class UsageMetricsController {
     this.usageMetricsServices = usageMetricsServices;
   }
 
-  @PostMapping(
-      path = "/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
-      consumes = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<UsageMetricsSearchQueryResponse> searchUsageMetrics(
-      @RequestBody final UsageMetricsSearchQueryRequest query) {
+  @GetMapping(
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public ResponseEntity<UsageMetricsSearchQueryResponse> getUsageMetrics(
+      @RequestParam(required = false) final String startTime,
+      @RequestParam(required = false) final String endTime) {
 
-    return SearchQueryRequestMapper.toUsageMetricsQuery(query)
-        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+    return SearchQueryRequestMapper.toUsageMetricsQuery(startTime, endTime)
+        .fold(RestErrorMapper::mapProblemToResponse, this::getMetrics);
   }
 
-  private ResponseEntity<UsageMetricsSearchQueryResponse> search(final UsageMetricsQuery query) {
+  private ResponseEntity<UsageMetricsSearchQueryResponse> getMetrics(
+      final UsageMetricsQuery query) {
     try {
       final var result =
           usageMetricsServices.withAuthentication(RequestMapper.getAuthentication()).search(query);

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
@@ -11,7 +11,7 @@ import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
 
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.service.UsageMetricsServices;
-import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsResponse;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
@@ -34,7 +34,7 @@ public class UsageMetricsController {
 
   @GetMapping(
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
-  public ResponseEntity<UsageMetricsSearchQueryResponse> getUsageMetrics(
+  public ResponseEntity<UsageMetricsResponse> getUsageMetrics(
       @RequestParam(required = false) final String startTime,
       @RequestParam(required = false) final String endTime) {
 
@@ -42,12 +42,11 @@ public class UsageMetricsController {
         .fold(RestErrorMapper::mapProblemToResponse, this::getMetrics);
   }
 
-  private ResponseEntity<UsageMetricsSearchQueryResponse> getMetrics(
-      final UsageMetricsQuery query) {
+  private ResponseEntity<UsageMetricsResponse> getMetrics(final UsageMetricsQuery query) {
     try {
       final var result =
           usageMetricsServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
-      return ResponseEntity.ok(SearchQueryResponseMapper.toUsageMetricsSearchQueryResponse(result));
+      return ResponseEntity.ok(SearchQueryResponseMapper.toUsageMetricsResponse(result));
     } catch (final Exception e) {
       return mapErrorToResponse(e);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsController.java
@@ -25,11 +25,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestController
 @RequestMapping("/v2/usage-metrics")
-public class UsageMetricsQueryController {
+public class UsageMetricsController {
 
   private final UsageMetricsServices usageMetricsServices;
 
-  public UsageMetricsQueryController(final UsageMetricsServices usageMetricsServices) {
+  public UsageMetricsController(final UsageMetricsServices usageMetricsServices) {
     this.usageMetricsServices = usageMetricsServices;
   }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static io.camunda.zeebe.gateway.rest.RestErrorMapper.mapErrorToResponse;
+
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.service.UsageMetricsServices;
+import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UsageMetricsSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestQueryController
+@RequestMapping("/v2/usage-metrics")
+public class UsageMetricsQueryController {
+
+  private final UsageMetricsServices usageMetricsServices;
+
+  public UsageMetricsQueryController(final UsageMetricsServices usageMetricsServices) {
+    this.usageMetricsServices = usageMetricsServices;
+  }
+
+  @PostMapping(
+      path = "/search",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<UsageMetricsSearchQueryResponse> searchUsageMetrics(
+      @RequestBody(required = true) final UsageMetricsSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toUsageMetricsQuery(query)
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
+  }
+
+  private ResponseEntity<UsageMetricsSearchQueryResponse> search(final UsageMetricsQuery query) {
+    try {
+      final var result =
+          usageMetricsServices.withAuthentication(RequestMapper.getAuthentication()).search(query);
+      return ResponseEntity.ok(SearchQueryResponseMapper.toUsageMetricsSearchQueryResponse(result));
+    } catch (final Exception e) {
+      return mapErrorToResponse(e);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
@@ -38,7 +38,7 @@ public class UsageMetricsQueryController {
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<UsageMetricsSearchQueryResponse> searchUsageMetrics(
-      @RequestBody(required = true) final UsageMetricsSearchQueryRequest query) {
+      @RequestBody final UsageMetricsSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUsageMetricsQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
@@ -39,6 +39,7 @@ public class UsageMetricsQueryController {
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<UsageMetricsSearchQueryResponse> searchUsageMetrics(
       @RequestBody final UsageMetricsSearchQueryRequest query) {
+
     return SearchQueryRequestMapper.toUsageMetricsQuery(query)
         .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-@CamundaRestQueryController
+@CamundaRestController
 @RequestMapping("/v2/usage-metrics")
 public class UsageMetricsQueryController {
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
@@ -26,8 +26,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-@WebMvcTest(UsageMetricsQueryController.class)
-public class UsageMetricsQueryControllerTest extends RestControllerTest {
+@WebMvcTest(UsageMetricsController.class)
+public class UsageMetricsControllerTest extends RestControllerTest {
   static final String USAGE_METRICS_URL = "/v2/usage-metrics/";
   static final String USAGE_METRICS_SEARCH_URL = USAGE_METRICS_URL + "search";
 
@@ -61,6 +61,7 @@ public class UsageMetricsQueryControllerTest extends RestControllerTest {
            "endTime":   "2024-12-31T10:50:26.000Z"
         }
         """;
+    // when/then
     webClient
         .post()
         .uri(USAGE_METRICS_SEARCH_URL)
@@ -90,20 +91,102 @@ public class UsageMetricsQueryControllerTest extends RestControllerTest {
   }
 
   @Test
-  void shouldThrowExceptionIfNoStartAndEndTimeAreGiven() {
+  void shouldYieldBadRequestIfNoStartAndEndTimeAreGiven() {
+    // given
+    final var request = "{}";
+    final var expectedResponse =
+        """
+        {
+          "type":"about:blank",
+          "title":"INVALID_ARGUMENT",
+          "status":400,
+          "detail":"startTime and endTime must be specified.",
+          "instance":"/v2/usage-metrics/search"
+        }
+        """;
+    // when/then
     webClient
         .post()
         .uri(USAGE_METRICS_SEARCH_URL)
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
-        .bodyValue("{}")
+        .bodyValue(request)
         .exchange()
         .expectStatus()
         .isBadRequest()
         .expectHeader()
         .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
         .expectBody()
-        .json(
-            "{\"type\":\"about:blank\",\"title\":\"INVALID_ARGUMENT\",\"status\":400,\"detail\":\"startTime and endTime must be specified.\",\"instance\":\"/v2/usage-metrics/search\"}");
+        .json(expectedResponse);
+  }
+
+  @Test
+  void shouldYieldBadRequestIfNoStartTimeIsGiven() {
+    // given
+    final var request =
+        """
+        {
+           "endTime":   "2024-12-31T10:50:26.000Z"
+        }
+        """;
+    final var expectedResponse =
+        """
+        {
+          "type":"about:blank",
+          "title":"INVALID_ARGUMENT",
+          "status":400,
+          "detail":"startTime and endTime must be specified.",
+          "instance":"/v2/usage-metrics/search"
+        }
+        """;
+    // when/then
+    webClient
+        .post()
+        .uri(USAGE_METRICS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+        .expectBody()
+        .json(expectedResponse);
+  }
+
+  @Test
+  void shouldYieldBadRequestIfNoEndTimeIsGiven() {
+    // given
+    final var request =
+        """
+        {
+           "startTime":   "2024-12-31T10:50:26.000Z"
+        }
+        """;
+    final var expectedResponse =
+        """
+        {
+          "type":"about:blank",
+          "title":"INVALID_ARGUMENT",
+          "status":400,
+          "detail":"startTime and endTime must be specified.",
+          "instance":"/v2/usage-metrics/search"
+        }
+        """;
+    // when/then
+    webClient
+        .post()
+        .uri(USAGE_METRICS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+        .expectBody()
+        .json(expectedResponse);
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsControllerTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.search.entities.UsageMetricsCount;
-import io.camunda.search.filter.Operation;
 import io.camunda.search.filter.UsageMetricsFilter;
 import io.camunda.search.query.UsageMetricsQuery;
 import io.camunda.security.auth.Authentication;
@@ -83,10 +82,7 @@ public class UsageMetricsControllerTest extends RestControllerTest {
         .search(
             new UsageMetricsQuery.Builder()
                 .filter(
-                    new UsageMetricsFilter.Builder()
-                        .startTime(Operation.gte(startTime))
-                        .endTime(Operation.lte(endTime))
-                        .build())
+                    new UsageMetricsFilter.Builder().startTime(startTime).endTime(endTime).build())
                 .build());
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
@@ -7,11 +7,24 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.search.entities.UsageMetricsCount;
+import io.camunda.search.filter.Operation;
+import io.camunda.search.filter.UsageMetricsFilter;
+import io.camunda.search.query.UsageMetricsQuery;
+import io.camunda.security.auth.Authentication;
 import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 
 @WebMvcTest(
     value = UsageMetricsQueryController.class,
@@ -20,22 +33,79 @@ public class UsageMetricsQueryControllerTest extends RestControllerTest {
   static final String USAGE_METRICS_URL = "/v2/usage-metrics/";
   static final String USAGE_METRICS_SEARCH_URL = USAGE_METRICS_URL + "search";
 
-  static final String USAGE_METRICS_ENTITY_JSON =
-      """
-      {
-         "assignees": 15,
-         "processInstances": 12345,
-         "decisionInstances": 5354365
-      }""";
   static final String EXPECTED_SEARCH_RESPONSE =
       """
-     """;
+      {
+         "assignees": 5,
+         "processInstances": 23,
+         "decisionInstances": 17
+      }""";
+
+  static final UsageMetricsCount USAGE_METRICS_COUNT_ENTITY = new UsageMetricsCount(5L, 23L, 17L);
 
   @MockBean UsageMetricsServices usageMetricsServices;
 
-  @Test
-  void shouldSearchUsageMetrics() {
-    // when
+  @BeforeEach
+  void setupUsageMetricsServices() {
+    when(usageMetricsServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(usageMetricsServices);
+  }
 
+  @Test
+  void shouldSearchWithStartTimeAndEndTime() {
+    // given
+    when(usageMetricsServices.search(any(UsageMetricsQuery.class)))
+        .thenReturn(USAGE_METRICS_COUNT_ENTITY);
+    final var request =
+        """
+        {
+           "startTime": "1970-11-14T10:50:26.000Z",
+           "endTime":   "2024-12-31T10:50:26.000Z"
+        }
+        """;
+    webClient
+        .post()
+        .uri(USAGE_METRICS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    final var startTime = OffsetDateTime.of(1970, 11, 14, 10, 50, 26, 0, ZoneOffset.UTC);
+    final var endTime = OffsetDateTime.of(2024, 12, 31, 10, 50, 26, 0, ZoneOffset.UTC);
+
+    verify(usageMetricsServices)
+        .search(
+            new UsageMetricsQuery.Builder()
+                .filter(
+                    new UsageMetricsFilter.Builder()
+                        .startTime(Operation.gte(startTime))
+                        .endTime(Operation.lte(endTime))
+                        .build())
+                .build());
+  }
+
+  @Test
+  void shouldThrowExceptionIfNoStartAndEndTimeAreGiven() {
+    webClient
+        .post()
+        .uri(USAGE_METRICS_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue("{}")
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE)
+        .expectBody()
+        .json(
+            "{\"type\":\"about:blank\",\"title\":\"INVALID_ARGUMENT\",\"status\":400,\"detail\":\"startTime and endTime must be specified.\",\"instance\":\"/v2/usage-metrics/search\"}");
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
@@ -29,11 +29,6 @@ public class UsageMetricsQueryControllerTest extends RestControllerTest {
       }""";
   static final String EXPECTED_SEARCH_RESPONSE =
       """
-       {
-         "assignees": 15,
-         "processInstances": 12345,
-         "decisionInstances": 5354365
-       }
      """;
 
   @MockBean UsageMetricsServices usageMetricsServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = UsageMetricsQueryController.class,
+    properties = "camunda.rest.query.enabled=true")
+public class UsageMetricsQueryControllerTest extends RestControllerTest {
+  static final String USAGE_METRICS_URL = "/v2/usage-metrics/";
+  static final String USAGE_METRICS_SEARCH_URL = USAGE_METRICS_URL + "search";
+
+  static final String USAGE_METRICS_ENTITY_JSON =
+      """
+      {
+         "assignees": 15,
+         "processInstances": 12345,
+         "decisionInstances": 5354365
+      }""";
+  static final String EXPECTED_SEARCH_RESPONSE =
+      """
+       {
+         "assignees": 15,
+         "processInstances": 12345,
+         "decisionInstances": 5354365
+       }
+     """;
+
+  @Test
+  void shouldSearchUsageMetrics() {
+    // when
+
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
@@ -26,9 +26,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-@WebMvcTest(
-    value = UsageMetricsQueryController.class,
-    properties = "camunda.rest.query.enabled=true")
+@WebMvcTest(UsageMetricsQueryController.class)
 public class UsageMetricsQueryControllerTest extends RestControllerTest {
   static final String USAGE_METRICS_URL = "/v2/usage-metrics/";
   static final String USAGE_METRICS_SEARCH_URL = USAGE_METRICS_URL + "search";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UsageMetricsQueryControllerTest.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
+import io.camunda.service.UsageMetricsServices;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @WebMvcTest(
     value = UsageMetricsQueryController.class,
@@ -33,6 +35,8 @@ public class UsageMetricsQueryControllerTest extends RestControllerTest {
          "decisionInstances": 5354365
        }
      """;
+
+  @MockBean UsageMetricsServices usageMetricsServices;
 
   @Test
   void shouldSearchUsageMetrics() {


### PR DESCRIPTION
## Description

Current implementation is done in Service layer by using Java Stream API.
When aggregation is integrated in search modules the implementation should be switch to do
the distinct count in databases.

* Add OpenAPI definition.
* Add RestController and service infrastructure.
* Fix [findAll](https://github.com/camunda/camunda/pull/25690/commits/121654110f47d406f316120656b9188bbb696815) bug
* Add tests for RestController, Filter, Sort and Service.
* Add UsageMetricsSearchClient methods in RDBMSClient to make integration tests green.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23812 
