### PR TITLE
feat: leave assigned roles, groups and tenants before deleting entity

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingDeleteProcessor.java
@@ -16,12 +16,18 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.authorization.PersistedMapping;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
 import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -77,7 +83,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
       return;
     }
 
-    stateWriter.appendFollowUpEvent(mappingKey, MappingIntent.DELETED, record);
+    deleteMapping(persistedMapping.get());
     responseWriter.writeEventOnCommand(mappingKey, MappingIntent.DELETED, record, command);
 
     final long key = keyGenerator.nextKey();
@@ -93,9 +99,7 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
     mappingState
         .get(record.getMappingKey())
         .ifPresentOrElse(
-            persistedMapping ->
-                stateWriter.appendFollowUpEvent(
-                    command.getKey(), MappingIntent.DELETED, command.getValue()),
+            this::deleteMapping,
             () -> {
               final var errorMessage =
                   MAPPING_NOT_FOUND_ERROR_MESSAGE.formatted(record.getMappingKey());
@@ -103,5 +107,29 @@ public class MappingDeleteProcessor implements DistributedTypedRecordProcessor<M
             });
 
     commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void deleteMapping(final PersistedMapping mapping) {
+    final var mappingKey = mapping.getMappingKey();
+    for (final var roleKey : mapping.getRoleKeysList()) {
+      stateWriter.appendFollowUpEvent(
+          roleKey,
+          RoleIntent.ENTITY_REMOVED,
+          new RoleRecord()
+              .setRoleKey(roleKey)
+              .setEntityKey(mappingKey)
+              .setEntityType(EntityType.MAPPING));
+    }
+    for (final var groupKey : mapping.getGroupKeysList()) {
+      stateWriter.appendFollowUpEvent(
+          groupKey,
+          GroupIntent.ENTITY_REMOVED,
+          new GroupRecord()
+              .setGroupKey(groupKey)
+              .setEntityKey(mappingKey)
+              .setEntityType(EntityType.MAPPING));
+    }
+    stateWriter.appendFollowUpEvent(
+        mappingKey, MappingIntent.DELETED, new MappingRecord().setMappingKey(mappingKey));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
@@ -37,6 +37,7 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
     }
     // remove mapping from authorization state
     authorizationState.deleteOwnerTypeByKey(mappingKey);
+    authorizationState.deleteAuthorizationsByOwnerKeyPrefix(mappingKey);
     mappingState.delete(mappingKey);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
@@ -10,10 +10,8 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.authorization.PersistedMapping;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
-import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableRoleState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
@@ -22,16 +20,12 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
 
   private final MutableMappingState mappingState;
   private final MutableAuthorizationState authorizationState;
-  private final MutableRoleState roleState;
   private final MutableTenantState tenantState;
-  private final MutableGroupState groupState;
 
   public MappingDeletedApplier(final MutableProcessingState state) {
     mappingState = state.getMappingState();
     authorizationState = state.getAuthorizationState();
-    roleState = state.getRoleState();
     tenantState = state.getTenantState();
-    groupState = state.getGroupState();
   }
 
   @Override
@@ -46,18 +40,10 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
               value.getMappingKey()));
     }
     final var persistedMapping = mapping.get();
-    removeMappingFromRoleState(persistedMapping);
-    removeMappingFromGroupState(persistedMapping);
     removeMappingFromTenantState(persistedMapping);
     // remove mapping from authorization state
     authorizationState.deleteOwnerTypeByKey(mappingKey);
     mappingState.delete(mappingKey);
-  }
-
-  private void removeMappingFromRoleState(final PersistedMapping mapping) {
-    mapping
-        .getRoleKeysList()
-        .forEach(roleKey -> roleState.removeEntity(roleKey, mapping.getMappingKey()));
   }
 
   private void removeMappingFromTenantState(final PersistedMapping persistedMapping) {
@@ -65,11 +51,5 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
         .getTenantKeysList()
         .forEach(
             tenantKey -> tenantState.removeEntity(tenantKey, persistedMapping.getMappingKey()));
-  }
-
-  private void removeMappingFromGroupState(final PersistedMapping persistedMapping) {
-    persistedMapping
-        .getGroupKeysList()
-        .forEach(groupKey -> groupState.removeEntity(groupKey, persistedMapping.getMappingKey()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MappingDeletedApplier.java
@@ -8,11 +8,9 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.authorization.PersistedMapping;
 import io.camunda.zeebe.engine.state.mutable.MutableAuthorizationState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
-import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 
@@ -20,12 +18,10 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
 
   private final MutableMappingState mappingState;
   private final MutableAuthorizationState authorizationState;
-  private final MutableTenantState tenantState;
 
   public MappingDeletedApplier(final MutableProcessingState state) {
     mappingState = state.getMappingState();
     authorizationState = state.getAuthorizationState();
-    tenantState = state.getTenantState();
   }
 
   @Override
@@ -39,17 +35,8 @@ public class MappingDeletedApplier implements TypedEventApplier<MappingIntent, M
               "Expected to delete mapping with key '%s', but a mapping with this key does not exist.",
               value.getMappingKey()));
     }
