### PR TITLE
feat: modify cluster patch operation

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -235,6 +235,7 @@ public class ClusterEndpoint {
         return ClusterApiUtils.mapOperationResponse(
             requestSender.scaleCluster(scaleRequest).join());
       } else {
+        LOG.info("Invoking patchCluster...");
         return patchCluster(
             dryRun,
             request,
@@ -274,6 +275,7 @@ public class ClusterEndpoint {
     Optional<Set<PartitionMetadata>> newPartitionsMetadata = Optional.empty();
 
     if (newPartitionDistribution.isPresent()) {
+      LOG.info("Setting partitions metadata...");
       newPartitionsMetadata =
           Optional.of(convertToPartitionsMetadata(newPartitionDistribution.get()));
     }
@@ -287,6 +289,7 @@ public class ClusterEndpoint {
             newPartitionsMetadata,
             dryRun);
 
+    LOG.info("Invoking requestSender.patchCluster...");
     return ClusterApiUtils.mapOperationResponse(requestSender.patchCluster(patchRequest).join());
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -275,6 +275,7 @@ public class ClusterEndpoint {
       LOG.info("Setting partitions metadata...");
       newPartitionsDistribution =
           Optional.of(convertToPartitionsDistribution(newPartitionDistribution.get()));
+      LOG.info("Set partitions metadata!" + newPartitionsDistribution.get());
     }
 
     final var patchRequest =

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -215,12 +215,6 @@ public class ClusterEndpoint {
                 + newPartitionDistribution.get().getPartitioning().getFirst().getPartitionId()
                 + " with nodes "
                 + newPartitionDistribution.get().getPartitioning().getFirst().getNodes());
-        // Trigger partition redistribution
-        //        final ReassignPartitionsRequest reassignPartitionRequest =
-        //            new ReassignPartitionsRequest(
-        //                Set.of(new MemberId("0"), new MemberId("1"), new MemberId("2")), dryRun);
-        //        return ClusterApiUtils.mapOperationResponse(
-        //            requestSender.reassignPartitions(reassignPartitionRequest).join());
       } else {
         LOG.info("Didn't get new PartitionDistribution!");
       }

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -92,6 +92,15 @@ schemas:
             format: int32
             description: The new replication factor. Can be omitted if the replication factor is not changed.
             example: 3
+          distribution:
+            type: object
+            description: The new partition distribution with the assigned brokers and corresponding priority values.
+            properties:
+              partitioning:
+                type: array
+                items:
+                  $ref: "components.yaml#/schemas/Partitioning"
+
 
   PlannedOperationsResponse:
     title: PlannedOperationsResponse
@@ -457,3 +466,28 @@ schemas:
     description: The ID of an exporter
     type: string
     example: "my-exporter"
+
+  Partitioning:
+    title: Partitioning
+    description: Brokers assigned to the partition
+    type: object
+    properties:
+      partitionId:
+        $ref: "components.yaml#/schemas/PartitionId"
+      nodes:
+        type: array
+        items:
+          $ref: "components.yaml#/schemas/PartitionNode"
+
+  PartitionNode:
+    title: PartitionNode
+    type: object
+    description: Broker and respective priority for this partition
+    properties:
+      nodeId:
+        $ref: "components.yaml#/schemas/BrokerId"
+      priority:
+        type: integer
+        format: int32
+        description: The priority of the broker in the partition
+        example: 1

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -28,9 +28,13 @@ import java.util.stream.Collectors;
  * intentionally not publicly instantiable to reduce the risk of configuration errors.
  */
 public final class FixedPartitionDistributor implements PartitionDistributor {
-  private final Map<PartitionId, Set<FixedDistributionMember>> distribution;
+  private Map<PartitionId, Set<FixedDistributionMember>> distribution;
 
   FixedPartitionDistributor(final Map<PartitionId, Set<FixedDistributionMember>> distribution) {
+    this.distribution = distribution;
+  }
+
+  public void setDistribution(final Map<PartitionId, Set<FixedDistributionMember>> distribution) {
     this.distribution = distribution;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributor.java
@@ -11,7 +11,18 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.PartitionDistributor;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -130,5 +141,122 @@ public final class FixedPartitionDistributor implements PartitionDistributor {
                   + " is replicated across members %s",
               replicationFactor, partitionId.id(), members));
     }
+  }
+
+  private int getReplicationFactor(final ClusterConfiguration clusterConfiguration) {
+    return clusterConfiguration.minReplicationFactor();
+  }
+
+  private int getPartitionCount(final ClusterConfiguration clusterConfiguration) {
+    return clusterConfiguration.partitionCount();
+  }
+
+  Either<Exception, List<ClusterConfigurationChangeOperation>>
+      newGeneratePartitionDistributionOperations(
+          final ClusterConfiguration currentConfiguration,
+          final Set<MemberId> brokers,
+          final Set<PartitionMetadata> newPartitionDistribution) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+
+    final var oldDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(currentConfiguration, "temp");
+
+    final int partitionCount = getPartitionCount(currentConfiguration);
+    if (partitionCount < currentConfiguration.partitionCount()) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "New partition count [%d] must be greater than or equal to the current partition count [%d]",
+                  partitionCount, currentConfiguration.partitionCount())));
+    }
+
+    final int replicationFactor = getReplicationFactor(currentConfiguration);
+    if (replicationFactor <= 0) {
+      return Either.left(
+          new InvalidRequest(
+              String.format("Replication factor [%d] must be greater than 0", replicationFactor)));
+    }
+
+    if (brokers.size() < replicationFactor) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Number of brokers [%d] is less than the replication factor [%d]",
+                  brokers.size(), replicationFactor)));
+    }
+
+    // Can bootstrap partitions only in the sorted order
+    final var sortedPartitionMetadata =
+        newPartitionDistribution.stream()
+            .sorted(Comparator.comparingInt(p -> p.id().id()))
+            .toList();
+    for (final PartitionMetadata newMetadata : sortedPartitionMetadata) {
+      oldDistribution.stream()
+          .filter(old -> old.id().id().equals(newMetadata.id().id()))
+          .findFirst()
+          .ifPresentOrElse(
+              oldMetadata -> operations.addAll(movePartition(oldMetadata, newMetadata)),
+              () -> operations.addAll(addPartition(newMetadata)));
+    }
+
+    return Either.right(operations);
+  }
+
+  private List<ClusterConfigurationChangeOperation> addPartition(
+      final PartitionMetadata newMetadata) {
+    final Integer partitionId = newMetadata.id().id();
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+
+    // Bootstrap the partition in the primary
+    final var primary =
+        newMetadata.getPrimary().orElse(newMetadata.members().stream().findAny().orElseThrow());
+    operations.add(
+        new PartitionBootstrapOperation(primary, partitionId, newMetadata.getPriority(primary)));
+
+    // Join each remaining members to the partition
+    for (final MemberId member : newMetadata.members()) {
+      if (!member.equals(primary)) {
+        operations.add(
+            new PartitionJoinOperation(member, partitionId, newMetadata.getPriority(member)));
+      }
+    }
+
+    return operations;
+  }
+
+  private List<ClusterConfigurationChangeOperation> movePartition(
+      final PartitionMetadata oldMetadata, final PartitionMetadata newMetadata) {
+    final Integer partitionId = newMetadata.id().id();
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+
+    final var membersToJoin =
+        newMetadata.members().stream()
+            .filter(member -> !oldMetadata.members().contains(member))
+            .map(
+                newMember ->
+                    new PartitionJoinOperation(
+                        newMember, partitionId, newMetadata.getPriority(newMember)))
+            .toList();
+    final var membersToLeave =
+        oldMetadata.members().stream()
+            .filter(member -> !newMetadata.members().contains(member))
+            .map(oldMember -> new PartitionLeaveOperation(oldMember, partitionId))
+            .toList();
+    final var membersToChangePriority =
+        oldMetadata.members().stream()
+            .filter(memberId -> newMetadata.members().contains(memberId))
+            .filter(
+                memberId -> newMetadata.getPriority(memberId) != oldMetadata.getPriority(memberId))
+            .map(
+                memberId ->
+                    new PartitionReconfigurePriorityOperation(
+                        memberId, partitionId, newMetadata.getPriority(memberId)))
+            .toList();
+
+    // TODO: interleave join and leave operation
+    operations.addAll(membersToJoin);
+    operations.addAll(membersToLeave);
+    operations.addAll(membersToChangePriority);
+    return operations;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/distribution/FixedPartitionDistributorTest.java
@@ -13,6 +13,10 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
+import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -155,10 +159,8 @@ final class FixedPartitionDistributorTest {
         .containsExactlyInAnyOrderElementsOf(expectedDistribution);
   }
 
-  // TODO test an initial fixed partition distribution and try to set a new fixed partitions
-  // distribution
   @Test
-  void shouldProcessNewFixedPartitionDistribution() {
+  void shouldProcessNewFixedPartitionDistribution6() {
     // given
     final var initialDistribution =
         Set.of(
@@ -193,7 +195,7 @@ final class FixedPartitionDistributorTest {
         .as("should distribute the partitions as expected")
         .containsExactlyInAnyOrderElementsOf(initialDistribution);
 
-    // now test the new distribution
+    // now test newDistribution -> should produce 6 operations
     final var newDistribution =
         Set.of(
             new PartitionMetadata(
@@ -218,6 +220,98 @@ final class FixedPartitionDistributorTest {
             partition(3),
             Set.of(
                 new FixedDistributionMember(node(0), 1), new FixedDistributionMember(node(1), 2))));
+
+    final var currentConfiguration =
+        ConfigurationUtil.getClusterConfigFrom(
+            false, initialDistribution, DynamicPartitionConfig.uninitialized());
+    final Either<Exception, List<ClusterConfigurationChangeOperation>> operations =
+        distributor.newGeneratePartitionDistributionOperations(
+            currentConfiguration, clusterMembers, newDistribution);
+
+    assertThat(operations.isRight()).isTrue();
+    assertThat(operations.get()).as("should generate the expected operations").hasSize(6);
+
+    // when
+    final var changedDistribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2);
+
+    // then
+    assertThat(changedDistribution)
+        .as("should distribute the partitions as expected")
+        .containsExactlyInAnyOrderElementsOf(newDistribution);
+  }
+
+  @Test
+  void shouldProcessNewFixedPartitionDistribution9() {
+    // given
+    final var initialDistribution =
+        Set.of(
+            new PartitionMetadata(
+                partition(1), Set.of(node(0), node(1)), Map.of(node(0), 2, node(1), 1), 2, node(0)),
+            new PartitionMetadata(
+                partition(2), Set.of(node(1), node(2)), Map.of(node(1), 2, node(2), 1), 2, node(1)),
+            new PartitionMetadata(
+                partition(3),
+                Set.of(node(2), node(0)),
+                Map.of(node(2), 2, node(0), 1),
+                2,
+                node(2)));
+    final var distributor =
+        new FixedPartitionDistributorBuilder(PARTITION_GROUP_NAME)
+            .assignMember(1, 0, 2)
+            .assignMember(1, 1, 1)
+            .assignMember(2, 1, 2)
+            .assignMember(2, 2, 1)
+            .assignMember(3, 2, 2)
+            .assignMember(3, 0, 1)
+            .build();
+    final var clusterMembers = Set.of(node(0), node(1), node(2));
+    final var sortedPartitionIds = List.of(partition(1), partition(2), partition(3));
+
+    // when
+    final var distribution =
+        distributor.distributePartitions(clusterMembers, sortedPartitionIds, 2);
+
+    // then
+    assertThat(distribution)
+        .as("should distribute the partitions as expected")
+        .containsExactlyInAnyOrderElementsOf(initialDistribution);
+
+    // now test newDistribution -> should produce 9 operations
+    final var newDistribution =
+        Set.of(
+            new PartitionMetadata(
+                partition(1), Set.of(node(1), node(2)), Map.of(node(1), 2, node(2), 1), 2, node(1)),
+            new PartitionMetadata(
+                partition(2), Set.of(node(2), node(0)), Map.of(node(2), 2, node(0), 1), 2, node(2)),
+            new PartitionMetadata(
+                partition(3),
+                Set.of(node(0), node(1)),
+                Map.of(node(0), 2, node(1), 1),
+                2,
+                node(0)));
+
+    distributor.setDistribution(
+        Map.of(
+            partition(1),
+            Set.of(
+                new FixedDistributionMember(node(1), 2), new FixedDistributionMember(node(2), 1)),
+            partition(2),
+            Set.of(
+                new FixedDistributionMember(node(2), 2), new FixedDistributionMember(node(0), 1)),
+            partition(3),
+            Set.of(
+                new FixedDistributionMember(node(0), 2), new FixedDistributionMember(node(1), 1))));
+
+    final var currentConfiguration =
+        ConfigurationUtil.getClusterConfigFrom(
+            false, initialDistribution, DynamicPartitionConfig.uninitialized());
+    final Either<Exception, List<ClusterConfigurationChangeOperation>> operations =
+        distributor.newGeneratePartitionDistributionOperations(
+            currentConfiguration, clusterMembers, newDistribution);
+
+    assertThat(operations.isRight()).isTrue();
+    assertThat(operations.get()).as("should generate the expected operations").hasSize(9);
 
     // when
     final var changedDistribution =

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
-import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionsDistribution;
 import java.util.Optional;
 import java.util.Set;
 
@@ -56,7 +56,7 @@ public sealed interface ClusterConfigurationManagementRequest {
       Set<MemberId> membersToRemove,
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
-      Optional<Set<PartitionMetadata>> newPartitionsMetadata,
+      Optional<PartitionsDistribution> newPartitionsDistribution,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionMetadata;
 import java.util.Optional;
 import java.util.Set;
 
@@ -55,7 +56,7 @@ public sealed interface ClusterConfigurationManagementRequest {
       Set<MemberId> membersToRemove,
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
-      //      Optional<ClusterConfigPatchRequestPartitionsDistribution> newPartitionDistribution,
+      Optional<Set<PartitionMetadata>> newPartitionsMetadata,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -55,6 +55,7 @@ public sealed interface ClusterConfigurationManagementRequest {
       Set<MemberId> membersToRemove,
       Optional<Integer> newPartitionCount,
       Optional<Integer> newReplicationFactor,
+      //      Optional<ClusterConfigPatchRequestPartitionsDistribution> newPartitionDistribution,
       boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -171,12 +171,12 @@ public final class ClusterConfigurationManagementRequestsHandler
               });
     }
 
-    if (!enablePartitionScaling && clusterPatchRequest.newPartitionCount().isPresent()) {
-      final var failedFuture = executor.<ClusterConfigurationChangeResponse>createFuture();
-      failedFuture.completeExceptionally(
-          new UnsupportedOperationException("Partition scaling is not enabled."));
-      return failedFuture;
-    }
+    //    if (!enablePartitionScaling && clusterPatchRequest.newPartitionCount().isPresent()) {
+    //      final var failedFuture = executor.<ClusterConfigurationChangeResponse>createFuture();
+    //      failedFuture.completeExceptionally(
+    //          new UnsupportedOperationException("Partition scaling is not enabled."));
+    //      return failedFuture;
+    //    }
 
     return handleRequest(
         clusterPatchRequest.dryRun(),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -33,6 +33,8 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles the requests for the configuration management. This is expected be running on the
@@ -40,6 +42,8 @@ import java.util.function.Function;
  */
 public final class ClusterConfigurationManagementRequestsHandler
     implements ClusterConfigurationManagementApi {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ClusterConfigurationManagementRequestsHandler.class);
   private final ConfigurationChangeCoordinator coordinator;
   private final ConcurrencyControl executor;
   private final MemberId localMemberId;
@@ -156,6 +160,16 @@ public final class ClusterConfigurationManagementRequestsHandler
   @Override
   public ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
       final ClusterPatchRequest clusterPatchRequest) {
+
+    if (clusterPatchRequest.newPartitionsMetadata().isPresent()) {
+      clusterPatchRequest
+          .newPartitionsMetadata()
+          .get()
+          .forEach(
+              partitionMetadata -> {
+                LOG.info("Got new partitionMetadata " + partitionMetadata.toString());
+              });
+    }
 
     if (!enablePartitionScaling && clusterPatchRequest.newPartitionCount().isPresent()) {
       final var failedFuture = executor.<ClusterConfigurationChangeResponse>createFuture();

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionsDistribution;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.util.Either;
@@ -23,16 +24,19 @@ public final class ClusterPatchRequestTransformer implements ConfigurationChange
   private final Set<MemberId> membersToRemove;
   private final Optional<Integer> newPartitionCount;
   private final Optional<Integer> newReplicationFactor;
+  private final Optional<PartitionsDistribution> newPartitionsDistribution;
 
   public ClusterPatchRequestTransformer(
       final Set<MemberId> membersToAdd,
       final Set<MemberId> membersToRemove,
       final Optional<Integer> newPartitionCount,
-      final Optional<Integer> newReplicationFactor) {
+      final Optional<Integer> newReplicationFactor,
+      final Optional<PartitionsDistribution> newPartitionsDistribution) {
     this.membersToAdd = membersToAdd;
     this.membersToRemove = membersToRemove;
     this.newPartitionCount = newPartitionCount;
     this.newReplicationFactor = newReplicationFactor;
+    this.newPartitionsDistribution = newPartitionsDistribution;
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -928,6 +928,10 @@ public class ProtoBufSerializer
           clusterPatchRequest.hasNewReplicationFactor()
               ? Optional.of(clusterPatchRequest.getNewReplicationFactor())
               : Optional.empty();
+      //      final Optional<Set<PartitionMetadata>> newPartitionsMetadata =
+      //          clusterPatchRequest.hasNewPartitionsMetadata()
+      //              ? Optional.of(clusterPatchRequest.getNewPartitionsMetadata())
+      //              : Optional.empty();
       return new ClusterPatchRequest(
           clusterPatchRequest.getMembersToAddList().stream()
               .map(MemberId::from)
@@ -937,6 +941,8 @@ public class ProtoBufSerializer
               .collect(Collectors.toSet()),
           newPartitionCount,
           newReplicationFactor,
+          Optional.empty(),
+          //          newPartitionsMetadata,
           clusterPatchRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.dynamic.config.protocol.Topology;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.ChangeStatus;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.CompletedChange;
 import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionConfig;
+import io.camunda.zeebe.dynamic.config.protocol.Topology.PartitionsDistribution;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.CompletedOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -928,10 +929,10 @@ public class ProtoBufSerializer
           clusterPatchRequest.hasNewReplicationFactor()
               ? Optional.of(clusterPatchRequest.getNewReplicationFactor())
               : Optional.empty();
-      //      final Optional<Set<PartitionMetadata>> newPartitionsMetadata =
-      //          clusterPatchRequest.hasNewPartitionsMetadata()
-      //              ? Optional.of(clusterPatchRequest.getNewPartitionsMetadata())
-      //              : Optional.empty();
+      final Optional<PartitionsDistribution> newPartitionsDistribution =
+          clusterPatchRequest.hasNewPartitionsDistribution()
+              ? Optional.of(clusterPatchRequest.getNewPartitionsDistribution())
+              : Optional.empty();
       return new ClusterPatchRequest(
           clusterPatchRequest.getMembersToAddList().stream()
               .map(MemberId::from)
@@ -941,8 +942,7 @@ public class ProtoBufSerializer
               .collect(Collectors.toSet()),
           newPartitionCount,
           newReplicationFactor,
-          Optional.empty(),
-          //          newPartitionsMetadata,
+          newPartitionsDistribution,
           clusterPatchRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -752,6 +752,9 @@ public class ProtoBufSerializer
 
     clusterPatchRequest.newPartitionCount().ifPresent(builder::setNewPartitionCount);
     clusterPatchRequest.newReplicationFactor().ifPresent(builder::setNewReplicationFactor);
+    clusterPatchRequest
+        .newPartitionsDistribution()
+        .ifPresent(builder::setNewPartitionsDistribution);
     clusterPatchRequest.membersToAdd().stream()
         .forEach(memberId -> builder.addMembersToAdd(memberId.id()));
     clusterPatchRequest.membersToRemove().stream()

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -47,6 +47,7 @@ message ClusterPatchRequest {
   optional uint32 newPartitionCount = 3;
   optional uint32 newReplicationFactor = 4;
   bool dryRun = 5;
+  optional topology_protocol.PartitionsDistribution newPartitionsDistribution = 6;
 }
 
 message ForceRemoveBrokersRequest {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -56,6 +56,20 @@ message MemberState {
   map<int32, PartitionState> partitions = 4;
 }
 
+message PartitionsDistribution {
+  repeated PartitionDistribution partitions = 1;
+}
+
+message PartitionDistribution {
+  int32 partitionId = 1;
+  repeated PartitionMembers members = 2;
+}
+
+message PartitionMembers {
+  string memberId = 1;
+  int32 priority = 2;
+}
+
 message PartitionState {
   State state = 1;
   int32 priority = 2;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -368,7 +368,8 @@ final class ClusterConfigurationManagementApiTest {
   void shouldPatchCluster() {
     // given
     final var request =
-        new ClusterPatchRequest(Set.of(id1), Set.of(), Optional.of(3), Optional.empty(), false);
+        new ClusterPatchRequest(
+            Set.of(id1), Set.of(), Optional.of(3), Optional.empty(), Optional.empty(), false);
     final ClusterConfiguration currentTopology =
         initialTopology
             .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -56,7 +56,8 @@ final class ClusterPatchRequestTransformerTest {
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
-                patchRequest.newReplicationFactor())
+                patchRequest.newReplicationFactor(),
+                patchRequest.newPartitionsDistribution())
             .operations(ClusterConfiguration.init());
 
     // then
@@ -82,7 +83,8 @@ final class ClusterPatchRequestTransformerTest {
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
-                patchRequest.newReplicationFactor())
+                patchRequest.newReplicationFactor(),
+                patchRequest.newPartitionsDistribution())
             .operations(ClusterConfiguration.init());
 
     // then
@@ -235,7 +237,8 @@ final class ClusterPatchRequestTransformerTest {
                 patchRequest.membersToAdd(),
                 patchRequest.membersToRemove(),
                 patchRequest.newPartitionCount(),
-                patchRequest.newReplicationFactor())
+                patchRequest.newReplicationFactor(),
+                patchRequest.newPartitionsDistribution())
             .operations(oldClusterTopology);
     assertThat(result).isRight();
     final var operations = result.get();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPatchRequestTransformerTest.java
@@ -43,7 +43,12 @@ final class ClusterPatchRequestTransformerTest {
     // given
     final var patchRequest =
         new ClusterPatchRequest(
-            Set.of(id0, id2), Set.of(id0, id1), Optional.empty(), Optional.empty(), false);
+            Set.of(id0, id2),
+            Set.of(id0, id1),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            false);
 
     // when
     final var result =
@@ -70,7 +75,8 @@ final class ClusterPatchRequestTransformerTest {
 
     // when
     final var patchRequest =
-        new ClusterPatchRequest(Set.of(), Set.of(), Optional.of(1), Optional.empty(), false);
+        new ClusterPatchRequest(
+            Set.of(), Set.of(), Optional.of(1), Optional.empty(), Optional.empty(), false);
     final var result =
         new ClusterPatchRequestTransformer(
                 patchRequest.membersToAdd(),
@@ -97,7 +103,8 @@ final class ClusterPatchRequestTransformerTest {
 
     // when
     final var patchRequest =
-        new ClusterPatchRequest(Set.of(id2), Set.of(), Optional.empty(), Optional.empty(), false);
+        new ClusterPatchRequest(
+            Set.of(id2), Set.of(), Optional.empty(), Optional.empty(), Optional.empty(), false);
     final var expectedDistribution =
         new RoundRobinPartitionDistributor()
             .distributePartitions(Set.of(id0, id1, id2), getSortedPartitionIds(2), 2);
@@ -119,7 +126,8 @@ final class ClusterPatchRequestTransformerTest {
 
     // when
     final var patchRequest =
-        new ClusterPatchRequest(Set.of(), Set.of(id1), Optional.empty(), Optional.empty(), false);
+        new ClusterPatchRequest(
+            Set.of(), Set.of(id1), Optional.empty(), Optional.empty(), Optional.empty(), false);
 
     final var expectedDistribution =
         new RoundRobinPartitionDistributor()
@@ -143,7 +151,7 @@ final class ClusterPatchRequestTransformerTest {
     // when
     final var patchRequest =
         new ClusterPatchRequest(
-            Set.of(id2), Set.of(id1), Optional.empty(), Optional.empty(), false);
+            Set.of(id2), Set.of(id1), Optional.empty(), Optional.empty(), Optional.empty(), false);
 
     final var expectedDistribution =
         new RoundRobinPartitionDistributor()
@@ -168,7 +176,12 @@ final class ClusterPatchRequestTransformerTest {
     final int newPartitionCount = 4;
     final var patchRequest =
         new ClusterPatchRequest(
-            Set.of(id2), Set.of(id1), Optional.of(newPartitionCount), Optional.empty(), false);
+            Set.of(id2),
+            Set.of(id1),
+            Optional.of(newPartitionCount),
+            Optional.empty(),
+            Optional.empty(),
+            false);
 
     final var expectedDistribution =
         new RoundRobinPartitionDistributor()
@@ -193,7 +206,12 @@ final class ClusterPatchRequestTransformerTest {
     final int newPartitionCount = 4;
     final var patchRequest =
         new ClusterPatchRequest(
-            Set.of(id2), Set.of(id1), Optional.of(newPartitionCount), Optional.of(2), false);
+            Set.of(id2),
+            Set.of(id1),
+            Optional.of(newPartitionCount),
+            Optional.of(2),
+            Optional.empty(),
+            false);
 
     final var expectedDistribution =
         new RoundRobinPartitionDistributor()

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -156,6 +156,7 @@ final class ProtoBufSerializerTest {
             Set.of(MemberId.from("4"), MemberId.from("5")),
             Optional.of(10),
             Optional.of(4),
+            Optional.empty(),
             true);
 
     // when


### PR DESCRIPTION
## Description

Dynamic Partition Distribution PoC. Not to be merged!

Changes:

- REST cluster patch endpoint accepts a partitions distribution object
- Map and propagate this new object to coordinator
- Compare it to existing topology and get changes plan
- Apply changes to get final topology

## Related issues

PoC for #19565
