### PR TITLE
refactor: fallback to legacy authorization configuration

### DIFF
--- a/dist/src/main/resources/application-tasklist.properties
+++ b/dist/src/main/resources/application-tasklist.properties
@@ -35,3 +35,8 @@ camunda.identity.issuerBackendUrl=${camunda.tasklist.identity.issuerBackendUrl:$
 #---
 spring.config.activate.on-profile=dev
 camunda.tasklist.graphql-introspection-enabled=true
+
+#---
+spring.config.activate.on-profile=standalone
+# Fallback authorizations configuration for deprecated env variable naming
+camunda.security.authorizations.enabled=${camunda.tasklist.identity.resourcePermissionsEnabled:false}

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/IdentityProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/IdentityProperties.java
@@ -11,7 +11,6 @@ public class IdentityProperties {
   public static final String ALL_RESOURCES = "*";
   public static final String FULL_GROUP_ACCESS = "";
   private String redirectRootUrl;
-  private boolean resourcePermissionsEnabled = false;
   private boolean userAccessRestrictionsEnabled = true;
 
   public String getRedirectRootUrl() {
@@ -29,16 +28,6 @@ public class IdentityProperties {
   public IdentityProperties setUserAccessRestrictionsEnabled(
       final boolean userAccessRestrictionsEnabled) {
     this.userAccessRestrictionsEnabled = userAccessRestrictionsEnabled;
-    return this;
-  }
-
-  public boolean isResourcePermissionsEnabled() {
-    return resourcePermissionsEnabled;
-  }
-
-  public IdentityProperties setResourcePermissionsEnabled(
-      final boolean resourcePermissionsEnabled) {
-    this.resourcePermissionsEnabled = resourcePermissionsEnabled;
     return this;
   }
 }

--- a/tasklist/els-schema/pom.xml
+++ b/tasklist/els-schema/pom.xml
@@ -25,6 +25,11 @@
       <artifactId>webapps-schema</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
     <!-- SPRING -->
 
     <dependency>

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.store.elasticsearch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.data.conditionals.ElasticSearchCondition;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
@@ -71,6 +72,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
   private ObjectMapper objectMapper;
 
   @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private SecurityConfiguration securityConfiguration;
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
@@ -176,7 +178,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
       final List<String> processDefinitions, final String tenantId, final Boolean isStartedByForm) {
     final QueryBuilder qb;
 
-    if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()) {
+    if (securityConfiguration.getAuthorizations().isEnabled()) {
       if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }
@@ -231,7 +233,7 @@ public class ProcessStoreElasticSearch implements ProcessStore {
             .mustNot(QueryBuilders.termQuery(ProcessIndex.BPMN_PROCESS_ID, ""))
             .minimumShouldMatch(1);
 
-    if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()) {
+    if (securityConfiguration.getAuthorizations().isEnabled()) {
       if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.store.opensearch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
@@ -70,6 +71,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 
   @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private SecurityConfiguration securityConfiguration;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")
@@ -291,7 +293,7 @@ public class ProcessStoreOpenSearch implements ProcessStore {
                 mn -> mn.term(t -> t.field(ProcessIndex.BPMN_PROCESS_ID).value(FieldValue.of(""))))
             .minimumShouldMatch("1");
 
-    if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()) {
+    if (securityConfiguration.getAuthorizations().isEnabled()) {
       if (processDefinitions.isEmpty()) {
         return new ArrayList<>();
       }

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>tasklist-els-schema</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-security-core</artifactId>
+    </dependency>
+
     <!-- ZEEBE -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthentication.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthentication.java
@@ -13,6 +13,7 @@ import io.camunda.identity.sdk.authentication.Tokens;
 import io.camunda.identity.sdk.authentication.UserDetails;
 import io.camunda.identity.sdk.authentication.exception.TokenDecodeException;
 import io.camunda.identity.sdk.impl.rest.exception.RestException;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.webapp.security.OldUsernameAware;
@@ -178,8 +179,7 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
     }
 
     try {
-      final TasklistProperties props = getTasklistProperties();
-      if (props.getIdentity().isResourcePermissionsEnabled()) {
+      if (getSecurityConfiguration().getAuthorizations().isEnabled()) {
         authorization =
             new IdentityAuthorization(
                 getIdentity().authorizations().forToken(this.tokens.getAccessToken()));
@@ -214,6 +214,11 @@ public class IdentityAuthentication extends AbstractAuthenticationToken
   @NotNull
   private static TasklistProperties getTasklistProperties() {
     return SpringContextHolder.getBean(TasklistProperties.class);
+  }
+
+  @NotNull
+  private static SecurityConfiguration getSecurityConfiguration() {
+    return SpringContextHolder.getBean(SecurityConfiguration.class);
   }
 
   private String retrieveName(final UserDetails userDetails) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationServiceImpl.java
@@ -12,7 +12,7 @@ import static io.camunda.tasklist.property.IdentityProperties.FULL_GROUP_ACCESS;
 
 import io.camunda.identity.autoconfigure.IdentityProperties;
 import io.camunda.identity.sdk.Identity;
-import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.webapp.security.sso.TokenAuthentication;
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ public class IdentityAuthorizationServiceImpl implements IdentityAuthorizationSe
 
   private final Logger logger = LoggerFactory.getLogger(IdentityAuthorizationServiceImpl.class);
 
-  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private SecurityConfiguration securityConfiguration;
   @Autowired private IdentityProperties identityProperties;
 
   @Override
@@ -78,7 +78,7 @@ public class IdentityAuthorizationServiceImpl implements IdentityAuthorizationSe
   }
 
   private Optional<IdentityAuthorization> getIdentityAuthorization() {
-    if (!tasklistProperties.getIdentity().isResourcePermissionsEnabled()
+    if (!securityConfiguration.getAuthorizations().isEnabled()
         || identityProperties.baseUrl() == null) {
       return Optional.empty();
     }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Authentication;
+import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.IdentityProperties;
@@ -70,6 +72,7 @@ class ProcessStoreElasticSearchTest {
   @Mock private ObjectMapper objectMapper;
   @InjectMocks private SpringContextHolder springContextHolder;
   @Mock private TasklistProperties tasklistProperties;
+  @Mock private SecurityConfiguration securityConfiguration;
   @Mock private io.camunda.identity.autoconfigure.IdentityProperties identityProperties;
 
   @BeforeEach
@@ -168,8 +171,9 @@ class ProcessStoreElasticSearchTest {
   public void shouldNotReturnProcessesWhenResourceAuthIsEnabledButNoAuthorization()
       throws IOException {
     // when
-    when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
-    when(tasklistProperties.getIdentity().isResourcePermissionsEnabled()).thenReturn(true);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
     when(identityProperties.baseUrl()).thenReturn("baseUrl");
     mockAuthenticationOverIdentity(false);
     when(processIndex.getAlias()).thenReturn("index_alias");
@@ -214,8 +218,9 @@ class ProcessStoreElasticSearchTest {
   @Test
   public void shouldReturnProcessesWhenResourceAuthorizationIsFalse() throws Exception {
     // when
-    when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
-    when(tasklistProperties.getIdentity().isResourcePermissionsEnabled()).thenReturn(false);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
     mockElasticSearchSuccessWithAggregatedResponse();
 
     final List<String> authorizations = identityService.getProcessDefinitionsFromAuthorization();
@@ -235,7 +240,9 @@ class ProcessStoreElasticSearchTest {
     // Mock IdentityProperties
     final IdentityProperties tasklistIdentityProperties = mock(IdentityProperties.class);
     springContextHolder.setApplicationContext(mock(ConfigurableApplicationContext.class));
-    when(tasklistIdentityProperties.isResourcePermissionsEnabled()).thenReturn(true);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
 
     // Define behavior of tasklistProperties.getIdentity()
     when(tasklistProperties.getIdentity()).thenReturn(tasklistIdentityProperties);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.Authentication;
+import io.camunda.security.configuration.AuthorizationsConfiguration;
+import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.IdentityProperties;
@@ -72,6 +74,7 @@ class ProcessStoreOpenSearchTest {
   @Mock private ObjectMapper objectMapper;
   @InjectMocks private SpringContextHolder springContextHolder;
   @Mock private TasklistProperties tasklistProperties;
+  @Mock private SecurityConfiguration securityConfiguration;
   @Mock private io.camunda.identity.autoconfigure.IdentityProperties identityProperties;
 
   @BeforeEach
@@ -170,8 +173,9 @@ class ProcessStoreOpenSearchTest {
   public void shouldNotReturnProcessesWhenResourceAuthIsEnabledButNoAuthorization()
       throws IOException {
     // when
-    when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
-    when(tasklistProperties.getIdentity().isResourcePermissionsEnabled()).thenReturn(true);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
     when(identityProperties.baseUrl()).thenReturn("baseUrl");
     mockAuthenticationOverIdentity(false);
     when(processIndex.getAlias()).thenReturn("index_alias");
@@ -220,8 +224,9 @@ class ProcessStoreOpenSearchTest {
   @Test
   public void shouldReturnProcessesWhenResourceAuthorizationIsFalse() throws Exception {
     // when
-    when(tasklistProperties.getIdentity()).thenReturn(mock(IdentityProperties.class));
-    when(tasklistProperties.getIdentity().isResourcePermissionsEnabled()).thenReturn(false);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(false);
     mockOpenSearchSuccessWithAggregatedResponse();
 
     final List<String> authorizations = identityService.getProcessDefinitionsFromAuthorization();
@@ -243,7 +248,9 @@ class ProcessStoreOpenSearchTest {
     springContextHolder.setApplicationContext(mock(ConfigurableApplicationContext.class));
 
     // Define behavior of IdentityProperties methods
-    when(tasklistIdentityProperties.isResourcePermissionsEnabled()).thenReturn(true);
+    when(securityConfiguration.getAuthorizations())
+        .thenReturn(mock(AuthorizationsConfiguration.class));
+    when(securityConfiguration.getAuthorizations().isEnabled()).thenReturn(true);
     when(identityProperties.baseUrl()).thenReturn("baseUrl");
 
     // Define behavior of tasklistProperties.getIdentity()


### PR DESCRIPTION
## Description

Apply (global) security configuration to enable/disable authorization checks to the old Tasklist backend.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #24665 