### PR TITLE
feat: provide access to `action` and `priority` user task properties in task listeners

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -184,7 +184,7 @@ public final class BpmnJobBehavior {
             listenerJobProperties -> {
               final var taskHeaders =
                   Collections.singletonMap(
-                      Protocol.RESERVED_HEADER_NAME_PREFIX + "userTaskKey",
+                      Protocol.USER_TASK_KEY_HEADER_NAME,
                       Objects.toString(taskRecordValue.getUserTaskKey()));
               writeJobCreatedEvent(
                   context,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -181,18 +181,13 @@ public final class BpmnJobBehavior {
       final TaskListener listener) {
     evaluateTaskListenerJobExpressions(listener.getJobWorkerProperties(), context, taskRecordValue)
         .thenDo(
-            listenerJobProperties -> {
-              final var taskHeaders =
-                  Collections.singletonMap(
-                      Protocol.USER_TASK_KEY_HEADER_NAME,
-                      Objects.toString(taskRecordValue.getUserTaskKey()));
-              writeJobCreatedEvent(
-                  context,
-                  listenerJobProperties,
-                  JobKind.TASK_LISTENER,
-                  fromTaskListenerEventType(listener.getEventType()),
-                  taskHeaders);
-            })
+            listenerJobProperties ->
+                writeJobCreatedEvent(
+                    context,
+                    listenerJobProperties,
+                    JobKind.TASK_LISTENER,
+                    fromTaskListenerEventType(listener.getEventType()),
+                    extractUserTaskHeaders(taskRecordValue)))
         .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
   }
 
@@ -328,6 +323,17 @@ public final class BpmnJobBehavior {
       headers.put(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, formKey);
     }
     return headerEncoder.encode(headers);
+  }
+
+  private Map<String, String> extractUserTaskHeaders(final UserTaskRecord userTaskRecord) {
+    final var headers = new HashMap<String, String>();
+
+    if (userTaskRecord.getUserTaskKey() > 0) {
+      headers.put(
+          Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getUserTaskKey()));
+    }
+
+    return Collections.unmodifiableMap(headers);
   }
 
   public void cancelJob(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -333,6 +333,15 @@ public final class BpmnJobBehavior {
           Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getUserTaskKey()));
     }
 
+    if (userTaskRecord.getPriority() > 0) {
+      headers.put(
+          Protocol.USER_TASK_PRIORITY_HEADER_NAME, String.valueOf(userTaskRecord.getPriority()));
+    }
+
+    if (StringUtils.isNotEmpty(userTaskRecord.getAction())) {
+      headers.put(Protocol.USER_TASK_ACTION_HEADER_NAME, userTaskRecord.getAction());
+    }
+
     return Collections.unmodifiableMap(headers);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -1113,12 +1113,8 @@ public class TaskListenerTest {
             entry(Protocol.USER_TASK_CANDIDATE_USERS_HEADER_NAME, "[\"new_candidate_user\"]"),
             entry(Protocol.USER_TASK_CANDIDATE_GROUPS_HEADER_NAME, "[\"new_candidate_group\"]"),
             entry(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "new_due_date"),
-            entry(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "new_follow_up_date")
-            /*
-             // priority is not yet accessible as a custom header
-             , entry(Protocol.USER_TASK_PRIORITY_HEADER_NAME, "100")
-            */
-            );
+            entry(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "new_follow_up_date"),
+            entry(Protocol.USER_TASK_PRIORITY_HEADER_NAME, "100"));
 
     completeJobs(processInstanceKey, listenerType + "_2");
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -67,8 +67,6 @@ public class TaskListenerTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   private static final String PROCESS_ID = "process";
-  private static final String USER_TASK_KEY_HEADER_NAME =
-      Protocol.RESERVED_HEADER_NAME_PREFIX + "userTaskKey";
 
   private static final String USER_TASK_ELEMENT_ID = "my_user_task";
 
@@ -627,7 +625,7 @@ public class TaskListenerTest {
                         .zeebeTaskListener(l -> l.completing().type(listenerType))));
 
     // when
