### PR TITLE
Allow configuration of default user credentials

### DIFF
--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -55,8 +55,10 @@ spring.autoconfigure.exclude=\
   org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration, \
   org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, \
   org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
-camunda.identity.init.users[0].username=demo
-camunda.identity.init.users[0].password=demo
+camunda.security.initialization.users[0].username=demo
+camunda.security.initialization.users[0].password=demo
+camunda.security.initialization.users[0].name=Demo
+camunda.security.initialization.users[0].email=demo@demo.com
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=validate
 

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-workflow-engine</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>operate-webapp</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/BrokerITInvocationProvider.java
@@ -14,6 +14,8 @@ import io.camunda.application.commons.configuration.BrokerBasedConfiguration.Bro
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
 import io.camunda.it.utils.ZeebeClientTestFactory.Authenticated;
 import io.camunda.it.utils.ZeebeClientTestFactory.User;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
@@ -55,7 +57,17 @@ public class BrokerITInvocationProvider
   private final Map<ExporterType, TestStandaloneBroker> testBrokers = new HashMap<>();
   private final Set<Profile> additionalProfiles = new HashSet<>();
   private Consumer<BrokerBasedProperties> additionalBrokerConfig = cfg -> {};
-  private Consumer<CamundaSecurityProperties> additionalSecurityConfig = cfg -> {};
+  private Consumer<CamundaSecurityProperties> additionalSecurityConfig =
+      cfg -> {
+        cfg.getInitialization()
+            .getUsers()
+            .add(
+                new ConfiguredUser(
+                    InitializationConfiguration.DEFAULT_USER_USERNAME,
+                    InitializationConfiguration.DEFAULT_USER_PASSWORD,
+                    InitializationConfiguration.DEFAULT_USER_NAME,
+                    InitializationConfiguration.DEFAULT_USER_EMAIL));
+      };
   private final Map<String, Object> additionalProperties = new HashMap<>();
   private final List<AutoCloseable> closeables = new ArrayList<>();
   private final Map<ExporterType, ZeebeClientTestFactory> zeebeClientTestFactories =

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
@@ -7,9 +7,6 @@
  */
 package io.camunda.it.utils;
 
-import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_PASSWORD;
-import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_USERNAME;
-
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
@@ -34,6 +31,9 @@ import org.slf4j.LoggerFactory;
 public final class ZeebeClientTestFactory implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeClientTestFactory.class);
+
+  private static final String DEFAULT_USER_USERNAME = "demo";
+  private static final String DEFAULT_USER_PASSWORD = "demo";
 
   private final Map<String, User> usersRegistry = new HashMap<>();
   private final Map<String, ZeebeClient> cachedClients = new ConcurrentHashMap<>();

--- a/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/utils/ZeebeClientTestFactory.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.it.utils;
 
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.protocol.rest.PermissionTypeEnum;
@@ -32,14 +33,11 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeClientTestFactory.class);
 
-  private static final String DEFAULT_USER_USERNAME = "demo";
-  private static final String DEFAULT_USER_PASSWORD = "demo";
-
   private final Map<String, User> usersRegistry = new HashMap<>();
   private final Map<String, ZeebeClient> cachedClients = new ConcurrentHashMap<>();
 
   public ZeebeClientTestFactory() {
-    usersRegistry.put(DEFAULT_USER_USERNAME, User.DEFAULT);
+    usersRegistry.put(InitializationConfiguration.DEFAULT_USER_USERNAME, User.DEFAULT);
   }
 
   public ZeebeClientTestFactory withUsers(final List<User> users) {
@@ -61,9 +59,10 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
     }
     final ZeebeClient defaultClient =
         cachedClients.computeIfAbsent(
-            DEFAULT_USER_USERNAME, __ -> createDefaultUserClient(gateway));
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            __ -> createDefaultUserClient(gateway));
     final String username = authenticated.value();
