### PR TITLE
fix: do not generate keys in scheduled task to setup identity

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -31,6 +31,6 @@ public final class IdentitySetupProcessors {
             IdentitySetupIntent.INITIALIZE,
             new IdentitySetupInitializeProcessor(
                 processingState, writers, keyGenerator, distributionBehavior))
-        .withListener(new IdentitySetupInitializer(keyGenerator, securityConfig, processingState));
+        .withListener(new IdentitySetupInitializer(securityConfig, processingState));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import org.slf4j.Logger;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -39,7 +38,6 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   public static final String DEFAULT_TENANT_ID = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   public static final String DEFAULT_TENANT_NAME = "Default";
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
-  private final KeyGenerator keyGenerator;
   private final SecurityConfiguration securityConfig;
   private final PasswordEncoder passwordEncoder;
   private final RoleState roleState;
@@ -47,10 +45,7 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   private final TenantState tenantState;
 
   public IdentitySetupInitializer(
-      final KeyGenerator keyGenerator,
-      final SecurityConfiguration securityConfig,
-      final MutableProcessingState processingState) {
-    this.keyGenerator = keyGenerator;
+      final SecurityConfiguration securityConfig, final MutableProcessingState processingState) {
     this.securityConfig = securityConfig;
     passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
     userState = processingState.getUserState();
@@ -90,21 +85,16 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    final var defaultRole =
-        new RoleRecord().setRoleKey(keyGenerator.nextKey()).setName(DEFAULT_ROLE_NAME);
+    final var defaultRole = new RoleRecord().setName(DEFAULT_ROLE_NAME);
     final var defaultUser =
         new UserRecord()
-            .setUserKey(keyGenerator.nextKey())
             .setUsername(DEFAULT_USER_USERNAME)
             .setName(DEFAULT_USER_USERNAME)
             .setEmail(DEFAULT_USER_EMAIL)
             .setPassword(passwordEncoder.encode(DEFAULT_USER_PASSWORD))
             .setUserType(UserType.DEFAULT);
     final var defaultTenant =
-        new TenantRecord()
-            .setTenantKey(keyGenerator.nextKey())
-            .setTenantId(DEFAULT_TENANT_ID)
-            .setName(DEFAULT_TENANT_NAME);
+        new TenantRecord().setTenantId(DEFAULT_TENANT_ID).setName(DEFAULT_TENANT_NAME);
 
     final var setupRecord =
         new IdentitySetupRecord()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -44,35 +44,34 @@ public class IdentitySetupInitializeTest {
   @Test
   public void shouldCreateRoleUserAndTenant() {
     // given
-    final var roleKey = 1;
     final var roleName = "roleName";
-    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
-    final var userKey = 2L;
+    final var role = new RoleRecord().setName(roleName);
     final var username = "username";
     final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
-            .setUserKey(userKey)
             .setUsername(username)
             .setName(userName)
             .setPassword(password)
             .setEmail(mail);
-    final var tenantKey = 3;
     final var tenantId = "tenant-id";
     final var tenantName = "tenant-name";
-    final var tenant =
-        new TenantRecord().setTenantKey(tenantKey).setName(tenantName).setTenantId(tenantId);
+    final var tenant = new TenantRecord().setName(tenantName).setTenantId(tenantId);
 
     // when
-    engine
-        .identitySetup()
-        .initialize()
-        .withRole(role)
-        .withUser(user)
-        .withTenant(tenant)
-        .initialize();
+    final var initialized =
+        engine
+            .identitySetup()
+            .initialize()
+            .withRole(role)
+            .withUser(user)
+            .withTenant(tenant)
+            .initialize();
+    final var userKey = initialized.getValue().getDefaultUser().getUserKey();
+    final var roleKey = initialized.getValue().getDefaultRole().getRoleKey();
+    final var tenantKey = initialized.getValue().getDefaultTenant().getTenantKey();
 
     // then
     assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).getFirst().getValue())
@@ -95,16 +94,14 @@ public class IdentitySetupInitializeTest {
   @Test
   public void shouldNotCreateUserIfAlreadyExists() {
     // given
-    final var roleKey = 1;
     final var roleName = "roleName";
-    final var role = new RoleRecord().setRoleKey(roleKey).setName(roleName);
+    final var role = new RoleRecord().setName(roleName);
     final var username = "username";
     final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
-            .setUserKey(2)
             .setUsername(username)
             .setName(userName)
             .setPassword(password)
@@ -125,7 +122,7 @@ public class IdentitySetupInitializeTest {
 
     // then
     assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertUserIsAssignedToRole(roleKey, userKey);
+    assertUserIsAssignedToRole(initializeRecord.getValue().getDefaultRole().getRoleKey(), userKey);
   }
 
   @Test
@@ -133,14 +130,12 @@ public class IdentitySetupInitializeTest {
     // given
     final var roleName = "roleName";
     final var role = new RoleRecord().setRoleKey(1).setName(roleName);
-    final var userKey = 2;
     final var username = "username";
     final var userName = "userName";
     final var password = "password";
     final var mail = "e@mail.com";
     final var user =
         new UserRecord()
-            .setUserKey(userKey)
             .setUsername(username)
             .setName(userName)
             .setPassword(password)
@@ -153,7 +148,7 @@ public class IdentitySetupInitializeTest {
 
     // then
     assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertUserIsAssignedToRole(roleKey, userKey);
+    assertUserIsAssignedToRole(roleKey, initializeRecord.getValue().getDefaultUser().getUserKey());
     Assertions.assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -12,9 +12,6 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
-import io.camunda.zeebe.protocol.record.value.RoleRecordValue;
-import io.camunda.zeebe.protocol.record.value.TenantRecordValue;
-import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 
 public class IdentitySetupRecord extends UnifiedRecordValue implements IdentitySetupRecordValue {
 
@@ -33,7 +30,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   @Override
-  public RoleRecordValue getDefaultRole() {
+  public RoleRecord getDefaultRole() {
     return defaultRoleProp.getValue();
   }
 
@@ -43,7 +40,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   @Override
-  public UserRecordValue getDefaultUser() {
+  public UserRecord getDefaultUser() {
     return defaultUserProp.getValue();
   }
 
@@ -53,7 +50,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   @Override
-  public TenantRecordValue getDefaultTenant() {
+  public TenantRecord getDefaultTenant() {
     return defaultTenantProp.getValue();
   }
 


### PR DESCRIPTION
Scheduled tasks are not allowed to modify the state. The identity setup relied on this to generate the keys for the default entities.

This is now fixed by generating the keys on the deployment partition when processing the (now key-less) `IdentitySetup/Initialize` command.