### PR TITLE
refactor: fetch tasks by key and not by id

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/views/TaskSearchView.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/views/TaskSearchView.java
@@ -362,7 +362,7 @@ public class TaskSearchView {
   public static TaskSearchView createFrom(TaskEntity taskEntity, Object[] sortValues) {
     final TaskSearchView taskSearchView =
         new TaskSearchView()
-            .setId(taskEntity.getId())
+            .setId(String.valueOf(taskEntity.getKey()))
             .setCreationTime(taskEntity.getCreationTime())
             .setCompletionTime(taskEntity.getCompletionTime())
             .setProcessInstanceId(taskEntity.getProcessInstanceId())

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/VariableStore.java
@@ -151,7 +151,7 @@ public interface VariableStore {
 
     public static GetVariablesRequest createFrom(TaskEntity taskEntity, Set<String> fieldNames) {
       return new GetVariablesRequest()
-          .setTaskId(taskEntity.getId())
+          .setTaskId(String.valueOf(taskEntity.getKey()))
           .setFlowNodeInstanceId(taskEntity.getFlowNodeInstanceId())
           .setState(taskEntity.getState())
           .setProcessInstanceId(taskEntity.getProcessInstanceId())
@@ -160,7 +160,7 @@ public interface VariableStore {
 
     public static GetVariablesRequest createFrom(TaskEntity taskEntity) {
       return new GetVariablesRequest()
-          .setTaskId(taskEntity.getId())
+          .setTaskId(String.valueOf(taskEntity.getKey()))
           .setFlowNodeInstanceId(taskEntity.getFlowNodeInstanceId())
           .setState(taskEntity.getState())
           .setProcessInstanceId(taskEntity.getProcessInstanceId());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -11,7 +11,6 @@ import static io.camunda.tasklist.util.CollectionUtil.asMap;
 import static io.camunda.tasklist.util.CollectionUtil.getOrDefaultFromMap;
 import static io.camunda.tasklist.util.ElasticsearchUtil.SCROLL_KEEP_ALIVE_MS;
 import static io.camunda.tasklist.util.ElasticsearchUtil.fromSearchHit;
-import static io.camunda.tasklist.util.ElasticsearchUtil.getRawResponseWithTenantCheck;
 import static io.camunda.tasklist.util.ElasticsearchUtil.joinWithAnd;
 import static io.camunda.tasklist.util.ElasticsearchUtil.mapSearchHits;
 import static java.util.stream.Collectors.toList;
@@ -47,6 +46,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -60,10 +60,10 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
@@ -109,15 +109,44 @@ public class TaskStoreElasticSearch implements TaskStore {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Override
-  public TaskEntity getTask(final String id) {
+  private SearchHit getRawTaskByUserTaskKey(final String userTaskKey) {
     try {
-      final SearchHit response =
-          getRawResponseWithTenantCheck(id, taskTemplate, QueryType.ALL, tenantAwareClient);
-      return fromSearchHit(response.getSourceAsString(), objectMapper, TaskEntity.class);
+      final SearchRequest searchRequest =
+          ElasticsearchUtil.createSearchRequest(taskTemplate)
+              .source(
+                  SearchSourceBuilder.searchSource()
+                      .query(termQuery(TaskTemplate.KEY, userTaskKey)));
+
+      final var response = tenantAwareClient.search(searchRequest);
+      if (response.getHits().getHits().length == 1) {
+        return response.getHits().getHits()[0];
+      } else if (response.getHits().getTotalHits().value > 1) {
+        throw new NotFoundException(
+            String.format(
+                "Unique %s with id %s was not found", taskTemplate.getIndexName(), userTaskKey));
+      } else {
+        throw new NotFoundException(
+            String.format("%s with id %s was not found", taskTemplate.getIndexName(), userTaskKey));
+      }
     } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
+  }
+
+  private String getRoutingToUpsertTask(final TaskEntity taskEntity) {
+    final var taskId = taskEntity.getId();
+    final var taskKey = String.valueOf(taskEntity.getKey());
+    if (Objects.equals(taskId, taskKey)) {
+      return taskId;
+    } else {
+      return taskEntity.getProcessInstanceId();
+    }
+  }
+
+  @Override
+  public TaskEntity getTask(final String id) {
+    final var rawTask = getRawTaskByUserTaskKey(id);
+    return fromSearchHit(rawTask.getSourceAsString(), objectMapper, TaskEntity.class);
   }
 
   @Override
@@ -127,7 +156,7 @@ public class TaskStoreElasticSearch implements TaskStore {
             .source(
                 SearchSourceBuilder.searchSource()
                     .query(termQuery(TaskTemplate.PROCESS_INSTANCE_ID, processInstanceId))
-                    .fetchField(TaskTemplate.ID));
+                    .fetchField(TaskTemplate.KEY));
     try {
       return ElasticsearchUtil.scrollIdsToList(searchRequest, esClient);
     } catch (final IOException e) {
@@ -143,7 +172,7 @@ public class TaskStoreElasticSearch implements TaskStore {
             .source(
                 SearchSourceBuilder.searchSource()
                     .query(termQuery(TaskTemplate.PROCESS_DEFINITION_ID, processDefinitionId))
-                    .fetchField(TaskTemplate.ID));
+                    .fetchField(TaskTemplate.KEY));
     try {
       return ElasticsearchUtil.scrollIdsWithIndexToMap(searchRequest, esClient);
     } catch (final IOException e) {
@@ -174,14 +203,8 @@ public class TaskStoreElasticSearch implements TaskStore {
    */
   @Override
   public TaskEntity persistTaskCompletion(final TaskEntity taskBefore) {
-    final SearchHit taskBeforeSearchHit;
-    try {
-      taskBeforeSearchHit =
-          getRawResponseWithTenantCheck(
-              taskBefore.getId(), taskTemplate, QueryType.ALL, tenantAwareClient);
-    } catch (final IOException e) {
-      throw new TasklistRuntimeException(e.getMessage(), e);
-    }
+    final SearchHit taskBeforeSearchHit =
+        getRawTaskByUserTaskKey(String.valueOf(taskBefore.getKey()));
 
     final TaskEntity completedTask =
         makeCopyOf(taskBefore)
@@ -204,7 +227,8 @@ public class TaskStoreElasticSearch implements TaskStore {
               .doc(jsonMap)
               .setRefreshPolicy(WAIT_UNTIL)
               .setIfSeqNo(taskBeforeSearchHit.getSeqNo())
-              .setIfPrimaryTerm(taskBeforeSearchHit.getPrimaryTerm());
+              .setIfPrimaryTerm(taskBeforeSearchHit.getPrimaryTerm())
+              .routing(getRoutingToUpsertTask(completedTask));
       ElasticsearchUtil.executeUpdate(esClient, updateRequest);
     } catch (final Exception e) {
       // we're OK with not updating the task here, it will be marked as completed within import
@@ -215,15 +239,8 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   @Override
   public TaskEntity rollbackPersistTaskCompletion(final TaskEntity taskBefore) {
-    final SearchHit taskBeforeSearchHit;
-    try {
-      taskBeforeSearchHit =
-          getRawResponseWithTenantCheck(
-              taskBefore.getId(), taskTemplate, QueryType.ALL, tenantAwareClient);
-    } catch (final IOException e) {
-      throw new TasklistRuntimeException(e.getMessage(), e);
-    }
-
+    final SearchHit taskBeforeSearchHit =
+        getRawTaskByUserTaskKey(String.valueOf(taskBefore.getKey()));
     final TaskEntity completedTask = makeCopyOf(taskBefore).setCompletionTime(null);
 
     try {
@@ -242,7 +259,8 @@ public class TaskStoreElasticSearch implements TaskStore {
               .doc(jsonMap)
               .setRefreshPolicy(WAIT_UNTIL)
               .setIfSeqNo(taskBeforeSearchHit.getSeqNo())
-              .setIfPrimaryTerm(taskBeforeSearchHit.getPrimaryTerm());
+              .setIfPrimaryTerm(taskBeforeSearchHit.getPrimaryTerm())
+              .routing(getRoutingToUpsertTask(completedTask));
       ElasticsearchUtil.executeUpdate(esClient, updateRequest);
     } catch (final Exception e) {
       LOGGER.error("Error when trying to rollback Task to CREATED state: {}", e.getMessage());
@@ -253,14 +271,14 @@ public class TaskStoreElasticSearch implements TaskStore {
   @Override
   public TaskEntity persistTaskClaim(final TaskEntity taskBefore, final String assignee) {
 
-    updateTask(taskBefore.getId(), asMap(TaskTemplate.ASSIGNEE, assignee));
+    updateTask(String.valueOf(taskBefore.getKey()), asMap(TaskTemplate.ASSIGNEE, assignee));
 
     return makeCopyOf(taskBefore).setAssignee(assignee);
   }
 
   @Override
   public TaskEntity persistTaskUnclaim(final TaskEntity task) {
-    updateTask(task.getId(), asMap(TaskTemplate.ASSIGNEE, null));
+    updateTask(String.valueOf(task.getKey()), asMap(TaskTemplate.ASSIGNEE, null));
     return makeCopyOf(task).setAssignee(null);
   }
 
@@ -278,13 +296,13 @@ public class TaskStoreElasticSearch implements TaskStore {
   public void updateTaskLinkedForm(
       final TaskEntity task, final String formBpmnId, final long formVersion) {
     updateTask(
-        task.getId(),
+        String.valueOf(task.getKey()),
         asMap(TaskTemplate.FORM_ID, formBpmnId, TaskTemplate.FORM_VERSION, formVersion));
   }
 
   private SearchHit[] getTasksRawResponse(final List<String> ids) throws IOException {
 
-    final QueryBuilder query = idsQuery().addIds(Arrays.toString(ids.toArray()));
+    final QueryBuilder query = termsQuery(TaskTemplate.KEY, ids);
 
     final SearchRequest request =
         ElasticsearchUtil.createSearchRequest(taskTemplate)
@@ -461,9 +479,9 @@ public class TaskStoreElasticSearch implements TaskStore {
       assigneesQ = termsQuery(TaskTemplate.ASSIGNEE, query.getAssignees());
     }
 
-    IdsQueryBuilder idsQuery = null;
+    TermsQueryBuilder taskIdsQuery = null;
     if (taskIds != null) {
-      idsQuery = idsQuery().addIds(taskIds.toArray(new String[0]));
+      taskIdsQuery = termsQuery(TaskTemplate.KEY, taskIds);
     }
 
     QueryBuilder taskDefinitionQ = null;
@@ -539,7 +557,7 @@ public class TaskStoreElasticSearch implements TaskStore {
             assignedQ,
             assigneeQ,
             assigneesQ,
-            idsQuery,
+            taskIdsQuery,
             taskDefinitionQ,
             candidateGroupQ,
             candidateGroupsQ,
@@ -667,8 +685,9 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   private void updateTask(final String taskId, final Map<String, Object> updateFields) {
     try {
-      final SearchHit searchHit =
-          getRawResponseWithTenantCheck(taskId, taskTemplate, QueryType.ALL, tenantAwareClient);
+      final SearchHit searchHit = getRawTaskByUserTaskKey(taskId);
+      final var taskEntity =
+          fromSearchHit(searchHit.getSourceAsString(), objectMapper, TaskEntity.class);
       // update task with optimistic locking
       // format date fields properly
       final Map<String, Object> jsonMap =
@@ -676,11 +695,12 @@ public class TaskStoreElasticSearch implements TaskStore {
       final UpdateRequest updateRequest =
           new UpdateRequest()
               .index(taskTemplate.getFullQualifiedName())
-              .id(taskId)
+              .id(searchHit.getId())
               .doc(jsonMap)
               .setRefreshPolicy(WAIT_UNTIL)
               .setIfSeqNo(searchHit.getSeqNo())
-              .setIfPrimaryTerm(searchHit.getPrimaryTerm());
+              .setIfPrimaryTerm(searchHit.getPrimaryTerm())
+              .routing(getRoutingToUpsertTask(taskEntity));
       ElasticsearchUtil.executeUpdate(esClient, updateRequest);
     } catch (final Exception e) {
       throw new TasklistRuntimeException(e.getMessage(), e);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -85,7 +85,7 @@ public class FormStoreOpenSearch implements FormStore {
                         term ->
                             term.field(FormIndex.PROCESS_DEFINITION_ID)
                                 .value(FieldValue.of(processDefinitionId))))
-            .fields(f -> f.field(TaskTemplate.ID));
+            .fields(f -> f.field(FormIndex.ID));
     try {
       return OpenSearchUtil.scrollIdsToList(searchRequest, osClient);
     } catch (final IOException e) {

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/common/UserTaskRecordToTaskEntityMapper.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/common/UserTaskRecordToTaskEntityMapper.java
@@ -66,7 +66,7 @@ public class UserTaskRecordToTaskEntityMapper {
     final TaskEntity entity =
         new TaskEntity()
             .setImplementation(TaskImplementation.ZEEBE_USER_TASK)
-            .setId(String.valueOf(record.getKey()))
+            .setId(String.valueOf(record.getValue().getElementInstanceKey()))
             .setKey(record.getKey())
             .setPartitionId(record.getPartitionId())
             .setFlowNodeBpmnId(recordValue.getElementId())

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -218,7 +218,8 @@ public class JobZeebeRecordProcessorElasticSearch {
           .id(entity.getId())
           .upsert(objectMapper.writeValueAsString(entity), XContentType.JSON)
           .doc(jsonMap)
-          .retryOnConflict(UPDATE_RETRY_COUNT);
+          .retryOnConflict(UPDATE_RETRY_COUNT)
+          .routing(entity.getProcessInstanceId());
 
     } catch (final IOException e) {
       throw new PersistenceException(

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -90,7 +90,8 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
           .id(entity.getId())
           .upsert(objectMapper.writeValueAsString(entity), XContentType.JSON)
           .doc(jsonMap)
-          .retryOnConflict(UPDATE_RETRY_COUNT);
+          .retryOnConflict(UPDATE_RETRY_COUNT)
+          .routing(entity.getProcessInstanceId());
 
     } catch (final IOException e) {
       throw new PersistenceException(

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -205,7 +205,8 @@ public class JobZeebeRecordProcessorOpenSearch {
                         .id(entity.getId())
                         .document(CommonUtils.getJsonObjectFromEntity(updateFields))
                         .upsert(CommonUtils.getJsonObjectFromEntity(entity))
-                        .retryOnConflict(OpenSearchUtil.UPDATE_RETRY_COUNT)))
+                        .retryOnConflict(OpenSearchUtil.UPDATE_RETRY_COUNT)
+                        .routing(entity.getProcessInstanceId())))
         .build();
   }
 }

--- a/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-870/src/main/java/io/camunda/tasklist/zeebeimport/v870/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -83,7 +83,8 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
                         .id(entity.getId())
                         .document(CommonUtils.getJsonObjectFromEntity(updateFields))
                         .upsert(CommonUtils.getJsonObjectFromEntity(entity))
-                        .retryOnConflict(OpenSearchUtil.UPDATE_RETRY_COUNT)))
+                        .retryOnConflict(OpenSearchUtil.UPDATE_RETRY_COUNT)
+                        .routing(entity.getProcessInstanceId())))
         .build();
   }
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
@@ -174,7 +174,7 @@ public class ElasticsearchHelper implements NoSqlHelper {
   @Override
   public List<TaskEntity> getTasksFromIdAndIndex(final String index, final List<String> ids) {
     final TermsQueryBuilder q =
-        termsQuery(TaskTemplate.ID, CollectionUtil.toSafeArrayOfStrings(ids));
+        termsQuery(TaskTemplate.KEY, CollectionUtil.toSafeArrayOfStrings(ids));
     final SearchRequest searchRequest =
         new SearchRequest(index).source(new SearchSourceBuilder().query(q).size(QUERY_SIZE));
     try {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistTester.java
@@ -399,7 +399,7 @@ public class TasklistTester {
       final Optional<TaskEntity> teOptional =
           tasks.stream().filter(te -> state.equals(te.getState())).findFirst();
       if (teOptional.isPresent()) {
-        taskId = teOptional.get().getId();
+        taskId = String.valueOf(teOptional.get().getKey());
       } else {
         taskId = null;
       }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/TaskDTO.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/dto/TaskDTO.java
@@ -301,7 +301,7 @@ public final class TaskDTO {
             .setCreationTime(objectMapper.convertValue(taskEntity.getCreationTime(), String.class))
             .setCompletionTime(
                 objectMapper.convertValue(taskEntity.getCompletionTime(), String.class))
-            .setId(taskEntity.getId())
+            .setId(String.valueOf(taskEntity.getKey()))
             .setProcessInstanceId(taskEntity.getProcessInstanceId())
             .setTaskState(taskEntity.getState())
             .setAssignee(taskEntity.getAssignee())
@@ -369,7 +369,7 @@ public final class TaskDTO {
               .setCreationTime(
                   DateUtil.toOffsetDateTime(
                       DateUtil.SIMPLE_DATE_FORMAT.parse(taskDTO.getCreationTime()).toInstant()))
-              .setId(taskDTO.getId())
+              .setKey(Long.parseLong(taskDTO.getId()))
               .setProcessInstanceId(taskDTO.getProcessInstanceId())
               .setState(taskDTO.getTaskState())
               .setAssignee(taskDTO.getAssignee())

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -315,7 +315,7 @@ public class TaskService {
           taskStore.updateTaskLinkedForm(task, form.bpmnId(), form.version());
           LOGGER.debug(
               "Updated Task with id {} form link of key {} to formId {} and version {}",
-              task.getId(),
+              task.getKey(),
               task.getFormKey(),
               form.bpmnId(),
               form.version());
@@ -327,7 +327,7 @@ public class TaskService {
   }
 
   private void updateCompletedMetric(final TaskEntity task) {
-    LOGGER.info("Updating completed task metric for task with ID: {}", task.getId());
+    LOGGER.info("Updating completed task metric for task with ID: {}", task.getKey());
     try {
       metrics.recordCounts(COUNTER_NAME_COMPLETED_TASKS, 1, getTaskMetricLabels(task));
       assigneeMigrator.migrateUsageMetrics(getCurrentUser().getUserId());
@@ -338,9 +338,9 @@ public class TaskService {
         taskMetricsStore.registerTaskCompleteEvent(task);
       }
     } catch (final Exception e) {
-      LOGGER.error("Error updating completed task metric for task with ID: {}", task.getId(), e);
+      LOGGER.error("Error updating completed task metric for task with ID: {}", task.getKey(), e);
       throw new TasklistRuntimeException(
-          "Error updating completed task metric for task with ID: " + task.getId(), e);
+          "Error updating completed task metric for task with ID: " + task.getKey(), e);
     }
   }
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
@@ -596,7 +596,8 @@ public class VariableService {
       final String value,
       final int variableSizeThreshold) {
     return completeVariableSetup(
-        new DraftTaskVariableEntity().setId(getDraftVariableId(taskEntity.getId(), name)),
+        new DraftTaskVariableEntity()
+            .setId(getDraftVariableId(String.valueOf(taskEntity.getKey()), name)),
         taskEntity,
         name,
         value,
@@ -624,7 +625,10 @@ public class VariableService {
       final String value,
       final int variableSizeThreshold) {
 
-    entity.setTaskId(taskEntity.getId()).setName(name).setTenantId(taskEntity.getTenantId());
+    entity
+        .setTaskId(String.valueOf(taskEntity.getKey()))
+        .setName(name)
+        .setTenantId(taskEntity.getTenantId());
     if (value.length() > variableSizeThreshold) {
       // store preview
       entity.setValue(value.substring(0, variableSizeThreshold));

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/TaskServiceTest.java
@@ -260,18 +260,20 @@ class TaskServiceTest {
   @Test
   void getTask() {
     // Given
-    final String taskId = "123";
-    final var providedTask = new TaskEntity().setId(taskId).setState(TaskState.CREATED);
+    final var taskId = 123L;
+    final var taskIdAsString = String.valueOf(taskId);
+    final var providedTask =
+        new TaskEntity().setId(taskIdAsString).setKey(taskId).setState(TaskState.CREATED);
     final var expectedTask =
         new TaskDTO()
-            .setId(taskId)
+            .setId(taskIdAsString)
             .setTaskState(TaskState.CREATED)
             .setTenantId(DEFAULT_TENANT_IDENTIFIER)
             .setPriority(50);
-    when(taskStore.getTask(taskId)).thenReturn(providedTask);
+    when(taskStore.getTask(taskIdAsString)).thenReturn(providedTask);
 
     // When
-    final var result = instance.getTask(taskId);
+    final var result = instance.getTask(taskIdAsString);
 
     // Then
     assertThat(result).isEqualTo(expectedTask);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/VariableServiceTest.java
@@ -75,7 +75,8 @@ class VariableServiceTest {
   @Test
   void persistDraftTaskVariablesWhenValidInputShouldPersistVariables() {
     // given
-    final String taskId = "taskId_123";
+    final var taskId = 123L;
+    final var taskIdAsString = String.valueOf(taskId);
     final var flowNodeInstanceId = 456L;
     final List<VariableInputDTO> draftTaskVariables =
         List.of(
@@ -89,11 +90,12 @@ class VariableServiceTest {
                 .setValue("\"valueF_value_that_exceeds_variableSizeThreshold_limit\""));
     final TaskEntity task =
         new TaskEntity()
-            .setId(taskId)
+            .setId(taskIdAsString)
+            .setKey(taskId)
             .setFlowNodeInstanceId(String.valueOf(flowNodeInstanceId))
             .setProcessInstanceId("123")
             .setTenantId("tenant_a");
-    when(taskStore.getTask(taskId)).thenReturn(task);
+    when(taskStore.getTask(taskIdAsString)).thenReturn(task);
     final ImportProperties importProperties = mock(ImportProperties.class);
     when(tasklistProperties.getImporter()).thenReturn(importProperties);
     final int variableSizeThreshold = 30;
@@ -105,11 +107,11 @@ class VariableServiceTest {
             createVariableEntity(flowNodeInstanceId, "varD", "\"valueD\"", variableSizeThreshold)));
 
     // when
-    instance.persistDraftTaskVariables(taskId, draftTaskVariables);
+    instance.persistDraftTaskVariables(taskIdAsString, draftTaskVariables);
 
     // then
     verify(taskValidator).validateCanPersistDraftTaskVariables(task);
-    verify(draftVariableStore).deleteAllByTaskId(taskId);
+    verify(draftVariableStore).deleteAllByTaskId(taskIdAsString);
     verify(draftVariableStore).createOrUpdate(draftTaskVariableCaptor.capture());
 
     final Collection<DraftTaskVariableEntity> variablesToPersist =
@@ -117,17 +119,17 @@ class VariableServiceTest {
     assertThat(variablesToPersist)
         .extracting("id", "name", "value", "isPreview", "fullValue", "tenantId")
         .containsExactlyInAnyOrder(
-            tuple("taskId_123-varB", "varB", "\"valueB\"", false, "\"valueB\"", "tenant_a"),
+            tuple("123-varB", "varB", "\"valueB\"", false, "\"valueB\"", "tenant_a"),
             tuple("456-varC", "varC", "\"updateValueC\"", false, "\"updateValueC\"", "tenant_a"),
             tuple(
-                "taskId_123-varE",
+                "123-varE",
                 "varE",
                 "\"valueE_duplicate2\"",
                 false,
                 "\"valueE_duplicate2\"",
                 "tenant_a"),
             tuple(
-                "taskId_123-varF",
+                "123-varF",
                 "varF",
                 "\"valueF_value_that_exceeds_var",
                 true,

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/tasklist/TaskEntity.java
@@ -94,55 +94,6 @@ public class TaskEntity extends TasklistEntity<TaskEntity> {
 
   public TaskEntity() {}
 
-  public TaskEntity(
-      final Long key,
-      final String tenantId,
-      final Integer partitionId,
-      final String flowNodeBpmnId,
-      final String flowNodeInstanceId,
-      final OffsetDateTime completionTime,
-      final String processInstanceId,
-      final Long position,
-      final TaskState state,
-      final OffsetDateTime creationTime,
-      final String bpmnProcessId,
-      final String processDefinitionId,
-      final String assignee,
-      final String[] candidateGroups,
-      final String[] candidateUsers,
-      final String formKey,
-      final OffsetDateTime followUpDate,
-      final OffsetDateTime dueDate,
-      final String externalFormReference,
-      final Integer processDefinitionVersion,
-      final Map<String, String> customHeaders,
-      final Integer priority) {
-    super(flowNodeInstanceId, key, tenantId, partitionId);
-    this.flowNodeBpmnId = flowNodeBpmnId;
-    this.flowNodeInstanceId = flowNodeInstanceId;
-    this.completionTime = completionTime;
-    this.processInstanceId = processInstanceId;
-    this.position = position;
-    this.state = state;
-    this.creationTime = creationTime;
-    this.bpmnProcessId = bpmnProcessId;
-    this.processDefinitionId = processDefinitionId;
-    this.assignee = assignee;
-    this.candidateGroups = candidateGroups;
-    this.candidateUsers = candidateUsers;
-    this.formKey = formKey;
-    this.followUpDate = followUpDate;
-    this.dueDate = dueDate;
-    this.externalFormReference = externalFormReference;
-    this.processDefinitionVersion = processDefinitionVersion;
-    this.customHeaders = customHeaders;
-    this.priority = priority;
-    final TaskJoinRelationship joinRelation = new TaskJoinRelationship();
-    joinRelation.setName("task");
-    joinRelation.setParent(Long.valueOf(processInstanceId));
-    setJoin(joinRelation);
-  }
-
   public String getFlowNodeBpmnId() {
     return flowNodeBpmnId;
   }


### PR DESCRIPTION
## Description

* Ensures that the `key` is returned as `taskId` (and not the document id because they might differ)
* Ensures that all operations use the `key` field to fetch the tasks
* Provides the correct routing value when updating the task document
* As the 8.7 import is still in place, it is adjusted to deal with key vs. id and provides the routing value (it does not consider if the task has been created with 8.6 or not) - Since the importer will be deleted soon, this is just an intermediate state.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to #25293 
