### PR TITLE
poc: create sort filter enums for search

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -2837,7 +2837,7 @@ paths:
           content:
             application/problem+json:
               schema:
-                $ref: "#/components/schemas/ProblemDetail"                
+                $ref: "#/components/schemas/ProblemDetail"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /groups/search:
@@ -3805,6 +3805,12 @@ components:
           description: The user task search filters.
           allOf:
             - $ref: "#/components/schemas/UserTaskFilterRequest"
+        sort:
+          description: Sort field criteria.
+          type: array
+          items:
+            $ref: "#/components/schemas/UserTaskSearchQuerySortRequest"
+
     UserTaskVariableSearchQueryRequest:
       allOf:
         - $ref: "#/components/schemas/SearchQueryRequest"
@@ -5847,12 +5853,6 @@ components:
     SearchQueryRequest:
       type: object
       properties:
-        sort:
-          description: Sort field criteria.
-          type: array
-          items:
-            allOf:
-              - $ref: "#/components/schemas/SearchQuerySortRequest"
         page:
           description: Pagination criteria.
           allOf:
@@ -5891,6 +5891,16 @@ components:
           default: asc
       required:
         - field
+    UserTaskSearchQuerySortRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQuerySortRequest"
+      properties:
+        field:
+          type: string
+          description: My fancy foo bar
+          enum:
+            - assignee
+            - priority
     SearchQueryResponse:
       type: object
       properties:


### PR DESCRIPTION
## Description

Creates search-specific sort properties that define the allowed sort keys.

Resulting swagger editor:
![Swagger Editor result](https://github.com/user-attachments/assets/1dfa875a-5568-4265-b7b2-29a26a14472b)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
