### PR TITLE
Support activating Inclusive Gateway via Process Instance Modification

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceModifiedEventApplier.java
@@ -68,7 +68,8 @@ final class ProcessInstanceModifiedEventApplier
             instruction -> {
               final var element =
                   process.getElementById(instruction.getElementId(), ExecutableFlowNode.class);
-              if (!element.getElementType().equals(BpmnElementType.PARALLEL_GATEWAY)) {
+              if (!element.getElementType().equals(BpmnElementType.PARALLEL_GATEWAY)
+                  && !element.getElementType().equals(BpmnElementType.INCLUSIVE_GATEWAY)) {
                 return;
               }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/ModifyProcessInstanceTest.java
@@ -1206,6 +1206,68 @@ public class ModifyProcessInstanceTest {
   }
 
   @Test
+  public void shouldActivateInclusiveGatewayRetainingAlreadyTakenFlows() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .inclusiveGateway("fork")
+                .conditionExpression("true")
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .inclusiveGateway("join")
+                .endEvent()
+                .moveToNode("fork")
+                .conditionExpression("true")
+                .serviceTask("B", b -> b.zeebeJobType("B"))
+                .connectTo("join")
+                .done())
+        .deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    Assertions.assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ACTIVATE_ELEMENT)
+        .onlyCommandRejections()
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("join")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .modification()
+        .activateElement("join")
+        .modify();
+
+    // then
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("join")
+        .await();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .processInstanceRecords()
+                .withElementId("join")
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .describedAs("Expect that the join gateway activated again after completing task B")
+        .hasSize(2);
+  }
+
+  @Test
   public void verifyCallActivityWithIncidentInOutputMappingCanBeTerminated() {
     final var child = Bpmn.createExecutableProcess("child").startEvent().endEvent().done();
     final var parent =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Adds support for activating Inclusive Gateway via a Process Instance Modification.

Specifically, adds the ability to reference an Inclusive Gateway in the activate instructions of a Process Instance Modification command. Previously, such activation instructions had no effect because the `ACTIVATE_ELEMENT` command for the gateway would be rejected.

By incrementing the number of times each of its incoming sequence flows have been taken, we ensure it isn't rejected. These recorded values are decremented again after the gateway has reached the `ELEMENT_ACTIVATING` lifecycle state.

These changes ensure that any previously taken sequence flows are retained after the modification has finished.

## Related issues

closes #20587 
closes #25099
