### PR TITLE
ci: POC to restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -54,6 +54,16 @@ deny[msg] {
 }
 
 deny[msg] {
+    # only enforced on Unified CI and related workflows
+    input.name == ["CI", "Tasklist Frontend Jobs", "Zeebe CI"][_]
+
+    count(get_jobs_without_permissions(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using default GITHUB_TOKEN permissions which are too wide! Affected job IDs: %s",
+        [concat(", ", get_jobs_without_permissions(input.jobs))])
+}
+
+deny[msg] {
     # only enforced on Unified CI since it is specific to check-results job
     input.name == "CI"
 
@@ -124,6 +134,7 @@ warn[msg] {
     msg := sprintf("There are GitHub Actions jobs calling other workflows but not using 'secrets: inherit' which prevents access to secrets even for CI health metrics! Affected job IDs: %s",
         [concat(", ", get_jobs_with_usesbutnosecrets(input.jobs))])
 }
+
 ###########################   RULE HELPERS   ##################################
 
 get_jobs_without_timeoutminutes(jobInput) = jobs_without_timeoutminutes {
@@ -237,5 +248,16 @@ get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
             need == "detect-changes"
         }
         count(job_needs_detectchanges) == 0
+    }
+}
+
+get_jobs_without_permissions(jobInput) = jobs_without_permissions {
+    jobs_without_permissions := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        not job.permissions
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       openapi-changes: ${{ steps.filter.outputs.openapi-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       # Detect changes against the base branch
@@ -58,6 +60,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       # renovate: datasource=github-releases depName=rhysd/actionlint
       ACTIONLINT_VERSION: '1.7.4'
@@ -87,6 +90,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -111,6 +115,7 @@ jobs:
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: gcp-perf-core-8-default
     steps:
       - uses: actions/checkout@v4
@@ -137,6 +142,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/build-frontend
@@ -170,6 +176,7 @@ jobs:
     needs: [detect-changes]
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -221,6 +228,7 @@ jobs:
     name: "[IT] ${{ matrix.name }}"
     needs: [ detect-changes ]
     timeout-minutes: 25
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
@@ -325,6 +333,8 @@ jobs:
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      security-events: write
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:
@@ -407,6 +417,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: identity/client
@@ -457,6 +468,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
@@ -496,6 +508,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     steps:
@@ -535,6 +548,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: optimize/client
@@ -582,6 +596,7 @@ jobs:
     needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       LIMITS_CPU: 4
     steps:
@@ -622,17 +637,19 @@ jobs:
 
   protobuf-checks:
     name: "Protobuf Backwards Compatibility"
-    timeout-minutes: 10
     needs: [detect-changes]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       # set the comparison based on the type of workflow trigger:
       #   - for PRs, we use the last commit of the base
       #   - for merge queues, we use the last commit of the target merge queue
       #   - for a push, we use the last commit before the push
       BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
-    if: |
-      needs.detect-changes.outputs.protobuf-changes == 'true'
+    if: needs.detect-changes.outputs.protobuf-changes == 'true'
     steps:
       - uses: actions/checkout@v4
       - id: pr-body
@@ -672,11 +689,11 @@ jobs:
 
   openapi-lint:
     name: C8 REST OpenAPI linting
-    timeout-minutes: 2
+    if: needs.detect-changes.outputs.openapi-changes == 'true'
     needs: [detect-changes]
     runs-on: ubuntu-latest
-    if: |
-      needs.detect-changes.outputs.openapi-changes == 'true'
+    timeout-minutes: 2
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - name: Install Vacuum
@@ -702,6 +719,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions:
+      checks: read
     needs:
       - actionlint
       - build-operate-backend
@@ -735,6 +754,7 @@ jobs:
     needs: [ check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-maven-snapshot
@@ -806,6 +826,7 @@ jobs:
     needs: [ docker-checks, check-results ]
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
     concurrency:
       group: deploy-camunda-docker-snapshot

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -8,6 +8,7 @@ jobs:
     name: Type check
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -37,6 +38,7 @@ jobs:
     name: ESLint
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -66,6 +68,7 @@ jobs:
     name: Stylelint
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -95,6 +98,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions: {}  # GITHUB_TOKEN unused in this job
     defaults:
       run:
         working-directory: tasklist/client
@@ -124,6 +128,7 @@ jobs:
     name: Visual regression tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.47.2
       options: --user 1001:1000
@@ -168,6 +173,7 @@ jobs:
     name: a11y tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions: {}  # GITHUB_TOKEN unused in this job
     container:
       image: mcr.microsoft.com/playwright:v1.47.2
       options: --user 1001:1000

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -17,6 +17,7 @@ jobs:
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -94,6 +95,7 @@ jobs:
     name: Property Tests
     runs-on: gcp-perf-core-8-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
@@ -141,6 +143,7 @@ jobs:
     name: Performance Tests
     runs-on: gcp-perf-core-16-default
     timeout-minutes: 30
+    permissions: {}  # GITHUB_TOKEN unused in this job
     env:
       ZEEBE_PERFORMANCE_TEST_RESULTS_DIR: "/tmp/jmh"
     steps:
@@ -202,6 +205,7 @@ jobs:
     name: Strace Tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions: {}  # GITHUB_TOKEN unused in this job
     steps:
       - uses: actions/checkout@v4
       - name: Install and allow strace tests
@@ -251,8 +255,10 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
-    timeout-minutes: 20
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:
@@ -321,6 +327,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 3
+    permissions: {}  # GITHUB_TOKEN unused in this job
     needs:
       - smoke-tests
       - property-tests
@@ -334,6 +341,7 @@ jobs:
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     timeout-minutes: 15
+    permissions: {}  # GITHUB_TOKEN unused in this job
     needs: [ test-summary ]
     runs-on: ubuntu-latest
     if: github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Description

Used https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor temporarily to identify minimal [permissions for the default GITHUB_TOKEN](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) available in every job. This prevents risks and exploits since most CI jobs *don't need any access to GitHub API* at all!

Also adding a linting rule to verify that Unified CI jobs specify `permissions` key and make a conscious decision which permissions are really needed, if at all. [There is now docs in the wiki](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria) about that.

Risk: some jobs only run on `main` and couldn't be tested yet, be prepared to roll back.

EDIT: after merge to `main` the [deploy jobs](https://github.com/camunda/camunda/actions/runs/12293765693/job/34308151881) are green.

(Previously tried https://github.com/step-security/harden-runner (see https://app.stepsecurity.io/github/camunda/camunda/actions/runs/12236247645) but info about `GITHUB_TOKEN` usage is a premium feature as is running on self-hosted runners.)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
