### PR TITLE
Rename task listener event types

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/TaskListenerBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/TaskListenerBuilder.java
@@ -34,24 +34,64 @@ public class TaskListenerBuilder {
     return this;
   }
 
+  /**
+   * @deprecated use {@link #creating()} instead
+   */
+  @Deprecated
   public TaskListenerBuilder create() {
     return eventType(ZeebeTaskListenerEventType.create);
   }
 
+  public TaskListenerBuilder creating() {
+    return eventType(ZeebeTaskListenerEventType.creating);
+  }
+
+  /**
+   * @deprecated use {@link #updating()} instead
+   */
+  @Deprecated
   public TaskListenerBuilder update() {
     return eventType(ZeebeTaskListenerEventType.update);
   }
 
+  public TaskListenerBuilder updating() {
+    return eventType(ZeebeTaskListenerEventType.updating);
+  }
+
+  /**
+   * @deprecated use {@link #assigning()} instead
+   */
+  @Deprecated
   public TaskListenerBuilder assignment() {
     return eventType(ZeebeTaskListenerEventType.assignment);
   }
 
+  public TaskListenerBuilder assigning() {
+    return eventType(ZeebeTaskListenerEventType.assigning);
+  }
+
+  /**
+   * @deprecated use {@link #completing()} instead
+   */
+  @Deprecated
   public TaskListenerBuilder complete() {
     return eventType(ZeebeTaskListenerEventType.complete);
   }
 
