### PR TITLE
feat: verify permissions of mappings

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -115,11 +115,7 @@ public final class EngineProcessors {
     final var decisionBehavior =
         new DecisionBehavior(
             DecisionEngineFactory.createDecisionEngine(), processingState, processEngineMetrics);
-    final var authCheckBehavior =
-        new AuthorizationCheckBehavior(
-            processingState.getAuthorizationState(),
-            processingState.getUserState(),
-            securityConfig);
+    final var authCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
     final var transientProcessMessageSubscriptionState =
         typedRecordProcessorContext.getTransientProcessMessageSubscriptionState();
     final BpmnBehaviorsImpl bpmnBehaviors =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -145,33 +145,6 @@ public final class AuthorizationCheckBehavior {
     return authorizationState.getResourceIdentifiers(ownerKey, resourceType, permissionType);
   }
 
-  /**
-   * Get all authorized resource identifiers for a given owner, resource type and permission type.
-   * This includes direct authorizations and inherited authorizations, for example authorizations
-   * for users from assigned roles or groups.
-   */
-  public Set<String> getAllAuthorizedResourceIdentifiers(
-      final long ownerKey,
-      final AuthorizationOwnerType ownerType,
-      final AuthorizationResourceType resourceType,
-      final PermissionType permissionType) {
-    return switch (ownerType) {
-      case USER -> {
-        final var userOptional = userState.getUser(ownerKey);
-        if (userOptional.isEmpty()) {
-          yield new HashSet<>();
-        }
-        yield getUserAuthorizedResourceIdentifiers(userOptional.get(), resourceType, permissionType)
-            .collect(Collectors.toSet());
-      }
-      case ROLE, GROUP ->
-          // Roles and groups can only have direct authorizations
-          getDirectAuthorizedResourceIdentifiers(ownerKey, resourceType, permissionType);
-      // TODO add MAPPING
-      default -> new HashSet<>();
-    };
-  }
-
   private Stream<String> getUserAuthorizedResourceIdentifiers(
       final PersistedUser user,
       final AuthorizationResourceType resourceType,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/AuthorizationCheckBehavior.java
@@ -137,16 +137,17 @@ public final class AuthorizationCheckBehavior {
 
     return getUserKey(request)
         .map(
-            userKey -> {
-              final var userOptional = userState.getUser(userKey);
-              return userOptional
-                  .map(
-                      user ->
-                          getUserAuthorizedResourceIdentifiers(
-                              user, request.getResourceType(), request.getPermissionType()))
-                  .orElseGet(Stream::empty);
-            })
-        .orElseGet(Stream::empty)
+            userKey ->
+                userState
+                    .getUser(userKey)
+                    .map(
+                        persistedUser ->
+                            getUserAuthorizedResourceIdentifiers(
+                                persistedUser,
+                                request.getResourceType(),
+                                request.getPermissionType()))
+                    .orElseGet(Stream::empty))
+        .orElseGet(() -> getMappingsAuthorizedResourceIdentifiers(request))
         .collect(Collectors.toSet());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/MappingProcessors.java
@@ -36,7 +36,7 @@ public class MappingProcessors {
         ValueType.MAPPING,
         MappingIntent.DELETE,
         new MappingDeleteProcessor(
-            processingState.getMappingState(),
+            processingState,
             authCheckBehavior,
             keyGenerator,
             writers,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/tenant/TenantAddEntityProcessor.java
@@ -123,7 +123,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
       final String tenantId) {
     return switch (entityType) {
       case USER -> checkUserAssignment(entityKey, command, tenantId, tenantKey);
-      case MAPPING -> checkMappingAssignment(entityKey, command, tenantKey);
+      case MAPPING -> checkMappingAssignment(entityKey, command, tenantId, tenantKey);
       default ->
           throw new IllegalStateException(
               formatErrorMessage(entityKey, tenantKey, "doesn't exist"));
@@ -154,7 +154,10 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
   }
 
   private boolean checkMappingAssignment(
-      final long entityKey, final TypedRecord<TenantRecord> command, final long tenantKey) {
+      final long entityKey,
+      final TypedRecord<TenantRecord> command,
+      final String tenantId,
+      final long tenantKey) {
     final var mapping = mappingState.get(entityKey);
     if (mapping.isEmpty()) {
       rejectCommand(
@@ -163,7 +166,7 @@ public class TenantAddEntityProcessor implements DistributedTypedRecordProcessor
           formatErrorMessage(entityKey, tenantKey, "doesn't exist"));
       return false;
     }
-    if (mapping.get().getTenantKeysList().contains(tenantKey)) {
+    if (mapping.get().getTenantIdsList().contains(tenantId)) {
       rejectCommand(
           command,
           RejectionType.INVALID_ARGUMENT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityAddedApplier.java
@@ -32,7 +32,7 @@ public class TenantEntityAddedApplier implements TypedEventApplier<TenantIntent,
     tenantState.addEntity(tenant);
     switch (tenant.getEntityType()) {
       case USER -> userState.addTenantId(tenant.getEntityKey(), tenant.getTenantId());
-      case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantKey());
+      case MAPPING -> mappingState.addTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->
           throw new IllegalStateException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TenantEntityRemovedApplier.java
@@ -32,7 +32,7 @@ public class TenantEntityRemovedApplier implements TypedEventApplier<TenantInten
     tenantState.removeEntity(tenant.getTenantKey(), tenant.getEntityKey());
     switch (tenant.getEntityType()) {
       case USER -> userState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
-      case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantKey());
+      case MAPPING -> mappingState.removeTenant(tenant.getEntityKey(), tenant.getTenantId());
       default ->
           throw new UnsupportedOperationException(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/DbMappingState.java
@@ -80,6 +80,18 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public void addTenant(final long mappingKey, final String tenantId) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
+      persistedMapping.addTenantId(tenantId);
+      mappingColumnFamily.update(claim, persistedMapping);
+    }
+  }
+
+  @Override
   public void addGroup(final long mappingKey, final long groupKey) {
     this.mappingKey.wrapLong(mappingKey);
     final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
@@ -87,18 +99,6 @@ public class DbMappingState implements MutableMappingState {
       final var claim = fkClaim.inner();
       final var persistedMapping = mappingColumnFamily.get(claim);
       persistedMapping.addGroupKey(groupKey);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
-  public void addTenant(final long mappingKey, final long tenantKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      persistedMapping.addTenantKey(tenantKey);
       mappingColumnFamily.update(claim, persistedMapping);
     }
   }
@@ -118,6 +118,20 @@ public class DbMappingState implements MutableMappingState {
   }
 
   @Override
+  public void removeTenant(final long mappingKey, final String tenantId) {
+    this.mappingKey.wrapLong(mappingKey);
+    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
+    if (fkClaim != null) {
+      final var claim = fkClaim.inner();
+      final var persistedMapping = mappingColumnFamily.get(claim);
+      final var tenantIds = persistedMapping.getTenantIdsList();
+      tenantIds.remove(tenantId);
+      persistedMapping.setTenantIdsList(tenantIds);
+      mappingColumnFamily.update(claim, persistedMapping);
+    }
+  }
+
+  @Override
   public void removeGroup(final long mappingKey, final long groupKey) {
     this.mappingKey.wrapLong(mappingKey);
     final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
@@ -127,20 +141,6 @@ public class DbMappingState implements MutableMappingState {
       final List<Long> groupKeys = persistedMapping.getGroupKeysList();
       groupKeys.remove(groupKey);
       persistedMapping.setGroupKeysList(groupKeys);
-      mappingColumnFamily.update(claim, persistedMapping);
-    }
-  }
-
-  @Override
-  public void removeTenant(final long mappingKey, final long tenantKey) {
-    this.mappingKey.wrapLong(mappingKey);
-    final var fkClaim = claimByKeyColumnFamily.get(this.mappingKey);
-    if (fkClaim != null) {
-      final var claim = fkClaim.inner();
-      final var persistedMapping = mappingColumnFamily.get(claim);
-      final List<Long> tenantKeys = persistedMapping.getTenantKeysList();
-      tenantKeys.remove(tenantKey);
-      persistedMapping.setTenantKeysList(tenantKeys);
       mappingColumnFamily.update(claim, persistedMapping);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/authorization/PersistedMapping.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,8 +26,8 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
   private final StringProperty claimValueProp = new StringProperty("claimValue", "");
   private final ArrayProperty<LongValue> roleKeysProp =
       new ArrayProperty<>("roleKeys", LongValue::new);
-  private final ArrayProperty<LongValue> tenantKeysProp =
-      new ArrayProperty<>("tenantKeys", LongValue::new);
+  private final ArrayProperty<StringValue> tenantIdsProp =
+      new ArrayProperty<>("tenantIds", StringValue::new);
   private final ArrayProperty<LongValue> groupKeysProp =
       new ArrayProperty<>("groupKeys", LongValue::new);
 
@@ -36,7 +37,7 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
         .declareProperty(claimNameProp)
         .declareProperty(claimValueProp)
         .declareProperty(roleKeysProp)
-        .declareProperty(tenantKeysProp)
+        .declareProperty(tenantIdsProp)
         .declareProperty(groupKeysProp);
   }
 
@@ -84,20 +85,21 @@ public class PersistedMapping extends UnpackedObject implements DbValue {
     return this;
   }
 
-  public List<Long> getTenantKeysList() {
-    return StreamSupport.stream(tenantKeysProp.spliterator(), false)
-        .map(LongValue::getValue)
+  public List<String> getTenantIdsList() {
+    return StreamSupport.stream(tenantIdsProp.spliterator(), false)
+        .map(StringValue::getValue)
+        .map(BufferUtil::bufferAsString)
         .collect(Collectors.toList());
   }
 
-  public PersistedMapping setTenantKeysList(final List<Long> tenantKeys) {
-    tenantKeysProp.reset();
-    tenantKeys.forEach(tenantKey -> tenantKeysProp.add().setValue(tenantKey));
+  public PersistedMapping setTenantIdsList(final List<String> tenantIds) {
+    tenantIdsProp.reset();
+    tenantIds.forEach(tenantId -> tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId)));
     return this;
   }
 
-  public PersistedMapping addTenantKey(final long tenantKey) {
-    tenantKeysProp.add().setValue(tenantKey);
+  public PersistedMapping addTenantId(final String tenantId) {
+    tenantIdsProp.add().wrap(BufferUtil.wrapString(tenantId));
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMappingState.java
@@ -16,13 +16,13 @@ public interface MutableMappingState extends MappingState {
 
   void addRole(final long mappingKey, final long roleKey);
 
-  void addTenant(final long mappingKey, final long tenantKey);
+  void addTenant(final long mappingKey, final String tenantId);
 
   void addGroup(final long mappingKey, final long groupKey);
 
   void removeRole(final long mappingKey, final long roleKey);
 
-  void removeTenant(final long mappingKey, final long tenantKey);
+  void removeTenant(final long mappingKey, final String tenantId);
 
   void removeGroup(final long mappingKey, final long groupKey);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -688,6 +688,21 @@ public class AuthorizationCheckBehaviorTest {
         .isEqualTo(tenantId);
   }
 
+  @Test
+  public void shouldGetDefaultAuthorizedTenantForMapping() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    // then
+    assertThat(authorizationCheckBehavior.getAuthorizedTenantIds(command))
+        .singleElement()
+        .isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
   private TypedRecord<?> mockCommandWithMapping(final String claimName, final String claimValue) {
     final var command = mock(TypedRecord.class);
     when(command.getAuthorizations())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/AuthorizationCheckBehaviorTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.authorization;
 
 import static io.camunda.zeebe.auth.impl.Authorization.AUTHORIZED_USER_KEY;
+import static io.camunda.zeebe.auth.impl.Authorization.USER_TOKEN_CLAIM_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -22,7 +23,9 @@ import io.camunda.zeebe.protocol.record.value.EntityType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.Before;
@@ -42,11 +45,7 @@ public class AuthorizationCheckBehaviorTest {
     final var authConfig = new AuthorizationsConfiguration();
     authConfig.setEnabled(true);
     securityConfig.setAuthorizations(authConfig);
-    authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(
-            processingState.getAuthorizationState(),
-            processingState.getUserState(),
-            securityConfig);
+    authorizationCheckBehavior = new AuthorizationCheckBehavior(processingState, securityConfig);
   }
 
   @Test
@@ -285,6 +284,304 @@ public class AuthorizationCheckBehaviorTest {
 
     // then
     assertThat(authorizedTenantIds).containsOnly(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+  @Test
+  public void shouldBeAuthorizedWhenMappingHasPermission() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(mapping.getMappingKey(), resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isRight();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsAssignedToRequestedTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var mappingKey = mapping.getMappingKey();
+    final var tenantId = "tenant";
+    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
+    engine
+        .tenant()
+        .addEntity(tenantKey)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityKey(mappingKey)
+        .add();
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(mappingKey, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, tenantId)
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isRight();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsNotAssignedToRequestedTenant() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mapping =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var mappingKey = mapping.getMappingKey();
+    final var tenantId = "tenant";
+    final var tenantKey = engine.tenant().newTenant().withTenantId(tenantId).create().getKey();
+    engine
+        .tenant()
+        .addEntity(tenantKey)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityKey(mappingKey)
+        .add();
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var resourceId = UUID.randomUUID().toString();
+    addPermission(mappingKey, resourceType, permissionType, resourceId);
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType, "anotherTenantId")
+            .addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isLeft();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsAuthorizedThroughGroup() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingKey =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getKey();
+    final var groupKey = engine.group().newGroup(UUID.randomUUID().toString()).create().getKey();
+    engine
+        .group()
+        .addEntity(groupKey)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityKey(mappingKey)
+        .add();
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var resourceId = UUID.randomUUID().toString();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(groupKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, resourceId)
+        .add();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isRight();
+  }
+
+  @Test
+  public void shouldBeAuthorizedWhenMappingIsAuthorizedThroughRole() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    final var mappingKey =
+        engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getKey();
+    final var roleKey = engine.role().newRole("role").create().getKey();
+    engine
+        .role()
+        .addEntity(roleKey)
+        .withEntityType(EntityType.MAPPING)
+        .withEntityKey(mappingKey)
+        .add();
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var resourceId = UUID.randomUUID().toString();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(roleKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, resourceId)
+        .add();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(command, resourceType, permissionType).addResourceId(resourceId);
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isRight();
+  }
+
+  @Test
+  public void shouldNotBeAuthorizedWhenMappingHasNoPermission() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var claimValue = UUID.randomUUID().toString();
+    engine.mapping().newMapping(claimName).withClaimValue(claimValue).create().getValue();
+    final var command = mockCommandWithMapping(claimName, claimValue);
+
+    // when
+    final var request =
+        new AuthorizationRequest(
+            command, AuthorizationResourceType.DEPLOYMENT, PermissionType.DELETE)
+            .addResourceId(UUID.randomUUID().toString());
+    final var authorized = authorizationCheckBehavior.isAuthorized(request);
+
+    // then
+    EitherAssert.assertThat(authorized).isLeft();
+  }
+
+  @Test
+  public void shouldBeAuthorizedThroughMultipleMappings() {
+    // given
+    final var firstClaimName = UUID.randomUUID().toString();
+    final var firstClaimValue = UUID.randomUUID().toString();
+    final var firstMappingKey =
+        engine
+            .mapping()
+            .newMapping(firstClaimName)
+            .withClaimValue(firstClaimValue)
+            .create()
+            .getKey();
+    final var secondClaimName = UUID.randomUUID().toString();
+    final var secondClaimValue = UUID.randomUUID().toString();
+    final var secondMappingKey =
+        engine
+            .mapping()
+            .newMapping(secondClaimName)
+            .withClaimValue(secondClaimValue)
+            .create()
+            .getKey();
+
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var firstResourceId = UUID.randomUUID().toString();
+    final var secondResourceId = UUID.randomUUID().toString();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(firstMappingKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, firstResourceId)
+        .add();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(secondMappingKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, secondResourceId)
+        .add();
+
+    // when
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(
+            Map.of(
+                USER_TOKEN_CLAIM_PREFIX + firstClaimName,
+                firstClaimValue,
+                USER_TOKEN_CLAIM_PREFIX + secondClaimName,
+                secondClaimValue));
+    when(command.hasRequestMetadata()).thenReturn(true);
+
+    // then
+    EitherAssert.assertThat(
+            authorizationCheckBehavior.isAuthorized(
+                new AuthorizationRequest(command, resourceType, permissionType)
+                    .addResourceId(firstResourceId)))
+        .isRight();
+    EitherAssert.assertThat(
+            authorizationCheckBehavior.isAuthorized(
+                new AuthorizationRequest(command, resourceType, permissionType)
+                    .addResourceId(secondResourceId)))
+        .isRight();
+  }
+
+  @Test
+  public void shouldBeAuthorizedThroughMappingWithMultipleClaimValues() {
+    // given
+    final var claimName = UUID.randomUUID().toString();
+    final var firstClaimValue = UUID.randomUUID().toString();
+    final var firstMappingKey =
+        engine.mapping().newMapping(claimName).withClaimValue(firstClaimValue).create().getKey();
+    final var secondClaimValue = UUID.randomUUID().toString();
+    final var secondMappingKey =
+        engine.mapping().newMapping(claimName).withClaimValue(secondClaimValue).create().getKey();
+
+    final var resourceType = AuthorizationResourceType.DEPLOYMENT;
+    final var permissionType = PermissionType.DELETE;
+    final var firstResourceId = UUID.randomUUID().toString();
+    final var secondResourceId = UUID.randomUUID().toString();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(firstMappingKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, firstResourceId)
+        .add();
+    engine
+        .authorization()
+        .permission()
+        .withOwnerKey(secondMappingKey)
+        .withResourceType(resourceType)
+        .withPermission(permissionType, secondResourceId)
+        .add();
+
+    // when
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(
+            Map.of(
+                USER_TOKEN_CLAIM_PREFIX + claimName, List.of(firstClaimValue, secondClaimValue)));
+    when(command.hasRequestMetadata()).thenReturn(true);
+
+    // then
+    EitherAssert.assertThat(
+            authorizationCheckBehavior.isAuthorized(
+                new AuthorizationRequest(command, resourceType, permissionType)
+                    .addResourceId(firstResourceId)))
+        .isRight();
+    EitherAssert.assertThat(
+            authorizationCheckBehavior.isAuthorized(
+                new AuthorizationRequest(command, resourceType, permissionType)
+                    .addResourceId(secondResourceId)))
+        .isRight();
+  }
+
+  private TypedRecord<?> mockCommandWithMapping(final String claimName, final String claimValue) {
+    final var command = mock(TypedRecord.class);
+    when(command.getAuthorizations())
+        .thenReturn(Map.of(USER_TOKEN_CLAIM_PREFIX + claimName, claimValue));
+    when(command.hasRequestMetadata()).thenReturn(true);
+    return command;
   }
 
   private long createUser() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobBatchCollectorTest.java
@@ -60,8 +60,7 @@ final class JobBatchCollectorTest {
   @BeforeEach
   void beforeEach() {
     final var authorizationCheckBehavior =
-        new AuthorizationCheckBehavior(
-            state.getAuthorizationState(), state.getUserState(), new SecurityConfiguration());
+        new AuthorizationCheckBehavior(state, new SecurityConfiguration());
     collector = new JobBatchCollector(state, lengthEvaluator, authorizationCheckBehavior);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/MappingAppliersTest.java
@@ -76,9 +76,11 @@ public class MappingAppliersTest {
     roleState.addEntity(role);
     // create tenant
     final long tenantKey = 3L;
-    mappingState.addTenant(mappingKey, tenantKey);
+    final var tenantId = "tenant";
+    mappingState.addTenant(mappingKey, tenantId);
     final var tenant =
         new TenantRecord()
+            .setTenantId(tenantId)
             .setTenantKey(tenantKey)
             .setEntityKey(mappingKey)
             .setEntityType(EntityType.MAPPING);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/TenantAppliersTest.java
@@ -94,7 +94,7 @@ public class TenantAppliersTest {
     // then
     assertThat(tenantState.getEntityType(tenantKey, entityKey).get().equals(EntityType.MAPPING));
     final var persistedMapping = mappingState.get(entityKey).get();
-    assertThat(persistedMapping.getTenantKeysList()).containsExactly(tenantKey);
+    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
   }
 
   @Test
@@ -206,7 +206,7 @@ public class TenantAppliersTest {
     // Ensure the mapping is associated with the tenant before removal
     assertThat(tenantState.getEntityType(tenantKey, entityKey).get().equals(EntityType.MAPPING));
     final var persistedMapping = mappingState.get(entityKey).get();
-    assertThat(persistedMapping.getTenantKeysList()).containsExactly(tenantKey);
+    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
 
     // when
     tenantEntityRemovedApplier.applyState(tenantKey, tenantRecord);
@@ -214,7 +214,7 @@ public class TenantAppliersTest {
     // then
     assertThat(tenantState.getEntityType(tenantKey, entityKey)).isEmpty();
     final var updatedMapping = mappingState.get(entityKey).get();
-    assertThat(updatedMapping.getTenantKeysList()).isEmpty();
+    assertThat(updatedMapping.getTenantIdsList()).isEmpty();
   }
 
   private TenantRecord createTenant(final long tenantKey, final String tenantId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/authorization/MappingStateTest.java
@@ -131,14 +131,14 @@ public class MappingStateTest {
     final var mapping =
         new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
     mappingState.create(mapping);
-    final long tenantKey = 1L;
+    final var tenantId = "tenant";
 
     // when
-    mappingState.addTenant(key, tenantKey);
+    mappingState.addTenant(key, tenantId);
 
     // then
     final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getTenantKeysList()).containsExactly(tenantKey);
+    assertThat(persistedMapping.getTenantIdsList()).containsExactly(tenantId);
   }
 
   @Test
@@ -150,15 +150,15 @@ public class MappingStateTest {
     final var mapping =
         new MappingRecord().setMappingKey(key).setClaimName(claimName).setClaimValue(claimValue);
     mappingState.create(mapping);
-    final long tenantKey = 1L;
-    mappingState.addTenant(key, tenantKey);
+    final var tenantId = "tenant";
+    mappingState.addTenant(key, tenantId);
 
     // when
-    mappingState.removeTenant(key, tenantKey);
+    mappingState.removeTenant(key, tenantId);
 
     // then
     final var persistedMapping = mappingState.get(key).get();
-    assertThat(persistedMapping.getTenantKeysList()).isEmpty();
+    assertThat(persistedMapping.getTenantIdsList()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
The `AuthorizationCheckBehavior` is extended to also check request claims for tenants and authorizations of matching mappings.

I've included a refactoring to store tenant ids instead of keys in the `PersistedMapping`. This is more aligned with how users work and makes it easier to verify a request's tenant id against the claimed mapping.

Closes #24176
