### PR TITLE
ci: add best practices linting rule to avoid "self-hosted" label

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -71,6 +71,16 @@ deny[msg] {
         [concat(", ", get_jobs_with_setupnodecaching(input.jobs))])
 }
 
+deny[msg] {
+    # This rule prevents usage of forbidden "self-hosted" label in a "runs-on"
+    # clause as described by Infra team: https://confluence.camunda.com/x/_IlZBw
+
+    count(get_jobs_with_selfhostedlabel(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs using forbidden 'self-hosted' label in 'runs-on' clause! Affected job IDs: %s",
+        [concat(", ", get_jobs_with_selfhostedlabel(input.jobs))])
+}
+
 warn[msg] {
     # This rule warns in situations where no "secrets: inherit" is passed on
     # calling other workflows as this is usually an oversight that prevents
@@ -139,6 +149,31 @@ get_jobs_with_setupnodecaching(jobInput) = jobs_with_setupnodecaching {
             step["with"].cache == "yarn"
         }
         count(setupnodecaching_steps) > 0
+    }
+}
+
+get_jobs_with_selfhostedlabel(jobInput) = jobs_with_selfhostedlabel1 | jobs_with_selfhostedlabel2 {
+    # expression to check for jobs using "runs-on: self-hosted" notation (without array)
+    jobs_with_selfhostedlabel1 := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        job["runs-on"] == "self-hosted"
+    }
+    # expression to check for jobs using "runs-on: [self-hosted, ...]" notation (array)
+    jobs_with_selfhostedlabel2 := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on jobs that invoke other reusable workflows (instead enforced there)
+        not job.uses
+
+        selfhosted_labels := { label |
+            label := job["runs-on"][_]
+            label == "self-hosted"
+        }
+        count(selfhosted_labels) > 0
     }
 }
 


### PR DESCRIPTION
## Description

See https://confluence.camunda.com/display/HAN/Github+Actions+Self-Hosted+Runners#GithubActionsSelfHostedRunners-Usage for details: basically using the `"self-hosted"` label in a `runs-on:` clause can prevent scheduling of a GHA job. There is no need to use the `"self-hosted"` label, but some tutorials recommend it so we want to prevent mistakes.

This PR adds a rule to detect problematic situations using the linting framework introduced in https://github.com/camunda/camunda/issues/25306

See [demo PR](https://github.com/camunda/camunda/pull/25834) for which notations this new rule can detect (it cannot follow variables though, no 100% perfect protection):

`FAIL - .github/workflows/ci.yml - main - There are GitHub Actions jobs using forbidden 'self-hosted' label in 'runs-on' clause! Affected job IDs: actionlint, detect-changes, maven-spotless-linter`

This cannot be achieved via `actionlint` sadly as @Kerruba reported.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None