-    final var userTaskRecordValue = ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    final var userTaskRecord = ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // then
     final var activatedListenerJob = activateJob(processInstanceKey, listenerType);
@@ -641,7 +639,7 @@ public class TaskListenerTest {
             entry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "admin"),
             entry(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2095-09-18T10:31:10+02:00"),
             entry(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, Objects.toString(form.getFormKey())),
-            entry(USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecordValue.getKey())));
+            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getKey())));
     completeJobs(processInstanceKey, listenerType);
   }
 
@@ -667,7 +665,7 @@ public class TaskListenerTest {
 
     // when
     ENGINE.userTask().ofInstance(processInstanceKey).update(changes);
-    final var userTaskRecordValue = ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    final var userTaskRecord = ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // then
     final var activatedListenerJob = activateJob(processInstanceKey, listenerType);
@@ -678,7 +676,7 @@ public class TaskListenerTest {
             entry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "admin"),
             entry(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2087-09-21T11:22:33+02:00"),
             entry(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2097-09-21T11:22:33+02:00"),
-            entry(USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecordValue.getKey())));
+            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getKey())));
     completeJobs(processInstanceKey, listenerType);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -622,10 +622,11 @@ public class TaskListenerTest {
                         .zeebeCandidateGroups("group_A, group_C, group_F")
                         .zeebeFormId("Form_0w7r08e")
                         .zeebeDueDate("2095-09-18T10:31:10+02:00")
+                        .zeebeTaskPriority("88")
                         .zeebeTaskListener(l -> l.completing().type(listenerType))));
 
     // when
-    final var userTaskRecord = ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    final var userTaskCommand = ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // then
     final var activatedListenerJob = activateJob(processInstanceKey, listenerType);
@@ -639,7 +640,9 @@ public class TaskListenerTest {
             entry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "admin"),
             entry(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2095-09-18T10:31:10+02:00"),
             entry(Protocol.USER_TASK_FORM_KEY_HEADER_NAME, Objects.toString(form.getFormKey())),
-            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getKey())));
+            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskCommand.getKey())),
+            entry(Protocol.USER_TASK_PRIORITY_HEADER_NAME, "88"),
+            entry(Protocol.USER_TASK_ACTION_HEADER_NAME, "complete"));
     completeJobs(processInstanceKey, listenerType);
   }
 
