### PR TITLE
fix: user task local variable fix flushing

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserTaskVariableHandler.java
@@ -7,8 +7,10 @@
  */
 package io.camunda.exporter.handlers;
 
+import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
+import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
 import io.camunda.webapps.schema.entities.tasklist.TaskVariableEntity;
@@ -16,6 +18,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class UserTaskVariableHandler
-    implements ExportHandler<TaskVariableEntity, VariableRecordValue> {
+    implements ExportHandler<UserTaskVariableBatch, VariableRecordValue> {
 
   private static final Logger LOG = LoggerFactory.getLogger(UserTaskVariableHandler.class);
 
@@ -42,8 +45,8 @@ public class UserTaskVariableHandler
   }
 
   @Override
-  public Class<TaskVariableEntity> getEntityType() {
-    return TaskVariableEntity.class;
+  public Class<UserTaskVariableBatch> getEntityType() {
+    return UserTaskVariableBatch.class;
   }
 
   @Override
@@ -53,74 +56,56 @@ public class UserTaskVariableHandler
 
   @Override
   public List<String> generateIds(final Record<VariableRecordValue> record) {
-    final String id =
-        ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName());
-
-    /* Process Instance Variable */
-    if (isProcessInstanceVariable(record.getValue())) {
-      return List.of(id);
-    }
-    /*
-     * Local Variable
-     * Generate two IDs for process variable and local
-     * */
-    return List.of(id, id + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
+    return List.of(
+        ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName()));
   }
 
   @Override
-  public TaskVariableEntity createNewEntity(final String id) {
-    return new TaskVariableEntity().setId(id);
+  public UserTaskVariableBatch createNewEntity(final String id) {
+    return new UserTaskVariableBatch().setId(id).setVariables(new ArrayList<>());
   }
 
   @Override
   public void updateEntity(
-      final Record<VariableRecordValue> record, final TaskVariableEntity entity) {
-    entity
-        .setPartitionId(record.getPartitionId())
-        .setPosition(record.getPosition())
-        .setTenantId(record.getValue().getTenantId())
-        .setKey(record.getKey())
-        .setProcessInstanceId(record.getValue().getProcessInstanceKey())
-        .setScopeKey(record.getValue().getScopeKey())
-        .setName(record.getValue().getName());
+      final Record<VariableRecordValue> record, final UserTaskVariableBatch batchEntity) {
 
-    if (record.getValue().getValue().length() > variableSizeThreshold) {
-      entity.setValue(record.getValue().getValue().substring(0, variableSizeThreshold));
-      entity.setFullValue(record.getValue().getValue());
-      entity.setIsTruncated(true);
-    } else {
-      entity.setValue(record.getValue().getValue());
-      entity.setFullValue(null);
-      entity.setIsTruncated(false);
-    }
-
-    final boolean isProcessInstanceVariable = isProcessInstanceVariable(record.getValue());
+    final var processVariable = createVariableFromRecord(record);
+    processVariable.setId(
+        ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName()));
 
     final TaskJoinRelationship joinRelationship = new TaskJoinRelationship();
-    joinRelationship.setParent(
-        isProcessInstanceVariable ? entity.getProcessInstanceId() : entity.getScopeKey());
+    joinRelationship.setParent(processVariable.getProcessInstanceId());
+    joinRelationship.setName(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
+    processVariable.setJoin(joinRelationship);
+    batchEntity.getVariables().add(processVariable);
 
-    joinRelationship.setName(
-        isProcessInstanceVariable
-            ? TaskJoinRelationshipType.PROCESS_VARIABLE.getType()
-            : TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
-    entity.setJoin(joinRelationship);
+    if (record.getValue().getProcessInstanceKey() != record.getValue().getScopeKey()) {
+      final TaskVariableEntity taskVariable = createVariableFromRecord(record);
+      taskVariable.setId(
+          ID_PATTERN.formatted(record.getValue().getScopeKey(), record.getValue().getName())
+              + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
+
+      final TaskJoinRelationship localTaskJoinRelationship = new TaskJoinRelationship();
+      localTaskJoinRelationship.setParent(taskVariable.getScopeKey());
+      localTaskJoinRelationship.setName(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
+      taskVariable.setJoin(localTaskJoinRelationship);
+      batchEntity.getVariables().add(taskVariable);
+    }
   }
 
   @Override
-  public void flush(final TaskVariableEntity entity, final BatchRequest batchRequest) {
-    final Map<String, Object> updateFields = new HashMap<>();
-
-    updateFields.put(TaskTemplate.VARIABLE_VALUE, entity.getValue());
-    updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, entity.getFullValue());
-    updateFields.put(TaskTemplate.IS_TRUNCATED, entity.getIsTruncated());
-
-    batchRequest.upsertWithRouting(
-        indexName,
-        entity.getId(),
-        entity,
-        updateFields,
-        String.valueOf(entity.getProcessInstanceId()));
+  public void flush(final UserTaskVariableBatch entity, final BatchRequest batchRequest) {
+    entity
+        .getVariables()
+        .forEach(
+            v -> {
+              final Map<String, Object> updateFields = new HashMap<>();
+              updateFields.put(TaskTemplate.VARIABLE_VALUE, v.getValue());
+              updateFields.put(TaskTemplate.VARIABLE_FULL_VALUE, v.getFullValue());
+              updateFields.put(TaskTemplate.IS_TRUNCATED, v.getIsTruncated());
+              batchRequest.upsertWithRouting(
+                  indexName, v.getId(), v, updateFields, String.valueOf(v.getProcessInstanceId()));
+            });
   }
 
   @Override
@@ -128,7 +113,45 @@ public class UserTaskVariableHandler
     return indexName;
   }
 
-  private boolean isProcessInstanceVariable(final VariableRecordValue recordValue) {
-    return recordValue.getScopeKey() == recordValue.getProcessInstanceKey();
+  private TaskVariableEntity createVariableFromRecord(final Record<VariableRecordValue> record) {
+    final var variable =
+        new TaskVariableEntity()
+            .setPartitionId(record.getPartitionId())
+            .setPosition(record.getPosition())
+            .setTenantId(record.getValue().getTenantId())
+            .setKey(record.getKey())
+            .setProcessInstanceId(record.getValue().getProcessInstanceKey())
+            .setScopeKey(record.getValue().getScopeKey())
+            .setName(record.getValue().getName());
+    setVariableValues(record, variable);
+
+    return variable;
+  }
+
+  private void setVariableValues(
+      final Record<VariableRecordValue> record, final TaskVariableEntity taskVariable) {
+    if (record.getValue().getValue().length() > variableSizeThreshold) {
+      taskVariable.setValue(record.getValue().getValue().substring(0, variableSizeThreshold));
+      taskVariable.setFullValue(record.getValue().getValue());
+      taskVariable.setIsTruncated(true);
+    } else {
+      taskVariable.setValue(record.getValue().getValue());
+      taskVariable.setFullValue(null);
+      taskVariable.setIsTruncated(false);
+    }
+  }
+
+  public static final class UserTaskVariableBatch
+      extends AbstractExporterEntity<UserTaskVariableBatch> {
+    private List<TaskVariableEntity> variables;
+
+    public List<TaskVariableEntity> getVariables() {
+      return variables;
+    }
+
+    public UserTaskVariableBatch setVariables(final List<TaskVariableEntity> variables) {
+      this.variables = variables;
+      return this;
+    }
   }
 }

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/UserTaskVariableHandlerTest.java
@@ -8,10 +8,12 @@
 package io.camunda.exporter.handlers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import io.camunda.exporter.handlers.UserTaskVariableHandler.UserTaskVariableBatch;
 import io.camunda.exporter.store.BatchRequest;
 import io.camunda.webapps.schema.descriptors.tasklist.template.TaskTemplate;
 import io.camunda.webapps.schema.entities.tasklist.TaskJoinRelationship.TaskJoinRelationshipType;
@@ -23,10 +25,13 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.ImmutableVariableRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class UserTaskVariableHandlerTest {
 
@@ -41,7 +46,7 @@ public class UserTaskVariableHandlerTest {
 
   @Test
   void testGetEntityType() {
-    assertThat(underTest.getEntityType()).isEqualTo(TaskVariableEntity.class);
+    assertThat(underTest.getEntityType()).isEqualTo(UserTaskVariableBatch.class);
   }
 
   @Test
@@ -68,7 +73,7 @@ public class UserTaskVariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateSingleIdForProcessVariable() {
+  void shouldGenerateId() {
     // given
     final long processInstanceKey = 123L;
     final String name = "name";
@@ -92,33 +97,6 @@ public class UserTaskVariableHandlerTest {
   }
 
   @Test
-  void shouldGenerateTwoIdsForLocalVariable() {
-    // given
-    final long processInstanceKey = 123L;
-    final long scopeKey = 456L;
-    final String name = "name";
-    final Record<VariableRecordValue> processInstanceRecord =
-        factory.generateRecord(
-            ValueType.VARIABLE,
-            r ->
-                r.withIntent(VariableIntent.CREATED)
-                    .withValue(
-                        ImmutableVariableRecordValue.builder()
-                            .withName("name")
-                            .withProcessInstanceKey(processInstanceKey)
-                            .withScopeKey(scopeKey)
-                            .build()));
-
-    // when
-    final var idList = underTest.generateIds(processInstanceRecord);
-
-    // then
-    assertThat(idList)
-        .containsExactlyInAnyOrder(
-            scopeKey + "-" + name, scopeKey + "-" + name + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
-  }
-
-  @Test
   void shouldCreateNewEntity() {
     // when
     final var result = underTest.createNewEntity("id");
@@ -131,30 +109,66 @@ public class UserTaskVariableHandlerTest {
   @Test
   void shouldAddEntityOnFlush() {
     // given
-    final TaskVariableEntity inputEntity =
+    final String id = "id";
+    final UserTaskVariableBatch variableBatch =
+        new UserTaskVariableBatch().setId(id).setVariables(new ArrayList<>());
+
+    final TaskVariableEntity processVariableEntity =
         new TaskVariableEntity()
-            .setId("111")
+            .setId(id)
             .setValue("value")
             .setIsTruncated(false)
+            .setProcessInstanceId(123L)
             .setScopeKey(123L);
+
+    final TaskVariableEntity taskVariableEntity =
+        new TaskVariableEntity()
+            .setId(id + TaskTemplate.LOCAL_VARIABLE_SUFFIX)
+            .setValue("value")
+            .setIsTruncated(false)
+            .setProcessInstanceId(123L)
+            .setScopeKey(456L);
+
+    variableBatch.getVariables().addAll(List.of(processVariableEntity, taskVariableEntity));
     final BatchRequest mockRequest = mock(BatchRequest.class);
 
+    final ArgumentCaptor<String> idCaptor = ArgumentCaptor.forClass(String.class);
+    final ArgumentCaptor<TaskVariableEntity> entityCaptor =
+        ArgumentCaptor.forClass(TaskVariableEntity.class);
+    final ArgumentCaptor<Map<String, Object>> updateFieldsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+    final ArgumentCaptor<String> routingCaptor = ArgumentCaptor.forClass(String.class);
+
     // when
-    underTest.flush(inputEntity, mockRequest);
+    underTest.flush(variableBatch, mockRequest);
 
     // then
+    assertThat(variableBatch.getVariables()).hasSize(2);
+    verify(mockRequest, times(2))
+        .upsertWithRouting(
+            eq(indexName),
+            idCaptor.capture(),
+            entityCaptor.capture(),
+            updateFieldsCaptor.capture(),
+            routingCaptor.capture());
+
+    // Get the captured values
+    final List<String> capturedIds = idCaptor.getAllValues();
+    final List<TaskVariableEntity> capturedEntities = entityCaptor.getAllValues();
+    final List<Map<String, Object>> capturedUpdateFields = updateFieldsCaptor.getAllValues();
+    final List<String> capturedRoutings = routingCaptor.getAllValues();
+
     final Map<String, Object> updateFieldsMap = new HashMap<>();
     updateFieldsMap.put(TaskTemplate.VARIABLE_FULL_VALUE, null);
     updateFieldsMap.put(TaskTemplate.VARIABLE_VALUE, "value");
     updateFieldsMap.put(TaskTemplate.IS_TRUNCATED, false);
 
-    verify(mockRequest, times(1))
-        .upsertWithRouting(
-            indexName,
-            inputEntity.getId(),
-            inputEntity,
-            updateFieldsMap,
-            String.valueOf(inputEntity.getProcessInstanceId()));
+    // Perform assertions without considering the order
+    assertThat(capturedIds).containsExactlyInAnyOrder(id, id + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
+    assertThat(capturedEntities)
+        .containsExactlyInAnyOrder(processVariableEntity, taskVariableEntity);
+    assertThat(capturedUpdateFields).containsExactlyInAnyOrder(updateFieldsMap, updateFieldsMap);
+    assertThat(capturedRoutings).containsExactlyInAnyOrder("123", "123");
   }
 
   @Test
@@ -176,35 +190,73 @@ public class UserTaskVariableHandlerTest {
             r -> r.withIntent(ProcessIntent.CREATED).withValue(variableRecordValue));
 
     // when
-    final TaskVariableEntity variableEntity =
-        new TaskVariableEntity()
-            .setId(
-                variableScopeKey
-                    + "-"
-                    + variableRecordValue.getName()
-                    + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
-    underTest.updateEntity(variableRecord, variableEntity);
+    final var batch = new UserTaskVariableBatch().setVariables(new ArrayList<>()).setId("id");
+
+    underTest.updateEntity(variableRecord, batch);
 
     // then
-    assertThat(variableEntity.getId())
+    assertThat(batch.getVariables()).hasSize(2);
+    final var processVariable =
+        batch.getVariables().stream()
+            .filter(
+                v ->
+                    TaskJoinRelationshipType.PROCESS_VARIABLE
+                        .getType()
+                        .equals(v.getJoin().getName()))
+            .findFirst()
+            .get();
+
+    final var localVariable =
+        batch.getVariables().stream()
+            .filter(
+                v ->
+                    TaskJoinRelationshipType.LOCAL_VARIABLE.getType().equals(v.getJoin().getName()))
+            .findFirst()
+            .get();
+
+    assertThat(processVariable).isNotNull();
+    assertThat(localVariable).isNotNull();
+
+    // Local Variable Assertions
+    assertThat(localVariable.getId())
         .isEqualTo(
             variableRecordValue.getScopeKey()
                 + "-"
                 + variableRecordValue.getName()
                 + TaskTemplate.LOCAL_VARIABLE_SUFFIX);
-    assertThat(variableEntity.getKey()).isEqualTo(variableRecord.getKey());
-    assertThat(variableEntity.getName()).isEqualTo(variableRecordValue.getName());
-    assertThat(variableEntity.getScopeKey()).isEqualTo(variableRecordValue.getScopeKey());
-    assertThat(variableEntity.getTenantId()).isEqualTo(variableRecordValue.getTenantId());
-    assertThat(variableEntity.getValue()).isEqualTo(variableRecordValue.getValue());
-    assertThat(variableEntity.getProcessInstanceId()).isEqualTo(processInstanceKey);
-    assertThat(variableEntity.getIsTruncated()).isFalse();
-    assertThat(variableEntity.getFullValue()).isNull();
-    assertThat(variableEntity.getPosition()).isEqualTo(variableRecord.getPosition());
-    assertThat(variableEntity.getJoin()).isNotNull();
-    assertThat(variableEntity.getJoin().getParent()).isEqualTo(variableRecordValue.getScopeKey());
-    assertThat(variableEntity.getJoin().getName())
+
+    assertThat(localVariable.getKey()).isEqualTo(variableRecord.getKey());
+    assertThat(localVariable.getName()).isEqualTo(variableRecordValue.getName());
+    assertThat(localVariable.getScopeKey()).isEqualTo(variableRecordValue.getScopeKey());
+    assertThat(localVariable.getTenantId()).isEqualTo(variableRecordValue.getTenantId());
+    assertThat(localVariable.getValue()).isEqualTo(variableRecordValue.getValue());
+    assertThat(localVariable.getProcessInstanceId()).isEqualTo(processInstanceKey);
+    assertThat(localVariable.getIsTruncated()).isFalse();
+    assertThat(localVariable.getFullValue()).isNull();
+    assertThat(localVariable.getPosition()).isEqualTo(variableRecord.getPosition());
+    assertThat(localVariable.getJoin()).isNotNull();
+    assertThat(localVariable.getJoin().getParent()).isEqualTo(variableRecordValue.getScopeKey());
+    assertThat(localVariable.getJoin().getName())
         .isEqualTo(TaskJoinRelationshipType.LOCAL_VARIABLE.getType());
+
+    // Process Variable Assertions
+    assertThat(processVariable.getId())
+        .isEqualTo(variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName());
+
+    assertThat(processVariable.getKey()).isEqualTo(variableRecord.getKey());
+    assertThat(processVariable.getName()).isEqualTo(variableRecordValue.getName());
+    assertThat(processVariable.getScopeKey()).isEqualTo(variableRecordValue.getScopeKey());
+    assertThat(processVariable.getTenantId()).isEqualTo(variableRecordValue.getTenantId());
+    assertThat(processVariable.getValue()).isEqualTo(variableRecordValue.getValue());
+    assertThat(processVariable.getProcessInstanceId()).isEqualTo(processInstanceKey);
+    assertThat(processVariable.getIsTruncated()).isFalse();
+    assertThat(processVariable.getFullValue()).isNull();
+    assertThat(processVariable.getPosition()).isEqualTo(variableRecord.getPosition());
+    assertThat(processVariable.getJoin()).isNotNull();
+    assertThat(processVariable.getJoin().getParent())
+        .isEqualTo(variableRecordValue.getProcessInstanceKey());
+    assertThat(processVariable.getJoin().getName())
+        .isEqualTo(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
   }
 
   @Test
@@ -225,11 +277,13 @@ public class UserTaskVariableHandlerTest {
             r -> r.withIntent(ProcessIntent.CREATED).withValue(variableRecordValue));
 
     // when
-    final TaskVariableEntity variableEntity =
-        new TaskVariableEntity().setId(processInstanceKey + "-" + variableRecordValue.getName());
-    underTest.updateEntity(variableRecord, variableEntity);
+    final UserTaskVariableBatch batch = new UserTaskVariableBatch().setVariables(new ArrayList<>());
+    underTest.updateEntity(variableRecord, batch);
 
     // then
+    assertThat(batch.getVariables()).hasSize(1);
+    final var variableEntity = batch.getVariables().get(0);
+    assertThat(variableEntity).isNotNull();
     assertThat(variableEntity.getId())
         .isEqualTo(variableRecordValue.getScopeKey() + "-" + variableRecordValue.getName());
     assertThat(variableEntity.getKey()).isEqualTo(variableRecord.getKey());
@@ -242,7 +296,8 @@ public class UserTaskVariableHandlerTest {
     assertThat(variableEntity.getFullValue()).isNull();
     assertThat(variableEntity.getPosition()).isEqualTo(variableRecord.getPosition());
     assertThat(variableEntity.getJoin()).isNotNull();
-    assertThat(variableEntity.getJoin().getParent()).isEqualTo(variableRecordValue.getScopeKey());
+    assertThat(variableEntity.getJoin().getParent())
+        .isEqualTo(variableRecordValue.getProcessInstanceKey());
     assertThat(variableEntity.getJoin().getName())
         .isEqualTo(TaskJoinRelationshipType.PROCESS_VARIABLE.getType());
   }
@@ -254,6 +309,8 @@ public class UserTaskVariableHandlerTest {
         ImmutableVariableRecordValue.builder()
             .from(factory.generateObject(VariableRecordValue.class))
             .withValue("v".repeat(underTest.variableSizeThreshold + 1))
+            .withScopeKey(123)
+            .withProcessInstanceKey(123)
             .build();
 
     final Record<VariableRecordValue> variableRecord =
@@ -262,10 +319,12 @@ public class UserTaskVariableHandlerTest {
             r -> r.withIntent(ProcessIntent.CREATED).withValue(variableRecordValue));
 
     // when
-    final TaskVariableEntity variableEntity = new TaskVariableEntity().setId("id");
-    underTest.updateEntity(variableRecord, variableEntity);
+    final UserTaskVariableBatch batch = new UserTaskVariableBatch().setVariables(new ArrayList<>());
+    underTest.updateEntity(variableRecord, batch);
 
     // then
+    assertThat(batch.getVariables()).hasSize(1);
+    final var variableEntity = batch.getVariables().get(0);
     assertThat(variableEntity.getValue()).isEqualTo("v".repeat(underTest.variableSizeThreshold));
     assertThat(variableEntity.getFullValue())
         .isEqualTo("v".repeat(underTest.variableSizeThreshold + 1));


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fix implementation for UserTask local variables to flush both global and local variable.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
