### PR TITLE
feat: java client supports assigned groups to tenants

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -1537,20 +1537,6 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
   AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(long tenantKey);
 
   /**
-   * Command to create a group.
-   *
-   * <pre>
-   * zeebeClient
-   *  .newCreateGroupCommand()
-   *  .name("Group Name")
-   *  .send();
-   * </pre>
-   *
-   * @return a builder for the create group command
-   */
-  CreateGroupCommandStep1 newCreateGroupCommand();
-
-  /**
    * Command to unassign a group from a tenant.
    *
    * <p>Example usage:

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -50,6 +50,7 @@ import io.camunda.zeebe.client.api.command.RemoveUserFromTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateJobCommandStep1;
@@ -1548,4 +1549,21 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the create group command
    */
   CreateGroupCommandStep1 newCreateGroupCommand();
+
+  /**
+   * Command to unassign a group from a tenant.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * zeebeClient
+   *   .newUnassignGroupFromTenantCommand(tenantKey)
+   *   .groupKey(groupKey)
+   *   .send();
+   * </pre>
+   *
+   * @param tenantKey the unique identifier of the tenant
+   * @return a builder to configure and send the unassign group from tenant command
+   */
+  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(long tenantKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
+import io.camunda.zeebe.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignMappingToTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserToTenantCommandStep1;
@@ -1516,4 +1517,35 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the remove user from tenant command
    */
   RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(long tenantKey);
+
+  /**
+   * Command to assign a group to a tenant.
+   *
+   * <p>Example usage:
+   *
+   * <pre>
+   * zeebeClient
+   *   .newAssignGroupToTenantCommand(tenantKey)
+   *   .groupKey(groupKey)
+   *   .send();
+   * </pre>
+   *
+   * @param tenantKey the unique identifier of the tenant
+   * @return a builder to configure and send the assign group to tenant command
+   */
+  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(long tenantKey);
+
+  /**
+   * Command to create a group.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newCreateGroupCommand()
+   *  .name("Group Name")
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the create group command
+   */
+  CreateGroupCommandStep1 newCreateGroupCommand();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -1526,15 +1526,14 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * zeebeClient
-   *   .newAssignGroupToTenantCommand(tenantKey)
-   *   .groupKey(groupKey)
+   *   .newAssignGroupToTenantCommand(tenantKey, groupKey)
    *   .send();
    * </pre>
    *
    * @param tenantKey the unique identifier of the tenant
    * @return a builder to configure and send the assign group to tenant command
    */
-  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(long tenantKey);
+  AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(long tenantKey, long groupKey);
 
   /**
    * Command to unassign a group from a tenant.
@@ -1543,13 +1542,13 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *
    * <pre>
    * zeebeClient
-   *   .newUnassignGroupFromTenantCommand(tenantKey)
-   *   .groupKey(groupKey)
+   *   .newUnassignGroupFromTenantCommand(tenantKey, groupKey)
    *   .send();
    * </pre>
    *
    * @param tenantKey the unique identifier of the tenant
    * @return a builder to configure and send the unassign group from tenant command
    */
-  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(long tenantKey);
+  UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(
+      long tenantKey, long groupKey);
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignGroupToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignGroupToTenantCommandStep1.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.AssignGroupToTenantResponse;
+
+public interface AssignGroupToTenantCommandStep1
+    extends FinalCommandStep<AssignGroupToTenantResponse> {
+
+  /**
+   * Specifies the group to assign to the tenant.
+   *
+   * @param groupKey the unique key of the group
+   * @return the builder for this command
+   */
+  AssignGroupToTenantCommandStep1 groupKey(long groupKey);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignGroupToTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignGroupToTenantCommandStep1.java
@@ -18,13 +18,4 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.AssignGroupToTenantResponse;
 
 public interface AssignGroupToTenantCommandStep1
-    extends FinalCommandStep<AssignGroupToTenantResponse> {
-
-  /**
-   * Specifies the group to assign to the tenant.
-   *
-   * @param groupKey the unique key of the group
-   * @return the builder for this command
-   */
-  AssignGroupToTenantCommandStep1 groupKey(long groupKey);
-}
+    extends FinalCommandStep<AssignGroupToTenantResponse> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignGroupFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignGroupFromTenantCommandStep1.java
@@ -18,13 +18,4 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.UnassignGroupFromTenantResponse;
 
 public interface UnassignGroupFromTenantCommandStep1
-    extends FinalCommandStep<UnassignGroupFromTenantResponse> {
-
-  /**
-   * Specifies the group to unassign from the tenant.
-   *
-   * @param groupKey the unique key of the group
-   * @return the builder for this command
-   */
-  UnassignGroupFromTenantCommandStep1 groupKey(long groupKey);
-}
+    extends FinalCommandStep<UnassignGroupFromTenantResponse> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignGroupFromTenantCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignGroupFromTenantCommandStep1.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.UnassignGroupFromTenantResponse;
+
+public interface UnassignGroupFromTenantCommandStep1
+    extends FinalCommandStep<UnassignGroupFromTenantResponse> {
+
+  /**
+   * Specifies the group to unassign from the tenant.
+   *
+   * @param groupKey the unique key of the group
+   * @return the builder for this command
+   */
+  UnassignGroupFromTenantCommandStep1 groupKey(long groupKey);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignGroupToTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignGroupToTenantResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface AssignGroupToTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignGroupFromTenantResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignGroupFromTenantResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface UnassignGroupFromTenantResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.AddPermissionsCommandStep1;
+import io.camunda.zeebe.client.api.command.AssignGroupToTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignMappingToTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.AssignUserToTenantCommandStep1;
@@ -859,6 +860,16 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public RemoveUserFromTenantCommandStep1 newRemoveUserFromTenantCommand(final long tenantKey) {
     return new RemoveUserFromTenantCommandImpl(httpClient, tenantKey);
+  }
+
+  @Override
+  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final long tenantKey) {
+    return new AssignGroupToTenantCommandImpl(httpClient, tenantKey);
+  }
+
+  @Override
+  public CreateGroupCommandStep1 newCreateGroupCommand() {
+    return new CreateGroupCommandImpl(httpClient, jsonMapper);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -865,19 +865,15 @@ public final class ZeebeClientImpl implements ZeebeClient {
   }
 
   @Override
-  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(final long tenantKey) {
-    return new AssignGroupToTenantCommandImpl(httpClient, tenantKey);
-  }
-
-  @Override
-  public CreateGroupCommandStep1 newCreateGroupCommand() {
-    return new CreateGroupCommandImpl(httpClient, jsonMapper);
+  public AssignGroupToTenantCommandStep1 newAssignGroupToTenantCommand(
+      final long tenantKey, final long groupKey) {
+    return new AssignGroupToTenantCommandImpl(httpClient, tenantKey, groupKey);
   }
 
   @Override
   public UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(
-      final long tenantKey) {
-    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantKey);
+      final long tenantKey, final long groupKey) {
+    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantKey, groupKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -100,6 +100,7 @@ import io.camunda.zeebe.client.api.search.query.VariableQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.command.AddPermissionsCommandImpl;
+import io.camunda.zeebe.client.impl.command.AssignGroupToTenantCommandImpl;
 import io.camunda.zeebe.client.impl.command.AssignMappingToTenantCommandImpl;
 import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.AssignUserToTenantCommandImpl;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -62,6 +62,7 @@ import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.command.UnassignGroupFromTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateGroupCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateJobCommandStep1;
@@ -135,6 +136,7 @@ import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.TopologyRequestImpl;
+import io.camunda.zeebe.client.impl.command.UnassignGroupFromTenantCommandImpl;
 import io.camunda.zeebe.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.UpdateGroupCommandImpl;
 import io.camunda.zeebe.client.impl.command.UpdateTenantCommandImpl;
@@ -870,6 +872,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public CreateGroupCommandStep1 newCreateGroupCommand() {
     return new CreateGroupCommandImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public UnassignGroupFromTenantCommandStep1 newUnassignGroupFromTenantCommand(
+      final long tenantKey) {
+    return new UnassignGroupFromTenantCommandImpl(httpClient, tenantKey);
   }
 
   private JobClient newJobClient() {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -28,19 +28,15 @@ public final class AssignGroupToTenantCommandImpl implements AssignGroupToTenant
 
   private final HttpClient httpClient;
   private final long tenantKey;
-  private long groupKey;
+  private final long groupKey;
   private final RequestConfig.Builder httpRequestConfig;
 
-  public AssignGroupToTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public AssignGroupToTenantCommandImpl(
+      final HttpClient httpClient, final long tenantKey, final long groupKey) {
     this.httpClient = httpClient;
     this.tenantKey = tenantKey;
-    httpRequestConfig = httpClient.newRequestConfig();
-  }
-
-  @Override
-  public AssignGroupToTenantCommandStep1 groupKey(final long groupKey) {
     this.groupKey = groupKey;
-    return this;
+    httpRequestConfig = httpClient.newRequestConfig();
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignGroupToTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignGroupToTenantCommandImpl.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.AssignGroupToTenantCommandStep1;
+import io.camunda.zeebe.client.api.response.AssignGroupToTenantResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class AssignGroupToTenantCommandImpl implements AssignGroupToTenantCommandStep1 {
+
+  private final HttpClient httpClient;
+  private final long tenantKey;
+  private long groupKey;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public AssignGroupToTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+    this.httpClient = httpClient;
+    this.tenantKey = tenantKey;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public AssignGroupToTenantCommandStep1 groupKey(final long groupKey) {
+    this.groupKey = groupKey;
+    return this;
+  }
+
+  @Override
+  public AssignGroupToTenantCommandStep1 requestTimeout(final Duration timeout) {
+    httpRequestConfig.setResponseTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<AssignGroupToTenantResponse> send() {
+    final HttpZeebeFuture<AssignGroupToTenantResponse> result = new HttpZeebeFuture<>();
+    httpClient.put(
+        "/tenants/" + tenantKey + "/groups/" + groupKey,
+        null, // No request body needed
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -30,18 +30,14 @@ public final class UnassignGroupFromTenantCommandImpl
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
   private final long tenantKey;
-  private long groupKey;
+  private final long groupKey;
 
-  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+  public UnassignGroupFromTenantCommandImpl(
+      final HttpClient httpClient, final long tenantKey, final long groupKey) {
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
     this.tenantKey = tenantKey;
-  }
-
-  @Override
-  public UnassignGroupFromTenantCommandStep1 groupKey(final long groupKey) {
     this.groupKey = groupKey;
-    return this;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -1,0 +1,46 @@
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.UnassignGroupFromTenantCommandStep1;
+import io.camunda.zeebe.client.api.response.UnassignGroupFromTenantResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class UnassignGroupFromTenantCommandImpl
+    implements UnassignGroupFromTenantCommandStep1 {
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+  private final long tenantKey;
+  private long groupKey;
+
+  public UnassignGroupFromTenantCommandImpl(final HttpClient httpClient, final long tenantKey) {
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    this.tenantKey = tenantKey;
+  }
+
+  @Override
+  public UnassignGroupFromTenantCommandStep1 groupKey(final long groupKey) {
+    this.groupKey = groupKey;
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<UnassignGroupFromTenantResponse> requestTimeout(
+      final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<UnassignGroupFromTenantResponse> send() {
+    final HttpZeebeFuture<UnassignGroupFromTenantResponse> result = new HttpZeebeFuture<>();
+    final String endpoint = String.format("/tenants/%d/groups/%d", tenantKey, groupKey);
+    httpClient.delete(endpoint, httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignGroupFromTenantCommandImpl.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.camunda.zeebe.client.impl.command;
 
 import io.camunda.zeebe.client.api.ZeebeFuture;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/tenant/AssignGroupToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/tenant/AssignGroupToTenantTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.tenant;
+
+import static io.camunda.zeebe.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class AssignGroupToTenantTest extends ClientRestTest {
+
+  private static final long TENANT_KEY = 123L;
+  private static final long GROUP_KEY = 456L;
+
+  @Test
+  void shouldAssignGroupToTenant() {
+    // when
+    client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundTenant() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundGroup() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldHandleServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/tenant/AssignGroupToTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/tenant/AssignGroupToTenantTest.java
@@ -33,7 +33,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+    client.newAssignGroupToTenantCommand(TENANT_KEY, GROUP_KEY).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -50,8 +50,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -65,8 +64,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -80,8 +78,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -95,8 +92,7 @@ public class AssignGroupToTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client.newAssignGroupToTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join())
+            () -> client.newAssignGroupToTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/tenant/UnassignGroupFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/tenant/UnassignGroupFromTenantTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.tenant;
+
+import static io.camunda.zeebe.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class UnassignGroupFromTenantTest extends ClientRestTest {
+
+  private static final long TENANT_KEY = 123L;
+  private static final long GROUP_KEY = 456L;
+
+  @Test
+  void shouldUnassignGroupFromTenant() {
+    // when
+    client.newUnassignGroupFromTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath)
+        .isEqualTo(REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundTenant() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .groupKey(GROUP_KEY)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundGroup() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .groupKey(GROUP_KEY)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldHandleServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .groupKey(GROUP_KEY)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/tenants/" + TENANT_KEY + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
+                    .groupKey(GROUP_KEY)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/tenant/UnassignGroupFromTenantTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/tenant/UnassignGroupFromTenantTest.java
@@ -33,7 +33,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(TENANT_KEY).groupKey(GROUP_KEY).send().join();
+    client.newUnassignGroupFromTenantCommand(TENANT_KEY, GROUP_KEY).send().join();
 
     // then
     final String requestPath = RestGatewayService.getLastRequest().getUrl();
@@ -50,12 +50,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
-                    .groupKey(GROUP_KEY)
-                    .send()
-                    .join())
+            () -> client.newUnassignGroupFromTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -69,12 +64,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
-                    .groupKey(GROUP_KEY)
-                    .send()
-                    .join())
+            () -> client.newUnassignGroupFromTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'");
   }
@@ -88,12 +78,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
-                    .groupKey(GROUP_KEY)
-                    .send()
-                    .join())
+            () -> client.newUnassignGroupFromTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
   }
@@ -107,12 +92,7 @@ public class UnassignGroupFromTenantTest extends ClientRestTest {
 
     // when / then
     assertThatThrownBy(
-            () ->
-                client
-                    .newUnassignGroupFromTenantCommand(TENANT_KEY)
-                    .groupKey(GROUP_KEY)
-                    .send()
-                    .join())
+            () -> client.newUnassignGroupFromTenantCommand(TENANT_KEY, GROUP_KEY).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 403: 'Forbidden'");
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -180,7 +180,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       return false;
     }
 
-    if (tenantState.getEntityType(tenantKey, entityKey).isPresent()) {
+    if (group.get().getTenantKeys().contains(tenantKey)) {
       createAlreadyAssignedRejectCommand(command, entityKey, tenantKey);
       return false;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantRemoveEntityProcessor.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.GroupState;
 import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
@@ -36,6 +37,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
   private final TenantState tenantState;
   private final UserState userState;
   private final MappingState mappingState;
+  private final GroupState groupState;
   private final AuthorizationCheckBehavior authCheckBehavior;
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -52,6 +54,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     tenantState = state.getTenantState();
     userState = state.getUserState();
     mappingState = state.getMappingState();
+    groupState = state.getGroupState();
     this.authCheckBehavior = authCheckBehavior;
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
@@ -129,6 +132,7 @@ public class TenantRemoveEntityProcessor implements DistributedTypedRecordProces
     return switch (entityType) {
       case USER -> userState.getUser(entityKey).isPresent();
       case MAPPING -> mappingState.get(entityKey).isPresent();
+      case GROUP -> groupState.get(entityKey).isPresent();
       default -> false;
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -36,7 +36,7 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
     switch (tenant.getEntityType()) {
       case USER -> userState.addTenantId(tenant.getEntityKey(), tenant.getTenantId());
       case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
-      case GROUP -> groupState.addTenant(tenant.getEntityKey(), tenant.getTenantKey());
+      case GROUP -> groupState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
@@ -20,11 +21,13 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
   private final MutableTenantState tenantState;
   private final MutableUserState userState;
   private final MutableMappingState mappingState;
+  private final MutableGroupState groupState;
 
   public TenantEntityAddedApplier(final MutableProcessingState state) {
     tenantState = state.getTenantState();
     userState = state.getUserState();
     mappingState = state.getMappingState();
+    groupState = state.getGroupState();
   }
 
   @Override
@@ -33,6 +36,7 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
     switch (tenant.getEntityType()) {
       case USER -> userState.addTenantId(tenant.getEntityKey(), tenant.getTenantId());
       case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
+      case GROUP -> groupState.addTenant(tenant.getEntityKey(), tenant.getTenantKey());
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableGroupState;
 import io.camunda.zeebe.engine.state.mutable.MutableMappingState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableTenantState;
@@ -20,11 +21,13 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
   private final MutableTenantState tenantState;
   private final MutableUserState userState;
   private final MutableMappingState mappingState;
+  private final MutableGroupState groupState;
 
   public TenantEntityRemovedApplier(final MutableProcessingState state) {
     tenantState = state.getTenantState();
     userState = state.getUserState();
     mappingState = state.getMappingState();
+    groupState = state.getGroupState();
   }
 
   @Override
@@ -33,6 +36,7 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
     switch (tenant.getEntityType()) {
       case USER -> userState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
+      case GROUP -> groupState.removeTenant(tenant.getEntityKey(), tenant.getTenantKey());
       default ->
           throw new UnsupportedOperationException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -36,7 +36,7 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
     switch (tenant.getEntityType()) {
       case USER -> userState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
-      case GROUP -> groupState.removeTenant(tenant.getEntityKey(), tenant.getTenantKey());
+      case GROUP -> groupState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->
           throw new UnsupportedOperationException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -127,12 +127,24 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public void addTenant(final long mappingKey, final long tenantKey) {
-    groupKey.wrapLong(mappingKey);
-    final PersistedGroup persistedGroup = groupColumnFamily.get(groupKey);
+  public void addTenant(final long groupKey, final long tenantKey) {
+    this.groupKey.wrapLong(groupKey);
+    final PersistedGroup persistedGroup = groupColumnFamily.get(this.groupKey);
     if (persistedGroup != null) {
       persistedGroup.addTenantKey(tenantKey);
-      groupColumnFamily.update(groupKey, persistedGroup);
+      groupColumnFamily.update(this.groupKey, persistedGroup);
+    }
+  }
+
+  @Override
+  public void removeTenant(final long groupKey, final long tenantKey) {
+    this.groupKey.wrapLong(groupKey);
+    final var persistedGroup = groupColumnFamily.get(this.groupKey);
+    if (persistedGroup != null) {
+      final List<Long> tenantKeys = persistedGroup.getTenantKeys();
+      tenantKeys.remove(tenantKey);
+      persistedGroup.setTenantKeys(tenantKeys);
+      groupColumnFamily.update(this.groupKey, persistedGroup);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -127,6 +127,16 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
+  public void addTenant(final long mappingKey, final long tenantKey) {
+    groupKey.wrapLong(mappingKey);
+    final PersistedGroup persistedGroup = groupColumnFamily.get(groupKey);
+    if (persistedGroup != null) {
+      persistedGroup.addTenantKey(tenantKey);
+      groupColumnFamily.update(groupKey, persistedGroup);
+    }
+  }
+
+  @Override
   public Optional<PersistedGroup> get(final long groupKey) {
     this.groupKey.wrapLong(groupKey);
     final var persistedGroup = groupColumnFamily.get(this.groupKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -127,25 +127,21 @@ public class DbGroupState implements MutableGroupState {
   }
 
   @Override
-  public void addTenant(final long groupKey, final long tenantKey) {
+  public void addTenant(final long groupKey, final String tenantId) {
     this.groupKey.wrapLong(groupKey);
     final PersistedGroup persistedGroup = groupColumnFamily.get(this.groupKey);
-    if (persistedGroup != null) {
-      persistedGroup.addTenantKey(tenantKey);
-      groupColumnFamily.update(this.groupKey, persistedGroup);
-    }
+    persistedGroup.addTenantId(tenantId);
+    groupColumnFamily.update(this.groupKey, persistedGroup);
   }
 
   @Override
-  public void removeTenant(final long groupKey, final long tenantKey) {
+  public void removeTenant(final long groupKey, final String tenantId) {
     this.groupKey.wrapLong(groupKey);
     final var persistedGroup = groupColumnFamily.get(this.groupKey);
-    if (persistedGroup != null) {
-      final List<Long> tenantKeys = persistedGroup.getTenantKeys();
-      tenantKeys.remove(tenantKey);
-      persistedGroup.setTenantKeys(tenantKeys);
-      groupColumnFamily.update(this.groupKey, persistedGroup);
-    }
+    final List<String> tenantIdsList = persistedGroup.getTenantIdsList();
+    tenantIdsList.remove(tenantId);
+    persistedGroup.setTenantIdsList(tenantIdsList);
+    groupColumnFamily.update(this.groupKey, persistedGroup);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -9,18 +9,25 @@ package io.camunda.zeebe.engine.state.group;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class PersistedGroup extends UnpackedObject implements DbValue {
 
   private final LongProperty groupKeyProp = new LongProperty("groupKey");
   private final StringProperty nameProp = new StringProperty("name");
+  private final ArrayProperty<LongValue> tenantKeysProp =
+      new ArrayProperty<>("tenantKeys", LongValue::new);
 
   public PersistedGroup() {
-    super(2);
-    declareProperty(groupKeyProp).declareProperty(nameProp);
+    super(3);
+    declareProperty(groupKeyProp).declareProperty(nameProp).declareProperty(tenantKeysProp);
   }
 
   public long getGroupKey() {
@@ -38,6 +45,23 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   public PersistedGroup setName(final String name) {
     nameProp.setValue(name);
+    return this;
+  }
+
+  public List<Long> getTenantKeys() {
+    return StreamSupport.stream(tenantKeysProp.spliterator(), false)
+        .map(LongValue::getValue)
+        .collect(Collectors.toList());
+  }
+
+  public PersistedGroup setTenantKeys(final List<Long> tenantKeys) {
+    tenantKeysProp.reset();
+    tenantKeys.forEach(tenantKey -> tenantKeysProp.add().setValue(tenantKey));
+    return this;
+  }
+
+  public PersistedGroup addTenantKey(final long tenantKey) {
+    tenantKeysProp.add().setValue(tenantKey);
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
-import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,12 +22,12 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
 
   private final LongProperty groupKeyProp = new LongProperty("groupKey");
   private final StringProperty nameProp = new StringProperty("name");
-  private final ArrayProperty<LongValue> tenantKeysProp =
-      new ArrayProperty<>("tenantKeys", LongValue::new);
+  private final ArrayProperty<StringValue> tenantIdsProp =
+      new ArrayProperty<>("tenantIds", StringValue::new);
 
   public PersistedGroup() {
     super(3);
-    declareProperty(groupKeyProp).declareProperty(nameProp).declareProperty(tenantKeysProp);
+    declareProperty(groupKeyProp).declareProperty(nameProp).declareProperty(tenantIdsProp);
   }
 
   public long getGroupKey() {
@@ -48,20 +48,21 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public List<Long> getTenantKeys() {
-    return StreamSupport.stream(tenantKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
+  public List<String> getTenantIdsList() {
+    return StreamSupport.stream(tenantIdsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
         .collect(Collectors.toList());
   }
 
-  public PersistedGroup setTenantKeys(final List<Long> tenantKeys) {
-    tenantKeysProp.reset();
-    tenantKeys.forEach(tenantKey -> tenantKeysProp.add().setValue(tenantKey));
+  public PersistedGroup setTenantIdsList(final List<String> tenantIds) {
+    tenantIdsProp.reset();
+    tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
     return this;
   }
 
-  public PersistedGroup addTenantKey(final long tenantKey) {
-    tenantKeysProp.add().setValue(tenantKey);
+  public PersistedGroup addTenantId(final String tenantId) {
+    tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
     return this;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -22,7 +22,7 @@ public interface MutableGroupState extends GroupState {
 
   void delete(final long groupKey);
 
-  void addTenant(final long groupKey, final long tenantKey);
+  void addTenant(final long groupKey, final String tenantId);
 
-  void removeTenant(final long groupKey, final long tenantKey);
+  void removeTenant(final long groupKey, final String tenantId);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -22,5 +22,7 @@ public interface MutableGroupState extends GroupState {
 
   void delete(final long groupKey);
 
-  void addTenant(final long mappingKey, final long tenantKey);
+  void addTenant(final long groupKey, final long tenantKey);
+
+  void removeTenant(final long groupKey, final long tenantKey);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableGroupState.java
@@ -21,4 +21,6 @@ public interface MutableGroupState extends GroupState {
   void removeEntity(final long groupKey, final long entityKey);
 
   void delete(final long groupKey);
+
+  void addTenant(final long mappingKey, final long tenantKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -174,8 +174,8 @@ public class AddEntityTenantTest {
     assertThat(notPresentUpdateRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to add entity with key '1' to tenant with key '%s', but the entity doesn't exist."
-                .formatted(tenantKey));
+            "Expected to add entity with key '1' to tenant with tenantId '%s', but the entity doesn't exist."
+                .formatted(tenantId));
   }
 
   @Test
@@ -202,8 +202,8 @@ public class AddEntityTenantTest {
     assertThat(alreadyAssignedRecord)
         .hasRejectionType(RejectionType.INVALID_ARGUMENT)
         .hasRejectionReason(
-            "Expected to add entity with key '%s' to tenant with key '%s', but the entity is already assigned to the tenant."
-                .formatted(userKey, tenantKey));
+            "Expected to add entity with key '%s' to tenant with tenantId '%s', but the entity is already assigned to the tenant."
+                .formatted(userKey, tenantId));
   }
 
   private Long createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -14,7 +14,6 @@ import static io.camunda.zeebe.protocol.record.value.EntityType.USER;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
@@ -30,17 +29,84 @@ public class AddEntityTenantTest {
       new RecordingExporterTestWatcher();
 
   @Test
-  public void shouldAddEntitiesToTenant() {
-    // We can't use JUnit 5 parameterized tests due to JUnit 4's @Rule incompatibility, and JUnit
-    // 4's parameterized tests are not suitable for this test class    shouldAddEntityToTenant(USER,
-    //  createUser());
-    shouldAddEntityToTenant(GROUP, createGroup());
-    shouldAddEntityToTenant(MAPPING, createMapping());
-    shouldAddEntityToTenant(USER, createUser());
+  public void shouldAddMappingToTenant() {
+    // given
+    final var entityType = MAPPING;
+    final var entityKey = createMapping();
+    final var tenantId = UUID.randomUUID().toString();
+    final var tenantKey =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(tenantId)
+            .withName("Tenant 1")
+            .create()
+            .getValue()
+            .getTenantKey();
+
+    // when add user entity to tenant
+    final var updatedTenant =
+        engine
+            .tenant()
+            .addEntity(tenantKey)
+            .withEntityKey(entityKey)
+            .withEntityType(entityType)
+            .add()
+            .getValue();
+
+    // then assert that the entity was added correctly
+    Assertions.assertThat(updatedTenant)
+        .describedAs(
+            "Entity of type %s with key %s should be correctly added to tenant with key %s",
+            entityType, entityKey, tenantKey)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("entityKey", entityKey)
+        .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
+        .hasFieldOrPropertyWithValue("entityType", entityType);
   }
 
-  public void shouldAddEntityToTenant(final EntityType entityType, final long entityKey) {
+  @Test
+  public void shouldAddUserToTenant() {
     // given
+    final var entityType = USER;
+    final var entityKey = createUser();
+    final var tenantId = UUID.randomUUID().toString();
+    final var tenantKey =
+        engine
+            .tenant()
+            .newTenant()
+            .withTenantId(tenantId)
+            .withName("Tenant 1")
+            .create()
+            .getValue()
+            .getTenantKey();
+
+    // when add user entity to tenant
+    final var updatedTenant =
+        engine
+            .tenant()
+            .addEntity(tenantKey)
+            .withEntityKey(entityKey)
+            .withEntityType(entityType)
+            .add()
+            .getValue();
+
+    // then assert that the entity was added correctly
+    Assertions.assertThat(updatedTenant)
+        .describedAs(
+            "Entity of type %s with key %s should be correctly added to tenant with key %s",
+            entityType, entityKey, tenantKey)
+        .isNotNull()
+        .hasFieldOrPropertyWithValue("entityKey", entityKey)
+        .hasFieldOrPropertyWithValue("tenantKey", tenantKey)
+        .hasFieldOrPropertyWithValue("entityType", entityType);
+  }
+
+  @Test
+  public void shouldAddGroupToTenant() {
+    // given
+    final var entityType = GROUP;
+    final var entityKey = createUser();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/tenant/AddEntityTenantTest.java
@@ -106,7 +106,7 @@ public class AddEntityTenantTest {
   public void shouldAddGroupToTenant() {
     // given
     final var entityType = GROUP;
-    final var entityKey = createUser();
+    final var entityKey = createGroup();
     final var tenantId = UUID.randomUUID().toString();
     final var tenantKey =
         engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -211,17 +211,17 @@ public class GroupStateTest {
     // given
     final var groupKey = 1L;
     final var groupName = "group";
-    final var tenantKey = 100L;
+    final var tenantId = "tenant1";
     final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
     groupState.create(groupKey, groupRecord);
 
     // when
-    groupState.addTenant(groupKey, tenantKey);
+    groupState.addTenant(groupKey, tenantId);
 
     // then
     final var group = groupState.get(groupKey);
     assertThat(group.isPresent()).isTrue();
-    assertThat(group.get().getTenantKeys()).containsExactly(tenantKey);
+    assertThat(group.get().getTenantIdsList()).containsExactly(tenantId);
   }
 
   @Test
@@ -229,27 +229,26 @@ public class GroupStateTest {
     // given
     final var groupKey = 1L;
     final var groupName = "group";
-    final var tenantKey1 = 100L;
-    final var tenantKey2 = 200L;
+    final var tenantId1 = "tenant1";
+    final var tenantId2 = "tenant2";
 
     // Create a group and add tenants
     final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
     groupState.create(groupKey, groupRecord);
-    groupState.addTenant(groupKey, tenantKey1);
-    groupState.addTenant(groupKey, tenantKey2);
+    groupState.addTenant(groupKey, tenantId1);
+    groupState.addTenant(groupKey, tenantId2);
 
     // Ensure tenants are added correctly
     final var groupBeforeRemove = groupState.get(groupKey);
     assertThat(groupBeforeRemove.isPresent()).isTrue();
-    assertThat(groupBeforeRemove.get().getTenantKeys())
-        .containsExactlyInAnyOrder(tenantKey1, tenantKey2);
+    assertThat(groupBeforeRemove.get().getTenantIdsList()).containsExactly(tenantId1, tenantId2);
 
     // when
-    groupState.removeTenant(groupKey, tenantKey1);
+    groupState.removeTenant(groupKey, tenantId1);
 
     // then
     final var groupAfterRemove = groupState.get(groupKey);
     assertThat(groupAfterRemove.isPresent()).isTrue();
-    assertThat(groupAfterRemove.get().getTenantKeys()).containsExactly(tenantKey2);
+    assertThat(groupAfterRemove.get().getTenantIdsList()).containsExactly(tenantId2);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -223,4 +223,33 @@ public class GroupStateTest {
     assertThat(group.isPresent()).isTrue();
     assertThat(group.get().getTenantKeys()).containsExactly(tenantKey);
   }
+
+  @Test
+  void shouldRemoveTenant() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var tenantKey1 = 100L;
+    final var tenantKey2 = 200L;
+
+    // Create a group and add tenants
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+    groupState.addTenant(groupKey, tenantKey1);
+    groupState.addTenant(groupKey, tenantKey2);
+
+    // Ensure tenants are added correctly
+    final var groupBeforeRemove = groupState.get(groupKey);
+    assertThat(groupBeforeRemove.isPresent()).isTrue();
+    assertThat(groupBeforeRemove.get().getTenantKeys())
+        .containsExactlyInAnyOrder(tenantKey1, tenantKey2);
+
+    // when
+    groupState.removeTenant(groupKey, tenantKey1);
+
+    // then
+    final var groupAfterRemove = groupState.get(groupKey);
+    assertThat(groupAfterRemove.isPresent()).isTrue();
+    assertThat(groupAfterRemove.get().getTenantKeys()).containsExactly(tenantKey2);
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/group/GroupStateTest.java
@@ -205,4 +205,22 @@ public class GroupStateTest {
     final var entitiesByGroup = groupState.getEntitiesByType(groupKey);
     assertThat(entitiesByGroup).isEmpty();
   }
+
+  @Test
+  void shouldAddTenant() {
+    // given
+    final var groupKey = 1L;
+    final var groupName = "group";
+    final var tenantKey = 100L;
+    final var groupRecord = new GroupRecord().setGroupKey(groupKey).setName(groupName);
+    groupState.create(groupKey, groupRecord);
+
+    // when
+    groupState.addTenant(groupKey, tenantKey);
+
+    // then
+    final var group = groupState.get(groupKey);
+    assertThat(group.isPresent()).isTrue();
+    assertThat(group.get().getTenantKeys()).containsExactly(tenantKey);
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -55,11 +56,12 @@ class AssignGroupToTenantTest {
     client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
 
     // then
-    ZeebeAssertHelper.assertGroupAssignedToTenant(
+    ZeebeAssertHelper.assertEntityAssignedToTenant(
         tenantKey,
+        groupKey,
         tenant -> {
           assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
-          assertThat(tenant.getEntityKey()).isEqualTo(groupKey);
+          assertThat(tenant.getEntityType()).isEqualTo(EntityType.GROUP);
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 @AutoCloseResources
 class AssignGroupToTenantTest {
 
+  private static final String TENANT_ID = "tenant-id";
+
   @TestZeebe
   private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
 
@@ -41,7 +43,7 @@ class AssignGroupToTenantTest {
     tenantKey =
         client
             .newCreateTenantCommand()
-            .tenantId("tenant-id")
+            .tenantId(TENANT_ID)
             .name("Tenant Name")
             .send()
             .join()
@@ -93,8 +95,8 @@ class AssignGroupToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with key '%d', but the entity doesn't exist."
-                .formatted(nonExistentGroupKey, tenantKey));
+            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
+                .formatted(nonExistentGroupKey, TENANT_ID));
   }
 
   @Test
@@ -108,7 +110,7 @@ class AssignGroupToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with key '%d', but the entity is already assigned to the tenant."
-                .formatted(groupKey, tenantKey));
+            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity is already assigned to the tenant."
+                .formatted(groupKey, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -102,4 +102,19 @@ class AssignGroupToTenantTest {
             "Expected to add entity with key '%d' to tenant with key '%d', but the entity doesn't exist."
                 .formatted(nonExistentGroupKey, tenantKey));
   }
+
+  @Test
+  void shouldRejectIfAlreadyAssigned() {
+    // given
+    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+
+    // when / then
+    assertThatThrownBy(
+            () -> client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 400: 'Bad Request'")
+        .hasMessageContaining(
+            "Expected to add entity with key '%d' to tenant with key '%d', but the entity is already assigned to the tenant."
+                .formatted(groupKey, tenantKey));
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignGroupToTenantTest.java
@@ -53,7 +53,7 @@ class AssignGroupToTenantTest {
   @Test
   void shouldAssignGroupToTenant() {
     // when
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(tenantKey, groupKey).send().join();
 
     // then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
@@ -73,11 +73,7 @@ class AssignGroupToTenantTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client
-                    .newAssignGroupToTenantCommand(nonExistentTenantKey)
-                    .groupKey(groupKey)
-                    .send()
-                    .join())
+                client.newAssignGroupToTenantCommand(nonExistentTenantKey, groupKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
@@ -93,11 +89,7 @@ class AssignGroupToTenantTest {
     // when / then
     assertThatThrownBy(
             () ->
-                client
-                    .newAssignGroupToTenantCommand(tenantKey)
-                    .groupKey(nonExistentGroupKey)
-                    .send()
-                    .join())
+                client.newAssignGroupToTenantCommand(tenantKey, nonExistentGroupKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
@@ -108,11 +100,11 @@ class AssignGroupToTenantTest {
   @Test
   void shouldRejectIfAlreadyAssigned() {
     // given
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(tenantKey, groupKey).send().join();
 
     // when / then
     assertThatThrownBy(
-            () -> client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join())
+            () -> client.newAssignGroupToTenantCommand(tenantKey, groupKey).send().join())
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 400: 'Bad Request'")
         .hasMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
@@ -71,9 +72,10 @@ class AssignMappingToTenantTest {
     // Then
     ZeebeAssertHelper.assertEntityAssignedToTenant(
         tenantKey,
+        mappingKey,
         tenant -> {
           assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
-          assertThat(tenant.getEntityKey()).isEqualTo(mappingKey);
+          assertThat(tenant.getEntityType()).isEqualTo(EntityType.MAPPING);
         });
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignMappingToTenantTest.java
@@ -115,7 +115,7 @@ class AssignMappingToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with key '%d', but the entity doesn't exist."
-                .formatted(invalidMappingKey, tenantKey));
+            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
+                .formatted(invalidMappingKey, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserToTenantTest.java
@@ -110,7 +110,7 @@ class AssignUserToTenantTest {
         .isInstanceOf(ProblemException.class)
         .hasMessageContaining("Failed with code 404: 'Not Found'")
         .hasMessageContaining(
-            "Expected to add entity with key '%d' to tenant with key '%d', but the entity doesn't exist."
-                .formatted(invalidUserKey, tenantKey));
+            "Expected to add entity with key '%d' to tenant with tenantId '%s', but the entity doesn't exist."
+                .formatted(invalidUserKey, TENANT_ID));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+@AutoCloseResources
+class UnassignGroupFromTenantTest {
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource private ZeebeClient client;
+
+  private long tenantKey;
+  private long groupKey;
+
+  @BeforeEach
+  void initClientAndInstances() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    tenantKey =
+        client
+            .newCreateTenantCommand()
+            .tenantId("tenant-id")
+            .name("Tenant Name")
+            .send()
+            .join()
+            .getTenantKey();
+
+    groupKey = client.newCreateGroupCommand().name("group").send().join().getGroupKey();
+
+    // Assign group to tenant to set up test scenario
+    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+  }
+
+  @Test
+  void shouldUnassignGroupFromTenant() {
+    // when
+    client.newUnassignGroupFromTenantCommand(tenantKey).groupKey(groupKey).send().join();
+
+    // then
+    ZeebeAssertHelper.assertGroupUnassignedFromTenant(
+        tenantKey,
+        (tenant) -> {
+          assertThat(tenant.getTenantKey()).isEqualTo(tenantKey);
+          assertThat(tenant.getEntityKey()).isEqualTo(groupKey);
+        });
+  }
+
+  @Test
+  void shouldRejectIfTenantDoesNotExist() {
+    // given
+    final long nonExistentTenantKey = 999999L;
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(nonExistentTenantKey)
+                    .groupKey(groupKey)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Expected to remove entity from tenant with key '%d', but no tenant with this key exists."
+                .formatted(nonExistentTenantKey));
+  }
+
+  @Test
+  void shouldRejectIfGroupDoesNotExist() {
+    // given
+    final long nonExistentGroupKey = 888888L;
+
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(tenantKey)
+                    .groupKey(nonExistentGroupKey)
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            " Expected to remove entity with key '%d' from tenant with key '%d', but the entity does not exist."
+                .formatted(nonExistentGroupKey, tenantKey));
+  }
+
+  @Test
+  void shouldRejectIfGroupNotAssignedToTenant() {
+    // when / then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newUnassignGroupFromTenantCommand(tenantKey)
+                    .groupKey(groupKey + 1) // Group key is not assigned
+                    .send()
+                    .join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Expected to remove entity with key '%d' from tenant with key '%d', but the entity does not exist."
+                .formatted(groupKey + 1, tenantKey));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UnassignGroupFromTenantTest.java
@@ -49,13 +49,13 @@ class UnassignGroupFromTenantTest {
     groupKey = client.newCreateGroupCommand().name("group").send().join().getGroupKey();
 
     // Assign group to tenant to set up test scenario
-    client.newAssignGroupToTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newAssignGroupToTenantCommand(tenantKey, groupKey).send().join();
   }
 
   @Test
   void shouldUnassignGroupFromTenant() {
     // when
-    client.newUnassignGroupFromTenantCommand(tenantKey).groupKey(groupKey).send().join();
+    client.newUnassignGroupFromTenantCommand(tenantKey, groupKey).send().join();
 
     // then
     ZeebeAssertHelper.assertGroupUnassignedFromTenant(
@@ -75,8 +75,7 @@ class UnassignGroupFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(nonExistentTenantKey)
-                    .groupKey(groupKey)
+                    .newUnassignGroupFromTenantCommand(nonExistentTenantKey, groupKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -95,8 +94,7 @@ class UnassignGroupFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(tenantKey)
-                    .groupKey(nonExistentGroupKey)
+                    .newUnassignGroupFromTenantCommand(tenantKey, nonExistentGroupKey)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)
@@ -112,8 +110,8 @@ class UnassignGroupFromTenantTest {
     assertThatThrownBy(
             () ->
                 client
-                    .newUnassignGroupFromTenantCommand(tenantKey)
-                    .groupKey(groupKey + 1) // Group key is not assigned
+                    // Group key is not assigned
+                    .newUnassignGroupFromTenantCommand(tenantKey, groupKey + 1)
                     .send()
                     .join())
         .isInstanceOf(ProblemException.class)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -530,4 +530,17 @@ public final class ZeebeAssertHelper {
 
     assertThat(mapping).isNotNull();
   }
+
+  public static void assertGroupCreated(
+      final String groupName, final Consumer<GroupRecordValue> consumer) {
+    final GroupRecordValue groupRecordValue =
+        RecordingExporter.groupRecords()
+            .withIntent(GroupIntent.CREATED)
+            .withName(groupName)
+            .getFirst()
+            .getValue();
+
+    assertThat(groupRecordValue).isNotNull();
+    consumer.accept(groupRecordValue);
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -543,4 +543,17 @@ public final class ZeebeAssertHelper {
     assertThat(groupRecordValue).isNotNull();
     consumer.accept(groupRecordValue);
   }
+
+  public static void assertGroupUnassignedFromTenant(
+      final long tenantKey, final Consumer<TenantRecordValue> consumer) {
+    final var tenantRecordValue =
+        RecordingExporter.tenantRecords()
+            .withIntent(TenantIntent.ENTITY_REMOVED)
+            .withTenantKey(tenantKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(tenantRecordValue).isNotNull();
+    consumer.accept(tenantRecordValue);
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -531,19 +531,6 @@ public final class ZeebeAssertHelper {
     assertThat(mapping).isNotNull();
   }
 
-  public static void assertGroupCreated(
-      final String groupName, final Consumer<GroupRecordValue> consumer) {
-    final GroupRecordValue groupRecordValue =
-        RecordingExporter.groupRecords()
-            .withIntent(GroupIntent.CREATED)
-            .withName(groupName)
-            .getFirst()
-            .getValue();
-
-    assertThat(groupRecordValue).isNotNull();
-    consumer.accept(groupRecordValue);
-  }
-
   public static void assertGroupUnassignedFromTenant(
       final long tenantKey, final Consumer<TenantRecordValue> consumer) {
     final var tenantRecordValue =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- added AssignGroupToTenantCommand to zeebe client
- added UnassignGroupFromTenantCommand to zeebe client
- fixed tenant applier and processor for support GROUP entity
- added tenantKeys list to groupPersisted
- added tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25784
