### PR TITLE
[Backport stable/8.3] fix: only create one CREATED event per form on distribution

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -219,7 +219,9 @@ public final class DeploymentCreateProcessor
         .forEach(
             metadata -> {
               for (final DeploymentResource resource : deploymentEvent.getResources()) {
-                if (resource.getResourceName().equals(metadata.getResourceName())) {
+                final var resourceChecksum =
+                    deploymentTransformer.getChecksum(resource.getResource());
+                if (resourceChecksum.equals(metadata.getChecksumBuffer())) {
                   stateWriter.appendFollowUpEvent(
                       metadata.getFormKey(),
                       FormIntent.CREATED,

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/FormDeploymentTest.java
@@ -154,6 +154,36 @@ public class FormDeploymentTest {
   }
 
   @Test
+  public void shouldSetInitialVersionIfContentDiffersForSameName() {
+    // given
+    final var formResource1 = readResource(TEST_FORM_1);
+    final var formResource2 = readResource(TEST_FORM_2);
+    final var deploymentEvent1 =
+        engine.deployment().withJsonResource(formResource1, "test-form.form").deploy();
+
+    // when
+    final var deploymentEvent2 =
+        engine.deployment().withJsonResource(formResource2, "test-form.form").deploy();
+
+    // then
+    assertThat(deploymentEvent1.getValue().getFormMetadata())
+        .extracting(FormMetadataValue::getVersion)
+        .describedAs("Expect that the Form version is 1")
+        .containsExactly(1);
+
+    assertThat(deploymentEvent2.getValue().getFormMetadata())
+        .extracting(FormMetadataValue::getVersion)
+        .describedAs("Expect that the Form version is 1")
+        .containsExactly(1);
+
+    assertThat(RecordingExporter.formRecords().limit(2))
+        .hasSize(2)
+        .extracting(Record::getValue)
+        .extracting(FormMetadataValue::getFormId, FormMetadataValue::getVersion)
+        .contains(tuple(TEST_FORM_1_ID, 1), tuple(TEST_FORM_2_ID, 1));
+  }
+
+  @Test
   public void shouldIncreaseVersionIfResourceNameDiffers() {
     // given
     final var formResource = readResource(TEST_FORM_1);

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -92,6 +92,11 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
         filter(r -> r.getValueType() == ValueType.JOB).map(Record.class::cast));
   }
 
+  public FormRecordStream formRecords() {
+    return new FormRecordStream(
+        filter(r -> r.getValueType() == ValueType.FORM).map(Record.class::cast));
+  }
+
   public IncidentRecordStream incidentRecords() {
     return new IncidentRecordStream(
         filter(r -> r.getValueType() == ValueType.INCIDENT).map(Record.class::cast));


### PR DESCRIPTION
# Description
Backport of #25728 to `stable/8.3`.

relates to #25727
original author: @tmetzke