### PR TITLE
feat: initialize identity even when authorizations are disabled

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -42,12 +42,6 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext context) {
-    if (!securityConfig.getAuthorizations().isEnabled()) {
-      // If authorization is disabled we don't need to setup identity.
-      LOG.debug("Skipping identity setup as authorization is disabled");
-      return;
-    }
-
     if (context.getPartitionId() != Protocol.DEPLOYMENT_PARTITION) {
       // We should only create users on the deployment partition. The command will be distributed to
       // the other partitions using our command distribution mechanism.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/ContinuouslyReplayTest.java
@@ -27,6 +27,7 @@ public class ContinuouslyReplayTest {
   @Rule
   public final EngineRule replay =
       EngineRule.withSharedStorage(sharedStorage)
+          .withoutAwaitingIdentitySetup()
           .withStreamProcessorMode(StreamProcessorMode.REPLAY);
 
   @Rule public final EngineRule processing = EngineRule.withSharedStorage(sharedStorage);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -47,7 +47,17 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.PROCESS_DEFINITION_KEY_BY_PROCESS_ID_AND_DEPLOYMENT_KEY,
           ZbColumnFamilies.MESSAGE_STATS,
           ZbColumnFamilies.MIGRATIONS_STATE,
-          ZbColumnFamilies.DEPLOYMENT_RAW);
+          ZbColumnFamilies.DEPLOYMENT_RAW,
+          ZbColumnFamilies.USERS,
+          ZbColumnFamilies.USER_KEY_BY_USERNAME,
+          ZbColumnFamilies.PERMISSIONS,
+          ZbColumnFamilies.AUTHORIZATION_KEY_BY_RESOURCE_ID,
+          ZbColumnFamilies.OWNER_TYPE_BY_OWNER_KEY,
+          ZbColumnFamilies.ROLES,
+          ZbColumnFamilies.ENTITY_BY_ROLE,
+          ZbColumnFamilies.ROLE_BY_NAME,
+          ZbColumnFamilies.TENANTS,
+          ZbColumnFamilies.TENANT_BY_ID);
 
   @Rule public EngineRule engineRule = EngineRule.singlePartition();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ReplayStateTest.java
@@ -52,6 +52,7 @@ public final class ReplayStateTest {
   @Rule
   public final EngineRule engine =
       EngineRule.singlePartition()
+          .withoutAwaitingIdentitySetup()
           .withOnProcessedCallback(record -> lastProcessedPosition = record.getPosition())
           .withOnSkippedCallback(record -> lastProcessedPosition = record.getPosition());
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -92,6 +92,7 @@ public final class EngineRule extends ExternalResource {
   private final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
   private final int partitionCount;
+  private boolean awaitIdentitySetup = true;
 
   private Consumer<TypedRecord> onProcessedCallback = record -> {};
   private Consumer<LoggedEvent> onSkippedCallback = record -> {};
@@ -136,7 +137,9 @@ public final class EngineRule extends ExternalResource {
   @Override
   protected void before() {
     start();
-    awaitIdentitySetup();
+    if (awaitIdentitySetup) {
+      awaitIdentitySetup();
+    }
   }
 
   public void start() {
@@ -149,6 +152,11 @@ public final class EngineRule extends ExternalResource {
 
   public void stop() {
     forEachPartition(environmentRule::closeStreamProcessor);
+  }
+
+  public EngineRule withoutAwaitingIdentitySetup() {
+    awaitIdentitySetup = false;
+    return this;
   }
 
   public EngineRule withJobStreamer(final JobStreamer jobStreamer) {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/SnapshotWithExportersTest.java
@@ -66,6 +66,8 @@ final class SnapshotWithExportersTest {
                           .flatMap(FileBasedSnapshotId::ofFileName),
                   Optional::isPresent)
               .orElseThrow();
+      // pause processing to avoid new processing to cause a new snapshot after restart
+      PartitionsActuator.of(zeebe).pauseProcessing();
       zeebe.stop();
 
       // when -- taking snapshot on broker with exporters configured

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/BrokerAdminServiceEndpointTest.java
@@ -40,7 +40,7 @@ public class BrokerAdminServiceEndpointTest {
       {
         "1": {
           "role": "LEADER",
-          "processedPosition": 1,
+          "processedPosition": 2,
           "snapshotId": null,
           "processedPositionInSnapshot": null,
           "streamProcessorPhase": "PROCESSING",
@@ -97,7 +97,7 @@ public class BrokerAdminServiceEndpointTest {
       """
       {
         "role": "LEADER",
-        "processedPosition": 1,
+        "processedPosition": 2,
         "snapshotId": null,
         "processedPositionInSnapshot": null,
         "streamProcessorPhase": "PROCESSING",

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -73,14 +73,14 @@ public class BrokerAdminServiceClusterTest {
     followerStatus.forEach(
         partitionStatus -> {
           assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.processedPosition()).isEqualTo(2L);
+          assertThat(partitionStatus.processedPosition()).isPositive();
           assertThat(partitionStatus.snapshotId()).isNull();
           assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
           assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
     assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(leaderStatus.processedPosition()).isEqualTo(2L);
+    assertThat(leaderStatus.processedPosition()).isPositive();
     assertThat(leaderStatus.snapshotId()).isNull();
     assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
     assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceClusterTest.java
@@ -73,14 +73,14 @@ public class BrokerAdminServiceClusterTest {
     followerStatus.forEach(
         partitionStatus -> {
           assertThat(partitionStatus.role()).isEqualTo(Role.FOLLOWER);
-          assertThat(partitionStatus.processedPosition()).isEqualTo(1L);
+          assertThat(partitionStatus.processedPosition()).isEqualTo(2L);
           assertThat(partitionStatus.snapshotId()).isNull();
           assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
           assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.REPLAY);
         });
 
     assertThat(leaderStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(leaderStatus.processedPosition()).isEqualTo(1L);
+    assertThat(leaderStatus.processedPosition()).isEqualTo(2L);
     assertThat(leaderStatus.snapshotId()).isNull();
     assertThat(leaderStatus.processedPositionInSnapshot()).isNull();
     assertThat(leaderStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -35,7 +35,7 @@ public class BrokerAdminServiceWithOutExporterTest {
     // then
     final var partitionStatus = leaderAdminService.getPartitionStatus().get(1);
     assertThat(partitionStatus.role()).isEqualTo(Role.LEADER);
-    assertThat(partitionStatus.processedPosition()).isEqualTo(1L);
+    assertThat(partitionStatus.processedPosition()).isPositive();
     assertThat(partitionStatus.snapshotId()).isNull();
     assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);


### PR DESCRIPTION
This changes the identity initialization to _always_ run, even when authorizations are disabled. This is so that Identity can always see the default user and role.

:thought_balloon: Initially the issue was just about creating the default user and role. We now also include the role's wildcard permissions and the default tenant.

closes #25700
