### PR TITLE
Add validation of unsupported task listener event types to 8.6

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskListener> {
+
+  @Override
+  public Class<ZeebeTaskListener> getElementType() {
+    return ZeebeTaskListener.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeTaskListener zeebeTaskListener,
+      final ValidationResultCollector validationResultCollector) {
+    final String errorMessage =
+        "Task listeners are not yet supported. Java BPMN-modeling API for task"
+            + " listeners was introduced with version 8.6, but the support for listener execution will "
+            + "be added in the upcoming versions.";
+    validationResultCollector.addError(0, errorMessage);
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -102,6 +102,7 @@ public final class ZeebeDesignTimeValidators {
                 ZeebeTaskListener::getEventType, ZeebeConstants.ATTRIBUTE_EVENT_TYPE)
             .hasNonEmptyAttribute(ZeebeTaskListener::getType, ZeebeConstants.ATTRIBUTE_TYPE)
             .hasNonEmptyAttribute(ZeebeTaskListener::getRetries, ZeebeConstants.ATTRIBUTE_RETRIES));
+    validators.add(new TaskListenerValidator());
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeSubscription.class)
             .hasNonEmptyAttribute(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.TaskListenerBuilder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,8 +42,15 @@ public class ZeebeTaskListenersValidationTest {
             .done();
 
     // when/then
+    // as we don't fully support TL yet, two violations are expected here.
     ProcessValidationUtil.assertThatProcessHasViolations(
-        process, expect(ZeebeTaskListener.class, "Attribute 'type' must be present and not empty"));
+        process,
+        expect(ZeebeTaskListener.class, "Attribute 'type' must be present and not empty"),
+        expect(
+            ZeebeTaskListener.class,
+            "Task listeners are not yet supported. Java BPMN-modeling API for task"
+                + " listeners was introduced with version 8.6, but the support for listener execution will "
+                + "be added in the upcoming versions."));
   }
 
   @Test
@@ -55,8 +63,42 @@ public class ZeebeTaskListenersValidationTest {
                 "io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.testEventTypeNotDefined.bpmn"));
 
     // when/then
+    // as we don't fully support TL yet, two violations are expected here.
     ProcessValidationUtil.assertThatProcessHasViolations(
         process,
-        expect(ZeebeTaskListener.class, "Attribute 'eventType' must be present and not empty"));
+        expect(ZeebeTaskListener.class, "Attribute 'eventType' must be present and not empty"),
+        expect(
+            ZeebeTaskListener.class,
+            "Task listeners are not yet supported. Java BPMN-modeling API for task"
+                + " listeners was introduced with version 8.6, but the support for listener execution will "
+                + "be added in the upcoming versions."));
+  }
+
+  @Test
+  @DisplayName("task listener with unsupported `eventType` property")
+  void testEventTypesNotSupported() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "user_task",
+                ut ->
+                    ut.zeebeUserTask()
+                        .zeebeTaskListener(
+                            l ->
+                                l.eventType(ZeebeTaskListenerEventType.assignment)
+                                    .type("not_supported_listener")))
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeTaskListener.class,
+            "Task listeners are not yet supported. Java BPMN-modeling API for task"
+                + " listeners was introduced with version 8.6, but the support for listener execution will "
+                + "be added in the upcoming versions."));
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -25,6 +25,8 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class ZeebeTaskListenersValidationTest {
 
@@ -74,9 +76,10 @@ public class ZeebeTaskListenersValidationTest {
                 + "be added in the upcoming versions."));
   }
 
-  @Test
   @DisplayName("task listener with unsupported `eventType` property")
-  void testEventTypesNotSupported() {
+  @ParameterizedTest(name = "unsupported event type: ''{0}''")
+  @EnumSource(ZeebeTaskListenerEventType.class)
+  void testEventTypesNotSupported(final ZeebeTaskListenerEventType unsupportedEventType) {
     // given
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess("process")
@@ -86,9 +89,7 @@ public class ZeebeTaskListenersValidationTest {
                 ut ->
                     ut.zeebeUserTask()
                         .zeebeTaskListener(
-                            l ->
-                                l.eventType(ZeebeTaskListenerEventType.assignment)
-                                    .type("not_supported_listener")))
+                            l -> l.eventType(unsupportedEventType).type("not_supported_listener")))
             .endEvent()
             .done();
 


### PR DESCRIPTION
## Description

Add validation of unsupported task listener event types for 8.6. 
As task listeners execution is not yet supported, the following validation violation was added:
```
"Task listeners are not yet supported. Java BPMN-modeling API for task"
                + " listeners was introduced with version 8.6, but the support for listener execution will "
                + "be added in the upcoming versions."
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25607
