### PR TITLE
fix: only create one CREATED event per form on distribution

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -267,7 +267,9 @@ public final class DeploymentCreateProcessor
         .forEach(
             metadata -> {
               for (final DeploymentResource resource : deploymentEvent.getResources()) {
-                if (resource.getResourceName().equals(metadata.getResourceName())) {
+                final var resourceChecksum =
+                    deploymentTransformer.getChecksum(resource.getResource());
+                if (resourceChecksum.equals(metadata.getChecksumBuffer())) {
                   stateWriter.appendFollowUpEvent(
                       metadata.getFormKey(),
                       FormIntent.CREATED,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment;
 
 import static io.camunda.zeebe.protocol.Protocol.DEPLOYMENT_PARTITION;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
@@ -21,17 +22,20 @@ import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 import java.util.function.Consumer;
 import org.junit.ClassRule;
@@ -52,6 +56,8 @@ public final class CreateDeploymentMultiplePartitionsTest {
   private static final String DMN_DECISION_TABLE_V2 = "/dmn/decision-table_v2.dmn";
   private static final String DMN_DECISION_TABLE_RENAMED =
       "/dmn/decision-table-with-renamed-drg-and-decision.dmn";
+  private static final String TEST_FORM_1 = "/form/test-form-1.form";
+  private static final String TEST_FORM_2 = "/form/test-form-2.form";
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
@@ -239,6 +245,43 @@ public final class CreateDeploymentMultiplePartitionsTest {
         .flatExtracting(DeploymentRecordValue::getProcessesMetadata)
         .extracting(ProcessMetadataValue::getBpmnProcessId)
         .containsOnly("process", "process2");
+  }
+
+  @Test
+  public void shouldCreateDeploymentResourceWithMultipleFormsWithSameResourceName() {
+    // given
+    final var formResource1 = readResource(TEST_FORM_1);
+    final var formResource2 = readResource(TEST_FORM_2);
+
+    // when
+    final Record<DeploymentRecordValue> deployment =
+        ENGINE
+            .deployment()
+            .withJsonResource(formResource1, "test-form.form")
+            .withJsonResource(formResource2, "test-form.form")
+            .deploy();
+
+    // then
+    assertThat(deployment.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(deployment.getIntent()).isEqualTo(DeploymentIntent.CREATED);
+
+    for (int partition = 1; partition <= PARTITION_COUNT; partition++) {
+      final var deployments =
+          RecordingExporter.records()
+              .withPartitionId(partition)
+              .limit(
+                  recordValueRecord ->
+                      recordValueRecord.getIntent().equals(DeploymentIntent.CREATED))
+              .formRecords()
+              .withIntent(FormIntent.CREATED);
+
+      assertThat(deployments)
+          .hasSize(2)
+          .extracting(Record::getValue)
+          .extracting(Form::getFormId, Form::getResource)
+          .containsExactlyInAnyOrder(
+              tuple("Form_0w7r08e", formResource1), tuple("Form_6s1b76p", formResource2));
+    }
   }
 
   @Test
@@ -775,5 +818,17 @@ public final class CreateDeploymentMultiplePartitionsTest {
     assertThat(deploymentCreatedEvent.getPartitionId()).isEqualTo(expectedPartition);
 
     deploymentAssert.accept(deploymentCreatedEvent);
+  }
+
+  private byte[] readResource(final String resourceName) {
+    final var resourceAsStream = getClass().getResourceAsStream(resourceName);
+    assertThat(resourceAsStream).isNotNull();
+
+    try {
+      return resourceAsStream.readAllBytes();
+    } catch (final IOException e) {
+      fail("Failed to read resource '{}'", resourceName, e);
+      return new byte[0];
+    }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
@@ -209,6 +209,36 @@ public class FormDeploymentTest {
   }
 
   @Test
+  public void shouldSetInitialVersionIfContentDiffersForSameName() {
+    // given
+    final var formResource1 = readResource(TEST_FORM_1);
+    final var formResource2 = readResource(TEST_FORM_2);
+    final var deploymentEvent1 =
+        engine.deployment().withJsonResource(formResource1, "test-form.form").deploy();
+
+    // when
+    final var deploymentEvent2 =
+        engine.deployment().withJsonResource(formResource2, "test-form.form").deploy();
+
+    // then
+    assertThat(deploymentEvent1.getValue().getFormMetadata())
+        .extracting(FormMetadataValue::getVersion)
+        .describedAs("Expect that the Form version is 1")
+        .containsExactly(1);
+
+    assertThat(deploymentEvent2.getValue().getFormMetadata())
+        .extracting(FormMetadataValue::getVersion)
+        .describedAs("Expect that the Form version is 1")
+        .containsExactly(1);
+
+    assertThat(RecordingExporter.formRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(FormMetadataValue::getFormId, FormMetadataValue::getVersion)
+        .contains(tuple(TEST_FORM_1_ID, 1), tuple(TEST_FORM_2_ID, 1));
+  }
+
+  @Test
   public void shouldIncreaseVersionIfResourceNameDiffers() {
     // given
     final var formResource = readResource(TEST_FORM_1);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -96,6 +96,11 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.JOB).map(Record.class::cast));
   }
 
+  public FormRecordStream formRecords() {
+    return new FormRecordStream(
+        filter(r -> r.getValueType() == ValueType.FORM).map(Record.class::cast));
+  }
+
   public IncidentRecordStream incidentRecords() {
     return new IncidentRecordStream(
         filter(r -> r.getValueType() == ValueType.INCIDENT).map(Record.class::cast));


### PR DESCRIPTION
## Description

Upon deployment CREATE distribution, we only create one CREATED event per form with the defined
resource content per partition. We use the checksum to identify the unqiue form resources instead
of relying on resource names as those can occur multiple times per deployment.

Otherwise, we are creating too many CREATED events for each form resource, one for each other form
with the same name and the content of that other form. This can lead to forms having the wrong
content in the end, depending on which event was processed last for a form.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25727 
