### PR TITLE
fix: allow SchemaManager to update current template index mappings

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/schema/SchemaManager.java
@@ -146,9 +146,8 @@ public class SchemaManager {
             "Index alias: '{}'. New fields will be added '{}'",
             descriptor.getFullQualifiedName(),
             newProperties);
-
-        searchEngineClient.putMapping(descriptor, newProperties);
       }
+      searchEngineClient.putMapping(descriptor, newProperties);
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
SchemaManager did not update the running index mappings when performing a Template update. Since all of our changes are new fields and not updates we can perform the update of the current index of a template without needing a reindexing.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
