### PR TITLE
fix: fix error when taking backup with ES

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchBackupRepository.java
@@ -8,7 +8,6 @@
 package io.camunda.application.commons.backup;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.webapps.backup.BackupRepository;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
@@ -28,17 +27,14 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class ElasticsearchBackupRepository {
 
   private final ElasticsearchClient esClient;
-  private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupRepositoryProps;
   private final Executor threadPoolTaskExecutor;
 
   public ElasticsearchBackupRepository(
       @Qualifier("elasticsearchClient") final ElasticsearchClient esClient,
-      final ObjectMapper objectMapper,
       final BackupRepositoryProps backupRepositoryProps,
       @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor) {
     this.esClient = esClient;
-    this.objectMapper = objectMapper;
     this.backupRepositoryProps = backupRepositoryProps;
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
   }
@@ -46,10 +42,6 @@ public class ElasticsearchBackupRepository {
   @Bean
   public BackupRepository backupRepository() {
     return new io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository(
-        esClient,
-        objectMapper,
-        backupRepositoryProps,
-        new WebappsSnapshotNameProvider(),
-        threadPoolTaskExecutor);
+        esClient, backupRepositoryProps, new WebappsSnapshotNameProvider(), threadPoolTaskExecutor);
   }
 }

--- a/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/ElasticsearchTasklistBackupRepository.java
@@ -37,7 +37,6 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class ElasticsearchTasklistBackupRepository {
 
   private final ElasticsearchClient esClient;
-  private final ObjectMapper objectMapper;
   private final BackupRepositoryProps backupRepositoryProps;
   private final Executor threadPoolTaskExecutor;
 
@@ -47,7 +46,6 @@ public class ElasticsearchTasklistBackupRepository {
       final BackupRepositoryProps backupRepositoryProps,
       @Qualifier("backupThreadPoolExecutor") final ThreadPoolTaskExecutor threadPoolTaskExecutor) {
     this.esClient = esClient;
-    this.objectMapper = objectMapper;
     this.backupRepositoryProps = backupRepositoryProps;
     this.threadPoolTaskExecutor = threadPoolTaskExecutor;
   }
@@ -55,10 +53,6 @@ public class ElasticsearchTasklistBackupRepository {
   @Bean
   public BackupRepository backupRepository() {
     return new ElasticsearchBackupRepository(
-        esClient,
-        objectMapper,
-        backupRepositoryProps,
-        new WebappsSnapshotNameProvider(),
-        threadPoolTaskExecutor);
+        esClient, backupRepositoryProps, new WebappsSnapshotNameProvider(), threadPoolTaskExecutor);
   }
 }

--- a/webapps-backup/pom.xml
+++ b/webapps-backup/pom.xml
@@ -39,14 +39,7 @@
       <artifactId>elasticsearch-java</artifactId>
     </dependency>
     <!--    Jackson -->
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
+
     <!--    OpenSearch -->
     <dependency>
       <groupId>org.opensearch.client</groupId>

--- a/webapps-backup/src/test/resources/log4j2-test.xml
+++ b/webapps-backup/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout
+        pattern="%d{HH:mm:ss.SSS} [%X{actor-scheduler}] [%X{actor-name}] [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda" level="debug"/>
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Description
`ElasticsearchRepository.executeSnapshotting` method was not working after migrating to the new ElasticsearchClient.

``` 
Exception in thread "webapps_backup_1" java.lang.IllegalArgumentException: Cannot construct instance of `co.elastic.clients.json.JsonData` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.LinkedHashMap["backupId"])
	at com.fasterxml.jackson.databind.ObjectMapper._convert(ObjectMapper.java:4636)
	at com.fasterxml.jackson.databind.ObjectMapper.convertValue(ObjectMapper.java:4577)
	at io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository.lambda$executeSnapshotting$7(ElasticsearchBackupRepository.java:265)
	at co.elastic.clients.elasticsearch.snapshot.CreateSnapshotRequest.of(CreateSnapshotRequest.java:114)
	at io.camunda.webapps.backup.repository.elasticsearch.ElasticsearchBackupRepository.executeSnapshotting(ElasticsearchBackupRepository.java:251)
	at io.camunda.webapps.backup.BackupServiceImpl.lambda$scheduleNextSnapshot$0(BackupServiceImpl.java:141)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `co.elastic.clients.json.JsonData` (no Creators, like default constructor, exist): abstract types either need to be mapped to concrete types, have custom deserializer, or contain additional type information
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: java.util.LinkedHashMap["backupId"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1888)
	at com.fasterxml.jackson.databind.DatabindContext.reportBadDefinition(DatabindContext.java:414)
	at com.fasterxml.jackson.databind.DeserializationContext.handleMissingInstantiator(DeserializationContext.java:1375)
	at com.fasterxml.jackson.databind.deser.AbstractDeserializer.deserialize(AbstractDeserializer.java:274)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer._readAndBindStringKeyMap(MapDeserializer.java:623)
	at com.fasterxml.jackson.databind.deser.std.MapDeserializer.deserialize(MapDeserializer.java:449… [message truncated due to size] 
```
  
Unfortunately there was no test covering executing a snapshot in  `ElasticsearchRepositoryTest` which would have surfaced the issue.
As a result, jackson is removed entirely from the package

Test coverage will be improved in followup PRs


# Related issues
closes #25938

