### PR TITLE
fix: exception type from ES is read correctly

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -78,13 +78,13 @@
       <artifactId>webapps-backup</artifactId>
       <scope>test</scope>
     </dependency>
-
     <!-- ELASTICSEARCH -->
     <dependency>
       <groupId>org.elasticsearch.client</groupId>
       <artifactId>elasticsearch-rest-high-level-client</artifactId>
       <scope>test</scope>
     </dependency>
+
     <!-- TEST CONTAINERS -->
     <dependency>
       <groupId>io.zeebe</groupId>
@@ -446,7 +446,6 @@
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>co.elastic.clients</groupId>
       <artifactId>elasticsearch-java</artifactId>

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -14,14 +14,13 @@ import static java.util.stream.Collectors.toList;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.ElasticsearchException;
-import co.elastic.clients.elasticsearch._types.ShardFailure;
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotRequest;
 import co.elastic.clients.elasticsearch.snapshot.CreateSnapshotResponse;
-import co.elastic.clients.elasticsearch.snapshot.DeleteSnapshotResponse;
 import co.elastic.clients.elasticsearch.snapshot.GetSnapshotRequest;
 import co.elastic.clients.elasticsearch.snapshot.GetSnapshotResponse;
 import co.elastic.clients.elasticsearch.snapshot.SnapshotInfo;
+import co.elastic.clients.elasticsearch.snapshot.SnapshotShardFailure;
 import co.elastic.clients.elasticsearch.snapshot.SnapshotSort;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -54,9 +53,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ElasticsearchBackupRepository implements BackupRepository {
-  public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "type=snapshot_missing_exception";
-  private static final String REPOSITORY_MISSING_EXCEPTION_TYPE =
-      "type=repository_missing_exception";
+  public static final String SNAPSHOT_MISSING_EXCEPTION_TYPE = "snapshot_missing_exception";
+  private static final String REPOSITORY_MISSING_EXCEPTION_TYPE = "repository_missing_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
   private final ElasticsearchClient esClient;
   private final ObjectMapper objectMapper;
@@ -83,43 +81,6 @@ public class ElasticsearchBackupRepository implements BackupRepository {
   }
 
   @Override
-  public void executeSnapshotting(
-      final BackupService.SnapshotRequest snapshotRequest,
-      final Runnable onSuccess,
-      final Runnable onFailure) {
-    final var request =
-        CreateSnapshotRequest.of(
-            b ->
-                b.repository(snapshotRequest.repositoryName())
-                    .snapshot(snapshotRequest.snapshotName())
-                    .indices(snapshotRequest.indices())
-                    // ignoreUnavailable = false - indices defined by their exact name MUST be
-                    // present
-                    // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE
-                    // absent
-                    .ignoreUnavailable(false)
-                    // TODO not all migrated
-                    //                    .(IndicesOptions.fromOptions(false, true, true, true))
-                    .includeGlobalState(backupProps.includeGlobalState())
-                    .metadata(
-                        objectMapper.convertValue(
-                            snapshotRequest.metadata(), new TypeReference<>() {}))
-                    .featureStates("none")
-                    .waitForCompletion(true));
-    final var listener = new CreateSnapshotListener(snapshotRequest, onSuccess, onFailure);
-
-    executor.execute(
-        () -> {
-          try {
-            esClient.snapshot().create(request);
-            listener.onSuccess.run();
-          } catch (final Exception e) {
-            listener.onFailure.run();
-          }
-        });
-  }
-
-  @Override
   public void deleteSnapshot(final String repositoryName, final String snapshotName) {
     executor.execute(
         () -> {
@@ -131,13 +92,15 @@ public class ElasticsearchBackupRepository implements BackupRepository {
             LOGGER.debug(
                 "Delete snapshot was acknowledged by Elasticsearch node: {}",
                 response.acknowledged());
-          } catch (final Exception e) {
+          } catch (final ElasticsearchException e) {
             if (isSnapshotMissingException(e)) {
               // no snapshot with given backupID exists, this is fine, log warning
               LOGGER.warn("No snapshot found for snapshot deletion: {} ", e.getMessage());
             } else {
               LOGGER.error("Exception occurred while deleting the snapshot: {}", e.getMessage(), e);
             }
+          } catch (final IOException e) {
+            throw new RuntimeException(e);
           }
         });
   }
@@ -157,7 +120,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
               "Encountered an error connecting to Elasticsearch while retrieving repository with name [%s].",
               repositoryName);
       throw new BackupRepositoryConnectionException(reason, ex);
