### PR TITLE
feat: implement `BatchOperationUpdateRepository` repository for Elasticsearch

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -8,6 +8,7 @@
 package io.camunda.exporter.tasks;
 
 import io.camunda.exporter.tasks.archiver.ArchiverRepository;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.VisibleForTesting;
@@ -22,6 +23,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
   private final int partitionId;
   private final ArchiverRepository archiverRepository;
   private final IncidentUpdateRepository incidentRepository;
+  private final BatchOperationUpdateRepository batchOperationUpdateRepository;
   private final Logger logger;
   private final ScheduledThreadPoolExecutor executor;
   private final List<Runnable> tasks;
@@ -33,6 +35,7 @@ public final class BackgroundTaskManager implements CloseableSilently {
       final int partitionId,
       final @WillCloseWhenClosed ArchiverRepository archiverRepository,
       final @WillCloseWhenClosed IncidentUpdateRepository incidentRepository,
+      final @WillCloseWhenClosed BatchOperationUpdateRepository batchOperationUpdateRepository,
       final Logger logger,
       final @WillCloseWhenClosed ScheduledThreadPoolExecutor executor,
       final List<Runnable> tasks) {
@@ -41,6 +44,9 @@ public final class BackgroundTaskManager implements CloseableSilently {
         Objects.requireNonNull(archiverRepository, "must specify an archiver repository");
     this.incidentRepository =
         Objects.requireNonNull(incidentRepository, "must specify an incident repository");
+    this.batchOperationUpdateRepository =
+        Objects.requireNonNull(
+            batchOperationUpdateRepository, "must specify a batch operation update repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");
@@ -59,7 +65,8 @@ public final class BackgroundTaskManager implements CloseableSilently {
     CloseHelper.closeAll(
         error -> logger.warn("Failed to close resource for partition {}", partitionId, error),
         archiverRepository,
-        incidentRepository);
+        incidentRepository,
+        batchOperationUpdateRepository);
   }
 
   public void start() {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManager.java
@@ -44,9 +44,12 @@ public final class BackgroundTaskManager implements CloseableSilently {
         Objects.requireNonNull(archiverRepository, "must specify an archiver repository");
     this.incidentRepository =
         Objects.requireNonNull(incidentRepository, "must specify an incident repository");
-    this.batchOperationUpdateRepository =
-        Objects.requireNonNull(
-            batchOperationUpdateRepository, "must specify a batch operation update repository");
+    // TODO enable null check when Opensearch is implemented
+    this.batchOperationUpdateRepository = batchOperationUpdateRepository;
+    //    this.batchOperationUpdateRepository =
+    //        Objects.requireNonNull(
+    //            batchOperationUpdateRepository, "must specify a batch operation update
+    // repository");
     this.logger = Objects.requireNonNull(logger, "must specify a logger");
     this.executor = Objects.requireNonNull(executor, "must specify an executor");
     this.tasks = Objects.requireNonNull(tasks, "must specify tasks");

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/BackgroundTaskManagerFactory.java
@@ -20,6 +20,9 @@ import io.camunda.exporter.tasks.archiver.BatchOperationArchiverJob;
 import io.camunda.exporter.tasks.archiver.ElasticsearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.OpenSearchArchiverRepository;
 import io.camunda.exporter.tasks.archiver.ProcessInstancesArchiverJob;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateTask;
+import io.camunda.exporter.tasks.batchoperations.ElasticsearchBatchOperationUpdateRepository;
 import io.camunda.exporter.tasks.incident.ElasticsearchIncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateRepository;
 import io.camunda.exporter.tasks.incident.IncidentUpdateTask;
@@ -53,6 +56,7 @@ public final class BackgroundTaskManagerFactory {
   private ScheduledThreadPoolExecutor executor;
   private ArchiverRepository archiverRepository;
   private IncidentUpdateRepository incidentRepository;
+  private BatchOperationUpdateRepository batchOperationUpdateRepository;
 
   public BackgroundTaskManagerFactory(
       final int partitionId,
@@ -75,10 +79,18 @@ public final class BackgroundTaskManagerFactory {
     executor = buildExecutor();
     archiverRepository = buildArchiverRepository();
     incidentRepository = buildIncidentRepository();
+    batchOperationUpdateRepository = buildBatchOperationUpdateRepository();
+
     final List<Runnable> tasks = buildTasks();
 
     return new BackgroundTaskManager(
-        partitionId, archiverRepository, incidentRepository, logger, executor, tasks);
+        partitionId,
+        archiverRepository,
+        incidentRepository,
+        batchOperationUpdateRepository,
+        logger,
+        executor,
+        tasks);
   }
 
   private List<Runnable> buildTasks() {
@@ -96,6 +108,9 @@ public final class BackgroundTaskManagerFactory {
         tasks.add(new ApplyRolloverPeriodJob(archiverRepository, metrics, logger));
       }
     }
+    if (partitionId == START_PARTITION_ID) {
+      tasks.add(buildBatchOperationUpdateTask());
+    }
 
     executor.setCorePoolSize(threadCount);
     return tasks;
@@ -112,6 +127,15 @@ public final class BackgroundTaskManagerFactory {
             logger),
         1,
         postExport.getDelayBetweenRuns(),
+        executor,
+        logger);
+  }
+
+  private ReschedulingTask buildBatchOperationUpdateTask() {
+    return new ReschedulingTask(
+        new BatchOperationUpdateTask(batchOperationUpdateRepository, logger),
+        config.getArchiver().getRolloverBatchSize(),
+        config.getArchiver().getDelayBetweenRuns(),
         executor,
         logger);
   }
@@ -249,6 +273,28 @@ public final class BackgroundTaskManagerFactory {
             connector.createAsyncClient(),
             executor,
             logger);
+      }
+    };
+  }
+
+  private BatchOperationUpdateRepository buildBatchOperationUpdateRepository() {
+    final var operationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(OperationTemplate.class);
+    final var batchOperationTemplate =
+        resourceProvider.getIndexTemplateDescriptor(BatchOperationTemplate.class);
+    return switch (ConnectionTypes.from(config.getConnect().getType())) {
+      case ELASTICSEARCH -> {
+        final var connector = new ElasticsearchConnector(config.getConnect());
+        yield new ElasticsearchBatchOperationUpdateRepository(
+            connector.createAsyncClient(),
+            executor,
+            batchOperationTemplate.getFullQualifiedName(),
+            operationTemplate.getFullQualifiedName(),
+            logger);
+      }
+      case OPENSEARCH -> {
+        // TODO
+        yield null;
       }
     };
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.exporter.tasks.batchoperations;
 
-import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -17,7 +17,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    * Returns the list of not finished batch operations. We can use endDate field to distinguish
    * finished from running.
    */
-  List<BatchOperationEntity> getNotFinishedBatchOperations();
+  Collection<String> getNotFinishedBatchOperations();
 
   /**
    * Counts amount of single operations that are finished (COMPLETED or FAILED state) that are

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -47,4 +47,26 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
   record DocumentUpdate(String id, Map<String, Object> doc) {}
 
   record OperationsAggData(String batchOperationId, long finishedOperationsCount) {}
+
+  class NoopBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
+
+    @Override
+    public Collection<String> getNotFinishedBatchOperations() {
+      return List.of();
+    }
+
+    @Override
+    public List<OperationsAggData> getFinishedOperationsCount(
+        final List<String> batchOperationIds) {
+      return List.of();
+    }
+
+    @Override
+    public Integer bulkUpdate(final List<DocumentUpdate> documentUpdates) {
+      return 0;
+    }
+
+    @Override
+    public void close() throws Exception {}
+  }
 }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -9,7 +9,6 @@ package io.camunda.exporter.tasks.batchoperations;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 public interface BatchOperationUpdateRepository extends AutoCloseable {
 
@@ -44,7 +43,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    *
    * <p>All fields are expected to be non-null, except routing.
    */
-  record DocumentUpdate(String id, Map<String, Object> doc) {}
+  record DocumentUpdate(String id, long finishedOperationsCount) {}
 
   record OperationsAggData(String batchOperationId, long finishedOperationsCount) {}
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -41,7 +41,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
   /**
    * Represents a specific document store agnostic update to execute.
    *
-   * <p>All fields are expected to be non-null, except routing.
+   * <p>All fields are expected to be non-null.
    */
   record DocumentUpdate(String id, long finishedOperationsCount) {}
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateRepository.java
@@ -26,7 +26,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
    *
    * @param batchOperationIds list of batch operation ids
    */
-  List<OperationsAggData> getFinishedOperationsCount(List<String> batchOperationIds);
+  List<OperationsAggData> getFinishedOperationsCount(Collection<String> batchOperationIds);
 
   /**
    * Updates the batch operations with the amount of finished operations. Update method additionally
@@ -56,7 +56,7 @@ public interface BatchOperationUpdateRepository extends AutoCloseable {
 
     @Override
     public List<OperationsAggData> getFinishedOperationsCount(
-        final List<String> batchOperationIds) {
+        final Collection<String> batchOperationIds) {
       return List.of();
     }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
@@ -9,12 +9,12 @@ package io.camunda.exporter.tasks.batchoperations;
 
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
-import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 public class BatchOperationUpdateTask implements BackgroundTask {
@@ -33,15 +33,12 @@ public class BatchOperationUpdateTask implements BackgroundTask {
   @Override
   public CompletionStage<Integer> execute() {
 
-    final var batchOperations = batchOperationUpdateRepository.getNotFinishedBatchOperations();
+    final var batchOperationIds = batchOperationUpdateRepository.getNotFinishedBatchOperations();
 
-    if (batchOperations.size() > 0) {
+    if (!batchOperationIds.isEmpty()) {
 
-      final var finishedSingleOperationsCount =
-          batchOperationUpdateRepository.getFinishedOperationsCount(
-              batchOperations.stream()
-                  .map(BatchOperationEntity::getId)
-                  .collect(Collectors.toList()));
+      final List<OperationsAggData> finishedSingleOperationsCount =
+          batchOperationUpdateRepository.getFinishedOperationsCount((List) batchOperationIds);
 
       final var documentUpdates =
           finishedSingleOperationsCount.stream()

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTask.java
@@ -10,9 +10,7 @@ package io.camunda.exporter.tasks.batchoperations;
 import io.camunda.exporter.tasks.BackgroundTask;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
-import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.slf4j.Logger;
@@ -42,13 +40,7 @@ public class BatchOperationUpdateTask implements BackgroundTask {
 
       final var documentUpdates =
           finishedSingleOperationsCount.stream()
-              .map(
-                  d ->
-                      new DocumentUpdate(
-                          d.batchOperationId(),
-                          Map.of(
-                              BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
-                              d.finishedOperationsCount())))
+              .map(d -> new DocumentUpdate(d.batchOperationId(), d.finishedOperationsCount()))
               .toList();
 
       if (documentUpdates.size() > 0) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -7,19 +7,35 @@
  */
 package io.camunda.exporter.tasks.batchoperations;
 
+import static io.camunda.exporter.tasks.util.ElasticsearchUtil.collectBulkErrors;
 import static io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate.END_DATE;
+import static io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate.BATCH_OPERATION_ID;
+import static io.camunda.webapps.schema.entities.operation.OperationState.COMPLETED;
+import static io.camunda.webapps.schema.entities.operation.OperationState.FAILED;
 
 import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.FieldValue;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
+import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
 import io.camunda.exporter.tasks.util.ElasticsearchUtil;
+import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 public class ElasticsearchBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
 
+  private static final String BATCH_OPERATION_IDAGG_NAME = "batchOperationId";
+  private static final Integer RETRY_COUNT = 3;
   private final ElasticsearchAsyncClient client;
   private final Executor executor;
   private final String batchOperationIndex;
@@ -53,12 +69,77 @@ public class ElasticsearchBatchOperationUpdateRepository implements BatchOperati
 
   @Override
   public List<OperationsAggData> getFinishedOperationsCount(final List<String> batchOperationIds) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    if (batchOperationIds == null || batchOperationIds.isEmpty()) {
+      return List.of();
+    }
+    final var batchOperationIdsValues = batchOperationIds.stream().map(FieldValue::of).toList();
+    final var completedStatesValues =
+        List.of(COMPLETED, FAILED).stream().map(FieldValue::of).toList();
+    final var batchOperationIdsQ =
+        QueryBuilders.bool(
+            b ->
+                b.must(
+                        m ->
+                            m.terms(
+                                t ->
+                                    t.field(OperationTemplate.BATCH_OPERATION_ID)
+                                        .terms(v -> v.value(batchOperationIdsValues))))
+                    .must(
+                        m ->
+                            m.terms(
+                                t ->
+                                    t.field(OperationTemplate.STATE)
+                                        .terms(v -> v.value(completedStatesValues)))));
+    final var aggregation =
+        Aggregation.of(
+            a -> a.terms(t -> t.field(BATCH_OPERATION_ID).size(batchOperationIds.size())));
+
+    final var request =
+        new SearchRequest.Builder()
+            .index(operationIndex)
+            .query(batchOperationIdsQ)
+            .size(0)
+            .aggregations(BATCH_OPERATION_IDAGG_NAME, aggregation)
+            .build();
+
+    final SearchResponse<Void> response = client.search(request, Void.class).join();
+
+    return response
+        .aggregations()
+        .get(BATCH_OPERATION_IDAGG_NAME)
+        .sterms()
+        .buckets()
+        .array()
+        .stream()
+        .map(b -> new OperationsAggData(b.key().stringValue(), b.docCount()))
+        .collect(Collectors.toList());
   }
 
   @Override
   public Integer bulkUpdate(final List<DocumentUpdate> documentUpdates) {
-    throw new UnsupportedOperationException("Not yet implemented");
+    final var updates = documentUpdates.stream().map(this::createUpdateOperation).toList();
+    final var request =
+        new BulkRequest.Builder().operations(updates).source(s -> s.fetch(false)).build();
+    return client
+        .bulk(request)
+        .thenCompose(
+            r -> {
+              if (r.errors()) {
+                return CompletableFuture.failedFuture(collectBulkErrors(r.items()));
+              }
+              return CompletableFuture.completedFuture(r.items().size());
+            })
+        .join();
+  }
+
+  private BulkOperation createUpdateOperation(final DocumentUpdate update) {
+    return new UpdateOperation.Builder<>()
+        .index(operationIndex)
+        .id(update.id())
+        .retryOnConflict(RETRY_COUNT)
+        .action(a -> a.doc(update.doc()))
+        .build()
+        ._toBulkOperation();
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import static io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate.END_DATE;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import io.camunda.exporter.tasks.util.ElasticsearchUtil;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executor;
+import org.slf4j.Logger;
+
+public class ElasticsearchBatchOperationUpdateRepository implements BatchOperationUpdateRepository {
+
+  private final ElasticsearchAsyncClient client;
+  private final Executor executor;
+  private final String batchOperationIndex;
+  private final String operationIndex;
+  private final Logger logger;
+
+  public ElasticsearchBatchOperationUpdateRepository(
+      final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final String batchOperationIndex,
+      final String operationIndex,
+      final Logger logger) {
+    this.client = client;
+    this.executor = executor;
+    this.batchOperationIndex = batchOperationIndex;
+    this.operationIndex = operationIndex;
+    this.logger = logger;
+  }
+
+  @Override
+  public Collection<String> getNotFinishedBatchOperations() {
+    final var request =
+        new SearchRequest.Builder()
+            .index(batchOperationIndex)
+            .query(q -> q.bool(b -> b.mustNot(m -> m.exists(e -> e.field(END_DATE)))));
+    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+            client, executor, logger, request, BatchOperationEntity.class, hit -> hit.id())
+        .toCompletableFuture()
+        .join();
+  }
+
+  @Override
+  public List<OperationsAggData> getFinishedOperationsCount(final List<String> batchOperationIds) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public Integer bulkUpdate(final List<DocumentUpdate> documentUpdates) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public void close() throws Exception {}
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepository.java
@@ -72,7 +72,8 @@ public class ElasticsearchBatchOperationUpdateRepository implements BatchOperati
   }
 
   @Override
