### PR TITLE
[Backport stable/8.6] fix: Redirect the /instances/* routes to /operate/instances/*

### DIFF
--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -40,7 +40,7 @@ public class OperateIndexController {
    * Redirects the old frontend routes to the /operate sub-path. This can be removed after the
    * creation of the auto-discovery service.
    */
-  @GetMapping({"/processes/*", "/decisions", "/decisions/*"})
+  @GetMapping({"/processes/*", "/decisions", "/decisions/*", "/instances", "/instances/*"})
   public String redirectOldRoutes(final HttpServletRequest request) {
     return "redirect:/operate" + getRequestedUrl(request);
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -42,7 +42,14 @@ public class OldRoutesRedirectionControllerIT {
 
   static Stream<String> redirectionTestDataProvider() {
     return Stream.of(
-        "", "/processes", "/processes/order", "/login", "/decisions", "/decisions/order");
+        "",
+        "/processes",
+        "/processes/order",
+        "/login",
+        "/decisions",
+        "/decisions/order",
+        "/instances",
+        "/instances/12345");
   }
 
   @ParameterizedTest


### PR DESCRIPTION
# Description
Backport of #25712 to `stable/8.6`.

relates to #25711
original author: @houssain-barouni