### PR TITLE
fix: remove zeebe classpath in connectors runtime for c8run

### DIFF
--- a/c8run/internal/unix/unix.go
+++ b/c8run/internal/unix/unix.go
@@ -51,7 +51,7 @@ func (w *UnixC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir stri
 }
 
 func (w *UnixC8Run) ConnectorsCmd(javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
-	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*:" + parentDir + "/camunda-zeebe-" + camundaVersion + "/lib/*"
+	classPath := parentDir + "/*:" + parentDir + "/custom_connectors/*"
 	mainClass := "io.camunda.connector.runtime.app.ConnectorRuntimeApplication"
 	springConfigLocation := "--spring.config.location=" + parentDir + "/connectors-application.properties"
 	connectorsCmd := exec.Command(javaBinary, "-cp", classPath, mainClass, springConfigLocation)

--- a/c8run/internal/windows/windows.go
+++ b/c8run/internal/windows/windows.go
@@ -46,7 +46,7 @@ func (w *WindowsC8Run) ElasticsearchCmd(elasticsearchVersion string, parentDir s
 }
 
 func (w *WindowsC8Run) ConnectorsCmd(javaBinary string, parentDir string, camundaVersion string) *exec.Cmd {
-	connectorsCmd := exec.Command(javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*;"+parentDir+"\\camunda-zeebe-"+camundaVersion+"\\lib\\*", "io.camunda.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.location="+parentDir+"\\connectors-application.properties")
+	connectorsCmd := exec.Command(javaBinary, "-classpath", parentDir+"\\*;"+parentDir+"\\custom_connectors\\*", "io.camunda.connector.runtime.app.ConnectorRuntimeApplication", "--spring.config.location="+parentDir+"\\connectors-application.properties")
 	connectorsCmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: 0x08000000 | 0x00000200, // CREATE_NO_WINDOW, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags
 		// CreationFlags: 0x00000008 | 0x00000200, // DETACHED_PROCESS, CREATE_NEW_PROCESS_GROUP : https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags

--- a/c8run/main.go
+++ b/c8run/main.go
@@ -133,6 +133,7 @@ func adjustJavaOpts(javaOpts string, settings C8RunSettings) string {
 	if settings.port != 8080 {
 		javaOpts = javaOpts + " -Dserver.port=" + strconv.Itoa(settings.port)
 	}
+	javaOpts = javaOpts + " -Dspring.profiles.active=operate,tasklist,broker,identity"
 	os.Setenv("CAMUNDA_OPERATE_ZEEBE_RESTADDRESS", protocol+"://localhost:"+strconv.Itoa(settings.port))
 	return javaOpts
 }
@@ -183,7 +184,6 @@ func main() {
 	os.Setenv("CAMUNDA_OPERATE_IMPORTER_READERBACKOFF", "1000")
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_DELAY", "1")
 	os.Setenv("ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE", "1")
-	os.Setenv("SPRING_PROFILES_ACTIVE", "operate,tasklist,broker,identity")
 
 	// classPath := filepath.Join(parentDir, "configuration", "userlib") + "," + filepath.Join(parentDir, "configuration", "keystore")
 

--- a/c8run/main_test.go
+++ b/c8run/main_test.go
@@ -22,7 +22,7 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 		keystore:         "/tmp/camundatest/certs/secret.jks",
 		keystorePassword: "changeme",
 	}
-	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword
+	expectedJavaOpts := "JAVA_OPTS= -Dserver.ssl.keystore=file:" + settings.keystore + " -Dserver.ssl.enabled=true" + " -Dserver.ssl.key-password=" + settings.keystorePassword + " -Dspring.profiles.active=operate,tasklist,broker,identity"
 
 	javaOpts := adjustJavaOpts("", settings)
 	c8runPlatform := getC8RunPlatform()
@@ -39,30 +39,6 @@ func TestCamundaCmdWithKeystoreSettings(t *testing.T) {
 		}
 	}
 	assert.Equal(t, expectedJavaOpts, foundVar)
-}
-
-func TestCamundaCmdHasNoJavaOpts(t *testing.T) {
-
-	settings := C8RunSettings{
-		config:           "",
-		detached:         false,
-		port:             8080,
-		keystore:         "",
-		keystorePassword: "",
-	}
-
-	javaOpts := adjustJavaOpts("", settings)
-	c8runPlatform := getC8RunPlatform()
-	err := validateKeystore(settings, "/tmp/camundatest/")
-	assert.Nil(t, err)
-
-	cmd := c8runPlatform.CamundaCmd("8.7.0", "/tmp/camundatest/", "", javaOpts)
-
-	for _, envVar := range cmd.Env {
-		if strings.Contains(envVar, "JAVA_OPTS") {
-			assert.Fail(t, "JAVA_OPTS should not be set")
-		}
-	}
 }
 
 func TestCamundaCmdKeystoreRequiresPassword(t *testing.T) {


### PR DESCRIPTION
## Description

Outbound connectors does not currently work due to an error where Liquibase modules from zeebe could not start in connectors.  This was due to an error when setting the classpath where c8run improperly references the zeebe classpath as part of it's own. This PR removes that part of the classpath.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