-  public List<OperationsAggData> getFinishedOperationsCount(final List<String> batchOperationIds) {
+  public List<OperationsAggData> getFinishedOperationsCount(
+      final Collection<String> batchOperationIds) {
     if (batchOperationIds == null || batchOperationIds.isEmpty()) {
       return List.of();
     }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -12,23 +12,20 @@ import co.elastic.clients.elasticsearch._types.ErrorCause;
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.Refresh;
 import co.elastic.clients.elasticsearch._types.SortOrder;
-import co.elastic.clients.elasticsearch._types.Time;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import co.elastic.clients.elasticsearch.core.BulkRequest;
-import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
 import co.elastic.clients.elasticsearch.core.CountRequest;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
-import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.bulk.BulkOperation;
 import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
 import co.elastic.clients.elasticsearch.core.bulk.UpdateOperation;
-import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import co.elastic.clients.elasticsearch.indices.AnalyzeRequest;
 import co.elastic.clients.elasticsearch.indices.analyze.AnalyzeToken;
 import co.elastic.clients.json.JsonData;
+import io.camunda.exporter.tasks.util.ElasticsearchUtil;
 import io.camunda.webapps.schema.descriptors.operate.template.IncidentTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.ListViewTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
@@ -49,7 +46,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.WillCloseWhenClosed;
 import org.slf4j.Logger;
@@ -60,8 +56,6 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
       List.of(
           FieldValue.of(OperationState.SENT.name()),
           FieldValue.of(OperationState.COMPLETED.name()));
-  private static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
-  private static final int SCROLL_PAGE_SIZE = 100;
 
   private final int partitionId;
   private final String pendingUpdateAlias;
@@ -135,7 +129,8 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
             .query(q -> q.bool(b -> b.must(idQ, typeQ)))
             .source(s -> s.fetch(false));
 
-    return fetchUnboundedDocumentCollection(request, hit -> new Document(hit.id(), hit.index()));
+    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+        client, executor, logger, request, hit -> new Document(hit.id(), hit.index()));
   }
 
   @Override
