### PR TITLE
Migrate active parallel gateway

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -57,7 +57,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.BUSINESS_RULE_TASK,
           BpmnElementType.SCRIPT_TASK,
           BpmnElementType.SEND_TASK,
-          BpmnElementType.MULTI_INSTANCE_BODY);
+          BpmnElementType.MULTI_INSTANCE_BODY,
+          BpmnElementType.PARALLEL_GATEWAY);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -35,10 +35,10 @@ public class MigrateParallelGatewayTest {
     final String sourceProcessId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "_target";
 
-    final String NON_EXISTING_EL_JOB_TYPE_EXP = "=source_execution_listener_job_type";
-    final String EXISTING_EL_JOB_TYPE_EXP = "=target_execution_listener_job_type";
-    final String EXISTING_EL_JOB_TYPE_VAR = "target_execution_listener_job_type";
-    final String EXISTING_EL_JOB_TYPE_VALUE = "elJobType";
+    final String nonExistingElJobTypeExp = "=source_execution_listener_job_type";
+    final String existingElJobTypeExp = "=target_execution_listener_job_type";
+    final String existingElJobTypeVar = "target_execution_listener_job_type";
+    final String existingElJobTypeValue = "elJobType";
 
     final var deployment =
         ENGINE
@@ -47,7 +47,7 @@ public class MigrateParallelGatewayTest {
                 Bpmn.createExecutableProcess(sourceProcessId)
                     .startEvent()
                     .parallelGateway("parallel1")
-                    .zeebeStartExecutionListener(NON_EXISTING_EL_JOB_TYPE_EXP)
+                    .zeebeStartExecutionListener(nonExistingElJobTypeExp)
                     .endEvent("end1")
                     .moveToLastGateway()
                     .endEvent()
@@ -56,7 +56,7 @@ public class MigrateParallelGatewayTest {
                 Bpmn.createExecutableProcess(targetProcessId)
                     .startEvent()
                     .parallelGateway("parallel2")
-                    .zeebeStartExecutionListener(EXISTING_EL_JOB_TYPE_EXP)
+                    .zeebeStartExecutionListener(existingElJobTypeExp)
                     .endEvent("end2")
                     .moveToLastGateway()
                     .endEvent()
@@ -69,7 +69,7 @@ public class MigrateParallelGatewayTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(sourceProcessId)
-            .withVariable(EXISTING_EL_JOB_TYPE_VAR, EXISTING_EL_JOB_TYPE_VALUE)
+            .withVariable(existingElJobTypeVar, existingElJobTypeValue)
             .create();
 
     final var incident =
@@ -93,7 +93,7 @@ public class MigrateParallelGatewayTest {
 
     // then
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
-    ENGINE.job().ofInstance(processInstanceKey).withType(EXISTING_EL_JOB_TYPE_VALUE).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(existingElJobTypeValue).complete();
 
     assertThat(
             RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateParallelGatewayTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateParallelGatewayWithIncident() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_target";
+
+    final String NON_EXISTING_EL_JOB_TYPE_EXP = "=source_execution_listener_job_type";
+    final String EXISTING_EL_JOB_TYPE_EXP = "=target_execution_listener_job_type";
+    final String EXISTING_EL_JOB_TYPE_VAR = "target_execution_listener_job_type";
+    final String EXISTING_EL_JOB_TYPE_VALUE = "elJobType";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("parallel1")
+                    .zeebeStartExecutionListener(NON_EXISTING_EL_JOB_TYPE_EXP)
+                    .endEvent("end1")
+                    .moveToLastGateway()
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("parallel2")
+                    .zeebeStartExecutionListener(EXISTING_EL_JOB_TYPE_EXP)
+                    .endEvent("end2")
+                    .moveToLastGateway()
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(sourceProcessId)
+            .withVariable(EXISTING_EL_JOB_TYPE_VAR, EXISTING_EL_JOB_TYPE_VALUE)
+            .create();
+
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("parallel1")
+            .getFirst();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("parallel1", "parallel2")
+        .migrate();
+
+    RecordingExporter.incidentRecords(IncidentIntent.MIGRATED)
+        .withRecordKey(incident.getKey())
+        .await();
+
+    // then
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(EXISTING_EL_JOB_TYPE_VALUE).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .limit(2))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs(
+            "Expected to successfully evaluate execution listener job type and resolve incident")
+        .contains("end2");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -96,10 +96,12 @@ public class MigrateParallelGatewayTest {
     ENGINE.job().ofInstance(processInstanceKey).withType(existingElJobTypeValue).complete();
 
     assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.END_EVENT)
-                .limit(2))
+                .withElementType(BpmnElementType.END_EVENT))
         .extracting(r -> r.getValue().getElementId())
         .describedAs(
             "Expected to successfully evaluate execution listener job type and resolve incident")


### PR DESCRIPTION
## Description

In order to support migration for active parallel gateways we need to add parallel gateway to supported element types. No other change is needed for incident migration because it is already handled as a part of the incident migration implementation.

## Related issues

closes #22128 
