### PR TITLE
Wrap the GroupRecord instead of making a full copy before insertion

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/DbGroupState.java
@@ -69,7 +69,7 @@ public class DbGroupState implements MutableGroupState {
   public void create(final long groupKey, final GroupRecord group) {
     this.groupKey.wrapLong(groupKey);
     groupName.wrapString(group.getName());
-    persistedGroup.copyFrom(group);
+    persistedGroup.wrap(group);
 
     groupColumnFamily.insert(this.groupKey, persistedGroup);
     groupByNameColumnFamily.insert(groupName, fkGroupKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/group/PersistedGroup.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.StringValue;
+import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,6 +29,12 @@ public class PersistedGroup extends UnpackedObject implements DbValue {
   public PersistedGroup() {
     super(3);
     declareProperty(groupKeyProp).declareProperty(nameProp).declareProperty(tenantIdsProp);
+  }
+
+  public void wrap(final GroupRecord group) {
+    groupKeyProp.setValue(group.getGroupKey());
+    nameProp.setValue(group.getNameBuffer());
+    tenantIdsProp.reset();
   }
 
   public long getGroupKey() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/group/GroupRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.group;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -14,6 +15,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import org.agrona.DirectBuffer;
 
 public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue {
 
@@ -69,5 +71,10 @@ public class GroupRecord extends UnifiedRecordValue implements GroupRecordValue 
   public GroupRecord setEntityType(final EntityType entityType) {
     entityTypeProp.setValue(entityType);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getNameBuffer() {
+    return nameProp.getValue();
   }
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Wrapping is more performant than copying. In this place we don't need a full copy as we immediately insert it in our ColumnFamily.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/pull/25635#pullrequestreview-2481712329