@@ -145,7 +140,8 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
     final var request =
         new SearchRequest.Builder().index(flowNodeAlias).query(query).source(s -> s.fetch(false));
 
-    return fetchUnboundedDocumentCollection(request, hit -> new Document(hit.id(), hit.index()));
+    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+        client, executor, logger, request, hit -> new Document(hit.id(), hit.index()));
   }
 
   @Override
@@ -163,7 +159,10 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
             .source(s -> s.filter(f -> f.includes(ListViewTemplate.TREE_PATH)))
             .query(q -> q.bool(b -> b.must(idQ, typeQ)));
 
-    return fetchUnboundedDocumentCollection(
+    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+        client,
+        executor,
+        logger,
         request,
         ProcessInstanceForListViewEntity.class,
         hit ->
@@ -239,102 +238,13 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
             .source(s -> s.filter(f -> f.includes(IncidentTemplate.TREE_PATH)))
             .index(incidentAlias);
 
-    return fetchUnboundedDocumentCollection(
-        request, IncidentEntity.class, h -> new ActiveIncident(h.id(), h.source().getTreePath()));
-  }
-
-  /**
-   * Variant of {@link #fetchUnboundedDocumentCollection(Builder, Class, Function)} to use when you
-   * don't care about the source document, meaning you won't be using any deserialization
-   * functionality.
-   */
-  private <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
-      final SearchRequest.Builder requestBuilder, final Function<Hit<Object>, T> transformer) {
-    return fetchUnboundedDocumentCollection(requestBuilder, Object.class, transformer);
-  }
-
-  private <TDocument, TResult>
-      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
-          final SearchRequest.Builder requestBuilder,
-          final Class<TDocument> type,
-          final Function<Hit<TDocument>, TResult> transformer) {
-    final var request =
-        requestBuilder
-            .allowNoIndices(true)
-            .ignoreUnavailable(true)
-            .scroll(SCROLL_KEEP_ALIVE)
-            .size(SCROLL_PAGE_SIZE)
-            .build();
-
-    return client
-        .search(request, type)
-        .thenComposeAsync(
-            r -> {
-              try {
-                return clearScrollOnComplete(
-                    r.scrollId(),
-                    scrollDocuments(
-                        r.hits().hits(), r.scrollId(), new ArrayList<>(), transformer, type));
-              } catch (final Exception e) {
-                // scrollDocuments may fail, in which case we still want to clear the scroll anyway
-                // we don't need to do this later on however, since at this point our async pipeline
-                // is set up already to clear it
-                return clearScroll(r.scrollId(), null, e);
-              }
-            },
-            executor);
-  }
-
-  private <T> CompletionStage<T> clearScrollOnComplete(
-      final String scrollId, final CompletionStage<T> scrollOperation) {
-    return scrollOperation
-        // we combine `handleAsync` and `thenComposeAsync` to emulate the behavior of a try/finally
-        // so we always clear the scroll even if the future is already failed
-        .handleAsync((result, error) -> clearScroll(scrollId, result, error), executor)
-        .thenComposeAsync(Function.identity(), executor);
-  }
-
-  private <T> CompletableFuture<T> clearScroll(
-      final String scrollId, final T result, final Throwable error) {
-    final var request = new ClearScrollRequest.Builder().scrollId(scrollId).build();
-    final CompletionStage<T> endResult =
-        error != null
-            ? CompletableFuture.failedFuture(error)
-            : CompletableFuture.completedFuture(result);
-    return client
-        .clearScroll(request)
-        .exceptionallyAsync(
-            clearError -> {
-              logger.warn(
-                  """
-                      Failed to clear scroll context; this could eventually lead to \
-                      increased resource usage in Elastic""",
-                  clearError);
-
-              return null;
-            },
-            executor)
-        .thenComposeAsync(ignored -> endResult);
-  }
-
-  private <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
-      final List<Hit<TResult>> hits,
-      final String scrollId,
-      final List<TDocument> accumulator,
-      final Function<Hit<TResult>, TDocument> transformer,
-      final Class<TResult> type) {
-    if (hits.isEmpty()) {
-      return CompletableFuture.completedFuture(accumulator);
-    }
-
-    for (final var hit : hits) {
-      accumulator.add(transformer.apply(hit));
-    }
-
-    return client
-        .scroll(r -> r.scrollId(scrollId).scroll(SCROLL_KEEP_ALIVE), type)
-        .thenComposeAsync(
-            r -> scrollDocuments(r.hits().hits(), r.scrollId(), accumulator, transformer, type));
+    return ElasticsearchUtil.fetchUnboundedDocumentCollection(
+        client,
+        executor,
+        logger,
+        request,
+        IncidentEntity.class,
+        h -> new ActiveIncident(h.id(), h.source().getTreePath()));
   }
 
   private Query createProcessInstanceDeletedQuery(final long processInstanceKey) {

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchUtil.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/util/ElasticsearchUtil.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.util;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.elasticsearch._types.Time;
+import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest.Builder;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
+import org.slf4j.Logger;
+
+public class ElasticsearchUtil {
+
+  public static final Time SCROLL_KEEP_ALIVE = Time.of(t -> t.time("1m"));
+  public static final int SCROLL_PAGE_SIZE = 100;
+
+  /**
+   * Variant of {@link #fetchUnboundedDocumentCollection(ElasticsearchAsyncClient, Executor, Logger,
+   * Builder, Class, Function)} to use when you don't care about the source document, meaning you
+   * won't be using any deserialization functionality.
+   */
+  public static <T> CompletionStage<Collection<T>> fetchUnboundedDocumentCollection(
+      final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final Builder requestBuilder,
+      final Function<Hit<Object>, T> transformer) {
+    return fetchUnboundedDocumentCollection(
+        client, executor, logger, requestBuilder, Object.class, transformer);
+  }
+
+  public static <TDocument, TResult>
+      CompletionStage<Collection<TResult>> fetchUnboundedDocumentCollection(
+          final ElasticsearchAsyncClient client,
+          final Executor executor,
+          final Logger logger,
+          final SearchRequest.Builder requestBuilder,
+          final Class<TDocument> type,
+          final Function<Hit<TDocument>, TResult> transformer) {
+    final var request =
+        requestBuilder
+            .allowNoIndices(true)
+            .ignoreUnavailable(true)
+            .scroll(SCROLL_KEEP_ALIVE)
+            .size(SCROLL_PAGE_SIZE)
+            .build();
+
+    return client
+        .search(request, type)
+        .thenComposeAsync(
+            r -> {
+              try {
+                return clearScrollOnComplete(
+                    client,
+                    executor,
+                    logger,
+                    r.scrollId(),
+                    scrollDocuments(
+                        client,
+                        r.hits().hits(),
+                        r.scrollId(),
+                        new ArrayList<>(),
+                        transformer,
+                        type));
+              } catch (final Exception e) {
+                // scrollDocuments may fail, in which case we still want to clear the scroll anyway
+                // we don't need to do this later on however, since at this point our async pipeline
+                // is set up already to clear it
+                return clearScroll(client, executor, logger, r.scrollId(), null, e);
+              }
+            },
+            executor);
+  }
+
+  private static <TResult, TDocument> CompletionStage<Collection<TDocument>> scrollDocuments(
+      final ElasticsearchAsyncClient client,
+      final List<Hit<TResult>> hits,
+      final String scrollId,
+      final List<TDocument> accumulator,
+      final Function<Hit<TResult>, TDocument> transformer,
+      final Class<TResult> type) {
+    if (hits.isEmpty()) {
+      return CompletableFuture.completedFuture(accumulator);
+    }
+
+    for (final var hit : hits) {
+      accumulator.add(transformer.apply(hit));
+    }
+
+    return client
+        .scroll(r -> r.scrollId(scrollId).scroll(SCROLL_KEEP_ALIVE), type)
+        .thenComposeAsync(
+            r ->
+                scrollDocuments(
+                    client, r.hits().hits(), r.scrollId(), accumulator, transformer, type));
+  }
+
+  private static <T> CompletionStage<T> clearScrollOnComplete(
+      final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final String scrollId,
+      final CompletionStage<T> scrollOperation) {
+    return scrollOperation
+        // we combine `handleAsync` and `thenComposeAsync` to emulate the behavior of a try/finally
+        // so we always clear the scroll even if the future is already failed
+        .handleAsync(
+            (result, error) -> clearScroll(client, executor, logger, scrollId, result, error),
+            executor)
+        .thenComposeAsync(Function.identity(), executor);
+  }
+
+  private static <T> CompletableFuture<T> clearScroll(
+      final ElasticsearchAsyncClient client,
+      final Executor executor,
+      final Logger logger,
+      final String scrollId,
+      final T result,
+      final Throwable error) {
+    final var request = new ClearScrollRequest.Builder().scrollId(scrollId).build();
+    final CompletionStage<T> endResult =
+        error != null
+            ? CompletableFuture.failedFuture(error)
+            : CompletableFuture.completedFuture(result);
+    return client
+        .clearScroll(request)
+        .exceptionallyAsync(
+            clearError -> {
+              logger.warn(
+                  """
+                      Failed to clear scroll context; this could eventually lead to \
+                      increased resource usage in Elastic""",
+                  clearError);
+
+              return null;
+            },
+            executor)
+        .thenComposeAsync(ignored -> endResult);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -13,6 +13,7 @@ import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -72,7 +73,7 @@ public class BatchOperationUpdateTaskTest {
 
     @Override
     public List<OperationsAggData> getFinishedOperationsCount(
-        final List<String> batchOperationIds) {
+        final Collection<String> batchOperationIds) {
       return finishedOperationsCount;
     }
 

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -11,11 +11,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
-import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -59,9 +57,7 @@ public class BatchOperationUpdateTaskTest {
     assertThat(result).succeedsWithin(Duration.ZERO).isEqualTo(2);
     assertThat(repository.documentUpdates).hasSize(2);
     assertThat(repository.documentUpdates)
-        .contains(
-            new DocumentUpdate("1", Map.of(BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT, 5L)),
-            new DocumentUpdate("2", Map.of(BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT, 6L)));
+        .contains(new DocumentUpdate("1", 5L), new DocumentUpdate("2", 6L));
   }
 
   private static final class TestRepository implements BatchOperationUpdateRepository {

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/BatchOperationUpdateTaskTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.DocumentUpdate;
 import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
-import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,7 +38,7 @@ public class BatchOperationUpdateTaskTest {
   @Test
   void shouldReturnZeroIfNoDocumentUpdatesRequired() {
     // given - when
-    repository.batchOperations.add(new BatchOperationEntity().setId("1"));
+    repository.batchOperationIds.add("1");
     final var result = task.execute();
 
     // then
@@ -49,9 +48,9 @@ public class BatchOperationUpdateTaskTest {
   @Test
   void shouldUpdateBatchOperations() {
     // given - when
-    repository.batchOperations.add(new BatchOperationEntity().setId("1"));
-    repository.batchOperations.add(new BatchOperationEntity().setId("2"));
-    repository.batchOperations.add(new BatchOperationEntity().setId("3"));
+    repository.batchOperationIds.add("1");
+    repository.batchOperationIds.add("2");
+    repository.batchOperationIds.add("3");
     repository.finishedOperationsCount.add(new OperationsAggData("1", 5));
     repository.finishedOperationsCount.add(new OperationsAggData("2", 6));
     final var result = task.execute();
@@ -66,13 +65,13 @@ public class BatchOperationUpdateTaskTest {
   }
 
   private static final class TestRepository implements BatchOperationUpdateRepository {
-    List<BatchOperationEntity> batchOperations = new ArrayList<>();
+    List<String> batchOperationIds = new ArrayList<>();
     List<OperationsAggData> finishedOperationsCount = new ArrayList<>();
     private List<DocumentUpdate> documentUpdates = new ArrayList<>();
 
     @Override
-    public List<BatchOperationEntity> getNotFinishedBatchOperations() {
-      return batchOperations;
+    public List<String> getNotFinishedBatchOperations() {
+      return batchOperationIds;
     }
 
     @Override

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
@@ -14,19 +14,26 @@ import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import io.camunda.exporter.adapters.ClientAdapter;
 import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.config.ExporterConfiguration.IndexSettings;
 import io.camunda.exporter.exceptions.PersistenceException;
 import io.camunda.exporter.schema.SearchEngineClient;
+import io.camunda.exporter.tasks.batchoperations.BatchOperationUpdateRepository.OperationsAggData;
 import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
 import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
 import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationEntity;
+import io.camunda.webapps.schema.entities.operation.OperationState;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.apache.http.HttpHost;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -60,7 +67,13 @@ abstract sealed class ElasticsearchBatchOperationUpdateRepositoryIT {
     operationTemplate = new OperationTemplate(indexPrefix, isElastic);
   }
 
-  protected abstract ElasticsearchBatchOperationUpdateRepository createRepository();
+  @BeforeEach
+  void beforeEach() {
+    Stream.of(batchOperationTemplate, operationTemplate)
+        .forEach(template -> engineClient.createIndexTemplate(template, new IndexSettings(), true));
+  }
+
+  protected abstract BatchOperationUpdateRepository createRepository();
 
   static final class ElasticsearchIT extends ElasticsearchBatchOperationUpdateRepositoryIT {
     @Container
@@ -136,6 +149,67 @@ abstract sealed class ElasticsearchBatchOperationUpdateRepositoryIT {
         throws PersistenceException {
       final var batchRequest = clientAdapter.createBatchRequest();
       batchRequest.add(batchOperationTemplate.getFullQualifiedName(), batchOperationEntity);
+      batchRequest.executeWithRefresh();
+    }
+  }
+
+  @Nested
+  final class GetFinishedOperationsCountTest {
+    @Test
+    void shouldReturnEmptyList() {
+      // given
+      final var repository = createRepository();
+
+      // when
+      var operationsAggData = repository.getFinishedOperationsCount(List.of());
+      // then
+      assertThat(operationsAggData)
+          .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
+          .isEmpty();
+
+      // when
+      operationsAggData = repository.getFinishedOperationsCount(null);
+      // then
+      assertThat(operationsAggData)
+          .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
+          .isEmpty();
+    }
+
+    @Test
+    void shouldReturnFinishedOperationsCount() throws PersistenceException {
+      // given
+      final var repository = createRepository();
+      // 1, 2, 4, 5 - not finished batch operations, 3 - finished batch operation
+      createOperationEntity("111", "1", OperationState.COMPLETED);
+      createOperationEntity("222", "1", OperationState.FAILED);
+      createOperationEntity("333", "2", OperationState.COMPLETED);
+      createOperationEntity("444", "3", OperationState.COMPLETED);
+      createOperationEntity("555", "4", OperationState.LOCKED);
+      createOperationEntity("666", "5", OperationState.SENT);
+      final var expected = List.of(new OperationsAggData("1", 2), new OperationsAggData("2", 1));
+
+      // when
+      final var documents = repository.getFinishedOperationsCount(List.of("1", "2", "4", "5"));
+
+      // then
+      assertThat(documents)
+          .asInstanceOf(InstanceOfAssertFactories.list(OperationsAggData.class))
+          .hasSize(2)
+          .isEqualTo(expected);
+    }
+
+    private OperationEntity createOperationEntity(
+        final String id, final String batchOperationId, final OperationState state)
+        throws PersistenceException {
+      final var operationEntity =
+          new OperationEntity().setId(id).setBatchOperationId(batchOperationId).setState(state);
+      indexOperation(operationEntity);
+      return operationEntity;
+    }
+
+    private void indexOperation(final OperationEntity operationEntity) throws PersistenceException {
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.add(operationTemplate.getFullQualifiedName(), operationEntity);
       batchRequest.executeWithRefresh();
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/tasks/batchoperations/ElasticsearchBatchOperationUpdateRepositoryIT.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.tasks.batchoperations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch.ElasticsearchAsyncClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import io.camunda.exporter.adapters.ClientAdapter;
+import io.camunda.exporter.config.ExporterConfiguration;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.schema.SearchEngineClient;
+import io.camunda.webapps.schema.descriptors.operate.template.BatchOperationTemplate;
+import io.camunda.webapps.schema.descriptors.operate.template.OperationTemplate;
+import io.camunda.webapps.schema.entities.operation.BatchOperationEntity;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.testcontainers.TestSearchContainers;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.apache.http.HttpHost;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.elasticsearch.client.RestClient;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+@AutoCloseResources
+abstract sealed class ElasticsearchBatchOperationUpdateRepositoryIT {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ElasticsearchBatchOperationUpdateRepositoryIT.class);
+  protected final BatchOperationTemplate batchOperationTemplate;
+  protected final OperationTemplate operationTemplate;
+  @AutoCloseResource private final ClientAdapter clientAdapter;
+  private final SearchEngineClient engineClient;
+
+  public ElasticsearchBatchOperationUpdateRepositoryIT(
+      final String databaseUrl, final boolean isElastic) {
+    final var config = new ExporterConfiguration();
+    final var indexPrefix = UUID.randomUUID().toString();
+    config.getConnect().setIndexPrefix(indexPrefix);
+    config.getConnect().setUrl(databaseUrl);
+    config.getConnect().setType(isElastic ? "elasticsearch" : "opensearch");
+
+    clientAdapter = ClientAdapter.of(config);
+    engineClient = clientAdapter.getSearchEngineClient();
+
+    batchOperationTemplate = new BatchOperationTemplate(indexPrefix, isElastic);
+    operationTemplate = new OperationTemplate(indexPrefix, isElastic);
+  }
+
+  protected abstract ElasticsearchBatchOperationUpdateRepository createRepository();
+
+  static final class ElasticsearchIT extends ElasticsearchBatchOperationUpdateRepositoryIT {
+    @Container
+    private static final ElasticsearchContainer CONTAINER =
+        TestSearchContainers.createDefeaultElasticsearchContainer();
+
+    @AutoCloseResource private final RestClientTransport transport = createTransport();
+    private final ElasticsearchAsyncClient client = new ElasticsearchAsyncClient(transport);
+
+    public ElasticsearchIT() {
+      super("http://" + CONTAINER.getHttpHostAddress(), true);
+    }
+
+    @Override
+    protected ElasticsearchBatchOperationUpdateRepository createRepository() {
+      return new ElasticsearchBatchOperationUpdateRepository(
+          client,
+          Runnable::run,
+          batchOperationTemplate.getFullQualifiedName(),
+          operationTemplate.getFullQualifiedName(),
+          LOGGER);
+    }
+
+    private RestClientTransport createTransport() {
+      final var restClient =
+          RestClient.builder(HttpHost.create(CONTAINER.getHttpHostAddress())).build();
+      return new RestClientTransport(restClient, new JacksonJsonpMapper());
+    }
+  }
+
+  // TODO OpenSearchIT
+
+  @Nested
+  final class GetNotFinishedBatchOperationsTest {
+    @Test
+    void shouldReturnEmptyList() {
+      // given
+      final var repository = createRepository();
+
+      // when
+      final var documents = repository.getNotFinishedBatchOperations();
+
+      // then
+      assertThat(documents).asInstanceOf(InstanceOfAssertFactories.list(String.class)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnBatchOperationIds() throws PersistenceException {
+      // given
+      final var repository = createRepository();
+      createBatchOperationEntity("1", OffsetDateTime.now());
+      createBatchOperationEntity("2", OffsetDateTime.now());
+      final var expected = createBatchOperationEntity("3", null);
+
+      // when
+      final var documents = repository.getNotFinishedBatchOperations();
+
+      // then
+      assertThat(documents)
+          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+          .hasSize(1)
+          .contains(expected.getId());
+    }
+
+    private BatchOperationEntity createBatchOperationEntity(
+        final String id, final OffsetDateTime endTime) throws PersistenceException {
+      final var batchOperationEntity = new BatchOperationEntity().setId(id).setEndDate(endTime);
+      indexBatchOperation(batchOperationEntity);
+      return batchOperationEntity;
+    }
+
+    private void indexBatchOperation(final BatchOperationEntity batchOperationEntity)
+        throws PersistenceException {
+      final var batchRequest = clientAdapter.createBatchRequest();
+      batchRequest.add(batchOperationTemplate.getFullQualifiedName(), batchOperationEntity);
+      batchRequest.executeWithRefresh();
+    }
+  }
+}


### PR DESCRIPTION
This PR contains implementation of `BatchOperationUpdateRepository` for Elasticsearch. I had to refactor the code a bit, so that I could reuse the code for Elastic scrolling. 

Next steps in separate PRs:
* convert logic to async run
* implement the same for Opensearch
* (separate task) refactor Repository classes to use abstracted data access layer

related with #24084