### PR TITLE
Add 'core' to prometheus metrics scraping.

### DIFF
--- a/monitor/prometheus/prometheus.yml
+++ b/monitor/prometheus/prometheus.yml
@@ -15,6 +15,14 @@ scrape_configs:
           namespace: 'local'
           pod: 'zeebe'
 
+  - job_name: 'core'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['core:9600']
+        labels:
+          namespace: 'local'
+          pod: 'core'
+
   - job_name: 'broker-1'
     static_configs:
       - targets: ['broker-1:9600']


### PR DESCRIPTION
## Description

This pr adds the scraping to the core pods. 

These changes are related to [refactor: replace zeebe and web-apps with camunda orchestration core](https://github.com/camunda/camunda-platform-helm/pull/2554) that replaces all the camunda pods with core. Therefore we need to poll these in our benchmarks dashboards as well. 

In the the future when all the benchmarks are 8.7+ we can stop polling the zeebe endpoint bellow.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
