### PR TITLE
ci: fix tasklist CI metrics sending

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -50,8 +50,14 @@ runs:
         secrets: |
           secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
 
+    - name: Check secrets availability
+      if: ${{ steps.secrets.outputs.gcloud_sa_key == '' }}
+      shell: bash
+      run: echo "::warning::Not sending any CI health metrics since no access to GHA secrets!"
+
     - name: Get build duration in milliseconds
       id: get-build-duration-millis
+      if: ${{ steps.secrets.outputs.gcloud_sa_key != '' }}
       shell: bash
       run: |
         duration=$(expr $(date +'%s') - $(date -r "$GITHUB_ACTION_PATH" +"%s"))

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -58,6 +58,7 @@ jobs:
               echo 'src_changed=true' >> $GITHUB_OUTPUT
             fi
           fi
+
   run-build:
     name: run-build
     uses: ./.github/workflows/tasklist-ci-build-reusable.yml
@@ -77,3 +78,4 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+    secrets: inherit

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -15,6 +15,7 @@ jobs:
   run-fe-ci:
     name: run-frontend-tests
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+    secrets: inherit
 
   tasklist-ci-test-summary:
     # Used by the merge queue to check all jobs.


### PR DESCRIPTION
## Description

In preparation for https://github.com/camunda/camunda/issues/21437 I wanted to check the build durations of Tasklist CI but noticed that there is no [CI health metrics](https://github.com/camunda/camunda/wiki/CI-&-Automation#ci-health-metrics) being submitted for a workflow called by `run-fe-ci` job ([example run where it does not work](https://github.com/camunda/camunda/actions/runs/12197326586/job/34026734130)). This is due to not specifying `secrets: inherit` like for all other jobs.

This PR fixes this problem and also adds a new rule for the linting framework introduced in https://github.com/camunda/camunda/issues/25306 to detect those situations in the future:

```
$ conftest test -p .github/conftest-*.rego .github/workflows/*.yml
WARN - .github/workflows/tasklist-ci.yml - main - There are GitHub Actions jobs calling other workflows but using 'secrets: inherit' which prevents access to secrets even for CI health metrics! Affected job IDs: run-fe-ci
WARN - .github/workflows/tasklist-merge-ci.yml - main - There are GitHub Actions jobs calling other workflows but using 'secrets: inherit' which prevents access to secrets even for CI health metrics! Affected job IDs: run-fe-ci
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
