### PR TITLE
feat: make rdbms exporter configurable via environment #23821

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/RdbmsService.java
@@ -149,6 +149,10 @@ public class RdbmsService {
   }
 
   public RdbmsWriter createWriter(final long partitionId) {
-    return rdbmsWriterFactory.createWriter(partitionId);
+    return rdbmsWriterFactory.createWriter(partitionId, -1);
+  }
+
+  public RdbmsWriter createWriter(final long partitionId, final int queueSize) {
+    return rdbmsWriterFactory.createWriter(partitionId, queueSize);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/RdbmsWriterFactory.java
@@ -8,7 +8,7 @@
 package io.camunda.db.rdbms.write;
 
 import io.camunda.db.rdbms.sql.ExporterPositionMapper;
-import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.service.ExporterPositionService;
 import org.apache.ibatis.session.SqlSessionFactory;
 
@@ -24,8 +24,8 @@ public class RdbmsWriterFactory {
     this.exporterPositionMapper = exporterPositionMapper;
   }
 
-  public RdbmsWriter createWriter(final long partitionId) {
-    final var executionQueue = new ExecutionQueue(sqlSessionFactory, partitionId, 100);
+  public RdbmsWriter createWriter(final long partitionId, final int queueSize) {
+    final var executionQueue = new DefaultExecutionQueue(sqlSessionFactory, partitionId, queueSize);
     return new RdbmsWriter(
         executionQueue, new ExporterPositionService(executionQueue, exporterPositionMapper));
   }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueue.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.db.rdbms.write.queue;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.ibatis.session.ExecutorType;
+import org.apache.ibatis.session.SqlSessionFactory;
+import org.apache.ibatis.session.TransactionIsolationLevel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DefaultExecutionQueue implements ExecutionQueue {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultExecutionQueue.class);
+
+  private final SqlSessionFactory sessionFactory;
+  private final List<PreFlushListener> preFlushListeners = new ArrayList<>();
+  private final List<PostFlushListener> postFlushListeners = new ArrayList<>();
+
+  private final LinkedList<QueueItem> queue = new LinkedList<>();
+
+  private final long partitionId; // for addressing the logger
+  private final int queueFlushLimit;
+
+  public DefaultExecutionQueue(
+      final SqlSessionFactory sessionFactory, final long partitionId, final int queueFlushLimit) {
+    this.sessionFactory = sessionFactory;
+    this.partitionId = partitionId;
+    this.queueFlushLimit = queueFlushLimit;
+  }
+
+  @Override
+  public void executeInQueue(final QueueItem entry) {
+    LOG.debug("[RDBMS ExecutionQueue, Partition {}] Added entry to queue: {}", partitionId, entry);
+    synchronized (queue) {
+      queue.add(entry);
+      checkQueueForFlush();
+    }
+  }
+
+  @Override
+  public void registerPreFlushListener(final PreFlushListener listener) {
+    preFlushListeners.add(listener);
+  }
+
+  @Override
+  public void registerPostFlushListener(final PostFlushListener listener) {
+    postFlushListeners.add(listener);
+  }
+
+  /**
+   * Performs flush on the queue.
+   *
+   * @return number of flushed items
+   */
+  @Override
+  public int flush() {
+    synchronized (queue) {
+      if (queue.isEmpty()) {
+        LOG.trace(
+            "[RDBMS ExecutionQueue, Partition {}] Skip Flushing because execution queue is empty",
+            partitionId);
+        return 0;
+      }
+      LOG.debug(
+          "[RDBMS ExecutionQueue, Partition {}] Flushing execution queue with {} items",
+          partitionId,
+          queue.size());
+
+      final var startMillis = System.currentTimeMillis();
+      final var session =
+          sessionFactory.openSession(
+              ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
+
+      var flushedElements = 0;
+      try {
+        while (!queue.isEmpty()) {
+          final var entry = queue.peek();
+          LOG.trace("[RDBMS ExecutionQueue, Partition {}] Executing entry: {}", partitionId, entry);
+          session.update(entry.statementId(), entry.parameter());
+          queue.remove();
+          flushedElements++;
+        }
+
+        if (!preFlushListeners.isEmpty()) {
+          LOG.debug("[RDBMS ExecutionQueue, Partition {}] Call pre flush listeners", partitionId);
+          preFlushListeners.forEach(PreFlushListener::onPreFlush);
+        }
+
+        session.flushStatements();
+        session.commit();
+        if (!postFlushListeners.isEmpty()) {
+          LOG.debug("[RDBMS ExecutionQueue, Partition {}] Call post flush listeners", partitionId);
+          postFlushListeners.forEach(PostFlushListener::onPostFlush);
+        }
+        LOG.debug(
+            "[RDBMS ExecutionQueue, Partition {}] Commit queue with {} entries in {}ms",
+            partitionId,
+            flushedElements,
+            System.currentTimeMillis() - startMillis);
+
+        return flushedElements;
+      } catch (final Exception e) {
+        LOG.error(
+            "[RDBMS ExecutionQueue, Partition {}] Error while executing queue", partitionId, e);
+        session.rollback();
+
+        throw e;
+      } finally {
+        session.close();
+      }
+    }
+  }
+
+  /**
+   * Iterate from end over the queue and try to find a last added compatible queueItem. The
+   * queueItem will be replaced with a new, combined queueItem.
+   */
+  @Override
+  public boolean tryMergeWithExistingQueueItem(final QueueItemMerger... combiners) {
+    synchronized (queue) {
+      int index = queue.size() - 1;
+      for (final Iterator<QueueItem> it = queue.descendingIterator(); it.hasNext(); ) {
+        final QueueItem item = it.next();
+
+        for (final QueueItemMerger merger : combiners) {
+          if (merger.canBeMerged(item)) {
+            LOG.debug("Merging new item with item {}, {}", item.contextType(), item.id());
+            queue.set(index, merger.merge(item));
+            return true;
+          }
+        }
+
+        index--;
+      }
+
+      return false;
+    }
+  }
+
+  LinkedList<QueueItem> getQueue() {
+    return queue;
+  }
+
+  private void checkQueueForFlush() {
+    if (queueFlushLimit <= 0) {
+      // no limits, exporter must take care of it
+      return;
+    }
+
+    LOG.trace(
+        "[RDBMS ExecutionQueue, Partition {}] Checking if queue is flushed. Queue size: {}",
+        partitionId,
+        queue.size());
+    if (queue.size() >= queueFlushLimit) {
+      flush();
+    }
+  }
+}

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/queue/ExecutionQueue.java
@@ -7,153 +7,15 @@
  */
 package io.camunda.db.rdbms.write.queue;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import org.apache.ibatis.session.ExecutorType;
-import org.apache.ibatis.session.SqlSessionFactory;
-import org.apache.ibatis.session.TransactionIsolationLevel;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+public interface ExecutionQueue {
 
-public class ExecutionQueue {
+  void executeInQueue(QueueItem entry);
 
-  private static final Logger LOG = LoggerFactory.getLogger(ExecutionQueue.class);
+  void registerPreFlushListener(PreFlushListener listener);
 
-  private final SqlSessionFactory sessionFactory;
-  private final List<PreFlushListener> preFlushListeners = new ArrayList<>();
-  private final List<PostFlushListener> postFlushListeners = new ArrayList<>();
+  void registerPostFlushListener(PostFlushListener listener);
 
-  private final LinkedList<QueueItem> queue = new LinkedList<>();
+  int flush();
 
-  private final long partitionId; // for addressing the logger
-  private final Integer queueFlushLimit;
-
-  public ExecutionQueue(
-      final SqlSessionFactory sessionFactory,
-      final long partitionId,
-      final Integer queueFlushLimit) {
-    this.sessionFactory = sessionFactory;
-    this.partitionId = partitionId;
-    this.queueFlushLimit = queueFlushLimit;
-  }
-
-  public void executeInQueue(final QueueItem entry) {
-    LOG.debug("[RDBMS ExecutionQueue, Partition {}] Added entry to queue: {}", partitionId, entry);
-    synchronized (queue) {
-      queue.add(entry);
-      checkQueueForFlush();
-    }
-  }
-
-  public void registerPreFlushListener(final PreFlushListener listener) {
-    preFlushListeners.add(listener);
-  }
-
-  public void registerPostFlushListener(final PostFlushListener listener) {
-    postFlushListeners.add(listener);
-  }
-
-  /**
-   * Performs flush on the queue.
-   *
-   * @return number of flushed items
-   */
-  public int flush() {
-    synchronized (queue) {
-      if (queue.isEmpty()) {
-        LOG.trace(
-            "[RDBMS ExecutionQueue, Partition {}] Skip Flushing because execution queue is empty",
-            partitionId);
-        return 0;
-      }
-      LOG.debug(
-          "[RDBMS ExecutionQueue, Partition {}] Flushing execution queue with {} items",
-          partitionId,
-          queue.size());
-
-      final var startMillis = System.currentTimeMillis();
-      final var session =
-          sessionFactory.openSession(
-              ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED);
-
-      var flushedElements = 0;
-      try {
-        while (!queue.isEmpty()) {
-          final var entry = queue.peek();
-          LOG.trace("[RDBMS ExecutionQueue, Partition {}] Executing entry: {}", partitionId, entry);
-          session.update(entry.statementId(), entry.parameter());
-          queue.remove();
-          flushedElements++;
-        }
-
-        if (!preFlushListeners.isEmpty()) {
-          LOG.debug("[RDBMS ExecutionQueue, Partition {}] Call pre flush listeners", partitionId);
-          preFlushListeners.forEach(PreFlushListener::onPreFlush);
-        }
-
-        session.flushStatements();
-        session.commit();
-        if (!postFlushListeners.isEmpty()) {
-          LOG.debug("[RDBMS ExecutionQueue, Partition {}] Call post flush listeners", partitionId);
-          postFlushListeners.forEach(PostFlushListener::onPostFlush);
-        }
-        LOG.debug(
-            "[RDBMS ExecutionQueue, Partition {}] Commit queue with {} entries in {}ms",
-            partitionId,
-            flushedElements,
-            System.currentTimeMillis() - startMillis);
-
-        return flushedElements;
-      } catch (final Exception e) {
-        LOG.error(
-            "[RDBMS ExecutionQueue, Partition {}] Error while executing queue", partitionId, e);
-        session.rollback();
-
-        throw e;
-      } finally {
-        session.close();
-      }
-    }
-  }
-
-  /**
-   * Iterate from end over the queue and try to find a last added compatible queueItem. The
-   * queueItem will be replaced with a new, combined queueItem.
-   */
-  public boolean tryMergeWithExistingQueueItem(final QueueItemMerger... combiners) {
-    synchronized (queue) {
-      int index = queue.size() - 1;
-      for (final Iterator<QueueItem> it = queue.descendingIterator(); it.hasNext(); ) {
-        final QueueItem item = it.next();
-
-        for (final QueueItemMerger merger : combiners) {
-          if (merger.canBeMerged(item)) {
-            LOG.debug("Merging new item with item {}, {}", item.contextType(), item.id());
-            queue.set(index, merger.merge(item));
-            return true;
-          }
-        }
-
-        index--;
-      }
-
-      return false;
-    }
-  }
-
-  LinkedList<QueueItem> getQueue() {
-    return queue;
-  }
-
-  private void checkQueueForFlush() {
-    LOG.trace(
-        "[RDBMS ExecutionQueue, Partition {}] Checking if queue is flushed. Queue size: {}",
-        partitionId,
-        queue.size());
-    if (queue.size() >= queueFlushLimit) {
-      flush();
-    }
-  }
+  boolean tryMergeWithExistingQueueItem(QueueItemMerger... combiners);
 }

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/queue/DefaultExecutionQueueTest.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-class ExecutionQueueTest {
+class DefaultExecutionQueueTest {
 
   private SqlSession session;
   private SqlSessionFactory sqlSessionFactory;
 
-  private ExecutionQueue executionQueue;
+  private DefaultExecutionQueue executionQueue;
 
   @BeforeEach
   public void beforeEach() {
@@ -38,11 +38,20 @@ class ExecutionQueueTest {
             ExecutorType.BATCH, TransactionIsolationLevel.READ_UNCOMMITTED))
         .thenReturn(session);
 
-    executionQueue = new ExecutionQueue(sqlSessionFactory, 1, 5);
+    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 5);
+  }
+
+  @Test
+  public void whenElementIsAddedNoFlushHappensBelowLimit() {
+    executionQueue.executeInQueue(mock(QueueItem.class));
+
+    Mockito.verifyNoInteractions(sqlSessionFactory);
   }
 
   @Test
   public void whenElementIsAddedNoFlushHappens() {
+    executionQueue = new DefaultExecutionQueue(sqlSessionFactory, 1, 0);
+
     executionQueue.executeInQueue(mock(QueueItem.class));
 
     Mockito.verifyNoInteractions(sqlSessionFactory);

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/write/service/FlowNodeInstanceWriterTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.db.rdbms.sql.FlowNodeInstanceMapper;
 import io.camunda.db.rdbms.write.queue.ContextType;
+import io.camunda.db.rdbms.write.queue.DefaultExecutionQueue;
 import io.camunda.db.rdbms.write.queue.ExecutionQueue;
 import io.camunda.db.rdbms.write.queue.QueueItem;
 import io.camunda.db.rdbms.write.queue.UpsertMerger;
@@ -33,7 +34,7 @@ class FlowNodeInstanceWriterTest {
 
   @BeforeEach
   void setUp() {
-    executionQueue = mock(ExecutionQueue.class);
+    executionQueue = mock(DefaultExecutionQueue.class);
     writer = new FlowNodeInstanceWriter(executionQueue);
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/RdbmsExporterConfiguration.java
@@ -11,8 +11,12 @@ import io.camunda.application.commons.rdbms.RdbmsConfiguration;
 import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.exporter.rdbms.RdbmsExporterFactory;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,8 +35,17 @@ public class RdbmsExporterConfiguration {
 
   @Bean
   public ExporterDescriptor rdbmsExporterDescriptor(
-      final RdbmsExporterFactory rdbmsExporterFactory) {
+      final RdbmsExporterFactory rdbmsExporterFactory, final ExporterCfg rdbmsExporterCfg) {
     LOGGER.info("Provide ExporterDescriptor for RDBMS Exporter");
-    return new ExporterDescriptor(rdbmsExporterFactory.exporterId(), rdbmsExporterFactory);
+    return new ExporterDescriptor(
+        rdbmsExporterFactory.exporterId(),
+        rdbmsExporterFactory,
+        Optional.ofNullable(rdbmsExporterCfg).map(ExporterCfg::getArgs).orElseGet(Map::of));
+  }
+
+  @ConfigurationProperties("zeebe.broker.exporters.rdbms")
+  @Bean
+  public ExporterCfg rdbmsExporterCfg() {
+    return new ExporterCfg();
   }
 }

--- a/dist/src/main/resources/application-rdbmsH2.yaml
+++ b/dist/src/main/resources/application-rdbmsH2.yaml
@@ -84,6 +84,9 @@ zeebe:
     exporters:
       rdbms:
         className: io.camunda.exporter.rdbms.RdbmsExporter
+        args:
+          flushInterval: 500
+          maxQueueSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/dist/src/main/resources/application-rdbmsPostgres.yaml
+++ b/dist/src/main/resources/application-rdbmsPostgres.yaml
@@ -85,6 +85,9 @@ zeebe:
       rdbms:
         # Classname doesn't matter, since this exporter is present via spring bean
         className: RdbmsExporter
+        args:
+          flushInterval: 500
+          maxQueueSize: 1000
       #elasticsearch:
       #  className: io.camunda.zeebe.exporter.ElasticsearchExporter
       #  args:

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/exporter/RdbmsExporterIT.java
@@ -26,7 +26,7 @@ import static io.camunda.it.rdbms.exporter.RecordFixtures.getUserTaskCreatedReco
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.db.rdbms.RdbmsService;
-import io.camunda.exporter.rdbms.RdbmsExporter;
+import io.camunda.exporter.rdbms.RdbmsExporterWrapper;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.IncidentEntity.IncidentState;
@@ -64,7 +64,6 @@ import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;
 import io.camunda.zeebe.protocol.record.value.deployment.Process;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -77,21 +76,26 @@ import org.springframework.test.context.TestPropertySource;
 
 @Tag("rdbms")
 @SpringBootTest(classes = {RdbmsTestConfiguration.class})
-@TestPropertySource(properties = {"spring.liquibase.enabled=false", "camunda.database.type=rdbms"})
+@TestPropertySource(
+    properties = {
+      "spring.liquibase.enabled=false",
+      "camunda.database.type=rdbms",
+      "zeebe.broker.exporters.rdbms.args.maxQueueSize=0"
+    })
 class RdbmsExporterIT {
 
   private final ExporterTestController controller = new ExporterTestController();
 
   @Autowired private RdbmsService rdbmsService;
 
-  private RdbmsExporter exporter;
+  private RdbmsExporterWrapper exporter;
 
   @BeforeEach
   void setUp() {
-    exporter = new RdbmsExporter(rdbmsService);
+    exporter = new RdbmsExporterWrapper(rdbmsService);
     exporter.configure(
         new ExporterContext(
-            null, new ExporterConfiguration("foo", Collections.emptyMap()), 1, null, null));
+            null, new ExporterConfiguration("foo", Map.of("maxQueueSize", 0)), 1, null, null));
     exporter.open(controller);
   }
 
@@ -102,8 +106,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(processInstanceRecord);
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var key =
@@ -116,7 +118,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(processInstanceCompletedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var completedProcessInstance = rdbmsService.getProcessInstanceReader().findOne(key);
@@ -131,8 +132,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(processDefinitionRecord);
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var key = ((Process) processDefinitionRecord.getValue()).getProcessDefinitionKey();
@@ -153,8 +152,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(variableCreatedRecord);
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var variable = rdbmsService.getVariableReader().findOne(variableCreatedRecord.getKey());
@@ -180,8 +177,6 @@ class RdbmsExporterIT {
 
     // when
     recordList.forEach(record -> exporter.export(record));
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var key =
@@ -203,7 +198,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(flowNodeRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var key = flowNodeRecord.getKey();
@@ -215,7 +209,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(flowNodeCompleteRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var completedFlowNode = rdbmsService.getFlowNodeInstanceReader().findOne(key);
@@ -230,7 +223,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(userTaskRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var key = ((UserTaskRecordValue) userTaskRecord.getValue()).getUserTaskKey();
@@ -245,8 +237,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(record);
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var key =
@@ -262,8 +252,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(decisionDefinitionRecord);
-    // and we do a manual flush
-    exporter.flushExecutionQueue();
 
     // then
     final var key = ((DecisionRecordValue) decisionDefinitionRecord.getValue()).getDecisionKey();
@@ -279,7 +267,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(userRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var user = rdbmsService.getUserReader().findOne(userRecord.getKey());
@@ -296,7 +283,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(updateUserRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedUser = rdbmsService.getUserReader().findOne(userRecord.getKey());
@@ -309,7 +295,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getUserRecord(42L, UserIntent.DELETED));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedUser = rdbmsService.getUserReader().findOne(userRecord.getKey());
@@ -324,7 +309,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(tenantRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var tenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
@@ -340,7 +324,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(updateTenantRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedTenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
@@ -358,7 +341,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(tenantRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var tenant = rdbmsService.getTenantReader().findOne(tenantRecord.getKey());
@@ -368,7 +350,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getTenantRecord(43L, TenantIntent.ENTITY_ADDED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedTenant =
@@ -377,7 +358,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getTenantRecord(43L, TenantIntent.ENTITY_REMOVED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedTenant =
@@ -393,7 +373,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(roleRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var role = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
@@ -407,7 +386,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(updateRoleRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
@@ -417,7 +395,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.DELETED));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
@@ -432,7 +409,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(roleRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var role = rdbmsService.getRoleReader().findOne(roleRecord.getKey());
@@ -442,7 +418,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_ADDED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
@@ -450,7 +425,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getRoleRecord(42L, RoleIntent.ENTITY_REMOVED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedRole = rdbmsService.getRoleReader().findOne(roleRecord.getKey()).orElseThrow();
@@ -465,7 +439,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(groupRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var group = rdbmsService.getGroupReader().findOne(groupRecord.getKey());
@@ -479,7 +452,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(updateGroupRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedGroup = rdbmsService.getGroupReader().findOne(groupRecord.getKey());
@@ -489,7 +461,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getGroupRecord(42L, GroupIntent.DELETED));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedGroup = rdbmsService.getGroupReader().findOne(groupRecord.getKey());
@@ -504,7 +475,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(groupRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var group = rdbmsService.getGroupReader().findOne(groupRecord.getKey());
@@ -514,7 +484,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_ADDED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedGroup =
@@ -523,7 +492,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(getGroupRecord(43L, GroupIntent.ENTITY_REMOVED, 1337L));
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedGroup =
@@ -548,7 +516,6 @@ class RdbmsExporterIT {
         getIncidentRecord(
             IncidentIntent.CREATED, incidentKey, processInstanceKey, flowNodeInstanceKey);
     exporter.export(incidentRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var flowNode = rdbmsService.getFlowNodeInstanceReader().findOne(flowNodeInstanceKey);
@@ -570,7 +537,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(incidentResolvedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var flowNode2 = rdbmsService.getFlowNodeInstanceReader().findOne(flowNodeInstanceKey);
@@ -592,7 +558,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(formCreatedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var formKey = ((Form) formCreatedRecord.getValue()).getFormKey();
@@ -607,7 +572,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(mappingCreatedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var key = ((MappingRecordValue) mappingCreatedRecord.getValue()).getMappingKey();
@@ -619,7 +583,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(mappingDeletedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var deletedMapping = rdbmsService.getMappingReader().findOne(key);
@@ -641,7 +604,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(authorizationRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var recordValue = (AuthorizationRecordValue) authorizationRecord.getValue();
@@ -668,7 +630,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(authorizationUpdatedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedRecordValue = (AuthorizationRecordValue) authorizationUpdatedRecord.getValue();
@@ -708,7 +669,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(authorizationRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var recordValue = (AuthorizationRecordValue) authorizationRecord.getValue();
@@ -735,7 +695,6 @@ class RdbmsExporterIT {
 
     // when
     exporter.export(authorizationUpdatedRecord);
-    exporter.flushExecutionQueue();
 
     // then
     final var updatedAuthorization =

--- a/zeebe/exporters/rdbms-exporter/pom.xml
+++ b/zeebe/exporters/rdbms-exporter/pom.xml
@@ -85,5 +85,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporter.java
@@ -7,66 +7,56 @@
  */
 package io.camunda.exporter.rdbms;
 
-import io.camunda.db.rdbms.RdbmsService;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.ExporterPositionModel;
-import io.camunda.zeebe.exporter.api.Exporter;
-import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
-public class RdbmsExporter implements Exporter {
-
-  /** The partition on which all process deployments are published */
-  public static final long PROCESS_DEFINITION_PARTITION = 1L;
+public class RdbmsExporter {
 
   private static final Logger LOG = LoggerFactory.getLogger(RdbmsExporter.class);
 
-  private final HashMap<ValueType, List<RdbmsExportHandler>> registeredHandlers = new HashMap<>();
+  private final Map<ValueType, List<RdbmsExportHandler>> registeredHandlers;
+  private final Controller controller;
 
-  private Controller controller;
-
-  private long partitionId;
-  private final RdbmsService rdbmsService;
-  private RdbmsWriter rdbmsWriter;
+  private final long partitionId;
+  private final RdbmsWriter rdbmsWriter;
 
   private ExporterPositionModel exporterRdbmsPosition;
   private long lastPosition = -1;
 
-  public RdbmsExporter(final RdbmsService rdbmsService) {
-    this.rdbmsService = rdbmsService;
-  }
+  // configuration
+  private final Duration flushInterval;
+  private final int maxQueueSize;
 
-  @Override
-  public void configure(final Context context) {
-    partitionId = context.getPartitionId();
+  public RdbmsExporter(final RdbmsExporterConfig config) {
+    rdbmsWriter = config.rdbmsWriter();
+    controller = config.controller();
+    registeredHandlers = config.handlers();
 
-    rdbmsWriter = rdbmsService.createWriter(partitionId);
-    registerHandler();
+    partitionId = config.partitionId();
+    flushInterval = config.flushInterval();
+    maxQueueSize = config.maxQueueSize();
 
-    LOG.info("[RDBMS Exporter] RDBMS Exporter configured!");
-  }
-
-  @Override
-  public void open(final Controller controller) {
-    this.controller = controller;
-    this.controller.scheduleCancellableTask(Duration.ofSeconds(5), this::flushAndReschedule);
+    if (!flushAfterEachRecord()) {
+      controller.scheduleCancellableTask(flushInterval, this::flushAndReschedule);
+    }
 
     initializeRdbmsPosition();
     lastPosition = controller.getLastExportedRecordPosition();
     if (exporterRdbmsPosition.lastExportedPosition() > -1
         && lastPosition <= exporterRdbmsPosition.lastExportedPosition()) {
-      // This is needed since the brokers last exported position is from it's last snapshot and kann
-      // be different than ours.
+      // This is needed since the brokers last exported position is from its last snapshot and can
+      // be different from ours.
       lastPosition = exporterRdbmsPosition.lastExportedPosition();
       updatePositionInBroker();
     }
@@ -76,7 +66,6 @@ public class RdbmsExporter implements Exporter {
     LOG.info("[RDBMS Exporter] Exporter opened with last exported position {}", lastPosition);
   }
 
-  @Override
   public void close() {
     try {
       rdbmsWriter.flush();
@@ -87,7 +76,6 @@ public class RdbmsExporter implements Exporter {
     LOG.info("[RDBMS Exporter] Exporter closed");
   }
 
-  @Override
   public void export(final Record<?> record) {
     LOG.debug(
         "[RDBMS Exporter] Process record {}-{} - {}:{}",
@@ -110,60 +98,16 @@ public class RdbmsExporter implements Exporter {
               handler.getClass(),
               record.getValueType());
         }
+
+        lastPosition = record.getPosition();
+
+        if (flushAfterEachRecord()) {
+          rdbmsWriter.flush();
+        }
       }
     } else {
       LOG.trace("[RDBMS Exporter] No registered handler found for {}", record.getValueType());
     }
-
-    lastPosition = record.getPosition();
-  }
-
-  private void registerHandler() {
-    if (partitionId == PROCESS_DEFINITION_PARTITION) {
-      registeredHandlers.put(
-          ValueType.PROCESS,
-          List.of(new ProcessExportHandler(rdbmsWriter.getProcessDefinitionWriter())));
-    }
-    registeredHandlers.put(
-        ValueType.AUTHORIZATION,
-        List.of(new AuthorizationExportHandler(rdbmsWriter.getAuthorizationWriter())));
-    registeredHandlers.put(
-        ValueType.DECISION,
-        List.of(new DecisionDefinitionExportHandler(rdbmsWriter.getDecisionDefinitionWriter())));
-    registeredHandlers.put(
-        ValueType.DECISION_REQUIREMENTS,
-        List.of(
-            new DecisionRequirementsExportHandler(rdbmsWriter.getDecisionRequirementsWriter())));
-    registeredHandlers.put(
-        ValueType.DECISION_EVALUATION,
-        List.of(new DecisionInstanceExportHandler(rdbmsWriter.getDecisionInstanceWriter())));
-    registeredHandlers.put(
-        ValueType.GROUP, List.of(new GroupExportHandler(rdbmsWriter.getGroupWriter())));
-    registeredHandlers.put(
-        ValueType.PROCESS_INSTANCE,
-        List.of(
-            new ProcessInstanceExportHandler(rdbmsWriter.getProcessInstanceWriter()),
-            new FlowNodeExportHandler(rdbmsWriter.getFlowNodeInstanceWriter())));
-    registeredHandlers.put(
-        ValueType.INCIDENT,
-        List.of(
-            new IncidentExportHandler(rdbmsWriter.getIncidentWriter()),
-            new ProcessInstanceIncidentExportHandler(rdbmsWriter.getProcessInstanceWriter()),
-            new FlowNodeInstanceIncidentExportHandler(rdbmsWriter.getFlowNodeInstanceWriter())));
-    registeredHandlers.put(
-        ValueType.TENANT, List.of(new TenantExportHandler(rdbmsWriter.getTenantWriter())));
-    registeredHandlers.put(
-        ValueType.VARIABLE, List.of(new VariableExportHandler(rdbmsWriter.getVariableWriter())));
-    registeredHandlers.put(
-        ValueType.ROLE, List.of(new RoleExportHandler(rdbmsWriter.getRoleWriter())));
-    registeredHandlers.put(
-        ValueType.USER, List.of(new UserExportHandler(rdbmsWriter.getUserWriter())));
-    registeredHandlers.put(
-        ValueType.USER_TASK, List.of(new UserTaskExportHandler(rdbmsWriter.getUserTaskWriter())));
-    registeredHandlers.put(
-        ValueType.FORM, List.of(new FormExportHandler(rdbmsWriter.getFormWriter())));
-    registeredHandlers.put(
-        ValueType.MAPPING, List.of(new MappingExportHandler(rdbmsWriter.getMappingWriter())));
   }
 
   private void updatePositionInBroker() {
@@ -186,7 +130,6 @@ public class RdbmsExporter implements Exporter {
   }
 
   private void initializeRdbmsPosition() {
-
     try {
       exporterRdbmsPosition = rdbmsWriter.getExporterPositionService().findOne(partitionId);
     } catch (final Exception e) {
@@ -212,14 +155,22 @@ public class RdbmsExporter implements Exporter {
     }
   }
 
+  private boolean flushAfterEachRecord() {
+    return flushInterval.isZero() || maxQueueSize <= 0;
+  }
+
   private void flushAndReschedule() {
     flushExecutionQueue();
-    controller.scheduleCancellableTask(Duration.ofMillis(100), this::flushAndReschedule);
+    controller.scheduleCancellableTask(flushInterval, this::flushAndReschedule);
   }
 
   @VisibleForTesting(
       "Each exporter creates it's own executionQueue, so we need an accessible flush method for tests")
   public void flushExecutionQueue() {
+    if (flushAfterEachRecord()) {
+      LOG.warn("Unnecessary flush called, since flush interval is zero or max queue size is zero");
+      return;
+    }
     LOG.debug("[RDBMS Exporter] flushing queue");
     rdbmsWriter.flush();
   }

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterConfig.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+public record RdbmsExporterConfig(
+    long partitionId,
+    Duration flushInterval,
+    int maxQueueSize,
+    Controller controller,
+    RdbmsWriter rdbmsWriter,
+    Map<ValueType, List<RdbmsExportHandler>> handlers) {
+
+  public static RdbmsExporterConfig of(Function<Builder, Builder> builderFunction) {
+    return builderFunction.apply(new Builder()).build();
+  }
+
+  // create a static builder for this record. Also create methods to add handlers to the map
+  public static final class Builder {
+
+    private long partitionId;
+    private Duration flushInterval;
+    private int maxQueueSize;
+    private Controller controller;
+    private RdbmsWriter rdbmsWriter;
+    private Map<ValueType, List<RdbmsExportHandler>> handlers = new HashMap<>();
+
+    public Builder partitionId(final long value) {
+      partitionId = value;
+      return this;
+    }
+
+    public Builder flushInterval(final Duration value) {
+      flushInterval = value;
+      return this;
+    }
+
+    public Builder maxQueueSize(final int value) {
+      maxQueueSize = value;
+      return this;
+    }
+
+    public Builder controller(final Controller value) {
+      controller = value;
+      return this;
+    }
+
+    public Builder rdbmsWriter(final RdbmsWriter value) {
+      rdbmsWriter = value;
+      return this;
+    }
+
+    public Builder handlers(final Map<ValueType, List<RdbmsExportHandler>> value) {
+      handlers = value;
+      return this;
+    }
+
+    public Builder withHandler(final ValueType valueType, RdbmsExportHandler handler) {
+      if (!handlers.containsKey(valueType)) {
+        handlers.put(valueType, new ArrayList<>());
+      }
+      handlers.get(valueType).add(handler);
+
+      return this;
+    }
+
+    public RdbmsExporterConfig build() {
+      return new RdbmsExporterConfig(
+          partitionId, flushInterval, maxQueueSize, controller, rdbmsWriter, handlers);
+    }
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterFactory.java
@@ -27,7 +27,7 @@ public class RdbmsExporterFactory implements ExporterFactory {
 
   @Override
   public Exporter newInstance() throws ExporterInstantiationException {
-    return new RdbmsExporter(rdbmsService);
+    return new RdbmsExporterWrapper(rdbmsService);
   }
 
   @Override

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/RdbmsExporterWrapper.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import io.camunda.db.rdbms.RdbmsService;
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.exporter.rdbms.handlers.DecisionDefinitionExportHandler;
+import io.camunda.exporter.rdbms.handlers.DecisionInstanceExportHandler;
+import io.camunda.exporter.rdbms.handlers.DecisionRequirementsExportHandler;
+import io.camunda.exporter.rdbms.handlers.FlowNodeExportHandler;
+import io.camunda.exporter.rdbms.handlers.FormExportHandler;
+import io.camunda.exporter.rdbms.handlers.GroupExportHandler;
+import io.camunda.exporter.rdbms.handlers.MappingExportHandler;
+import io.camunda.exporter.rdbms.handlers.ProcessExportHandler;
+import io.camunda.exporter.rdbms.handlers.ProcessInstanceExportHandler;
+import io.camunda.exporter.rdbms.handlers.RoleExportHandler;
+import io.camunda.exporter.rdbms.handlers.TenantExportHandler;
+import io.camunda.exporter.rdbms.handlers.UserExportHandler;
+import io.camunda.exporter.rdbms.handlers.UserTaskExportHandler;
+import io.camunda.exporter.rdbms.handlers.VariableExportHandler;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** https://docs.camunda.io/docs/next/components/zeebe/technical-concepts/process-lifecycles/ */
+public class RdbmsExporterWrapper implements Exporter {
+
+  /** The partition on which all process deployments are published */
+  public static final long PROCESS_DEFINITION_PARTITION = 1L;
+
+  private static final int DEFAULT_FLUSH_INTERVAL = 500;
+  private static final int DEFAULT_MAX_QUEUE_SIZE = 1000;
+  private static final Logger LOG = LoggerFactory.getLogger(RdbmsExporterWrapper.class);
+
+  private long partitionId;
+  private final RdbmsService rdbmsService;
+  private RdbmsWriter rdbmsWriter;
+
+  // configuration
+  private Duration flushInterval;
+  private int maxQueueSize;
+
+  private RdbmsExporter exporter;
+
+  public RdbmsExporterWrapper(final RdbmsService rdbmsService) {
+    this.rdbmsService = rdbmsService;
+  }
+
+  @Override
+  public void configure(final Context context) {
+    if (context.getConfiguration().getArguments() != null) {
+      final var arguments = context.getConfiguration().getArguments();
+      final var flushIntervalMillis =
+          (Integer) arguments.getOrDefault("flushInterval", DEFAULT_FLUSH_INTERVAL);
+      flushInterval = Duration.ofMillis(flushIntervalMillis);
+      maxQueueSize = (Integer) arguments.getOrDefault("maxQueueSize", DEFAULT_MAX_QUEUE_SIZE);
+    } else {
+      flushInterval = Duration.ofMillis(DEFAULT_FLUSH_INTERVAL);
+      maxQueueSize = DEFAULT_MAX_QUEUE_SIZE;
+    }
+
+    LOG.info(
+        "[RDBMS Exporter] Configuration: flushInterval={}, maxQueueSize={}",
+        flushInterval,
+        maxQueueSize);
+    partitionId = context.getPartitionId();
+
+    rdbmsWriter = rdbmsService.createWriter(partitionId, maxQueueSize);
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    final var builder =
+        new RdbmsExporterConfig.Builder()
+            .partitionId(partitionId)
+            .flushInterval(flushInterval)
+            .maxQueueSize(maxQueueSize)
+            .controller(controller)
+            .rdbmsWriter(rdbmsWriter);
+    createHandlers(partitionId, rdbmsWriter, builder);
+    exporter = new RdbmsExporter(builder.build());
+  }
+
+  @Override
+  public void close() {
+    exporter.close();
+  }
+
+  @Override
+  public void export(final Record<?> record) {
+    exporter.export(record);
+  }
+
+  private static void createHandlers(
+      final long partitionId,
+      final RdbmsWriter rdbmsWriter,
+      final RdbmsExporterConfig.Builder builder) {
+    if (partitionId == PROCESS_DEFINITION_PARTITION) {
+      builder.withHandler(
+          ValueType.PROCESS, new ProcessExportHandler(rdbmsWriter.getProcessDefinitionWriter()));
+    }
+    builder.withHandler(
+        ValueType.AUTHORIZATION,
+        new AuthorizationExportHandler(rdbmsWriter.getAuthorizationWriter()));
+    builder.withHandler(
+        ValueType.DECISION,
+        new DecisionDefinitionExportHandler(rdbmsWriter.getDecisionDefinitionWriter()));
+    builder.withHandler(
+        ValueType.DECISION_REQUIREMENTS,
+        new DecisionRequirementsExportHandler(rdbmsWriter.getDecisionRequirementsWriter()));
+    builder.withHandler(
+        ValueType.DECISION_EVALUATION,
+        new DecisionInstanceExportHandler(rdbmsWriter.getDecisionInstanceWriter()));
+    builder.withHandler(ValueType.GROUP, new GroupExportHandler(rdbmsWriter.getGroupWriter()));
+    builder.withHandler(
+        ValueType.INCIDENT, new IncidentExportHandler(rdbmsWriter.getIncidentWriter()));
+    builder.withHandler(
+        ValueType.INCIDENT,
+        new ProcessInstanceIncidentExportHandler(rdbmsWriter.getProcessInstanceWriter()));
+    builder.withHandler(
+        ValueType.INCIDENT,
+        new FlowNodeInstanceIncidentExportHandler(rdbmsWriter.getFlowNodeInstanceWriter()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE,
+        new ProcessInstanceExportHandler(rdbmsWriter.getProcessInstanceWriter()));
+    builder.withHandler(
+        ValueType.PROCESS_INSTANCE,
+        new FlowNodeExportHandler(rdbmsWriter.getFlowNodeInstanceWriter()));
+    builder.withHandler(ValueType.TENANT, new TenantExportHandler(rdbmsWriter.getTenantWriter()));
+    builder.withHandler(
+        ValueType.VARIABLE, new VariableExportHandler(rdbmsWriter.getVariableWriter()));
+    builder.withHandler(ValueType.ROLE, new RoleExportHandler(rdbmsWriter.getRoleWriter()));
+    builder.withHandler(ValueType.USER, new UserExportHandler(rdbmsWriter.getUserWriter()));
+    builder.withHandler(
+        ValueType.USER_TASK, new UserTaskExportHandler(rdbmsWriter.getUserTaskWriter()));
+    builder.withHandler(ValueType.FORM, new FormExportHandler(rdbmsWriter.getFormWriter()));
+    builder.withHandler(
+        ValueType.MAPPING, new MappingExportHandler(rdbmsWriter.getMappingWriter()));
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionDefinitionExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionDefinitionExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.DecisionDefinitionDbModel;
 import io.camunda.db.rdbms.write.service.DecisionDefinitionWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionInstanceExportHandler.java
@@ -5,12 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel;
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedInput;
 import io.camunda.db.rdbms.write.domain.DecisionInstanceDbModel.EvaluatedOutput;
 import io.camunda.db.rdbms.write.service.DecisionInstanceWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionDefinitionType;
 import io.camunda.search.entities.DecisionInstanceEntity.DecisionInstanceState;
 import io.camunda.zeebe.protocol.record.Record;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/DecisionRequirementsExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.DecisionRequirementsDbModel;
 import io.camunda.db.rdbms.write.service.DecisionRequirementsWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FlowNodeExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.FlowNodeInstanceDbModel.FlowNodeInstanceDbModelBuilder;
 import io.camunda.db.rdbms.write.service.FlowNodeInstanceWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeState;
 import io.camunda.search.entities.FlowNodeInstanceEntity.FlowNodeType;
 import io.camunda.zeebe.protocol.record.Record;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FormExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/FormExportHandler.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.FormDbModel;
 import io.camunda.db.rdbms.write.domain.FormDbModel.FormDbModelBuilder;
 import io.camunda.db.rdbms.write.service.FormWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.value.deployment.Form;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/GroupExportHandler.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.GroupDbModel;
 import io.camunda.db.rdbms.write.domain.GroupMemberDbModel;
 import io.camunda.db.rdbms.write.service.GroupWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
 import io.camunda.zeebe.protocol.record.value.GroupRecordValue;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/MappingExportHandler.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.MappingDbModel;
 import io.camunda.db.rdbms.write.domain.MappingDbModel.MappingDbModelBuilder;
 import io.camunda.db.rdbms.write.service.MappingWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.MappingIntent;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.ProcessDefinitionDbModel;
 import io.camunda.db.rdbms.write.service.ProcessDefinitionWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.operate.zeebeimport.util.XMLUtil;
 import io.camunda.webapps.schema.entities.operate.ProcessEntity;
 import io.camunda.zeebe.protocol.record.Record;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/ProcessInstanceExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.ProcessInstanceDbModel;
 import io.camunda.db.rdbms.write.service.ProcessInstanceWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.search.entities.ProcessInstanceEntity.ProcessInstanceState;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/RoleExportHandler.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.RoleDbModel;
 import io.camunda.db.rdbms.write.domain.RoleMemberDbModel;
 import io.camunda.db.rdbms.write.service.RoleWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.value.RoleRecordValue;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/TenantExportHandler.java
@@ -5,11 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.TenantDbModel;
 import io.camunda.db.rdbms.write.domain.TenantMemberDbModel;
 import io.camunda.db.rdbms.write.service.TenantWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.value.TenantRecordValue;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.UserDbModel;
 import io.camunda.db.rdbms.write.service.UserWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/UserTaskExportHandler.java
@@ -5,13 +5,18 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
-import static io.camunda.zeebe.protocol.record.intent.UserTaskIntent.*;
+import static io.camunda.zeebe.protocol.record.intent.UserTaskIntent.CANCELED;
+import static io.camunda.zeebe.protocol.record.intent.UserTaskIntent.COMPLETED;
+import static io.camunda.zeebe.protocol.record.intent.UserTaskIntent.CREATED;
+import static io.camunda.zeebe.protocol.record.intent.UserTaskIntent.MIGRATED;
 
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel;
 import io.camunda.db.rdbms.write.domain.UserTaskDbModel.UserTaskState;
 import io.camunda.db.rdbms.write.service.UserTaskWriter;
+import io.camunda.exporter.rdbms.DateUtil;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/handlers/VariableExportHandler.java
@@ -5,10 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.exporter.rdbms;
+package io.camunda.exporter.rdbms.handlers;
 
 import io.camunda.db.rdbms.write.domain.VariableDbModel;
 import io.camunda.db.rdbms.write.service.VariableWriter;
+import io.camunda.exporter.rdbms.RdbmsExportHandler;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;

--- a/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
+++ b/zeebe/exporters/rdbms-exporter/src/test/java/io/camunda/exporter/rdbms/RdbmsExporterTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.rdbms;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.db.rdbms.write.RdbmsWriter;
+import io.camunda.db.rdbms.write.queue.ExecutionQueue;
+import io.camunda.db.rdbms.write.queue.PostFlushListener;
+import io.camunda.db.rdbms.write.queue.PreFlushListener;
+import io.camunda.db.rdbms.write.queue.QueueItem;
+import io.camunda.db.rdbms.write.queue.QueueItemMerger;
+import io.camunda.db.rdbms.write.service.ExporterPositionService;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+class RdbmsExporterTest {
+
+  private Controller controller;
+  private RdbmsWriter rdbmsWriter;
+  private RdbmsExporter exporter;
+  private StubExecutionQueue executionQueue;
+  private ExporterPositionService positionService;
+
+  @Test
+  void shouldCallCorrectHandler() {
+    // given
+    final var jobHandler = mockHandler(ValueType.JOB);
+    final var otherJobHandler = mockHandler(ValueType.JOB, false);
+    final var piHandler = mockHandler(ValueType.PROCESS_INSTANCE);
+    final var record = mockRecord(ValueType.JOB, 1);
+
+    createExporter(
+        b ->
+            b.withHandler(ValueType.JOB, jobHandler)
+                .withHandler(ValueType.JOB, otherJobHandler)
+                .withHandler(ValueType.PROCESS_INSTANCE, piHandler));
+
+    // when
+    exporter.export(record);
+
+    // then
+    verify(jobHandler).canExport(record);
+    verify(otherJobHandler).canExport(record);
+    verify(piHandler, never()).canExport(record);
+    verify(jobHandler).export(record);
+    verify(otherJobHandler, never()).export(record);
+    verify(piHandler, never()).export(record);
+  }
+
+  @Test
+  void shouldRegisterFlushListeners() {
+    // given
+    createExporter(b -> b);
+
+    // then
+    assertThat(executionQueue.preFlushListeners).isNotEmpty();
+    assertThat(executionQueue.postFlushListeners).isNotEmpty();
+  }
+
+  @Test
+  void shouldUpdatePositionOnFlush() {
+    // given
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    exporter.export(mockRecord(ValueType.JOB, 2));
+    executionQueue.flush();
+
+    // then
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+  }
+
+  @Test
+  void shouldNotUpdatePositionOnFlushWhenNoRecordsHandled() {
+    // given
+    createExporter(b -> b);
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    exporter.export(mockRecord(ValueType.JOB, 2));
+    executionQueue.flush();
+
+    // then
+    verify(positionService, never()).update(any());
+  }
+
+  @Test
+  void shouldUpdatePositionAfterEachRecordWhenMaxQueueSizeIsZero() {
+    // given
+    createExporter(b -> b.maxQueueSize(0).withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    exporter.export(mockRecord(ValueType.JOB, 2));
+    executionQueue.flush();
+
+    // then
+    verify(positionService, times(2)).update(any());
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+  }
+
+  @Test
+  void shouldUpdatePositionAfterEachRecordWhenFlushIntervalIsZero() {
+    // given
+    createExporter(
+        b -> b.flushInterval(Duration.ZERO).withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    exporter.export(mockRecord(ValueType.JOB, 2));
+    executionQueue.flush();
+
+    // then
+    verify(positionService, times(2)).update(any());
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 2));
+  }
+
+  @Test
+  void shouldFlushOnClose() {
+    // given
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    exporter.close();
+
+    // then
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
+  }
+
+  @Test
+  void shouldRegisterFlushIntervalTimer() {
+    // given
+    createExporter(b -> b);
+
+    // then
+    verify(controller).scheduleCancellableTask(eq(Duration.ofMillis(500)), any());
+  }
+
+  @Test
+  void shouldNotRegisterFlushIntervalTimerWhenMaxQueueSizeIsZero() {
+    // given
+    createExporter(b -> b.flushInterval(Duration.ZERO));
+
+    // then
+    verify(controller, never()).scheduleCancellableTask(any(), any());
+  }
+
+  @Test
+  void shouldNotRegisterFlushIntervalTimerWhenFlushIntervalIsZero() {
+    // given
+    createExporter(b -> b.flushInterval(Duration.ZERO));
+
+    // then
+    verify(controller, never()).scheduleCancellableTask(any(), any());
+  }
+
+  @Test
+  void shouldFlushAndRescheduleWhenTimerTaskIsExecuted() {
+    // given
+    createExporter(b -> b.withHandler(ValueType.JOB, mockHandler(ValueType.JOB)));
+    final var runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+    verify(controller).scheduleCancellableTask(any(Duration.class), runnableCaptor.capture());
+    final var runnable = runnableCaptor.getValue();
+
+    // when
+    exporter.export(mockRecord(ValueType.JOB, 1));
+    runnable.run();
+
+    // then
+    // captures the initial and the rescheduled call
+    verify(controller, times(2)).scheduleCancellableTask(any(Duration.class), any());
+    verify(positionService).update(Mockito.argThat(p -> p.lastExportedPosition() == 1));
+  }
+
+  // ------------------------------------------------
+  // mocks and stubs
+  // ------------------------------------------------
+
+  private RdbmsExportHandler mockHandler(final ValueType valueType) {
+    return mockHandler(valueType, true);
+  }
+
+  private RdbmsExportHandler mockHandler(final ValueType valueType, final boolean canExport) {
+    final var handler = mock(RdbmsExportHandler.class);
+    when(handler.canExport(Mockito.argThat(r -> canExport && r.getValueType() == valueType)))
+        .thenReturn(true);
+
+    return handler;
+  }
+
+  private Record mockRecord(final ValueType valueType, final long position) {
+    final var record = mock(Record.class);
+    when(record.getValueType()).thenReturn(valueType);
+    when(record.getPosition()).thenReturn(position);
+
+    return record;
+  }
+
+  private void createExporter(
+      final Function<RdbmsExporterConfig.Builder, RdbmsExporterConfig.Builder> builderFunction) {
+    controller = mock(Controller.class);
+    when(controller.getLastExportedRecordPosition()).thenReturn(-1L);
+
+    rdbmsWriter = mock(RdbmsWriter.class);
+    executionQueue = new StubExecutionQueue();
+    positionService = mock(ExporterPositionService.class);
+    when(positionService.findOne(anyLong())).thenReturn(null);
+
+    when(rdbmsWriter.getExporterPositionService()).thenReturn(positionService);
+    when(rdbmsWriter.getExecutionQueue()).thenReturn(executionQueue);
+    doAnswer((invocation) -> executionQueue.flush()).when(rdbmsWriter).flush();
+
+    final var builder =
+        new RdbmsExporterConfig.Builder()
+            .controller(controller)
+            .rdbmsWriter(rdbmsWriter)
+            .partitionId(0)
+            .flushInterval(Duration.ofMillis(500))
+            .maxQueueSize(100);
+
+    exporter = new RdbmsExporter(builderFunction.apply(builder).build());
+  }
+
+  private static final class StubExecutionQueue implements ExecutionQueue {
+
+    final List<PreFlushListener> preFlushListeners = new ArrayList<>();
+    final List<PostFlushListener> postFlushListeners = new ArrayList<>();
+
+    @Override
+    public void executeInQueue(final QueueItem entry) {
+      // no-op
+    }
+
+    @Override
+    public void registerPreFlushListener(final PreFlushListener listener) {
+      preFlushListeners.add(listener);
+    }
+
+    @Override
+    public void registerPostFlushListener(final PostFlushListener listener) {
+      postFlushListeners.add(listener);
+    }
+
+    @Override
+    public int flush() {
+      preFlushListeners.forEach(PreFlushListener::onPreFlush);
+      postFlushListeners.forEach(PostFlushListener::onPostFlush);
+      return 0;
+    }
+
+    @Override
+    public boolean tryMergeWithExistingQueueItem(final QueueItemMerger... combiners) {
+      return false;
+    }
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -255,7 +255,12 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     withProperty("spring.datasource.password", "");
     withProperty("logging.level.io.camunda.db.rdbms", "DEBUG");
     withProperty("logging.level.org.mybatis", "DEBUG");
-    withExporter("rdbms", cfg -> cfg.setClassName("-"));
+    withExporter(
+        "rdbms",
+        cfg -> {
+          cfg.setClassName("-");
+          cfg.setArgs(Map.of("flushInterval", "0"));
+        });
     return this;
   }
 }


### PR DESCRIPTION
## Description

Goals:
- make the following rdbmsExporterParameters configurable:
  - queueFlushSize: controls the max size the exporters' executionQueue should have before flushing
  - flushInterval: An ISO-8861 interval after which the exporters' executionQueue will always be flushed even if size < queueFlushSize

Configuration can happen via yaml:
```yaml
zeebe:
  broker:
    exporters:
      rdbms:
        args:
          flushInterval: 5000
          maxQueueSize: 1000
```

Side goals:
- Whenever either queueFlushSize or flushInterval is ZERO, the exporter will flush after each processed record

Refactorings:
- since the RdbmsExporter contains a lot logic now, I added some UnitTests. To do so properly, I had to split the RdbmsExporter into two classes. The RdbmsExporterWrapper now does the configuration of the actual RdbmsExporter and forwards records and commands to it.

## Related issues

closes #23821