+  public TaskListenerBuilder completing() {
+    return eventType(ZeebeTaskListenerEventType.completing);
+  }
+
+  /**
+   * @deprecated use {@link #canceling()} instead
+   */
+  @Deprecated
   public TaskListenerBuilder cancel() {
     return eventType(ZeebeTaskListenerEventType.cancel);
+  }
+
+  public TaskListenerBuilder canceling() {
+    return eventType(ZeebeTaskListenerEventType.canceling);
   }
 
   public TaskListenerBuilder type(final String type) {

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
@@ -28,10 +28,34 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
  * </ul>
  */
 public enum ZeebeTaskListenerEventType {
+  /**
+   * @deprecated use {@link #creating} instead
+   */
+  @Deprecated
   create,
+
+  /**
+   * @deprecated use {@link #assigning} instead
+   */
+  @Deprecated
   assignment,
+
+  /**
+   * @deprecated use {@link #updating} instead
+   */
+  @Deprecated
   update,
+
+  /**
+   * @deprecated use {@link #completing} instead
+   */
+  @Deprecated
   complete,
+
+  /**
+   * @deprecated use {@link #canceling} instead
+   */
+  @Deprecated
   cancel,
 
   creating,

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerEventType.java
@@ -32,5 +32,11 @@ public enum ZeebeTaskListenerEventType {
   assignment,
   update,
   complete,
-  cancel
+  cancel,
+
+  creating,
+  assigning,
+  updating,
+  completing,
+  canceling
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
@@ -28,6 +28,8 @@ public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskLis
 
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_VALUES =
       Arrays.asList(ZeebeTaskListenerEventType.assigning, ZeebeTaskListenerEventType.completing);
+
+  @SuppressWarnings("deprecation")
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_DEPRECATED_VALUES =
       Arrays.asList(ZeebeTaskListenerEventType.assignment, ZeebeTaskListenerEventType.complete);
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/TaskListenerValidator.java
@@ -27,6 +27,8 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskListener> {
 
   private static final List<ZeebeTaskListenerEventType> SUPPORTED_VALUES =
+      Arrays.asList(ZeebeTaskListenerEventType.assigning, ZeebeTaskListenerEventType.completing);
+  private static final List<ZeebeTaskListenerEventType> SUPPORTED_DEPRECATED_VALUES =
       Arrays.asList(ZeebeTaskListenerEventType.assignment, ZeebeTaskListenerEventType.complete);
 
   @Override
@@ -39,11 +41,17 @@ public class TaskListenerValidator implements ModelElementValidator<ZeebeTaskLis
       final ZeebeTaskListener zeebeTaskListener,
       final ValidationResultCollector validationResultCollector) {
     final ZeebeTaskListenerEventType eventType = zeebeTaskListener.getEventType();
-    if (eventType != null && !SUPPORTED_VALUES.contains(eventType)) {
+    if (eventType != null
+        && !SUPPORTED_VALUES.contains(eventType)
+        && !SUPPORTED_DEPRECATED_VALUES.contains(eventType)) {
       final String errorMessage =
           String.format(
-              "Task listener event type '%s' is not supported. Currently, only %s event types are supported.",
-              eventType, SUPPORTED_VALUES.stream().map(Enum::name).collect(joining(", ")));
+              "Task listener event type '%s' is not supported. Currently, only %s event types and %s deprecated event types are supported.",
+              eventType,
+              SUPPORTED_VALUES.stream().map(Enum::name).collect(joining("', '", "'", "'")),
+              SUPPORTED_DEPRECATED_VALUES.stream()
+                  .map(Enum::name)
+                  .collect(joining("', '", "'", "'")));
       validationResultCollector.addError(0, errorMessage);
     }
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
@@ -66,7 +66,7 @@ public class ZeebeTaskListenerTest extends BpmnModelElementInstanceTest {
 
     final String modelXml =
         Bpmn.convertToString(modelInstance)
-            .replace("eventType=\"cancel\"", "eventType=\"rejection\"");
+            .replace("eventType=\"canceling\"", "eventType=\"rejection\"");
 
     // when
     final ZeebeTaskListeners taskListeners =

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenerTest.java
@@ -59,7 +59,8 @@ public class ZeebeTaskListenerTest extends BpmnModelElementInstanceTest {
             .userTask(
                 "my_user_task",
                 t ->
-                    t.zeebeUserTask().zeebeTaskListener(l -> l.cancel().type("rejection_listener")))
+                    t.zeebeUserTask()
+                        .zeebeTaskListener(l -> l.canceling().type("rejection_listener")))
             .endEvent()
             .done();
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
@@ -76,12 +76,12 @@ public class ZeebeTaskListenersTest extends BpmnModelElementInstanceTest {
     assertThat(taskListeners)
         .extracting("eventType", "type", "retries")
         .containsExactly(
-            tuple(ZeebeTaskListenerEventType.create, "create_listener", "2"),
-            tuple(ZeebeTaskListenerEventType.update, "update_listener", DEFAULT_RETRIES),
-            tuple(ZeebeTaskListenerEventType.update, "update_listener_2", "33"),
-            tuple(ZeebeTaskListenerEventType.assignment, "assignment_listener", "4"),
-            tuple(ZeebeTaskListenerEventType.complete, "complete_listener", "5"),
-            tuple(ZeebeTaskListenerEventType.cancel, "cancel_listener", "6"));
+            tuple(ZeebeTaskListenerEventType.creating, "create_listener", "2"),
+            tuple(ZeebeTaskListenerEventType.updating, "update_listener", DEFAULT_RETRIES),
+            tuple(ZeebeTaskListenerEventType.updating, "update_listener_2", "33"),
+            tuple(ZeebeTaskListenerEventType.assigning, "assignment_listener", "4"),
+            tuple(ZeebeTaskListenerEventType.completing, "complete_listener", "5"),
+            tuple(ZeebeTaskListenerEventType.canceling, "cancel_listener", "6"));
   }
 
   private Collection<ZeebeTaskListener> getTaskListeners(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeTaskListenersTest.java
@@ -57,13 +57,15 @@ public class ZeebeTaskListenersTest extends BpmnModelElementInstanceTest {
                 "my_user_task",
                 t ->
                     t.zeebeUserTask()
-                        .zeebeTaskListener(l -> l.create().type("create_listener").retries("2"))
-                        .zeebeTaskListener(l -> l.update().type("update_listener"))
-                        .zeebeTaskListener(l -> l.update().type("update_listener_2").retries("33"))
+                        .zeebeTaskListener(l -> l.creating().type("create_listener").retries("2"))
+                        .zeebeTaskListener(l -> l.updating().type("update_listener"))
                         .zeebeTaskListener(
-                            l -> l.assignment().type("assignment_listener").retries("4"))
-                        .zeebeTaskListener(l -> l.complete().type("complete_listener").retries("5"))
-                        .zeebeTaskListener(l -> l.cancel().type("cancel_listener").retries("6")))
+                            l -> l.updating().type("update_listener_2").retries("33"))
+                        .zeebeTaskListener(
+                            l -> l.assigning().type("assignment_listener").retries("4"))
+                        .zeebeTaskListener(
+                            l -> l.completing().type("complete_listener").retries("5"))
+                        .zeebeTaskListener(l -> l.canceling().type("cancel_listener").retries("6")))
             .endEvent()
             .done();
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -39,7 +39,7 @@ public class ZeebeTaskListenersValidationTest {
             .startEvent()
             .userTask(
                 "my_user_task",
-                ut -> ut.zeebeUserTask().zeebeTaskListener(TaskListenerBuilder::complete))
+                ut -> ut.zeebeUserTask().zeebeTaskListener(TaskListenerBuilder::completing))
             .endEvent()
             .done();
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskListenersValidationTest.java
@@ -69,7 +69,7 @@ public class ZeebeTaskListenersValidationTest {
       value = ZeebeTaskListenerEventType.class,
       mode = EnumSource.Mode.EXCLUDE,
       // supported event types
-      names = {"assignment", "complete"})
+      names = {"assigning", "assignment", "completing", "complete"})
   void testEventTypeNotSupported(final ZeebeTaskListenerEventType unsupportedEventType) {
     // given
     final BpmnModelInstance process =
@@ -91,7 +91,8 @@ public class ZeebeTaskListenersValidationTest {
             ZeebeTaskListener.class,
             String.format(
                 "Task listener event type '%s' is not supported. "
-                    + "Currently, only assignment, complete event types are supported.",
+                    + "Currently, only 'assigning', 'completing' event types "
+                    + "and 'assignment', 'complete' deprecated event types are supported.",
                 unsupportedEventType)));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -244,8 +244,8 @@ public final class BpmnJobBehavior {
   private static JobListenerEventType fromTaskListenerEventType(
       final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
-      case assignment -> JobListenerEventType.ASSIGNMENT;
-      case complete -> JobListenerEventType.COMPLETE;
+      case assigning -> JobListenerEventType.ASSIGNMENT;
+      case completing -> JobListenerEventType.COMPLETE;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -244,8 +244,8 @@ public final class BpmnJobBehavior {
   private static JobListenerEventType fromTaskListenerEventType(
       final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
-      case assigning -> JobListenerEventType.ASSIGNMENT;
-      case completing -> JobListenerEventType.COMPLETE;
+      case assigning -> JobListenerEventType.ASSIGNING;
+      case completing -> JobListenerEventType.COMPLETING;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -163,7 +163,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
       final UserTaskRecord userTaskRecord,
       final String assignee) {
     userTaskBehavior.userTaskAssigning(userTaskRecord, assignee);
-    element.getTaskListeners(ZeebeTaskListenerEventType.assignment).stream()
+    element.getTaskListeners(ZeebeTaskListenerEventType.assigning).stream()
         .findFirst()
         .ifPresentOrElse(
             listener -> jobBehavior.createNewTaskListenerJob(context, userTaskRecord, listener),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -321,6 +321,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     return listener;
   }
 
+  @SuppressWarnings("deprecation")
   private static ZeebeTaskListenerEventType getZeebeTaskListenerEventType(
       final ZeebeTaskListener zeebeTaskListener) {
     return switch (zeebeTaskListener.getEventType()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePriorityDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListenerEventType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskListeners;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTask;
@@ -307,9 +308,10 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
   }
 
   private TaskListener toTaskListenerModel(
-      ZeebeTaskListener zeebeTaskListener, final UserTaskProperties userTaskProperties) {
+      final ZeebeTaskListener zeebeTaskListener, final UserTaskProperties userTaskProperties) {
     final TaskListener listener = new TaskListener();
-    listener.setEventType(zeebeTaskListener.getEventType());
+    final var eventType = getZeebeTaskListenerEventType(zeebeTaskListener);
+    listener.setEventType(eventType);
 
     final JobWorkerProperties jobProperties = new JobWorkerProperties();
     jobProperties.wrap(userTaskProperties);
@@ -317,5 +319,16 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     jobProperties.setRetries(expressionLanguage.parseExpression(zeebeTaskListener.getRetries()));
     listener.setJobWorkerProperties(jobProperties);
     return listener;
+  }
+
+  private static ZeebeTaskListenerEventType getZeebeTaskListenerEventType(
+      final ZeebeTaskListener zeebeTaskListener) {
+    return switch (zeebeTaskListener.getEventType()) {
+      case create, creating -> ZeebeTaskListenerEventType.creating;
+      case assignment, assigning -> ZeebeTaskListenerEventType.assigning;
+      case update, updating -> ZeebeTaskListenerEventType.updating;
+      case complete, completing -> ZeebeTaskListenerEventType.completing;
+      case cancel, canceling -> ZeebeTaskListenerEventType.canceling;
+    };
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskProcessor.java
@@ -233,9 +233,9 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
   private ZeebeTaskListenerEventType mapIntentToEventType(final UserTaskIntent intent) {
     return switch (intent) {
-      case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assignment;
-      case UPDATE -> ZeebeTaskListenerEventType.update;
-      case COMPLETE -> ZeebeTaskListenerEventType.complete;
+      case ASSIGN, CLAIM -> ZeebeTaskListenerEventType.assigning;
+      case UPDATE -> ZeebeTaskListenerEventType.updating;
+      case COMPLETE -> ZeebeTaskListenerEventType.completing;
       default ->
           throw new IllegalArgumentException("Unexpected user task intent: '%s'".formatted(intent));
     };
@@ -244,11 +244,11 @@ public class UserTaskProcessor implements TypedRecordProcessor<UserTaskRecord> {
   private ZeebeTaskListenerEventType mapLifecycleStateToEventType(
       final LifecycleState lifecycleState) {
     return switch (lifecycleState) {
-      case CREATING -> ZeebeTaskListenerEventType.create;
-      case ASSIGNING, CLAIMING -> ZeebeTaskListenerEventType.assignment;
-      case UPDATING -> ZeebeTaskListenerEventType.update;
-      case COMPLETING -> ZeebeTaskListenerEventType.complete;
-      case CANCELING -> ZeebeTaskListenerEventType.cancel;
+      case CREATING -> ZeebeTaskListenerEventType.creating;
+      case ASSIGNING, CLAIMING -> ZeebeTaskListenerEventType.assigning;
+      case UPDATING -> ZeebeTaskListenerEventType.updating;
+      case COMPLETING -> ZeebeTaskListenerEventType.completing;
+      case CANCELING -> ZeebeTaskListenerEventType.canceling;
       default ->
           throw new IllegalArgumentException(
               "Unexpected user task lifecycle state: '%s'".formatted(lifecycleState));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -52,8 +52,8 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
 
   private ZeebeTaskListenerEventType toTaskListenerEventType(final JobListenerEventType eventType) {
     return switch (eventType) {
-      case COMPLETE -> ZeebeTaskListenerEventType.completing;
-      case ASSIGNMENT -> ZeebeTaskListenerEventType.assigning;
+      case COMPLETING -> ZeebeTaskListenerEventType.completing;
+      case ASSIGNING -> ZeebeTaskListenerEventType.assigning;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -50,10 +50,10 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
     }
   }
 
-  private ZeebeTaskListenerEventType toTaskListenerEventType(JobListenerEventType eventType) {
+  private ZeebeTaskListenerEventType toTaskListenerEventType(final JobListenerEventType eventType) {
     return switch (eventType) {
-      case COMPLETE -> ZeebeTaskListenerEventType.complete;
-      case ASSIGNMENT -> ZeebeTaskListenerEventType.assignment;
+      case COMPLETE -> ZeebeTaskListenerEventType.completing;
+      case ASSIGNMENT -> ZeebeTaskListenerEventType.assigning;
       default -> throw new IllegalStateException("Unexpected value: " + eventType);
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TaskListenerIndicesRecord.java
@@ -26,28 +26,28 @@ public final class TaskListenerIndicesRecord extends UnpackedObject implements D
     declareProperty(assignmentTaskListenerIndexProp).declareProperty(completeTaskListenerIndexProp);
   }
 
-  public Integer getTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public Integer getTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     return switch (eventType) {
-      case assignment -> assignmentTaskListenerIndexProp.getValue();
-      case complete -> completeTaskListenerIndexProp.getValue();
+      case assigning -> assignmentTaskListenerIndexProp.getValue();
+      case completing -> completeTaskListenerIndexProp.getValue();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     };
   }
 
-  public void incrementTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public void incrementTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
-      case assignment -> assignmentTaskListenerIndexProp.increment();
-      case complete -> completeTaskListenerIndexProp.increment();
+      case assigning -> assignmentTaskListenerIndexProp.increment();
+      case completing -> completeTaskListenerIndexProp.increment();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     }
   }
 
-  public void resetTaskListenerIndex(ZeebeTaskListenerEventType eventType) {
+  public void resetTaskListenerIndex(final ZeebeTaskListenerEventType eventType) {
     switch (eventType) {
-      case assignment -> assignmentTaskListenerIndexProp.reset();
-      case complete -> completeTaskListenerIndexProp.reset();
+      case assigning -> assignmentTaskListenerIndexProp.reset();
+      case completing -> completeTaskListenerIndexProp.reset();
       default ->
           throw new IllegalArgumentException("Unsupported ZeebeTaskListenerEventType " + eventType);
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -345,6 +345,7 @@ class UserTaskTransformerTest {
     @DisplayName(
         "Should transform user task with deprecated task listener event types and use new style")
     @Test
+    @SuppressWarnings("deprecation")
     void shouldTransformDeprecatedTaskListenersAndUseNewStyle() {
       final var create = ZeebeTaskListenerEventType.create;
       final var update = ZeebeTaskListenerEventType.update;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -279,16 +279,16 @@ class UserTaskTransformerTest {
     Stream<Arguments> taskListeners() {
       return Stream.of(
           Arguments.of(
-              wrap(l -> l.create().type("myType")),
+              wrap(l -> l.creating().type("myType")),
               new ExpectedTaskListener(ZeebeTaskListenerEventType.creating, "myType", "3")),
           Arguments.of(
-              wrap(l -> l.update().typeExpression("myTypeExp1").retries("8")),
+              wrap(l -> l.updating().typeExpression("myTypeExp1").retries("8")),
               new ExpectedTaskListener(ZeebeTaskListenerEventType.updating, "myTypeExp1", "8")),
           Arguments.of(
-              wrap(l -> l.assignment().type("=myTypeExp2").retries("1")),
+              wrap(l -> l.assigning().type("=myTypeExp2").retries("1")),
               new ExpectedTaskListener(ZeebeTaskListenerEventType.assigning, "myTypeExp2", "1")),
           Arguments.of(
-              wrap(l -> l.cancel().type("myType").retriesExpression("1+2")),
+              wrap(l -> l.canceling().type("myType").retriesExpression("1+2")),
               new ExpectedTaskListener(ZeebeTaskListenerEventType.canceling, "myType", "1+2")));
     }
 
@@ -322,13 +322,13 @@ class UserTaskTransformerTest {
           transformZeebeUserTask(
               processWithUserTask(
                   b ->
-                      b.zeebeTaskListener(tl -> tl.create().type("create_1"))
-                          .zeebeTaskListener(tl -> tl.update().type("update"))
-                          .zeebeTaskListener(tl -> tl.assignment().type("assignment_2"))
-                          .zeebeTaskListener(tl -> tl.create().type("create_3"))
-                          .zeebeTaskListener(tl -> tl.cancel().type("cancel"))
-                          .zeebeTaskListener(tl -> tl.assignment().type("assignment_1"))
-                          .zeebeTaskListener(tl -> tl.create().type("create_2"))
+                      b.zeebeTaskListener(tl -> tl.creating().type("create_1"))
+                          .zeebeTaskListener(tl -> tl.updating().type("update"))
+                          .zeebeTaskListener(tl -> tl.assigning().type("assignment_2"))
+                          .zeebeTaskListener(tl -> tl.creating().type("create_3"))
+                          .zeebeTaskListener(tl -> tl.canceling().type("cancel"))
+                          .zeebeTaskListener(tl -> tl.assigning().type("assignment_1"))
+                          .zeebeTaskListener(tl -> tl.creating().type("create_2"))
                           .zeebeUserTask()));
 
       assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -280,16 +280,16 @@ class UserTaskTransformerTest {
       return Stream.of(
           Arguments.of(
               wrap(l -> l.create().type("myType")),
-              new ExpectedTaskListener(ZeebeTaskListenerEventType.create, "myType", "3")),
+              new ExpectedTaskListener(ZeebeTaskListenerEventType.creating, "myType", "3")),
           Arguments.of(
               wrap(l -> l.update().typeExpression("myTypeExp1").retries("8")),
-              new ExpectedTaskListener(ZeebeTaskListenerEventType.update, "myTypeExp1", "8")),
+              new ExpectedTaskListener(ZeebeTaskListenerEventType.updating, "myTypeExp1", "8")),
           Arguments.of(
               wrap(l -> l.assignment().type("=myTypeExp2").retries("1")),
-              new ExpectedTaskListener(ZeebeTaskListenerEventType.assignment, "myTypeExp2", "1")),
+              new ExpectedTaskListener(ZeebeTaskListenerEventType.assigning, "myTypeExp2", "1")),
           Arguments.of(
               wrap(l -> l.cancel().type("myType").retriesExpression("1+2")),
-              new ExpectedTaskListener(ZeebeTaskListenerEventType.cancel, "myType", "1+2")));
+              new ExpectedTaskListener(ZeebeTaskListenerEventType.canceling, "myType", "1+2")));
     }
 
     @DisplayName("Should transform user task with task listener")
@@ -331,15 +331,15 @@ class UserTaskTransformerTest {
                           .zeebeTaskListener(tl -> tl.create().type("create_2"))
                           .zeebeUserTask()));
 
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.create))
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
           .extracting(this::type)
           .containsExactly("create_1", "create_3", "create_2");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assignment))
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
           .extracting(this::type)
           .containsExactly("assignment_2", "assignment_1");
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.update)).hasSize(1);
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.cancel)).hasSize(1);
-      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.complete)).isEmpty();
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating)).hasSize(1);
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling)).hasSize(1);
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing)).isEmpty();
     }
 
     private String type(TaskListener listener) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -342,15 +342,52 @@ class UserTaskTransformerTest {
       assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing)).isEmpty();
     }
 