@@ -661,11 +664,12 @@ public class TaskListenerTest {
             .setCandidateGroupsList(List.of("group_J", "group_R"))
             .setCandidateUsersList(List.of("user_T"))
             .setDueDate("2087-09-21T11:22:33+02:00")
-            .setFollowUpDate("2097-09-21T11:22:33+02:00");
+            .setFollowUpDate("2097-09-21T11:22:33+02:00")
+            .setPriority(42);
 
     // when
     ENGINE.userTask().ofInstance(processInstanceKey).update(changes);
-    final var userTaskRecord = ENGINE.userTask().ofInstance(processInstanceKey).complete();
+    final var userTaskCommand = ENGINE.userTask().ofInstance(processInstanceKey).complete();
 
     // then
     final var activatedListenerJob = activateJob(processInstanceKey, listenerType);
@@ -676,7 +680,9 @@ public class TaskListenerTest {
             entry(Protocol.USER_TASK_ASSIGNEE_HEADER_NAME, "admin"),
             entry(Protocol.USER_TASK_DUE_DATE_HEADER_NAME, "2087-09-21T11:22:33+02:00"),
             entry(Protocol.USER_TASK_FOLLOW_UP_DATE_HEADER_NAME, "2097-09-21T11:22:33+02:00"),
-            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskRecord.getKey())));
+            entry(Protocol.USER_TASK_KEY_HEADER_NAME, String.valueOf(userTaskCommand.getKey())),
+            entry(Protocol.USER_TASK_PRIORITY_HEADER_NAME, "42"),
+            entry(Protocol.USER_TASK_ACTION_HEADER_NAME, "complete"));
     completeJobs(processInstanceKey, listenerType);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -209,7 +209,8 @@ public final class UserTaskClient {
         .setCandidateGroupsChanged()
         .setCandidateUsersChanged()
         .setDueDateChanged()
-        .setFollowUpDateChanged();
+        .setFollowUpDateChanged()
+        .setPriorityChanged();
     userTaskRecord.wrapChangedAttributes(changes, true);
 
     final long userTaskKey = findUserTaskKey();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -71,9 +71,8 @@ public final class Protocol {
   /** Prefix for key of reserved task headers */
   public static final String RESERVED_HEADER_NAME_PREFIX = "io.camunda.zeebe:";
 
-  /** Task header key used for user tasks to contain form key from BPMN XML */
-  public static final String USER_TASK_FORM_KEY_HEADER_NAME =
-      RESERVED_HEADER_NAME_PREFIX + "formKey";
+  /** Task header key used for the action associated with the user task */
+  public static final String USER_TASK_ACTION_HEADER_NAME = RESERVED_HEADER_NAME_PREFIX + "action";
 
   /** Task header key used for assignee */
   public static final String USER_TASK_ASSIGNEE_HEADER_NAME =
@@ -95,6 +94,10 @@ public final class Protocol {
   public static final String USER_TASK_FOLLOW_UP_DATE_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "followUpDate";
 
+  /** Task header key used for user tasks to contain form key from BPMN XML */
+  public static final String USER_TASK_FORM_KEY_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "formKey";
+
   /** Task header key used for the unique user task key. */
   public static final String USER_TASK_KEY_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "userTaskKey";
@@ -102,9 +105,6 @@ public final class Protocol {
   /** Task header key used for the priority of the user task */
   public static final String USER_TASK_PRIORITY_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "priority";
-
-  /** Task header key used for the action associated with the user task */
-  public static final String USER_TASK_ACTION_HEADER_NAME = RESERVED_HEADER_NAME_PREFIX + "action";
 
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -95,6 +95,10 @@ public final class Protocol {
   public static final String USER_TASK_FOLLOW_UP_DATE_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "followUpDate";
 
+  /** Task header key used for the unique user task key. */
+  public static final String USER_TASK_KEY_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "userTaskKey";
+
   /** Task header key used for the priority of the user task */
   public static final String USER_TASK_PRIORITY_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "priority";

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/Protocol.java
@@ -95,6 +95,13 @@ public final class Protocol {
   public static final String USER_TASK_FOLLOW_UP_DATE_HEADER_NAME =
       RESERVED_HEADER_NAME_PREFIX + "followUpDate";
 
+  /** Task header key used for the priority of the user task */
+  public static final String USER_TASK_PRIORITY_HEADER_NAME =
+      RESERVED_HEADER_NAME_PREFIX + "priority";
+
+  /** Task header key used for the action associated with the user task */
+  public static final String USER_TASK_ACTION_HEADER_NAME = RESERVED_HEADER_NAME_PREFIX + "action";
+
   public static long encodePartitionId(final int partitionId, final long key) {
     return ((long) partitionId << KEY_BITS) + key;
   }


### PR DESCRIPTION
## Description

Task listener jobs currently provide headers for various user task properties (e.g., `assignee`, `dueDate`, `candidateUsers`). However, they lacked the **`priority`** and **`action`** properties, which limited the ability of task listeners to make decisions or perform specific actions based on these properties.

This PR introduces support for including the **`priority`** and **`action`** properties in task listener job headers. By adding these properties, task listeners now have richer context, enabling better handling and decision-making during task lifecycle processing.

> [!NOTE]  
Additionally, this PR introduces a dedicated `Protocol.USER_TASK_KEY_HEADER_NAME` constant for the **`userTaskKey`** property. Previously, the `userTaskKey` property was added directly using a string expression. Defining it as a constant improves consistency, aligning it with how other headers are defined.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #24102 