-    final var persistedMapping = mapping.get();
-    removeMappingFromTenantState(persistedMapping);
     // remove mapping from authorization state
     authorizationState.deleteOwnerTypeByKey(mappingKey);
     mappingState.delete(mappingKey);
-  }
-
-  private void removeMappingFromTenantState(final PersistedMapping persistedMapping) {
-    persistedMapping
-        .getTenantKeysList()
-        .forEach(
-            tenantKey -> tenantState.removeEntity(tenantKey, persistedMapping.getMappingKey()));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/MappingTest.java
@@ -12,6 +12,8 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -90,6 +92,7 @@ public class MappingTest {
         engine.mapping().newMapping(claimName).withClaimValue(claimValue).create();
     final var group = engine.group().newGroup("group").create();
     final var role = engine.role().newRole("role").create();
+    final var tenant = engine.tenant().newTenant().withTenantId("tenant").create();
     engine
         .group()
         .addEntity(group.getKey())
@@ -99,6 +102,12 @@ public class MappingTest {
     engine
         .role()
         .addEntity(role.getKey())
+        .withEntityKey(mappingRecord.getKey())
+        .withEntityType(EntityType.MAPPING)
+        .add();
+    engine
+        .tenant()
+        .addEntity(tenant.getKey())
         .withEntityKey(mappingRecord.getKey())
         .withEntityType(EntityType.MAPPING)
         .add();
@@ -116,6 +125,12 @@ public class MappingTest {
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
                 .withRoleKey(role.getKey())
+                .withEntityKey(mappingRecord.getKey())
+                .exists())
+        .isTrue();
+    Assertions.assertThat(
+            RecordingExporter.tenantRecords(TenantIntent.ENTITY_REMOVED)
+                .withTenantKey(tenant.getKey())
                 .withEntityKey(mappingRecord.getKey())
                 .exists())
         .isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/MappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/MappingTest.java
@@ -11,6 +11,9 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -77,6 +80,45 @@ public class MappingTest {
     Assertions.assertThat(deletedMapping)
         .isNotNull()
         .hasFieldOrPropertyWithValue("mappingKey", mappingKey);
+  }
+
+  @Test
+  public void shouldCleanupMembership() {
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingRecord =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create();
+    final var group = engine.group().newGroup("group").create();
+    final var role = engine.role().newRole("role").create();
+    engine
+        .group()
+        .addEntity(group.getKey())
+        .withEntityKey(mappingRecord.getKey())
+        .withEntityType(EntityType.MAPPING)
+        .add();
+    engine
+        .role()
+        .addEntity(role.getKey())
+        .withEntityKey(mappingRecord.getKey())
+        .withEntityType(EntityType.MAPPING)
+        .add();
+
+    // when
+    engine.mapping().deleteMapping(mappingRecord.getKey()).delete();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
+                .withGroupKey(group.getKey())
+                .withEntityKey(mappingRecord.getKey())
+                .exists())
+        .isTrue();
+    Assertions.assertThat(
+            RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
+                .withRoleKey(role.getKey())
+                .withEntityKey(mappingRecord.getKey())
+                .exists())
+        .isTrue();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -11,8 +11,12 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,6 +44,50 @@ public class DeleteUserTest {
         ENGINE.user().deleteUser(userRecord.getKey()).withUsername("").delete().getValue();
 
     assertThat(deletedUser).isNotNull().hasFieldOrPropertyWithValue("userKey", userRecord.getKey());
+  }
+
+  @Test
+  public void shouldCleanupMembership() {
+    final var username = UUID.randomUUID().toString();
+    final var userRecord =
+        ENGINE
+            .user()
+            .newUser(username)
+            .withName("Foo Bar")
+            .withEmail("foo@bar.com")
+            .withPassword("password")
+            .create();
+    final var group = ENGINE.group().newGroup("group").create();
+    final var role = ENGINE.role().newRole("role").create();
+    ENGINE
+        .group()
+        .addEntity(group.getKey())
+        .withEntityKey(userRecord.getKey())
+        .withEntityType(EntityType.USER)
+        .add();
+    ENGINE
+        .role()
+        .addEntity(role.getKey())
+        .withEntityKey(userRecord.getKey())
+        .withEntityType(EntityType.USER)
+        .add();
+
+    // when
+    ENGINE.user().deleteUser(userRecord.getKey()).withUsername("").delete();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.groupRecords(GroupIntent.ENTITY_REMOVED)
+                .withGroupKey(group.getKey())
+                .withEntityKey(userRecord.getKey())
+                .exists())
+        .isTrue();
+    Assertions.assertThat(
+            RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
+                .withRoleKey(role.getKey())
+                .withEntityKey(userRecord.getKey())
+                .exists())
+        .isTrue();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/user/DeleteUserTest.java
@@ -12,6 +12,8 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
+import io.camunda.zeebe.protocol.record.intent.RoleIntent;
+import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
@@ -59,6 +61,8 @@ public class DeleteUserTest {
             .create();
     final var group = ENGINE.group().newGroup("group").create();
     final var role = ENGINE.role().newRole("role").create();
+    final var tenant = ENGINE.tenant().newTenant().withTenantId("tenant").create();
+
     ENGINE
         .group()
         .addEntity(group.getKey())
@@ -68,6 +72,12 @@ public class DeleteUserTest {
     ENGINE
         .role()
         .addEntity(role.getKey())
+        .withEntityKey(userRecord.getKey())
+        .withEntityType(EntityType.USER)
+        .add();
+    ENGINE
+        .tenant()
+        .addEntity(tenant.getKey())
         .withEntityKey(userRecord.getKey())
         .withEntityType(EntityType.USER)
         .add();
@@ -85,6 +95,12 @@ public class DeleteUserTest {
     Assertions.assertThat(
             RecordingExporter.roleRecords(RoleIntent.ENTITY_REMOVED)
                 .withRoleKey(role.getKey())
+                .withEntityKey(userRecord.getKey())
+                .exists())
+        .isTrue();
+    Assertions.assertThat(
+            RecordingExporter.tenantRecords(TenantIntent.ENTITY_REMOVED)
+                .withTenantKey(tenant.getKey())
                 .withEntityKey(userRecord.getKey())
                 .exists())
         .isTrue();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -22,7 +22,10 @@ import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -93,6 +96,12 @@ public class MappingAppliersTest {
     groupState.addEntity(groupKey, group);
     // create owner
     authorizationState.insertOwnerTypeByKey(mappingKey, AuthorizationOwnerType.MAPPING);
+    // create authorization
+    authorizationState.createOrAddPermission(
+        mappingKey,
+        AuthorizationResourceType.PROCESS_DEFINITION,
+        PermissionType.READ,
+        Set.of("process"));
 
     // when
     mappingDeletedApplier.applyState(mappingKey, mappingRecord);
@@ -100,6 +109,10 @@ public class MappingAppliersTest {
     // then
     assertThat(mappingState.get(mappingKey)).isEmpty();
     assertThat(authorizationState.getOwnerType(mappingKey)).isEmpty();
+    assertThat(
+            authorizationState.getResourceIdentifiers(
+                mappingKey, AuthorizationResourceType.PROCESS_DEFINITION, PermissionType.READ))
+        .isEmpty();
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -99,10 +99,7 @@ public class MappingAppliersTest {
 
     // then
     assertThat(mappingState.get(mappingKey)).isEmpty();
-    assertThat(roleState.getEntitiesByType(roleKey)).isEmpty();
-    assertThat(tenantState.getEntitiesByType(tenantKey)).isEmpty();
     assertThat(authorizationState.getOwnerType(mappingKey)).isEmpty();
-    assertThat(groupState.getEntitiesByType(groupKey)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
This adjust the deletion of users and mapping such that we first emit `ENTITY_REMOVED` events for all assigned roles, groups and tenants. This resolves two problems:

1. Properly cleaning up internal state. Before this, deleting a user left remnants in some column families
2. Exporting the implicit cleanup such that the CamundaExporter does not have to re-implement this logic

:thought_balloon: Authorizations behave similar to memberships here, in that they are implicitly deleted when the owning entity is deleted. We could also emit `Authorization/DELETED` events for all directly owned authorizations before deleting a user or mapping.