### PR TITLE
ci: fix Unified CI check results depends on Tasklist FE tests

### DIFF
--- a/.github/conftest-gha-best-practices.rego
+++ b/.github/conftest-gha-best-practices.rego
@@ -44,6 +44,39 @@ deny[msg] {
 }
 
 deny[msg] {
+    # only enforced on Unified CI since it is specific to detect-changes job
+    input.name == "CI"
+
+    count(get_jobs_not_needing_detectchanges(input.jobs)) > 0
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that don't depend on detect-changes job! Affected job IDs: %s",
+        [concat(", ", get_jobs_not_needing_detectchanges(input.jobs))])
+}
+
+deny[msg] {
+    # only enforced on Unified CI since it is specific to check-results job
+    input.name == "CI"
+
+    jobs_that_should_fail_checkresults := { job_id |
+        job := input.jobs[job_id]
+
+        # no Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # no Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+    }
+
+    jobs_that_actually_fail_checkresults := {x | x := input.jobs["check-results"].needs[_]}
+
+    jobs_that_should_fail_checkresults != jobs_that_actually_fail_checkresults
+
+    msg := sprintf("There are GitHub Actions jobs in Unified CI that check-results job doesn't depend on! Affected job IDs: %s",
+        [concat(", ", jobs_that_should_fail_checkresults - jobs_that_actually_fail_checkresults)])
+}
+
+deny[msg] {
     # The "on" key gets transformed by conftest into "true" due to some legacy
     # YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
     # "on.push" becomes "true.push" which is why below statements use "true"
@@ -184,5 +217,25 @@ get_jobs_with_usesbutnosecrets(jobInput) = jobs_with_usesbutnosecrets {
         # check jobs that invoke other reusable workflows but don't specify "secrets: inherit"
         job.uses
         not job.secrets
+    }
+}
+
+get_jobs_not_needing_detectchanges(jobInput) = jobs_not_needing_detectchanges {
+    jobs_not_needing_detectchanges := { job_id |
+        job := jobInput[job_id]
+
+        # not enforced on Unified CI jobs that are part of change detection control flow structure
+        job_id != "detect-changes"
+        job_id != "check-results"
+
+        # not enforced on Unified CI jobs running after "check-results" job
+        not startswith(job_id, "deploy-")
+
+        # check if job declares dependency on "detect-changes" job anywhere
+        job_needs_detectchanges := { need |
+            need := job.needs[_]
+            need == "detect-changes"
+        }
+        count(job_needs_detectchanges) == 0
     }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -717,6 +717,7 @@ jobs:
       - optimize-backend-unit-tests
       - optimize-frontend-unit-tests
       - protobuf-checks
+      - tasklist-frontend-tests
       - zeebe-ci
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Fixup for https://github.com/camunda/camunda/pull/25816#issuecomment-2535908372 and https://github.com/camunda/camunda/pull/25717

I forgot to include the new `tasklist-frontend-tests` in the `check-results` job, so even if any `tasklist-frontend-tests` fails the overall `check-results` job will succeed which is obviously undesired. This PR fixes that and also includes new linting rules to detect such situations in the future, avoiding human errors.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21437 