-    } catch (final Exception e) {
+    } catch (final ElasticsearchException e) {
       if (isRepositoryMissingException(e)) {
         final String reason =
             String.format("No repository with name [%s] could be found.", repositoryName);
@@ -173,22 +136,29 @@ public class ElasticsearchBackupRepository implements BackupRepository {
 
   @Override
   public void validateNoDuplicateBackupId(final String repositoryName, final Long backupId) {
-    final GetSnapshotResponse response;
     try {
-      response =
+      final var response =
           esClient
               .snapshot()
               .get(
                   r ->
                       r.repository(repositoryName)
                           .snapshot(snapshotNameProvider.getSnapshotNamePrefix(backupId) + "*"));
+      if (!response.snapshots().isEmpty()) {
+        final String reason =
+            String.format(
+                "A backup with ID [%s] already exists. Found snapshots: [%s]",
+                backupId,
+                response.snapshots().stream().map(SnapshotInfo::snapshot).collect(joining(", ")));
+        throw new InvalidRequestException(reason);
+      }
     } catch (final IOException ex) {
       final String reason =
           String.format(
               "Encountered an error connecting to Elasticsearch while searching for duplicate backup. Repository name: [%s].",
               repositoryName);
       throw new BackupRepositoryConnectionException(reason, ex);
-    } catch (final Exception e) {
+    } catch (final ElasticsearchException e) {
       if (isSnapshotMissingException(e)) {
         // no snapshot with given backupID exists
         return;
@@ -198,14 +168,6 @@ public class ElasticsearchBackupRepository implements BackupRepository {
               "Exception occurred when validating whether backup with ID [%s] already exists.",
               backupId);
       throw new BackupRepositoryConnectionException(reason, e);
-    }
-    if (!response.snapshots().isEmpty()) {
-      final String reason =
-          String.format(
-              "A backup with ID [%s] already exists. Found snapshots: [%s]",
-              backupId,
-              response.snapshots().stream().map(SnapshotInfo::snapshot).collect(joining(", ")));
-      throw new InvalidRequestException(reason);
     }
   }
 
@@ -280,18 +242,57 @@ public class ElasticsearchBackupRepository implements BackupRepository {
     }
   }
 
-  public void onDeleteResponse(final DeleteSnapshotResponse response) {}
+  @Override
+  public void executeSnapshotting(
+      final BackupService.SnapshotRequest snapshotRequest,
+      final Runnable onSuccess,
+      final Runnable onFailure) {
+    final var request =
+        CreateSnapshotRequest.of(
+            b ->
+                b.repository(snapshotRequest.repositoryName())
+                    .snapshot(snapshotRequest.snapshotName())
+                    .indices(snapshotRequest.indices())
+                    // ignoreUnavailable = false - indices defined by their exact name MUST be
+                    // present
+                    // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE
+                    // absent
+                    .ignoreUnavailable(false)
+                    // TODO not all migrated
+                    //                    .(IndicesOptions.fromOptions(false, true, true, true))
+                    .includeGlobalState(backupProps.includeGlobalState())
+                    .metadata(
+                        objectMapper.convertValue(
+                            snapshotRequest.metadata(), new TypeReference<>() {}))
+                    .featureStates("none")
+                    .waitForCompletion(true));
+    final var listener = new CreateSnapshotListener(snapshotRequest, onSuccess, onFailure);
 
-  public void onDeleteFailure(final Exception e) {}
+    executor.execute(
+        () -> {
+          try {
+            esClient.snapshot().create(request);
+            listener.onSuccess.run();
+          } catch (final Exception e) {
+            listener.onFailure.run();
+          }
+        });
+  }
+
+  private boolean isErrorType(final Exception e, final String errorType) {
+    if (e instanceof ElasticsearchException) {
+      final var type = ((ElasticsearchException) e).error().type();
+      return Objects.equals(type, errorType);
+    }
+    return false;
+  }
 
   private boolean isSnapshotMissingException(final Exception e) {
-    return e instanceof ElasticsearchException
-        && e.getMessage().contains(SNAPSHOT_MISSING_EXCEPTION_TYPE);
+    return isErrorType(e, SNAPSHOT_MISSING_EXCEPTION_TYPE);
   }
 
   private boolean isRepositoryMissingException(final Exception e) {
-    return e instanceof ElasticsearchException
-        && e.getMessage().contains(REPOSITORY_MISSING_EXCEPTION_TYPE);
+    return isErrorType(e, REPOSITORY_MISSING_EXCEPTION_TYPE);
   }
 
   // Check: see inner
@@ -312,10 +313,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
               "Encountered an error connecting to Elasticsearch while searching for snapshots. Repository name: [%s].",
               repositoryName);
       throw new BackupRepositoryConnectionException(reason, ex);
-    } catch (final Exception e) {
+    } catch (final ElasticsearchException e) {
       if (isSnapshotMissingException(e)) {
         // no snapshot with given backupID exists
-        // Check Tasklist returns NotFoundApiException (Similar)
         throw new ResourceNotFoundException(
             String.format("No backup with id [%s] found.", backupId));
       }
@@ -431,11 +431,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       detail.setStartTime(
           OffsetDateTime.ofInstant(
               Instant.ofEpochMilli(snapshot.startTimeInMillis()), ZoneId.systemDefault()));
-      if (null != snapshot.shards() && null != snapshot.shards().failures()) {
+      if (snapshot.failures() != null && !snapshot.failures().isEmpty()) {
         detail.setFailures(
-            snapshot.shards().failures().stream()
-                .map(ShardFailure::toString)
-                .toArray(String[]::new));
+            snapshot.failures().stream().map(SnapshotShardFailure::reason).toArray(String[]::new));
       }
       detail.setState(snapshot.state());
       details.add(detail);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/MetadataMarshaller.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/MetadataMarshaller.java
@@ -14,7 +14,6 @@ import java.util.Map;
 
 public class MetadataMarshaller {
 
-  // used by open search backend
   public static Map<String, JsonData> asJson(
       final Metadata metadata, final JsonpMapper jsonpMapper) {
     return Map.of(
@@ -27,7 +26,15 @@ public class MetadataMarshaller {
   public static Metadata fromMetadata(
       final Map<String, JsonData> metadata, final JsonpMapper jsonpMapper) {
     try {
-      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
+      Long backupId = null;
+      try {
+        final var backupIdJsonData = metadata.get("backupId");
+        if (backupIdJsonData != null) {
+          backupId = backupIdJsonData.to(Long.class, jsonpMapper);
+        }
+      } catch (final NullPointerException ignored) {
+        // ignore and set as null
+      }
       final var version = metadata.get("version").to(String.class, jsonpMapper);
       final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
       final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/MetadataMarshaller.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/MetadataMarshaller.java
@@ -26,7 +26,15 @@ public class MetadataMarshaller {
   public static Metadata fromMetadata(
       final Map<String, JsonData> metadata, final JsonpMapper jsonpMapper) {
     try {
-      final var backupId = metadata.get("backupId").to(Long.class, jsonpMapper);
+      Long backupId = null;
+      try {
+        final var backupIdJsonData = metadata.get("backupId");
+        if (backupIdJsonData != null) {
+          backupId = backupIdJsonData.to(Long.class, jsonpMapper);
+        }
+      } catch (final NullPointerException ignored) {
+        // ignore and set as null
+      }
       final var version = metadata.get("version").to(String.class, jsonpMapper);
       final var partNo = metadata.get("partNo").to(Integer.class, jsonpMapper);
       final var partCount = metadata.get("partCount").to(Integer.class, jsonpMapper);


### PR DESCRIPTION

## Description
After migration to ElasticsearchClient the type of the exception is not read correctly.
As a result, if a repository is missing an INTERNAL_SERVER_ERROR is returned to the client instead of NOT_FOUND.

BackupControllerIT has been fixed by migrating it to ElasticsearchClient as well

<!-- Describe the goal and purpose of this PR. -->

## Related issues


closes #25679
