### PR TITLE
feat: Implement incident recovery after task listener properties expression evaluation failures

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentEventProcessors.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 
@@ -23,6 +24,7 @@ public final class IncidentEventProcessors {
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
+      final TypedRecordProcessor<UserTaskRecord> userTaskProcessor,
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final AuthorizationCheckBehavior authCheckBehavior) {
@@ -32,6 +34,7 @@ public final class IncidentEventProcessors {
         new IncidentResolveProcessor(
             processingState,
             bpmnStreamProcessor,
+            userTaskProcessor,
             writers,
             jobActivationBehavior,
             authCheckBehavior));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -7,24 +7,29 @@
  */
 package io.camunda.zeebe.engine.processing.incident;
 
-import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordMetadataEncoder;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.Map;
 
-final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> {
+/**
+ * A wrapper class for records that facilitates retrying commands after an incident is resolved.
+ *
+ * <p>This class is designed to handle different types of records and their corresponding intents,
+ * allowing seamless recovery by re-processing the failed command.
+ */
+final class IncidentRecordWrapper<T extends UnifiedRecordValue> implements TypedRecord<T> {
 
   private final long key;
-  private final ProcessInstanceIntent intent;
-  private final ProcessInstanceRecord record;
+  private final Intent intent;
+  private final T record;
 
-  IncidentRecordWrapper(
-      final long key, final ProcessInstanceIntent intent, final ProcessInstanceRecord record) {
+  IncidentRecordWrapper(final long key, final Intent intent, final T record) {
     this.key = key;
     this.intent = intent;
     this.record = record;
@@ -101,7 +106,7 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
-  public Record<ProcessInstanceRecord> copyOf() {
+  public Record<T> copyOf() {
     return this;
   }
 
@@ -111,18 +116,18 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
-  public ProcessInstanceRecord getValue() {
+  public T getValue() {
     return record;
   }
 
   @Override
   public int getRequestStreamId() {
-    return 0;
+    return RecordMetadataEncoder.requestStreamIdNullValue();
   }
 
   @Override
   public long getRequestId() {
-    return 0;
+    return RecordMetadataEncoder.requestIdNullValue();
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -21,7 +21,10 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -29,7 +32,9 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
@@ -42,8 +47,10 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       "Expected to resolve incident with key '%d', but no such incident was found";
   private static final String ELEMENT_NOT_IN_SUPPORTED_STATE_MSG =
       "Expected incident to refer to element in state ELEMENT_ACTIVATING or ELEMENT_COMPLETING, but element is in state %s";
-
-  private final ProcessInstanceRecord failedRecord = new ProcessInstanceRecord();
+  private static final String LIFECYCLE_STATE_CONVERSION_NOT_SUPPORTED_MSG =
+      "Conversion from '%s' user task lifecycle state to failed user task command is not yet supported";
+  private static final String UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG =
+      "Unexpected user task lifecycle state: '%s' encountered during conversion to failed user task command.";
 
   private final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor;
   private final TypedRecordProcessor<UserTaskRecord> userTaskProcessor;
@@ -52,6 +59,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
 
   private final IncidentState incidentState;
   private final ElementInstanceState elementInstanceState;
+  private final UserTaskState userTaskState;
   private final TypedResponseWriter responseWriter;
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final JobState jobState;
@@ -71,6 +79,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     responseWriter = writers.response();
     incidentState = processingState.getIncidentState();
     elementInstanceState = processingState.getElementInstanceState();
+    userTaskState = processingState.getUserTaskState();
     this.jobActivationBehavior = jobActivationBehavior;
     jobState = processingState.getJobState();
     this.authCheckBehavior = authCheckBehavior;
@@ -130,15 +139,15 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
 
   private void attemptToContinueProcessProcessing(
       final TypedRecord<IncidentRecord> command, final IncidentRecord incident) {
-    final long jobKey = incident.getJobKey();
 
+    final long jobKey = incident.getJobKey();
     if (isJobRelatedIncident(jobKey)) {
       return;
     }
 
     getFailedCommand(incident)
         .ifRightOrLeft(
-            bpmnStreamProcessor::processRecord,
+            this::processFailedCommand,
             failure -> {
               final var message =
                   String.format(
@@ -148,7 +157,25 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
             });
   }
 
-  private Either<String, TypedRecord<ProcessInstanceRecord>> getFailedCommand(
+  private void processFailedCommand(TypedRecord<? extends UnifiedRecordValue> failedCommand) {
+    if (failedCommand.getValue() instanceof ProcessInstanceRecord) {
+      bpmnStreamProcessor.processRecord((TypedRecord<ProcessInstanceRecord>) failedCommand);
+    } else if (failedCommand.getValue() instanceof UserTaskRecord) {
+      userTaskProcessor.processRecord((TypedRecord<UserTaskRecord>) failedCommand);
+    } else {
+      throw new IllegalStateException(
+          "Failed to process command due to unsupported record type: '%s'."
+              .formatted(failedCommand.getValue().getClass().getSimpleName()));
+    }
+  }
+
+  private boolean isUserTaskRelatedIncident(final ElementInstance elementInstance) {
+    return elementInstance.getState() == ProcessInstanceIntent.ELEMENT_ACTIVATED
+        && elementInstance.getValue().getBpmnElementType() == BpmnElementType.USER_TASK
+        && elementInstance.getUserTaskKey() > 0;
+  }
+
+  private Either<String, TypedRecord<? extends UnifiedRecordValue>> getFailedCommand(
       final IncidentRecord incidentRecord) {
     final long elementInstanceKey = incidentRecord.getElementInstanceKey();
     final var elementInstance = elementInstanceState.getInstance(elementInstanceKey);
@@ -158,13 +185,57 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
               "Expected to find failed command for element instance %d, but element instance not found",
               elementInstanceKey));
     }
+
+    return isUserTaskRelatedIncident(elementInstance)
+        ? createUserTaskCommand(elementInstance)
+        : createProcessInstanceCommand(elementInstance);
+  }
+
+  private Either<String, TypedRecord<? extends UnifiedRecordValue>> createUserTaskCommand(
+      final ElementInstance elementInstance) {
+
+    final var userTaskKey = elementInstance.getUserTaskKey();
+    final var intermediateState = userTaskState.getIntermediateState(userTaskKey);
+
+    if (intermediateState == null) {
+      return Either.left(
+          String.format("No intermediate state found for user task with key %d", userTaskKey));
+    }
+
+    return getFailedUserTaskCommandIntent(intermediateState.getLifecycleState())
+        .map(
+            intent -> {
+              final var userTaskRecord = new UserTaskRecord();
+              userTaskRecord.wrap(intermediateState.getRecord());
+              return new IncidentRecordWrapper<UserTaskRecord>(userTaskKey, intent, userTaskRecord);
+            });
+  }
+
+  private Either<String, TypedRecord<? extends UnifiedRecordValue>> createProcessInstanceCommand(
+      final ElementInstance elementInstance) {
+
     return getFailedCommandIntent(elementInstance)
         .map(
-            commandIntent -> {
-              failedRecord.wrap(elementInstance.getValue());
+            intent -> {
+              final var record = new ProcessInstanceRecord();
+              record.wrap(elementInstance.getValue());
               return new IncidentRecordWrapper<ProcessInstanceRecord>(
-                  elementInstanceKey, commandIntent, failedRecord);
+                  elementInstance.getKey(), intent, record);
             });
+  }
+
+  private Either<String, UserTaskIntent> getFailedUserTaskCommandIntent(
+      final LifecycleState lifecycleState) {
+    return switch (lifecycleState) {
+      case ASSIGNING -> Either.right(UserTaskIntent.ASSIGN);
+      case CLAIMING -> Either.right(UserTaskIntent.CLAIM);
+      case UPDATING -> Either.right(UserTaskIntent.UPDATE);
+      case COMPLETING -> Either.right(UserTaskIntent.COMPLETE);
+      case CREATING, CANCELING ->
+          Either.left(String.format(LIFECYCLE_STATE_CONVERSION_NOT_SUPPORTED_MSG, lifecycleState));
+      default ->
+          Either.left(String.format(UNEXPECTED_LIFECYCLE_STATE_CONVERSION_MSG, lifecycleState));
+    };
   }
 
   private Either<String, ProcessInstanceIntent> getFailedCommandIntent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -158,7 +158,8 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
         .map(
             commandIntent -> {
               failedRecord.wrap(elementInstance.getValue());
-              return new IncidentRecordWrapper(elementInstanceKey, commandIntent, failedRecord);
+              return new IncidentRecordWrapper<ProcessInstanceRecord>(
+                  elementInstanceKey, commandIntent, failedRecord);
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -45,6 +46,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private final ProcessInstanceRecord failedRecord = new ProcessInstanceRecord();
 
   private final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor;
+  private final TypedRecordProcessor<UserTaskRecord> userTaskProcessor;
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
 
@@ -58,10 +60,12 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   public IncidentResolveProcessor(
       final ProcessingState processingState,
       final TypedRecordProcessor<ProcessInstanceRecord> bpmnStreamProcessor,
+      final TypedRecordProcessor<UserTaskRecord> userTaskProcessor,
       final Writers writers,
       final BpmnJobActivationBehavior jobActivationBehavior,
       final AuthorizationCheckBehavior authCheckBehavior) {
     this.bpmnStreamProcessor = bpmnStreamProcessor;
+    this.userTaskProcessor = userTaskProcessor;
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -214,7 +214,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private Either<String, TypedRecord<? extends UnifiedRecordValue>> createProcessInstanceCommand(
       final ElementInstance elementInstance) {
 
-    return getFailedCommandIntent(elementInstance)
+    return getFailedProcessInstanceCommandIntent(elementInstance)
         .map(
             intent -> {
               final var record = new ProcessInstanceRecord();
@@ -238,17 +238,14 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
     };
   }
 
-  private Either<String, ProcessInstanceIntent> getFailedCommandIntent(
+  private Either<String, ProcessInstanceIntent> getFailedProcessInstanceCommandIntent(
       final ElementInstance elementInstance) {
     final var instanceState = elementInstance.getState();
-    switch (instanceState) {
-      case ELEMENT_ACTIVATING:
-        return Either.right(ProcessInstanceIntent.ACTIVATE_ELEMENT);
-      case ELEMENT_COMPLETING:
-        return Either.right(ProcessInstanceIntent.COMPLETE_ELEMENT);
-      default:
-        return Either.left(String.format(ELEMENT_NOT_IN_SUPPORTED_STATE_MSG, instanceState));
-    }
+    return switch (instanceState) {
+      case ELEMENT_ACTIVATING -> Either.right(ProcessInstanceIntent.ACTIVATE_ELEMENT);
+      case ELEMENT_COMPLETING -> Either.right(ProcessInstanceIntent.COMPLETE_ELEMENT);
+      default -> Either.left(String.format(ELEMENT_NOT_IN_SUPPORTED_STATE_MSG, instanceState));
+    };
   }
 
   private void publishIncidentRelatedJob(final long jobKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/processors/UserTaskCommandPreconditionChecker.java
@@ -71,7 +71,8 @@ public class UserTaskCommandPreconditionChecker {
     final long userTaskKey = command.getKey();
     final UserTaskRecord persistedRecord =
         command.hasRequestMetadata()
-            ? userTaskState.getUserTask(userTaskKey, authCheckBehavior.getAuthorizedTenantIds(command))
+            ? userTaskState.getUserTask(
+                userTaskKey, authCheckBehavior.getAuthorizedTenantIds(command))
             : userTaskState.getUserTask(userTaskKey);
 
     if (persistedRecord == null) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedV2Applier.java
@@ -41,7 +41,7 @@ final class IncidentResolvedV2Applier implements TypedEventApplier<IncidentInten
   @Override
   public void applyState(final long incidentKey, final IncidentRecord value) {
     if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
-      resetExecutionListenerIndex(value);
+      resetListenerIndices(value);
     }
 
     final var jobKey = value.getJobKey();
@@ -58,10 +58,11 @@ final class IncidentResolvedV2Applier implements TypedEventApplier<IncidentInten
     incidentState.deleteIncident(incidentKey);
   }
 
-  private void resetExecutionListenerIndex(final IncidentRecord value) {
+  private void resetListenerIndices(final IncidentRecord value) {
     final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
     if (elementInstance != null) {
       elementInstance.resetExecutionListenerIndex();
+      elementInstance.resetTaskListenerIndices();
       elementInstanceState.updateInstance(elementInstance);
     }
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -1318,7 +1318,7 @@ public class TaskListenerTest {
   @Test
   public void shouldRetryUserTaskCompleteCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
-        ZeebeTaskListenerEventType.complete,
+        ZeebeTaskListenerEventType.completing,
         "complete_listener_var_name",
         "expression_complete_listener_2",
         UserTaskClient::complete,
@@ -1329,7 +1329,7 @@ public class TaskListenerTest {
   @Test
   public void shouldRetryUserTaskAssignCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
-        ZeebeTaskListenerEventType.assignment,
+        ZeebeTaskListenerEventType.assigning,
         "assign_listener_var_name",
         "expression_assign_listener_2",
         userTask -> userTask.withAssignee("me").assign(),
@@ -1340,7 +1340,7 @@ public class TaskListenerTest {
   @Test
   public void shouldRetryUserTaskClaimCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
-        ZeebeTaskListenerEventType.assignment,
+        ZeebeTaskListenerEventType.assigning,
         "claim_listener_var_name",
         "expression_claim_listener_2",
         userTask -> userTask.withAssignee("me").claim(),
@@ -1420,10 +1420,10 @@ public class TaskListenerTest {
             createProcessWithZeebeUserTask(
                 task ->
                     task.zeebeAssignee(assignee)
-                        .zeebeTaskListener(l -> l.assignment().type(listenerType))
+                        .zeebeTaskListener(l -> l.assigning().type(listenerType))
                         .zeebeTaskListener(
-                            l -> l.assignment().typeExpression("assign_listener_var_name"))
-                        .zeebeTaskListener(l -> l.assignment().type(listenerType + "_3"))));
+                            l -> l.assigning().typeExpression("assign_listener_var_name"))
+                        .zeebeTaskListener(l -> l.assigning().type(listenerType + "_3"))));
 
     // complete the first task listener job
     ENGINE.job().ofInstance(processInstanceKey).withType(listenerType).complete();
@@ -1459,7 +1459,7 @@ public class TaskListenerTest {
     // then
     assertTaskListenerJobsCompletionSequence(
         processInstanceKey,
-        JobListenerEventType.ASSIGNMENT,
+        JobListenerEventType.ASSIGNING,
         listenerType,
         listenerType, // re-created task listener job
         "expression_assign_listener_2",
@@ -1620,10 +1620,10 @@ public class TaskListenerTest {
   }
 
   private static JobListenerEventType mapToJobListenerEventType(
-      ZeebeTaskListenerEventType eventType) {
+      final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
-      case assignment -> JobListenerEventType.ASSIGNMENT;
-      case complete -> JobListenerEventType.COMPLETE;
+      case ZeebeTaskListenerEventType.assigning -> JobListenerEventType.ASSIGNING;
+      case ZeebeTaskListenerEventType.completing -> JobListenerEventType.COMPLETING;
       default ->
           throw new IllegalArgumentException(
               "Unsupported zeebe task listener event type: '%s'".formatted(eventType));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -1319,8 +1319,8 @@ public class TaskListenerTest {
   public void shouldRetryUserTaskCompleteCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
         ZeebeTaskListenerEventType.completing,
-        "complete_listener_var_name",
-        "expression_complete_listener_2",
+        "completing_listener_var_name",
+        "expression_completing_listener_2",
         UserTaskClient::complete,
         UserTaskIntent.COMPLETED,
         userTask -> Assertions.assertThat(userTask).hasAction("complete"));
@@ -1330,8 +1330,8 @@ public class TaskListenerTest {
   public void shouldRetryUserTaskAssignCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
         ZeebeTaskListenerEventType.assigning,
-        "assign_listener_var_name",
-        "expression_assign_listener_2",
+        "assigning_listener_var_name",
+        "expression_assigning_listener_2",
         userTask -> userTask.withAssignee("me").assign(),
         UserTaskIntent.ASSIGNED,
         userTask -> Assertions.assertThat(userTask).hasAssignee("me").hasAction("assign"));
@@ -1341,8 +1341,8 @@ public class TaskListenerTest {
   public void shouldRetryUserTaskClaimCommandAfterExtractValueErrorIncidentResolution() {
     testUserTaskCommandRetryAfterExtractValueError(
         ZeebeTaskListenerEventType.assigning,
-        "claim_listener_var_name",
-        "expression_claim_listener_2",
+        "assigning_listener_var_name",
+        "expression_assigning_listener_2",
         userTask -> userTask.withAssignee("me").claim(),
         UserTaskIntent.ASSIGNED,
         userTask -> Assertions.assertThat(userTask).hasAssignee("me").hasAction("claim"));
@@ -1422,7 +1422,7 @@ public class TaskListenerTest {
                     task.zeebeAssignee(assignee)
                         .zeebeTaskListener(l -> l.assigning().type(listenerType))
                         .zeebeTaskListener(
-                            l -> l.assigning().typeExpression("assign_listener_var_name"))
+                            l -> l.assigning().typeExpression("assigning_listener_var_name"))
                         .zeebeTaskListener(l -> l.assigning().type(listenerType + "_3"))));
 
     // complete the first task listener job
@@ -1439,22 +1439,22 @@ public class TaskListenerTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-                Expected result of the expression 'assign_listener_var_name' to be 'STRING', but was 'NULL'. \
+                Expected result of the expression 'assigning_listener_var_name' to be 'STRING', but was 'NULL'. \
                 The evaluation reported the following warnings:
-                [NO_VARIABLE_FOUND] No variable found with name 'assign_listener_var_name'""");
+                [NO_VARIABLE_FOUND] No variable found with name 'assigning_listener_var_name'""");
 
     // when: fix the missing variable and resolve the incident
     ENGINE
         .variables()
         .ofScope(processInstanceKey)
-        .withDocument(Map.of("assign_listener_var_name", "expression_assign_listener_2"))
+        .withDocument(Map.of("assigning_listener_var_name", "expression_assigning_listener_2"))
         .update();
 
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
     // complete the retried task listener job and remaining task listeners
     completeRecreatedJobWithType(ENGINE, processInstanceKey, listenerType);
-    completeJobs(processInstanceKey, "expression_assign_listener_2", listenerType + "_3");
+    completeJobs(processInstanceKey, "expression_assigning_listener_2", listenerType + "_3");
 
     // then
     assertTaskListenerJobsCompletionSequence(
@@ -1462,7 +1462,7 @@ public class TaskListenerTest {
         JobListenerEventType.ASSIGNING,
         listenerType,
         listenerType, // re-created task listener job
-        "expression_assign_listener_2",
+        "expression_assigning_listener_2",
         listenerType + "_3");
 
     assertUserTaskRecordWithIntent(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -264,6 +264,27 @@ public class StreamProcessingComposite implements CommandWriter {
 
   @Override
   public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    final var writer =
+        streams
+            .newRecord(getLogName(partitionId))
+            .recordType(RecordType.COMMAND)
+            .key(key)
+            .requestStreamId(requestStreamId)
+            .requestId(requestId)
+            .intent(intent)
+            .authorizations(authorizedTenants)
+            .event(recordValue);
+    return writeActor.submit(writer::write).join();
+  }
+
+  @Override
+  public long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -261,6 +261,18 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   @Override
   public long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants) {
+    return streamProcessingComposite.writeCommand(
+        key, requestStreamId, requestId, intent, recordValue, authorizedTenants);
+  }
+
+  @Override
+  public long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/CommandWriter.java
@@ -43,6 +43,14 @@ public interface CommandWriter {
       final String... authorizedTenants);
 
   long writeCommand(
+      final long key,
+      final int requestStreamId,
+      final long requestId,
+      final Intent intent,
+      final UnifiedRecordValue recordValue,
+      final String... authorizedTenants);
+
+  long writeCommand(
       final int requestStreamId,
       final long requestId,
       final Intent intent,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -24,6 +24,8 @@ import org.agrona.concurrent.UnsafeBuffer;
 
 public final class UserTaskClient {
   private static final long DEFAULT_KEY = -1L;
+  private static final int DEFAULT_REQUEST_STREAM_ID = 1;
+  private static final long DEFAULT_REQUEST_ID = 1L;
 
   private static final Function<Long, Record<UserTaskRecordValue>> SUCCESS_SUPPLIER =
       (position) ->
@@ -122,6 +124,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.ASSIGN,
             userTaskRecord.setUserTaskKey(userTaskKey),
             authorizedTenantIds.toArray(new String[0]));
@@ -136,6 +140,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.ASSIGN,
             taskRecord,
             authorizedTenantIds.toArray(new String[0]));
@@ -147,6 +153,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.CLAIM,
             userTaskRecord.setUserTaskKey(userTaskKey),
             authorizedTenantIds.toArray(new String[0]));
@@ -158,6 +166,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.COMPLETE,
             userTaskRecord.setUserTaskKey(userTaskKey),
             authorizedTenantIds.toArray(new String[0]));
@@ -186,6 +196,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.UPDATE,
             userTaskRecord.setUserTaskKey(userTaskKey),
             authorizedTenantIds.toArray(new String[0]));
@@ -204,6 +216,8 @@ public final class UserTaskClient {
     final long position =
         writer.writeCommand(
             userTaskKey,
+            DEFAULT_REQUEST_STREAM_ID,
+            DEFAULT_REQUEST_ID,
             UserTaskIntent.UPDATE,
             userTaskRecord.setUserTaskKey(userTaskKey),
             authorizedTenantIds.toArray(new String[0]));


### PR DESCRIPTION
## Description

This PR introduces comprehensive support for retrying user task commands (ASSIGN, CLAIM, COMPLETE) when incidents occur due to task listener expression property evaluation failures.

These changes ensure that user task commands retried after task listener properties evaluation failures behave consistently with incident resolution behavior after execution listener expression evaluation failures.

By distinguishing user-initiated user task commands from internally retried commands, we avoid redundant processing in `UserTaskProcessor` and `UserTaskCommandPreconditionChecker` classes.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22717 
