### PR TITLE
ci: migrate Tasklist FE tests to Unified CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -51,6 +51,14 @@ outputs:
         steps.filter-common.outputs.maven-change == 'true' ||
         steps.filter-common.outputs.dockerfile-change == 'true'
       }}
+  tasklist-frontend-changes:
+    description: Output whether Tasklist frontend tests should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-tasklist.outputs.tasklist-frontend-change == 'true'
+      }}
   tasklist-backend-changes:
     description: Output whether Tasklist backend build should be run based on GitHub event and files changed
     value: >-
@@ -209,6 +217,9 @@ runs:
       filters: |
         tasklist-backend-change:
           - 'tasklist/!(client/**)/**'
+
+        tasklist-frontend-change:
+          - tasklist/client/**
 
   - uses: dorny/paths-filter@v3
     id: filter-optimize

--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -15,7 +15,7 @@ deny[msg] {
 
 deny[msg] {
     # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
+    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
 
     count(get_jobs_without_timeoutminutes(input.jobs)) > 0
 
@@ -25,7 +25,7 @@ deny[msg] {
 
 warn[msg] {
     # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
+    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
 
     count(get_jobs_with_timeoutminutes_higher_than(input.jobs, 15)) > 0
 
@@ -35,7 +35,7 @@ warn[msg] {
 
 deny[msg] {
     # only enforced on Unified CI and related workflows
-    input.name == ["CI", "Zeebe CI"][_]
+    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
 
     count(get_jobs_without_cihealth(input.jobs)) > 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
       frontend-changes: ${{ steps.filter.outputs.frontend-changes }}
       zeebe-changes: ${{ steps.filter.outputs.zeebe-changes }}
       operate-backend-changes: ${{ steps.filter.outputs.operate-backend-changes }}
+      tasklist-frontend-changes: ${{ steps.filter.outputs.tasklist-frontend-changes }}
       tasklist-backend-changes: ${{ steps.filter.outputs.tasklist-backend-changes }}
       optimize-frontend-changes: ${{ steps.filter.outputs.optimize-frontend-changes }}
       optimize-backend-changes: ${{ steps.filter.outputs.optimize-backend-changes }}
@@ -438,6 +439,12 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+
+  tasklist-frontend-tests:
+    if: needs.detect-changes.outputs.tasklist-frontend-changes == 'true'
+    needs: [detect-changes]
+    uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+    secrets: inherit
 
   zeebe-ci:
     if: needs.detect-changes.outputs.zeebe-changes == 'true'

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -7,6 +7,7 @@ jobs:
   fe-type-check:
     name: Type check
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     defaults:
       run:
         working-directory: tasklist/client
@@ -35,6 +36,7 @@ jobs:
   fe-eslint:
     name: ESLint
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     defaults:
       run:
         working-directory: tasklist/client
@@ -63,6 +65,7 @@ jobs:
   fe-stylelint:
     name: Stylelint
     runs-on: ubuntu-latest
+    timeout-minutes: 3
     defaults:
       run:
         working-directory: tasklist/client
@@ -91,6 +94,7 @@ jobs:
   fe-tests:
     name: Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     defaults:
       run:
         working-directory: tasklist/client
@@ -119,6 +123,7 @@ jobs:
   fe-visual-regression-tests:
     name: Visual regression tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       image: mcr.microsoft.com/playwright:v1.47.2
       options: --user 1001:1000
@@ -146,7 +151,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: visual-regression-report
+          name: tasklist-visual-regression-report
           path: tasklist/client/playwright-report/
           retention-days: 30
       - name: Observe build status
@@ -162,6 +167,7 @@ jobs:
   fe-a11y-tests:
     name: a11y tests
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container:
       image: mcr.microsoft.com/playwright:v1.47.2
       options: --user 1001:1000
@@ -189,7 +195,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: a11y-report
+          name: tasklist-a11y-report
           path: tasklist/client/playwright-report/
           retention-days: 30
       - name: Observe build status

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -33,32 +33,6 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
-  check_changes:
-    name: Check for changes in the client folder
-    runs-on: ubuntu-latest
-    outputs:
-      has_changed_frontend: ${{ steps.filter.outputs.src_changed }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
-      - id: filter
-        run: |
-          echo "src_changed=false" >> $GITHUB_OUTPUT
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # For pull requests, compare the PR base and head commits
-            git fetch origin ${{ github.base_ref }}
-
-            if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} | grep -q 'tasklist/client/'; then
-              echo 'src_changed=true' >> $GITHUB_OUTPUT
-            fi
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            # For pushes, compare the current commit with the previous one
-            if git diff --name-only ${{ github.event.before }} ${{ github.event.after }} | grep -q 'tasklist/client/'; then
-              echo 'src_changed=true' >> $GITHUB_OUTPUT
-            fi
-          fi
-
   run-build:
     name: run-build
     uses: ./.github/workflows/tasklist-ci-build-reusable.yml
@@ -72,10 +46,3 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
-
-  run-fe-ci:
-    name: run-frontend-tests
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
-    secrets: inherit


### PR DESCRIPTION
## Description

This PR aims to complete #21437 by migrating the remaining job behind the dedicated "Tasklist CI test summary" into the Unified CI: the Tasklist frontend tests. Those only need to be run when frontend-related files changed.

After merging this PR you have to manually remove the required status check "Tasklist CI test summary" in the GitHub admin settings + update the documentation + then merge https://github.com/camunda/camunda/pull/25816 ✔️

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21437