-    if (DEFAULT_USER_USERNAME.equals(username)) {
+    if (InitializationConfiguration.DEFAULT_USER_USERNAME.equals(username)) {
       return defaultClient;
     } else {
       return cachedClients.computeIfAbsent(
@@ -80,7 +79,10 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
 
   private ZeebeClient createDefaultUserClient(final TestGateway<?> gateway) {
     final ZeebeClient defaultClient =
-        createAuthenticatedClient(gateway, DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD);
+        createAuthenticatedClient(
+            gateway,
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD);
     // block until the default user is created
     Awaitility.await()
         .atMost(Duration.ofSeconds(20))
@@ -159,7 +161,10 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
 
   public record User(String username, String password, List<Permissions> permissions) {
     public static final User DEFAULT =
-        new User(DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD, List.of());
+        new User(
+            InitializationConfiguration.DEFAULT_USER_USERNAME,
+            InitializationConfiguration.DEFAULT_USER_PASSWORD,
+            List.of());
   }
 
   /**
@@ -173,6 +178,6 @@ public final class ZeebeClientTestFactory implements AutoCloseable {
   public @interface Authenticated {
 
     /** The username of the user to be used for authentication. */
-    String value() default DEFAULT_USER_USERNAME;
+    String value() default InitializationConfiguration.DEFAULT_USER_USERNAME;
   }
 }

--- a/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
+++ b/qa/util/src/main/java/io/camunda/qa/util/cluster/TestStandaloneCamunda.java
@@ -17,6 +17,8 @@ import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.exporter.CamundaExporter;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.property.OperateProperties;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -110,6 +112,15 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     withRecordingExporter(true).withCamundaExporter();
 
     securityConfig = new CamundaSecurityProperties();
+    securityConfig
+        .getInitialization()
+        .getUsers()
+        .add(
+            new ConfiguredUser(
+                InitializationConfiguration.DEFAULT_USER_USERNAME,
+                InitializationConfiguration.DEFAULT_USER_PASSWORD,
+                InitializationConfiguration.DEFAULT_USER_NAME,
+                InitializationConfiguration.DEFAULT_USER_EMAIL));
     withBean("securityConfig", securityConfig, CamundaSecurityProperties.class);
   }
 

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredUser.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredUser.java
@@ -9,10 +9,10 @@ package io.camunda.security.configuration;
 
 public class ConfiguredUser {
 
-  private String username = "demo";
-  private String password = "demo";
-  private String name = "Demo";
-  private String email = "demo@demo.com";
+  private String username;
+  private String password;
+  private String name;
+  private String email;
 
   public ConfiguredUser(
       final String username, final String password, final String name, final String email) {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredUser.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredUser.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.security.configuration;
 
-public class DefaultUserConfiguration {
+public class ConfiguredUser {
 
   private String username = "demo";
   private String password = "demo";
   private String name = "Demo";
   private String email = "demo@demo.com";
+
+  public ConfiguredUser(
+      final String username, final String password, final String name, final String email) {
+    this.username = username;
+    this.password = password;
+    this.name = name;
+    this.email = email;
+  }
 
   public String getUsername() {
     return username;

--- a/security/security-core/src/main/java/io/camunda/security/configuration/DefaultUserConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/DefaultUserConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class DefaultUserConfiguration {
+
+  private String username = "demo";
+  private String password = "demo";
+  private String name = "Demo";
+  private String email = "demo@demo.com";
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(final String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(final String password) {
+    this.password = password;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public void setEmail(final String email) {
+    this.email = email;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -7,15 +7,18 @@
  */
 package io.camunda.security.configuration;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class InitializationConfiguration {
 
-  private DefaultUserConfiguration defaultUser = new DefaultUserConfiguration();
+  private List<ConfiguredUser> users = new ArrayList<>();
 
-  public DefaultUserConfiguration getDefaultUser() {
-    return defaultUser;
+  public List<ConfiguredUser> getUsers() {
+    return users;
   }
 
-  public void setDefaultUser(final DefaultUserConfiguration defaultUser) {
-    this.defaultUser = defaultUser;
+  public void setUsers(final List<ConfiguredUser> users) {
+    this.users = users;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class InitializationConfiguration {
+
+  private DefaultUserConfiguration defaultUser = new DefaultUserConfiguration();
+
+  public DefaultUserConfiguration getDefaultUser() {
+    return defaultUser;
+  }
+
+  public void setDefaultUser(final DefaultUserConfiguration defaultUser) {
+    this.defaultUser = defaultUser;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 public class InitializationConfiguration {
 
+  public static final String DEFAULT_USER_USERNAME = "demo";
+  public static final String DEFAULT_USER_PASSWORD = "demo";
+  public static final String DEFAULT_USER_NAME = "Demo";
+  public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
+
   private List<ConfiguredUser> users = new ArrayList<>();
 
   public List<ConfiguredUser> getUsers() {

--- a/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/SecurityConfiguration.java
@@ -11,6 +11,8 @@ public class SecurityConfiguration {
 
   private AuthorizationsConfiguration authorizations = new AuthorizationsConfiguration();
 
+  private InitializationConfiguration initialization = new InitializationConfiguration();
+
   private MultiTenancyConfiguration multiTenancy = new MultiTenancyConfiguration();
 
   public AuthorizationsConfiguration getAuthorizations() {
@@ -19,6 +21,14 @@ public class SecurityConfiguration {
 
   public void setAuthorizations(final AuthorizationsConfiguration authorizations) {
     this.authorizations = authorizations;
+  }
+
+  public InitializationConfiguration getInitialization() {
+    return initialization;
+  }
+
+  public void setInitialization(final InitializationConfiguration initialization) {
+    this.initialization = initialization;
   }
 
   public MultiTenancyConfiguration getMultiTenancy() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -15,19 +15,18 @@ import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecord
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.authorization.PersistedRole;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
 import io.camunda.zeebe.engine.state.immutable.UserState;
-import io.camunda.zeebe.engine.state.tenant.PersistedTenant;
 import io.camunda.zeebe.engine.state.user.PersistedUser;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
+import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
@@ -39,7 +38,6 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.util.Optional;
 
 @ExcludeAuthorizationCheck
 public final class IdentitySetupInitializeProcessor
@@ -69,18 +67,11 @@ public final class IdentitySetupInitializeProcessor
   @Override
   public void processNewCommand(final TypedRecord<IdentitySetupRecord> command) {
     final var setupRecord = command.getValue();
-    final var existingEntityKeys = findExistingDefaultEntityKeys(setupRecord);
-    if (existingEntityKeys.role().isPresent()
-        && existingEntityKeys.user().isPresent()
-        && existingEntityKeys.tenant().isPresent()) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.ALREADY_EXISTS, "Default entities already exist");
-      return;
-    }
-
     final var key = keyGenerator.nextKey();
-    setNewEntityKeys(existingEntityKeys, setupRecord);
-    initializeDefaultEntities(key, existingEntityKeys, setupRecord);
+
+    createNewEntities(key, setupRecord);
+
+    stateWriter.appendFollowUpEvent(key, IdentitySetupIntent.INITIALIZED, setupRecord);
     commandDistributionBehavior
         .withKey(key)
         .inQueue(DistributionQueue.IDENTITY)
@@ -89,67 +80,90 @@ public final class IdentitySetupInitializeProcessor
 
   @Override
   public void processDistributedCommand(final TypedRecord<IdentitySetupRecord> command) {
-    roleState.getRole(command.getValue().getDefaultRole().getRoleKey());
-    final var existingEntities =
-        new DefaultEntityKeys(
-            roleState
-                .getRole(command.getValue().getDefaultRole().getRoleKey())
-                .map(PersistedRole::getRoleKey),
-            userState
-                .getUser(command.getValue().getDefaultUser().getUsername())
-                .map(PersistedUser::getUserKey),
-            tenantState
-                .getTenantByKey(command.getValue().getDefaultTenant().getTenantKey())
-                .map(PersistedTenant::getTenantKey));
-    initializeDefaultEntities(command.getKey(), existingEntities, command.getValue());
+    createDistributedEntities(command.getKey(), command.getValue());
+    stateWriter.appendFollowUpEvent(
+        command.getKey(), IdentitySetupIntent.INITIALIZED, command.getValue());
     commandDistributionBehavior.acknowledgeCommand(command);
   }
 
-  private DefaultEntityKeys findExistingDefaultEntityKeys(final IdentitySetupRecord record) {
-    final var roleKey = roleState.getRoleKeyByName(record.getDefaultRole().getName());
-    final var userKey =
-        userState.getUser(record.getDefaultUser().getUsername()).map(PersistedUser::getUserKey);
-    final var tenantKey = tenantState.getTenantKeyById(record.getDefaultTenant().getTenantId());
-    return new DefaultEntityKeys(roleKey, userKey, tenantKey);
+  private void createNewEntities(final long commandKey, final IdentitySetupRecord record) {
+    final var role = record.getDefaultRole();
+    roleState
+        .getRoleKeyByName(role.getName())
+        .ifPresentOrElse(
+            role::setRoleKey,
+            () -> {
+              final long roleKey = keyGenerator.nextKey();
+              role.setRoleKey(roleKey);
+              createRole(commandKey, role);
+            });
+
+    record.getUsers().stream()
+        .map(UserRecord.class::cast)
+        .forEach(
+            user ->
+                userState
+                    .getUser(user.getUsername())
+                    .map(PersistedUser::getUserKey)
+                    .ifPresentOrElse(
+                        userKey -> {
+                          user.setUserKey(userKey);
+                          assignUserToRole(commandKey, role.getRoleKey(), userKey);
+                        },
+                        () -> {
+                          final long userKey = keyGenerator.nextKey();
+                          user.setUserKey(userKey);
+                          createUser(commandKey, user, role.getRoleKey());
+                        }));
+
+    final var tenant = record.getDefaultTenant();
+    tenantState
+        .getTenantKeyById(tenant.getTenantId())
+        .ifPresentOrElse(
+            tenant::setTenantKey,
+            () -> {
+              final long tenantKey = keyGenerator.nextKey();
+              tenant.setTenantKey(tenantKey);
+              createTenant(commandKey, tenant);
+            });
   }
 
-  private void setNewEntityKeys(
-      final DefaultEntityKeys existingEntityKeys, final IdentitySetupRecord setup) {
-    if (existingEntityKeys.role().isEmpty()) {
-      setup.getDefaultRole().setRoleKey(keyGenerator.nextKey());
+  private void createDistributedEntities(final long commandKey, final IdentitySetupRecord record) {
+    final var role = record.getDefaultRole();
+    if (roleState.getRole(role.getRoleKey()).isEmpty()) {
+      createRole(commandKey, role);
     }
-    if (existingEntityKeys.user().isEmpty()) {
-      setup.getDefaultUser().setUserKey(keyGenerator.nextKey());
-    }
-    if (existingEntityKeys.tenant().isEmpty()) {
-      setup.getDefaultTenant().setTenantKey(keyGenerator.nextKey());
+
+    record.getUsers().stream()
+        .map(UserRecord.class::cast)
+        .forEach(
+            user ->
+                userState
+                    .getUser(user.getUserKey())
+                    .ifPresentOrElse(
+                        userKey ->
+                            assignUserToRole(commandKey, role.getRoleKey(), userKey.getUserKey()),
+                        () -> {
+                          createUser(commandKey, user, role.getRoleKey());
+                        }));
+
+    if (tenantState.getTenantByKey(record.getDefaultTenant().getTenantKey()).isEmpty()) {
+      createTenant(commandKey, record.getDefaultTenant());
     }
   }
 
-  private void initializeDefaultEntities(
-      final long commandKey,
-      final DefaultEntityKeys existingDefaultEntities,
-      final IdentitySetupRecord setup) {
-    final var roleRecord = setup.getDefaultRole();
-    final var userRecord = setup.getDefaultUser();
-    final var tenantRecord = setup.getDefaultTenant();
+  private void createRole(final long commandKey, final RoleRecord role) {
+    stateWriter.appendFollowUpEvent(commandKey, RoleIntent.CREATED, role);
+    addAllPermissions(role.getRoleKey());
+  }
 
-    if (existingDefaultEntities.role().isEmpty()) {
-      stateWriter.appendFollowUpEvent(commandKey, RoleIntent.CREATED, roleRecord);
-      addAllPermissions(roleRecord.getRoleKey());
-    }
-    if (existingDefaultEntities.user().isEmpty()) {
-      stateWriter.appendFollowUpEvent(commandKey, UserIntent.CREATED, userRecord);
-    }
-    if (existingDefaultEntities.tenant().isEmpty()) {
-      stateWriter.appendFollowUpEvent(commandKey, TenantIntent.CREATED, tenantRecord);
-    }
+  private void createUser(final long commandKey, final UserRecord user, final long roleKey) {
+    stateWriter.appendFollowUpEvent(commandKey, UserIntent.CREATED, user);
+    assignUserToRole(commandKey, roleKey, user.getUserKey());
+  }
 
-    assignUserToRole(
-        commandKey,
-        existingDefaultEntities.role().orElse(roleRecord.getRoleKey()),
-        existingDefaultEntities.user().orElse(userRecord.getUserKey()));
-    stateWriter.appendFollowUpEvent(commandKey, IdentitySetupIntent.INITIALIZED, setup);
+  private void createTenant(final long commandKey, final TenantRecord tenant) {
+    stateWriter.appendFollowUpEvent(commandKey, TenantIntent.CREATED, tenant);
   }
 
   private void assignUserToRole(final long commandKey, final long roleKey, final long userKey) {
@@ -179,6 +193,4 @@ public final class IdentitySetupInitializeProcessor
       stateWriter.appendFollowUpEvent(roleKey, AuthorizationIntent.PERMISSION_ADDED, record);
     }
   }
-
-  record DefaultEntityKeys(Optional<Long> role, Optional<Long> user, Optional<Long> tenant) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupProcessors.java
@@ -31,6 +31,6 @@ public final class IdentitySetupProcessors {
             IdentitySetupIntent.INITIALIZE,
             new IdentitySetupInitializeProcessor(
                 processingState, writers, keyGenerator, distributionBehavior))
-        .withListener(new IdentitySetupInitializer(securityConfig, processingState));
+        .withListener(new IdentitySetupInitializer(securityConfig));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -9,10 +9,6 @@ package io.camunda.zeebe.engine.processing.user;
 
 import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.Loggers;
-import io.camunda.zeebe.engine.state.immutable.RoleState;
-import io.camunda.zeebe.engine.state.immutable.TenantState;
-import io.camunda.zeebe.engine.state.immutable.UserState;
-import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
@@ -37,17 +33,10 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   private final SecurityConfiguration securityConfig;
   private final PasswordEncoder passwordEncoder;
-  private final RoleState roleState;
-  private final UserState userState;
-  private final TenantState tenantState;
 
-  public IdentitySetupInitializer(
-      final SecurityConfiguration securityConfig, final MutableProcessingState processingState) {
+  public IdentitySetupInitializer(final SecurityConfiguration securityConfig) {
     this.securityConfig = securityConfig;
     passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    userState = processingState.getUserState();
-    roleState = processingState.getRoleState();
-    tenantState = processingState.getTenantState();
   }
 
   @Override
@@ -67,17 +56,6 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
       return;
     }
 
-    final var roleExists = roleState.getRoleKeyByName(DEFAULT_ROLE_NAME).isPresent();
-    final var userExists =
-        userState
-            .getUser(securityConfig.getInitialization().getDefaultUser().getUsername())
-            .isPresent();
-    final var tenantExists = tenantState.getTenantKeyById(DEFAULT_TENANT_ID).isPresent();
-    if (roleExists && userExists && tenantExists) {
-      LOG.debug("Skipping identity setup as default user, role, and tenant already exist");
-      return;
-    }
-
     // We use a timestamp of 0L to ensure this is runs immediately once the stream processor is
     // started,
     context.getScheduleService().runAtAsync(0L, this);
@@ -85,23 +63,29 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    final var setupRecord = new IdentitySetupRecord();
+
     final var defaultRole = new RoleRecord().setName(DEFAULT_ROLE_NAME);
-    final var defaultUserConfig = securityConfig.getInitialization().getDefaultUser();
-    final var defaultUser =
-        new UserRecord()
-            .setUsername(defaultUserConfig.getUsername())
-            .setName(defaultUserConfig.getName())
-            .setEmail(defaultUserConfig.getEmail())
-            .setPassword(passwordEncoder.encode(defaultUserConfig.getPassword()))
-            .setUserType(UserType.DEFAULT);
+    setupRecord.setDefaultRole(defaultRole);
+
+    securityConfig
+        .getInitialization()
+        .getUsers()
+        .forEach(
+            user -> {
+              final var userRecord =
+                  new UserRecord()
+                      .setUsername(user.getUsername())
+                      .setName(user.getName())
+                      .setEmail(user.getEmail())
+                      .setPassword(passwordEncoder.encode(user.getPassword()))
+                      .setUserType(UserType.DEFAULT);
+              setupRecord.addUser(userRecord);
+            });
+
     final var defaultTenant =
         new TenantRecord().setTenantId(DEFAULT_TENANT_ID).setName(DEFAULT_TENANT_NAME);
-
-    final var setupRecord =
-        new IdentitySetupRecord()
-            .setDefaultRole(defaultRole)
-            .setDefaultUser(defaultUser)
-            .setDefaultTenant(defaultTenant);
+    setupRecord.setDefaultTenant(defaultTenant);
 
     taskResultBuilder.appendCommandRecord(IdentitySetupIntent.INITIALIZE, setupRecord);
     return taskResultBuilder.build();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -31,9 +31,6 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 public final class IdentitySetupInitializer implements StreamProcessorLifecycleAware, Task {
-  public static final String DEFAULT_USER_USERNAME = "demo";
-  public static final String DEFAULT_USER_PASSWORD = "demo";
-  public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
   public static final String DEFAULT_ROLE_NAME = "Admin";
   public static final String DEFAULT_TENANT_ID = TenantOwned.DEFAULT_TENANT_IDENTIFIER;
   public static final String DEFAULT_TENANT_NAME = "Default";
@@ -71,7 +68,10 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     }
 
     final var roleExists = roleState.getRoleKeyByName(DEFAULT_ROLE_NAME).isPresent();
-    final var userExists = userState.getUser(DEFAULT_USER_USERNAME).isPresent();
+    final var userExists =
+        userState
+            .getUser(securityConfig.getInitialization().getDefaultUser().getUsername())
+            .isPresent();
     final var tenantExists = tenantState.getTenantKeyById(DEFAULT_TENANT_ID).isPresent();
     if (roleExists && userExists && tenantExists) {
       LOG.debug("Skipping identity setup as default user, role, and tenant already exist");
@@ -86,12 +86,13 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     final var defaultRole = new RoleRecord().setName(DEFAULT_ROLE_NAME);
+    final var defaultUserConfig = securityConfig.getInitialization().getDefaultUser();
     final var defaultUser =
         new UserRecord()
-            .setUsername(DEFAULT_USER_USERNAME)
-            .setName(DEFAULT_USER_USERNAME)
-            .setEmail(DEFAULT_USER_EMAIL)
-            .setPassword(passwordEncoder.encode(DEFAULT_USER_PASSWORD))
+            .setUsername(defaultUserConfig.getUsername())
+            .setName(defaultUserConfig.getName())
+            .setEmail(defaultUserConfig.getEmail())
+            .setPassword(passwordEncoder.encode(defaultUserConfig.getPassword()))
             .setUserType(UserType.DEFAULT);
     final var defaultTenant =
         new TenantRecord().setTenantId(DEFAULT_TENANT_ID).setName(DEFAULT_TENANT_NAME);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -265,6 +265,38 @@ public class IdentitySetupInitializeTest {
     assertNoAssignmentIsCreated(initializeRecord.getSourceRecordPosition());
   }
 
+  @Test
+  public void shouldCreateMultipleUsers() {
+    // given
+    final var user1 =
+        new UserRecord()
+            .setUsername(UUID.randomUUID().toString())
+            .setName(UUID.randomUUID().toString())
+            .setPassword(UUID.randomUUID().toString())
+            .setEmail(UUID.randomUUID().toString());
+    final var user2 =
+        new UserRecord()
+            .setUsername(UUID.randomUUID().toString())
+            .setName(UUID.randomUUID().toString())
+            .setPassword(UUID.randomUUID().toString())
+            .setEmail(UUID.randomUUID().toString());
+
+    // when
+    engine.identitySetup().initialize().withUser(user1).withUser(user2).initialize();
+
+    // then
+    Assertions.assertThat(RecordingExporter.userRecords(UserIntent.CREATED).limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            UserRecordValue::getUsername,
+            UserRecordValue::getPassword,
+            UserRecordValue::getName,
+            UserRecordValue::getEmail)
+        .containsExactly(
+            tuple(user1.getUsername(), user1.getPassword(), user1.getName(), user1.getEmail()),
+            tuple(user2.getUsername(), user2.getPassword(), user2.getName(), user2.getEmail()));
+  }
+
   private static void assertThatAllPermissionsAreAddedToRole(final long roleKey) {
     final var addedPermissions =
         RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -59,7 +59,7 @@ public final class IdentitySetupClient {
     }
 
     public IdentitySetupInitializeClient withUser(final UserRecord user) {
-      record.setDefaultUser(user);
+      record.addUser(user);
       return this;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -7,26 +7,26 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.authorization;
 
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import java.util.List;
 
 public class IdentitySetupRecord extends UnifiedRecordValue implements IdentitySetupRecordValue {
 
   private final ObjectProperty<RoleRecord> defaultRoleProp =
       new ObjectProperty<>("defaultRole", new RoleRecord());
-  private final ObjectProperty<UserRecord> defaultUserProp =
-      new ObjectProperty<>("defaultUser", new UserRecord());
+  private final ArrayProperty<UserRecord> usersProp = new ArrayProperty<>("users", UserRecord::new);
   private final ObjectProperty<TenantRecord> defaultTenantProp =
       new ObjectProperty<>("defaultTenant", new TenantRecord());
 
   public IdentitySetupRecord() {
     super(3);
-    declareProperty(defaultRoleProp)
-        .declareProperty(defaultUserProp)
-        .declareProperty(defaultTenantProp);
+    declareProperty(defaultRoleProp).declareProperty(usersProp).declareProperty(defaultTenantProp);
   }
 
   @Override
@@ -40,13 +40,8 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   }
 
   @Override
-  public UserRecord getDefaultUser() {
-    return defaultUserProp.getValue();
-  }
-
-  public IdentitySetupRecord setDefaultUser(final UserRecord user) {
-    defaultUserProp.getValue().copyFrom(user);
-    return this;
+  public List<UserRecordValue> getUsers() {
+    return usersProp.stream().map(UserRecordValue.class::cast).toList();
   }
 
   @Override
@@ -56,6 +51,11 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
 
   public IdentitySetupRecord setDefaultTenant(final TenantRecord tenant) {
     defaultTenantProp.getValue().copyFrom(tenant);
+    return this;
+  }
+
+  public IdentitySetupRecord addUser(final UserRecord user) {
+    usersProp.add().copyFrom(user);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/user/UserRecord.java
@@ -37,6 +37,12 @@ public final class UserRecord extends UnifiedRecordValue implements UserRecordVa
         .declareProperty(userTypeProp);
   }
 
+  public UserRecord copy() {
+    final UserRecord copy = new UserRecord();
+    copy.copyFrom(this);
+    return copy;
+  }
+
   @Override
   public Long getUserKey() {
     return userKeyProp.getValue();

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3000,7 +3000,7 @@ final class JsonSerializableToJsonTest {
                             .setName("roleName")
                             .setEntityKey(2)
                             .setEntityType(EntityType.USER))
-                    .setDefaultUser(
+                    .addUser(
                         new UserRecord()
                             .setUserKey(3L)
                             .setUsername("username")

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3008,8 +3008,16 @@ final class JsonSerializableToJsonTest {
                             .setEmail("email")
                             .setPassword("password")
                             .setUserType(UserType.REGULAR))
+                    .addUser(
+                        new UserRecord()
+                            .setUserKey(4L)
+                            .setUsername("foo")
+                            .setName("bar")
+                            .setEmail("baz")
+                            .setPassword("qux")
+                            .setUserType(UserType.REGULAR))
                     .setDefaultTenant(
-                        new TenantRecord().setTenantKey(4).setTenantId("id").setName("name")),
+                        new TenantRecord().setTenantKey(5).setTenantId("id").setName("name")),
         """
       {
         "defaultRole": {
@@ -3018,16 +3026,26 @@ final class JsonSerializableToJsonTest {
           "entityKey": 2,
           "entityType": "USER"
         },
-        "defaultUser": {
-          "userKey": 3,
-          "username": "username",
-          "name": "name",
-          "email": "email",
-          "password": "password",
-          "userType": "REGULAR"
-        },
+        "users": [
+          {
+            "userKey": 3,
+            "username": "username",
+            "name": "name",
+            "email": "email",
+            "password": "password",
+            "userType": "REGULAR"
+          },
+          {
+            "userKey": 4,
+            "username": "foo",
+            "name": "bar",
+            "email": "baz",
+            "password": "qux",
+            "userType": "REGULAR"
+          }
+        ],
         "defaultTenant": {
-          "tenantKey": 4,
+          "tenantKey": 5,
           "tenantId": "id",
           "name": "name",
           "entityKey": -1,
@@ -3050,14 +3068,7 @@ final class JsonSerializableToJsonTest {
               "entityKey": -1,
               "entityType": "UNSPECIFIED"
           },
-          "defaultUser": {
-              "userKey": -1,
-              "name": "",
-              "username": "",
-              "password": "",
-              "email": "",
-              "userType": "REGULAR"
-          },
+          "users": [],
           "defaultTenant": {
               "tenantKey": -1,
               "tenantId": "",

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.protocol.record.value;
 
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import java.util.List;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -25,7 +26,7 @@ public interface IdentitySetupRecordValue extends RecordValue {
 
   RoleRecordValue getDefaultRole();
 
-  UserRecordValue getDefaultUser();
+  List<UserRecordValue> getUsers();
 
   TenantRecordValue getDefaultTenant();
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/IdentitySetupInitializerIT.java
@@ -38,6 +38,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @ZeebeIntegration
 final class IdentitySetupInitializerIT {
 
+  private static final String DEFAULT_USER_USERNAME = "demo";
+  private static final String DEFAULT_USER_NAME = "Demo";
+  private static final String DEFAULT_USER_PASSWORD = "demo";
+  private static final String DEFAULT_USER_EMAIL = "demo@demo.com";
+
   private static PasswordEncoder passwordEncoder;
   @AutoCloseResource private ZeebeClient client;
   @AutoCloseResource private TestStandaloneBroker broker;
@@ -61,13 +66,12 @@ final class IdentitySetupInitializerIT {
     final var createdUser = record.getDefaultUser();
     Assertions.assertThat(createdUser)
         .isNotNull()
-        .hasUsername(IdentitySetupInitializer.DEFAULT_USER_USERNAME)
-        .hasName(IdentitySetupInitializer.DEFAULT_USER_USERNAME)
-        .hasEmail(IdentitySetupInitializer.DEFAULT_USER_EMAIL)
+        .hasUsername(DEFAULT_USER_USERNAME)
+        .hasName(DEFAULT_USER_NAME)
+        .hasEmail(DEFAULT_USER_EMAIL)
         .hasUserType(UserType.DEFAULT);
     final var passwordMatches =
-        passwordEncoder.matches(
-            IdentitySetupInitializer.DEFAULT_USER_PASSWORD, createdUser.getPassword());
+        passwordEncoder.matches(DEFAULT_USER_PASSWORD, createdUser.getPassword());
     assertTrue(passwordMatches);
 
     final var createdRole = record.getDefaultRole();

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -129,7 +129,7 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-workflow-engine</artifactId>
+      <artifactId>camunda-security-core</artifactId>
     </dependency>
 
     <dependency>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.it.util;
 
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_PASSWORD;
+import static io.camunda.security.configuration.InitializationConfiguration.DEFAULT_USER_USERNAME;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
@@ -46,9 +49,9 @@ public class AuthorizationsUtil {
     final var authorizationUtil =
         new AuthorizationsUtil(
             gateway,
-            createClient(gateway, "demo", "demo"),
+            createClient(gateway, DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD),
             elasticsearchUrl);
-    authorizationUtil.awaitUserExistsInElasticsearch("demo");
+    authorizationUtil.awaitUserExistsInElasticsearch(DEFAULT_USER_USERNAME);
     return authorizationUtil;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/it/util/AuthorizationsUtil.java
@@ -7,9 +7,6 @@
  */
 package io.camunda.zeebe.it.util;
 
-import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_PASSWORD;
-import static io.camunda.zeebe.engine.processing.user.IdentitySetupInitializer.DEFAULT_USER_USERNAME;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
@@ -49,9 +46,9 @@ public class AuthorizationsUtil {
     final var authorizationUtil =
         new AuthorizationsUtil(
             gateway,
-            createClient(gateway, DEFAULT_USER_USERNAME, DEFAULT_USER_PASSWORD),
+            createClient(gateway, "demo", "demo"),
             elasticsearchUrl);
-    authorizationUtil.awaitUserExistsInElasticsearch(DEFAULT_USER_USERNAME);
+    authorizationUtil.awaitUserExistsInElasticsearch("demo");
     return authorizationUtil;
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -14,6 +14,8 @@ import io.camunda.application.commons.configuration.BrokerBasedConfiguration.Bro
 import io.camunda.application.commons.configuration.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.application.commons.search.SearchClientDatabaseConfiguration.SearchClientProperties;
 import io.camunda.application.commons.security.CamundaSecurityConfiguration.CamundaSecurityProperties;
+import io.camunda.security.configuration.ConfiguredUser;
+import io.camunda.security.configuration.InitializationConfiguration;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
@@ -61,6 +63,15 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withBean("config", config, BrokerBasedProperties.class).withAdditionalProfile(Profile.BROKER);
 
     securityConfig = new CamundaSecurityProperties();
+    securityConfig
+        .getInitialization()
+        .getUsers()
+        .add(
+            new ConfiguredUser(
+                InitializationConfiguration.DEFAULT_USER_USERNAME,
+                InitializationConfiguration.DEFAULT_USER_PASSWORD,
+                InitializationConfiguration.DEFAULT_USER_NAME,
+                InitializationConfiguration.DEFAULT_USER_EMAIL));
     withBean("securityConfig", securityConfig, CamundaSecurityProperties.class);
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR gives users the option to configure the credentials, name and email of the default user that's created once the Broker is started. The properties are set under:

- `camunda.security.initialization.defaultuser.username`
- `camunda.security.initialization.defaultuser.password`
- `camunda.security.initialization.defaultuser.name`
- `camunda.security.initialization.defaultuser.email`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22572 