-    private String type(TaskListener listener) {
+    @DisplayName(
+        "Should transform user task with deprecated task listener event types and use new style")
+    @Test
+    void shouldTransformDeprecatedTaskListenersAndUseNewStyle() {
+      final var create = ZeebeTaskListenerEventType.create;
+      final var update = ZeebeTaskListenerEventType.update;
+      final var assignment = ZeebeTaskListenerEventType.assignment;
+      final var complete = ZeebeTaskListenerEventType.complete;
+      final var cancel = ZeebeTaskListenerEventType.cancel;
+      final var userTask =
+          transformZeebeUserTask(
+              processWithUserTask(
+                  b ->
+                      b.zeebeTaskListener(tl -> tl.eventType(create).type("create"))
+                          .zeebeTaskListener(tl -> tl.eventType(assignment).type("assignment"))
+                          .zeebeTaskListener(tl -> tl.eventType(update).type("update"))
+                          .zeebeTaskListener(tl -> tl.eventType(complete).type("complete"))
+                          .zeebeTaskListener(tl -> tl.eventType(cancel).type("cancel"))
+                          .zeebeUserTask()));
+
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.creating))
+          .extracting(this::type)
+          .containsExactly("create");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.assigning))
+          .extracting(this::type)
+          .containsExactly("assignment");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.updating))
+          .extracting(this::type)
+          .containsExactly("update");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.completing))
+          .extracting(this::type)
+          .containsExactly("complete");
+      assertThat(userTask.getTaskListeners(ZeebeTaskListenerEventType.canceling))
+          .extracting(this::type)
+          .containsExactly("cancel");
+    }
+
+    private String type(final TaskListener listener) {
       return listener.getJobWorkerProperties().getType().getExpression();
     }
 
