### PR TITLE
Disable Operate schema managers for production

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -63,7 +63,7 @@ import org.springframework.util.StreamUtils;
 
 @Conditional(ElasticsearchCondition.class)
 @Component("schemaManager")
-@Profile("!test")
+@Profile("test")
 public class ElasticsearchSchemaManager implements SchemaManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchSchemaManager.class);

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -57,7 +57,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 
 @Component("schemaManager")
-@Profile("!test")
+@Profile("test")
 @Conditional(OpensearchCondition.class)
 public class OpensearchSchemaManager implements SchemaManager {
   public static final String SETTINGS = "settings";


### PR DESCRIPTION

## Description

SchemaManagers are only enabled for tests, disabled for prod.

This should avoid conflicts with Exporter schema managers

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #22897 
