### PR TITLE
refactor: adjust group entity group key property

### DIFF
--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/GroupEntity.java
@@ -11,18 +11,18 @@ import io.camunda.webapps.schema.entities.AbstractExporterEntity;
 
 public class GroupEntity extends AbstractExporterEntity<GroupEntity> {
 
-  private Long groupKey;
+  private Long key;
   private String name;
   private Long memberKey;
 
   private EntityJoinRelation join;
 
-  public Long getGroupKey() {
-    return groupKey;
+  public Long getKey() {
+    return key;
   }
 
-  public GroupEntity setGroupKey(final Long groupKey) {
-    this.groupKey = groupKey;
+  public GroupEntity setKey(final Long key) {
+    this.key = key;
     return this;
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupCreatedUpdatedHandler.java
@@ -59,7 +59,7 @@ public class GroupCreatedUpdatedHandler implements ExportHandler<GroupEntity, Gr
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
-    entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
+    entity.setKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupDeletedHandler.java
@@ -55,7 +55,7 @@ public class GroupDeletedHandler implements ExportHandler<GroupEntity, GroupReco
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createParent();
-    entity.setGroupKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
+    entity.setKey(value.getGroupKey()).setName(value.getName()).setJoin(joinRelation);
   }
 
   @Override

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/GroupEntityAddedHandler.java
@@ -56,7 +56,11 @@ public class GroupEntityAddedHandler implements ExportHandler<GroupEntity, Group
   public void updateEntity(final Record<GroupRecordValue> record, final GroupEntity entity) {
     final GroupRecordValue value = record.getValue();
     final var joinRelation = GroupIndex.JOIN_RELATION_FACTORY.createChild(value.getGroupKey());
-    entity.setMemberKey(value.getEntityKey()).setJoin(joinRelation);
+    entity
+        .setKey(value.getGroupKey())
+        .setName(value.getName())
+        .setMemberKey(value.getEntityKey())
+        .setJoin(joinRelation);
   }
 
   @Override


### PR DESCRIPTION
Rename the `GroupEntity#groupKey` property to `key`
so that it is aligned with the `GroupIndex` and
the other Identity-related entities.

The PR also sets the group key and name when adding
child entities (i.e. members) to the group index. This is
helpful when querying for these entities.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25893