-    private String retries(TaskListener listener) {
+    private String retries(final TaskListener listener) {
       return listener.getJobWorkerProperties().getRetries().getExpression();
     }
 
-    private Consumer<TaskListenerBuilder> wrap(Consumer<TaskListenerBuilder> modifier) {
+    private Consumer<TaskListenerBuilder> wrap(final Consumer<TaskListenerBuilder> modifier) {
       return modifier;
     }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -93,7 +93,7 @@ public class TaskListenerTest {
     // then
     assertTaskListenerJobsCompletionSequence(
         processInstanceKey,
-        JobListenerEventType.COMPLETE,
+        JobListenerEventType.COMPLETING,
         LISTENER_TYPE,
         LISTENER_TYPE + "_2",
         LISTENER_TYPE + "_3");
@@ -141,7 +141,7 @@ public class TaskListenerTest {
     // then
     assertTaskListenerJobsCompletionSequence(
         processInstanceKey,
-        JobListenerEventType.ASSIGNMENT,
+        JobListenerEventType.ASSIGNING,
         LISTENER_TYPE,
         LISTENER_TYPE + "_2",
         LISTENER_TYPE + "_3");
@@ -310,7 +310,7 @@ public class TaskListenerTest {
 
     // then
     assertTaskListenerJobsCompletionSequence(
-        processInstanceKey, JobListenerEventType.ASSIGNMENT, LISTENER_TYPE, LISTENER_TYPE + "_2");
+        processInstanceKey, JobListenerEventType.ASSIGNING, LISTENER_TYPE, LISTENER_TYPE + "_2");
 
     // ensure that `COMPLETE_TASK_LISTENER` commands were triggered between
     // `CLAIMING` and `ASSIGNED` events
@@ -355,7 +355,7 @@ public class TaskListenerTest {
     // then: verify the task listener completion sequence for the assignment event
     assertTaskListenerJobsCompletionSequence(
         processInstanceKey,
-        JobListenerEventType.ASSIGNMENT,
+        JobListenerEventType.ASSIGNING,
         LISTENER_TYPE,
         LISTENER_TYPE + "_2",
         LISTENER_TYPE + "_3");
@@ -810,7 +810,7 @@ public class TaskListenerTest {
             RecordingExporter.jobRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .withJobKind(JobKind.TASK_LISTENER)
-                .withJobListenerEventType(JobListenerEventType.COMPLETE)
+                .withJobListenerEventType(JobListenerEventType.COMPLETING)
                 .withIntent(JobIntent.COMPLETED)
                 .limit(3))
         .extracting(Record::getValue)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -78,7 +78,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(
+            createProcessWithCompletingTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
 
     // when
@@ -124,7 +124,7 @@ public class TaskListenerTest {
     final long processInstanceKey =
         createProcessInstance(
             createUserTaskWithTaskListeners(
-                ZeebeTaskListenerEventType.assignment,
+                ZeebeTaskListenerEventType.assigning,
                 LISTENER_TYPE,
                 LISTENER_TYPE + "_2",
                 LISTENER_TYPE + "_3"));
@@ -167,7 +167,7 @@ public class TaskListenerTest {
   public void shouldRejectUserTaskAssignmentWhenTaskListenerRejectsTheOperation() {
     // given
     final long processInstanceKey =
-        createProcessInstance(createProcessWithAssignmentTaskListeners(LISTENER_TYPE));
+        createProcessInstance(createProcessWithAssigningTaskListeners(LISTENER_TYPE));
 
     ENGINE.userTask().ofInstance(processInstanceKey).assign(ut -> ut.setAssignee("new_assignee"));
     ENGINE
@@ -200,7 +200,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithAssignmentTaskListeners(
+            createProcessWithAssigningTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
     ENGINE.userTask().ofInstance(processInstanceKey).assign(ut -> ut.setAssignee("new_assignee"));
     // assignment fails
@@ -297,7 +297,7 @@ public class TaskListenerTest {
     final long processInstanceKey =
         createProcessInstance(
             createUserTaskWithTaskListeners(
-                ZeebeTaskListenerEventType.assignment, LISTENER_TYPE, LISTENER_TYPE + "_2"));
+                ZeebeTaskListenerEventType.assigning, LISTENER_TYPE, LISTENER_TYPE + "_2"));
 
     // when
     ENGINE
@@ -384,7 +384,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(LISTENER_TYPE, LISTENER_TYPE + "_2"));
+            createProcessWithCompletingTaskListeners(LISTENER_TYPE, LISTENER_TYPE + "_2"));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
@@ -417,7 +417,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(
+            createProcessWithCompletingTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
@@ -519,7 +519,7 @@ public class TaskListenerTest {
   public void shouldMakeVariablesFromPreviousTaskListenersAvailableToSubsequentListeners() {
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(LISTENER_TYPE, LISTENER_TYPE + "_2"));
+            createProcessWithCompletingTaskListeners(LISTENER_TYPE, LISTENER_TYPE + "_2"));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
@@ -682,7 +682,7 @@ public class TaskListenerTest {
     // given
     final var processInstanceKey =
         createProcessInstanceWithVariables(
-            createProcessWithCompleteTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
+            createProcessWithCompletingTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
 
     // when
     ENGINE.userTask().ofInstance(processInstanceKey).withVariables(Map.of("baz", 123)).complete();
@@ -702,7 +702,7 @@ public class TaskListenerTest {
     // given
     final var processInstanceKey =
         createProcessInstanceWithVariables(
-            createProcessWithCompleteTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
+            createProcessWithCompletingTaskListeners(LISTENER_TYPE), Map.of("foo", "bar"));
 
     // when
     ENGINE
@@ -724,7 +724,7 @@ public class TaskListenerTest {
     // given
     final var processInstanceKey =
         createProcessInstanceWithVariables(
-            createProcessWithCompleteTaskListeners(LISTENER_TYPE),
+            createProcessWithCompletingTaskListeners(LISTENER_TYPE),
             Map.ofEntries(Map.entry("foo", "bar"), Map.entry("bar", 123)));
 
     // when
@@ -752,7 +752,7 @@ public class TaskListenerTest {
   public void shouldRejectCompleteTaskListenerJobCompletionWhenVariablesAreSet() {
     // given
     final long processInstanceKey =
-        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+        createProcessInstance(createProcessWithCompletingTaskListeners(LISTENER_TYPE));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
@@ -784,7 +784,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(
+            createProcessWithCompletingTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
 
     // when
@@ -826,7 +826,7 @@ public class TaskListenerTest {
   public void shouldRejectUserTaskCompletionWhenTaskListenerRejectsTheOperation() {
     // given
     final long processInstanceKey =
-        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+        createProcessInstance(createProcessWithCompletingTaskListeners(LISTENER_TYPE));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
     ENGINE
@@ -848,7 +848,7 @@ public class TaskListenerTest {
   public void shouldCompleteTaskWhenTaskListenerAcceptsOperationAfterRejection() {
     // given
     final long processInstanceKey =
-        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+        createProcessInstance(createProcessWithCompletingTaskListeners(LISTENER_TYPE));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
     ENGINE
@@ -879,7 +879,7 @@ public class TaskListenerTest {
     // given
     final long processInstanceKey =
         createProcessInstance(
-            createProcessWithCompleteTaskListeners(
+            createProcessWithCompletingTaskListeners(
                 LISTENER_TYPE, LISTENER_TYPE + "_2", LISTENER_TYPE + "_3"));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
@@ -912,7 +912,7 @@ public class TaskListenerTest {
   public void shouldAssignAndCompleteTaskAfterTaskListenerRejectsTheCompletion() {
     // given
     final long processInstanceKey =
-        createProcessInstance(createProcessWithCompleteTaskListeners(LISTENER_TYPE));
+        createProcessInstance(createProcessWithCompletingTaskListeners(LISTENER_TYPE));
 
     ENGINE.userTask().ofInstance(processInstanceKey).complete();
     ENGINE
@@ -996,9 +996,8 @@ public class TaskListenerTest {
         .done();
   }
 
-  private BpmnModelInstance createProcessWithAssignmentTaskListeners(
-      final String... listenerTypes) {
-    return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.assignment, listenerTypes);
+  private BpmnModelInstance createProcessWithAssigningTaskListeners(final String... listenerTypes) {
+    return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.assigning, listenerTypes);
   }
 
   private BpmnModelInstance createUserTaskWithTaskListenersAndAssignee(
@@ -1010,8 +1009,9 @@ public class TaskListenerTest {
                 .zeebeTaskListener(l -> l.assigning().type(listenerType)));
   }
 
-  private BpmnModelInstance createProcessWithCompleteTaskListeners(final String... listenerTypes) {
-    return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.complete, listenerTypes);
+  private BpmnModelInstance createProcessWithCompletingTaskListeners(
+      final String... listenerTypes) {
+    return createUserTaskWithTaskListeners(ZeebeTaskListenerEventType.completing, listenerTypes);
   }
 
   private BpmnModelInstance createUserTaskWithTaskListeners(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -340,9 +340,9 @@ public class TaskListenerTest {
             createProcessWithZeebeUserTask(
                 task ->
                     task.zeebeAssignee(assignee)
-                        .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE))
-                        .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_2"))
-                        .zeebeTaskListener(l -> l.assignment().type(LISTENER_TYPE + "_3"))));
+                        .zeebeTaskListener(l -> l.assigning().type(LISTENER_TYPE))
+                        .zeebeTaskListener(l -> l.assigning().type(LISTENER_TYPE + "_2"))
+                        .zeebeTaskListener(l -> l.assigning().type(LISTENER_TYPE + "_3"))));
 
     // await user task creation
     RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
@@ -487,7 +487,7 @@ public class TaskListenerTest {
                 t ->
                     t.zeebeTaskListener(
                         l ->
-                            l.complete()
+                            l.completing()
                                 .typeExpression("\"listener_1_\"+my_var")
                                 .retriesExpression("5+3"))),
             Map.of("my_var", "abc"));
@@ -550,7 +550,7 @@ public class TaskListenerTest {
                             t ->
                                 t.zeebeUserTask()
                                     .zeebeAssignee("foo")
-                                    .zeebeTaskListener(l -> l.complete().type(LISTENER_TYPE)))
+                                    .zeebeTaskListener(l -> l.completing().type(LISTENER_TYPE)))
                         .serviceTask(
                             "subsequent_service_task",
                             tb -> tb.zeebeJobType("subsequent_service_task"))));
@@ -585,7 +585,7 @@ public class TaskListenerTest {
                             t ->
                                 t.zeebeUserTask()
                                     .zeebeAssignee("foo")
-                                    .zeebeTaskListener(l -> l.complete().type(LISTENER_TYPE))
+                                    .zeebeTaskListener(l -> l.completing().type(LISTENER_TYPE))
                                     .zeebeOutput("=my_listener_var+\"_abc\"", "userTaskOutput"))
                         .serviceTask(
                             "subsequent_service_task",
@@ -619,7 +619,7 @@ public class TaskListenerTest {
                         .zeebeCandidateGroups("group_A, group_C, group_F")
                         .zeebeFormId("Form_0w7r08e")
                         .zeebeDueDate("2095-09-18T10:31:10+02:00")
-                        .zeebeTaskListener(l -> l.complete().type(LISTENER_TYPE))));
+                        .zeebeTaskListener(l -> l.completing().type(LISTENER_TYPE))));
 
     // when
     final var userTaskRecordValue = ENGINE.userTask().ofInstance(processInstanceKey).complete();
@@ -651,7 +651,7 @@ public class TaskListenerTest {
                         .zeebeCandidateGroups("group_A, group_C, group_F")
                         .zeebeDueDate("2085-09-21T11:22:33+02:00")
                         .zeebeFollowUpDate("2095-09-21T11:22:33+02:00")
-                        .zeebeTaskListener(l -> l.complete().type(LISTENER_TYPE))));
+                        .zeebeTaskListener(l -> l.completing().type(LISTENER_TYPE))));
 
     final var changes =
         new UserTaskRecord()
@@ -1007,7 +1007,7 @@ public class TaskListenerTest {
         taskBuilder ->
             taskBuilder
                 .zeebeAssignee(assignee)
-                .zeebeTaskListener(l -> l.assignment().type(listenerType)));
+                .zeebeTaskListener(l -> l.assigning().type(listenerType)));
   }
 
   private BpmnModelInstance createProcessWithCompleteTaskListeners(final String... listenerTypes) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobListenerEventType.java
@@ -36,15 +36,16 @@ public enum JobListenerEventType {
   END,
 
   /**
-   * Represents the `complete` event for a task listener. This event type is used to indicate that
-   * the listener should be triggered after a user task complete operation was invoked.
+   * Represents the `completing` event for a task listener. This event type is used to indicate that
+   * the listener should be triggered when a user task is completing. It allows to execute custom
+   * logic before the task is completed, to correct user task data, and to deny the completion.
    */
-  COMPLETE,
+  COMPLETING,
 
   /**
-   * Represents the `assignment` event for a task listener. This event type is used to indicate that
-   * the listener should be triggered when a user task is assigned, claimed (assigned to the current
-   * user), or unassigned.
+   * Represents the `assigning` event for a task listener. This event type is used to indicate that
+   * the listener should be triggered when a user task is assigning. It allows to execute custom
+   * logic before the task is assigned, to correct user task data, and to deny the assignment.
    */
-  ASSIGNMENT
+  ASSIGNING,
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -68,7 +68,7 @@ public class UserTaskListenersTest {
     final var action = "my_complete_action";
     final var userTaskKey =
         resourcesHelper.createSingleUserTask(
-            t -> t.zeebeTaskListener(l -> l.complete().type("my_listener")));
+            t -> t.zeebeTaskListener(l -> l.completing().type("my_listener")));
 
     final JobHandler completeJobHandler =
         (jobClient, job) -> client.newCompleteCommand(job).result().denied(false).send().join();
@@ -104,7 +104,7 @@ public class UserTaskListenersTest {
     final var action = "my_assign_action";
     final var userTaskKey =
         resourcesHelper.createSingleUserTask(
-            t -> t.zeebeTaskListener(l -> l.assignment().type("my_listener")));
+            t -> t.zeebeTaskListener(l -> l.assigning().type("my_listener")));
 
     final JobHandler completeJobHandler =
         (jobClient, job) -> client.newCompleteCommand(job).send().join();
@@ -159,7 +159,7 @@ public class UserTaskListenersTest {
                 task.zeebeTaskListener(
                     listener ->
                         listener
-                            .complete()
+                            .completing()
                             .type(listenerType)
                             .retries(String.valueOf(jobRetries))));
 
@@ -243,7 +243,7 @@ public class UserTaskListenersTest {
     final var listenerType = "my_listener";
     final var userTaskKey =
         resourcesHelper.createSingleUserTask(
-            t -> t.zeebeTaskListener(l -> l.complete().type(listenerType)));
+            t -> t.zeebeTaskListener(l -> l.completing().type(listenerType)));
 
     final JobHandler completeJobHandler =
         (jobClient, job) -> client.newCompleteCommand(job).result().denied(true).send().join();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Renames the task listener event types providing backward compatibility:
- from `create`, `assignment`, `update`, `complete`, `cancel`
- to `creating`, `assigning`, `updating`, `completing`, `canceling`

Also renames the job listener event types to align their naming although these do not require backward compatibility (released initially in `8.7.0-alpha1`).

## Related issues

closes #25544
