### PR TITLE
Migrate joining parallel gateway with at least one incoming sequence flow is taken

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -122,7 +122,8 @@ public final class BpmnProcessors {
         commandDistributionBehavior,
         partitionId,
         routingInfo,
-        authCheckBehavior);
+        authCheckBehavior,
+        keyGenerator);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -285,7 +286,8 @@ public final class BpmnProcessors {
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
       final RoutingInfo routingInfo,
-      final AuthorizationCheckBehavior authCheckBehavior) {
+      final AuthorizationCheckBehavior authCheckBehavior,
+      final KeyGenerator keyGenerator) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
@@ -296,7 +298,8 @@ public final class BpmnProcessors {
             commandDistributionBehavior,
             partitionId,
             routingInfo,
-            authCheckBehavior));
+            authCheckBehavior,
+            keyGenerator));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -296,7 +296,8 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetProcessDefinition,
         targetElementId,
         processInstanceKey);
-    requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
+    requireNoConcurrentCommand(
+        eventScopeInstanceState, elementInstance, sourceProcessDefinition, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(
         elementInstance.getKey(),

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -307,7 +307,7 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetElementId,
         processInstanceKey);
     requireNoConcurrentCommand(
-        eventScopeInstanceState, elementInstance, sourceProcessDefinition, processInstanceKey);
+        eventScopeInstanceState, elementInstanceState, elementInstance, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(
         elementInstance.getKey(),
@@ -325,18 +325,18 @@ public class ProcessInstanceMigrationMigrateProcessor
             sourceElementIdToTargetElementId,
             elementInstance);
 
-      sequenceFlows.forEach(
-          sequenceFlow -> {
-            final var sequenceFlowRecord = new ProcessInstanceRecord();
-            sequenceFlowRecord.copyFrom(elementInstanceRecord);
-            sequenceFlowRecord
-                .setElementId(sequenceFlow.getId())
-                .setBpmnElementType(sequenceFlow.getElementType())
-                .setBpmnEventType(sequenceFlow.getEventType())
-                .setFlowScopeKey(elementInstance.getKey())
-                .resetElementInstancePath()
-                .resetCallingElementPath()
-                .resetProcessDefinitionPath();
+    sequenceFlows.forEach(
+        sequenceFlow -> {
+          final var sequenceFlowRecord = new ProcessInstanceRecord();
+          sequenceFlowRecord.copyFrom(elementInstanceRecord);
+          sequenceFlowRecord
+              .setElementId(sequenceFlow.getId())
+              .setBpmnElementType(sequenceFlow.getElementType())
+              .setBpmnEventType(sequenceFlow.getEventType())
+              .setFlowScopeKey(elementInstance.getKey())
+              .resetElementInstancePath()
+              .resetCallingElementPath()
+              .resetProcessDefinitionPath();
 
           stateWriter.appendFollowUpEvent(
               keyGenerator.nextKey(), ProcessInstanceIntent.ELEMENT_MIGRATED, sequenceFlowRecord);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -318,15 +318,12 @@ public class ProcessInstanceMigrationMigrateProcessor
             .setVersion(targetProcessDefinition.getVersion())
             .setElementId(targetElementId));
 
-    final int numberOfTakenSequenceFlows =
-        elementInstanceState.getNumberOfTakenSequenceFlows(elementInstance.getKey());
-    if (numberOfTakenSequenceFlows > 0) {
-      final Set<ExecutableSequenceFlow> sequenceFlows =
-          getSequenceFlowsToMigrate(
-              sourceProcessDefinition,
-              targetProcessDefinition,
-              sourceElementIdToTargetElementId,
-              elementInstance);
+    final Set<ExecutableSequenceFlow> sequenceFlows =
+        getSequenceFlowsToMigrate(
+            sourceProcessDefinition,
+            targetProcessDefinition,
+            sourceElementIdToTargetElementId,
+            elementInstance);
 
       sequenceFlows.forEach(
           sequenceFlow -> {
@@ -336,12 +333,14 @@ public class ProcessInstanceMigrationMigrateProcessor
                 .setElementId(sequenceFlow.getId())
                 .setBpmnElementType(sequenceFlow.getElementType())
                 .setBpmnEventType(sequenceFlow.getEventType())
-                .setFlowScopeKey(elementInstance.getKey());
+                .setFlowScopeKey(elementInstance.getKey())
+                .resetElementInstancePath()
+                .resetCallingElementPath()
+                .resetProcessDefinitionPath();
 
-            stateWriter.appendFollowUpEvent(
-                keyGenerator.nextKey(), ProcessInstanceIntent.ELEMENT_MIGRATED, sequenceFlowRecord);
-          });
-    }
+          stateWriter.appendFollowUpEvent(
+              keyGenerator.nextKey(), ProcessInstanceIntent.ELEMENT_MIGRATED, sequenceFlowRecord);
+        });
 
     if (elementInstance.getJobKey() > 0) {
       final var job = jobState.getJob(elementInstance.getJobKey());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -219,7 +219,7 @@ public final class EventAppliers implements EventApplier {
         new ProcessInstanceSequenceFlowTakenApplier(elementInstanceState, processState));
     register(
         ProcessInstanceIntent.ELEMENT_MIGRATED,
-        new ProcessInstanceElementMigratedApplier(elementInstanceState));
+        new ProcessInstanceElementMigratedApplier(elementInstanceState, processState));
   }
 
   private void registerProcessInstanceCreationAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplier.java
@@ -7,26 +7,42 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.agrona.DirectBuffer;
 
 /** Applies state changes for `ProcessInstance:Element_Migrated` */
 final class ProcessInstanceElementMigratedApplier
     implements TypedEventApplier<ProcessInstanceIntent, ProcessInstanceRecord> {
 
   private final MutableElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public ProcessInstanceElementMigratedApplier(
-      final MutableElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState, final ProcessState processState) {
     this.elementInstanceState = elementInstanceState;
+    this.processState = processState;
   }
 
   @Override
   public void applyState(final long elementInstanceKey, final ProcessInstanceRecord value) {
+    // noElement is true when incoming sequence flows of the migrated gateway only partly taken
+    final boolean noElement = elementInstanceState.getInstance(elementInstanceKey) == null;
+    if (noElement && value.getBpmnElementType() == BpmnElementType.PARALLEL_GATEWAY) {
+      migrateTakenSequenceFlowsForGateway(value);
+      return;
+    }
+
     final var previousProcessDefinitionKey = new AtomicLong();
     elementInstanceState.updateInstance(
         elementInstanceKey,
@@ -47,5 +63,36 @@ final class ProcessInstanceElementMigratedApplier
       elementInstanceState.insertProcessInstanceKeyByDefinitionKey(
           value.getProcessInstanceKey(), value.getProcessDefinitionKey());
     }
+  }
+
+  private void migrateTakenSequenceFlowsForGateway(final ProcessInstanceRecord gatewayRecord) {
+    final Set<DirectBuffer> incomingSequenceFlowIds =
+        processState
+            .getFlowElement(
+                gatewayRecord.getProcessDefinitionKey(),
+                gatewayRecord.getTenantId(),
+                gatewayRecord.getElementIdBuffer(),
+                ExecutableFlowNode.class)
+            .getIncoming()
+            .stream()
+            .map(AbstractFlowElement::getId)
+            .collect(Collectors.toSet());
+
+    elementInstanceState.visitTakenSequenceFlows(
+        gatewayRecord.getFlowScopeKey(),
+        (flowScopeKey, gatewayElementId, sequenceFlowId, number) -> {
+          if (incomingSequenceFlowIds.contains(sequenceFlowId)) {
+            IntStream.range(0, number)
+                .forEach(
+                    ignore -> {
+                      // decrement the number of taken sequence flows for the old gateway
+                      elementInstanceState.decrementNumberOfTakenSequenceFlows(
+                          flowScopeKey, gatewayElementId, sequenceFlowId);
+                      // increment the number of taken sequence flows for the new gateway
+                      elementInstanceState.incrementNumberOfTakenSequenceFlows(
+                          flowScopeKey, gatewayRecord.getElementIdBuffer(), sequenceFlowId);
+                    });
+          }
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -63,6 +63,15 @@ public interface ElementInstanceState {
       final long flowScopeKey, final DirectBuffer gatewayElementId);
 
   /**
+   * Visits all taken sequence flows of the given (joining) gateway and applies the given visitor to
+   * each taken sequence flow
+   *
+   * @param flowScopeKey the key of the flow scope that contains the gateway
+   * @param visitor the visitor that is applied for each taken sequence flow
+   */
+  void visitTakenSequenceFlows(final long flowScopeKey, final TakenSequenceFlowVisitor visitor);
+
+  /**
    * Returns a list of process instance keys that belong to a specific process definition.
    *
    * <p>Caution: This will also return the keys of banned process instances!
@@ -80,4 +89,13 @@ public interface ElementInstanceState {
    * @return a boolean indicating if there are running instances
    */
   boolean hasActiveProcessInstances(long processDefinitionKey, final List<Long> bannedInstances);
+
+  @FunctionalInterface
+  interface TakenSequenceFlowVisitor {
+    void visit(
+        final long flowScopeKey,
+        final DirectBuffer gatewayElementId,
+        final DirectBuffer sequenceFlowId,
+        final int number);
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -53,6 +53,16 @@ public interface ElementInstanceState {
   int getNumberOfTakenSequenceFlows(final long flowScopeKey, final DirectBuffer gatewayElementId);
 
   /**
+   * Returns the number of the taken sequence flows in the scope of the given flow scope key.
+   *
+   * <p><b>NOTE</b>: Each sequence flow counts only as one, even if it is taken multiple times.
+   *
+   * @param flowScopeKey the key of the flow scope that contains the gateway
+   * @return the number of taken sequence flows in the scope of the given flow scope key
+   */
+  int getNumberOfTakenSequenceFlows(final long flowScopeKey);
+
+  /**
    * Returns the taken sequence flows that are connected to the given (joining) gateway.
    *
    * @param flowScopeKey the key of the flow scope that contains the gateway

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -402,6 +402,21 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
+  public void visitTakenSequenceFlows(
+      final long flowScopeKey, final TakenSequenceFlowVisitor visitor) {
+    this.flowScopeKey.wrapLong(flowScopeKey);
+    numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
+        this.flowScopeKey,
+        (key, number) -> {
+          visitor.visit(
+              key.first().first().getValue(),
+              key.first().second().getBuffer(),
+              key.second().getBuffer(),
+              number.getValue());
+        });
+  }
+
+  @Override
   public List<Long> getProcessInstanceKeysByDefinitionKey(final long processDefinitionKey) {
     final List<Long> processInstanceKeys = new ArrayList<>();
     this.processDefinitionKey.wrapLong(processDefinitionKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -293,6 +293,27 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
+  public void decrementNumberOfTakenSequenceFlows(
+      final long flowScopeKey,
+      final DirectBuffer gatewayElementId,
+      final DirectBuffer sequenceFlowElementId) {
+    this.flowScopeKey.wrapLong(flowScopeKey);
+    this.gatewayElementId.wrapBuffer(gatewayElementId);
+    this.sequenceFlowElementId.wrapBuffer(sequenceFlowElementId);
+
+    final var number = numberOfTakenSequenceFlowsColumnFamily.get(numberOfTakenSequenceFlowsKey);
+
+    final var newValue = number.getValue() - 1;
+    if (newValue > 0) {
+      numberOfTakenSequenceFlows.wrapInt(newValue);
+      numberOfTakenSequenceFlowsColumnFamily.update(
+          numberOfTakenSequenceFlowsKey, numberOfTakenSequenceFlows);
+    } else {
+      numberOfTakenSequenceFlowsColumnFamily.deleteExisting(numberOfTakenSequenceFlowsKey);
+    }
+  }
+
+  @Override
   public ElementInstance getInstance(final long key) {
     elementInstanceKey.wrapLong(key);
     final ElementInstance elementInstance = elementInstanceColumnFamily.get(elementInstanceKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -275,24 +275,6 @@ public final class DbElementInstanceState implements MutableElementInstanceState
   }
 
   @Override
-  public void insertProcessInstanceKeyByDefinitionKey(
-      final long processInstanceKey, final long processDefinitionKey) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    elementInstanceKey.wrapLong(processInstanceKey);
-    processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
-        processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
-  }
-
-  @Override
-  public void deleteProcessInstanceKeyByDefinitionKey(
-      final long processInstanceKey, final long processDefinitionKey) {
-    this.processDefinitionKey.wrapLong(processDefinitionKey);
-    elementInstanceKey.wrapLong(processInstanceKey);
-    processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
-        processInstanceKeyByProcessDefinitionKey);
-  }
-
-  @Override
   public void decrementNumberOfTakenSequenceFlows(
       final long flowScopeKey,
       final DirectBuffer gatewayElementId,
@@ -311,6 +293,24 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     } else {
       numberOfTakenSequenceFlowsColumnFamily.deleteExisting(numberOfTakenSequenceFlowsKey);
     }
+  }
+
+  @Override
+  public void insertProcessInstanceKeyByDefinitionKey(
+      final long processInstanceKey, final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    elementInstanceKey.wrapLong(processInstanceKey);
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.insert(
+        processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
+  }
+
+  @Override
+  public void deleteProcessInstanceKeyByDefinitionKey(
+      final long processInstanceKey, final long processDefinitionKey) {
+    this.processDefinitionKey.wrapLong(processDefinitionKey);
+    elementInstanceKey.wrapLong(processInstanceKey);
+    processInstanceKeyByProcessDefinitionKeyColumnFamily.deleteExisting(
+        processInstanceKeyByProcessDefinitionKey);
   }
 
   @Override
@@ -378,6 +378,20 @@ public final class DbElementInstanceState implements MutableElementInstanceState
     final var count = new MutableInteger(0);
     numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
         flowScopeKeyAndElementId,
+        (key, number) -> {
+          count.increment();
+        });
+
+    return count.get();
+  }
+
+  @Override
+  public int getNumberOfTakenSequenceFlows(final long flowScopeKey) {
+    this.flowScopeKey.wrapLong(flowScopeKey);
+
+    final var count = new MutableInteger(0);
+    numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
+        this.flowScopeKey,
         (key, number) -> {
           count.increment();
         });

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableElementInstanceState.java
@@ -62,6 +62,19 @@ public interface MutableElementInstanceState extends ElementInstanceState {
       final long flowScopeKey, final DirectBuffer gatewayElementId);
 
   /**
+   * Decrements the numbers that counts how often a sequence flow of the given gateway has been
+   * taken.
+   *
+   * @param flowScopeKey the key of the flow scope that contains the gateway
+   * @param gatewayElementId the element id of the gateway that is the target of the sequence flow
+   * @param sequenceFlowElementId the element id of the sequence flow that is taken
+   */
+  void decrementNumberOfTakenSequenceFlows(
+      final long flowScopeKey,
+      final DirectBuffer gatewayElementId,
+      final DirectBuffer sequenceFlowElementId);
+
+  /**
    * Inserts a new reference from process instance key to process definition key.
    *
    * <p>This makes it possible to query for all process instances of a specific process definition

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -12,12 +12,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.AssertionsForInterfaceTypes;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -111,5 +114,293 @@ public class MigrateParallelGatewayTest {
         .describedAs(
             "Expected to successfully evaluate execution listener job type and resolve incident")
         .contains("end2");
+  }
+
+  @Test
+  public void shouldMigrateJoiningParallelGatewayWithOneSequenceFlowTaken() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("flow1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to take the sequence flow to the joining gateway")
+        .isNotNull();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task2", "task3")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PARALLEL_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining parallel gateway")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateJoiningParallelGatewayWithMultipleSequenceFlowsTaken() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join1")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join1")
+                    .moveToNode("fork")
+                    .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                    .connectTo("join1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .parallelGateway("fork")
+                    .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                    .sequenceFlowId("flow1")
+                    .parallelGateway("join2")
+                    .endEvent()
+                    .moveToNode("fork")
+                    .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                    .sequenceFlowId("flow2")
+                    .connectTo("join2")
+                    .moveToNode("fork")
+                    .serviceTask("task4", b -> b.zeebeJobType("type4"))
+                    .connectTo("join2")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r ->
+                        r.getValue() instanceof ProcessInstanceRecord
+                            && ((ProcessInstanceRecord) r.getValue()).getElementId().equals("task1")
+                            && r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SEQUENCE_FLOW)
+                .limit(2))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expected to take the sequence flows to the joining gateway")
+        .contains("flow1", "flow2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("task3", "task4")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type3").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PARALLEL_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining parallel gateway")
+        .isNotNull();
+  }
+
+  @Test
+  public void shouldMigrateJoiningParallelGatewayInsideSubprocess() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub1",
+                        s ->
+                            s.embeddedSubProcess()
+                                .startEvent()
+                                .parallelGateway("fork")
+                                .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                                .sequenceFlowId("flow1")
+                                .parallelGateway("join1")
+                                .endEvent()
+                                .moveToNode("fork")
+                                .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                                .sequenceFlowId("flow2")
+                                .connectTo("join1")
+                                .moveToNode("fork")
+                                .serviceTask("task3", b -> b.zeebeJobType("type3"))
+                                .connectTo("join1"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .subProcess(
+                        "sub2",
+                        s ->
+                            s.embeddedSubProcess()
+                                .startEvent()
+                                .parallelGateway("fork")
+                                .serviceTask("task1", b -> b.zeebeJobType("type1"))
+                                .sequenceFlowId("flow1")
+                                .parallelGateway("join2")
+                                .endEvent()
+                                .moveToNode("fork")
+                                .serviceTask("task2", b -> b.zeebeJobType("type2"))
+                                .sequenceFlowId("flow2")
+                                .connectTo("join2")
+                                .moveToNode("fork")
+                                .serviceTask("task4", b -> b.zeebeJobType("type4"))
+                                .connectTo("join2"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    AssertionsForInterfaceTypes.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .limit(2))
+        .hasSize(2);
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("type1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
+
+    assertThat(
+            RecordingExporter.records()
+                .skipUntil(
+                    r ->
+                        r.getValue() instanceof ProcessInstanceRecord
+                            && ((ProcessInstanceRecord) r.getValue()).getElementId().equals("task1")
+                            && r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .processInstanceRecords()
+                .withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SEQUENCE_FLOW)
+                .limit(2))
+        .extracting(r -> r.getValue().getElementId())
+        .describedAs("Expected to take the sequence flows to the joining gateway")
+        .contains("flow1", "flow2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("sub1", "sub2")
+        .addMappingInstruction("task3", "task4")
+        .addMappingInstruction("join1", "join2")
+        .migrate();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("type3").complete();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.PARALLEL_GATEWAY)
+                .withElementId("join2")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to activate the joining parallel gateway")
+        .isNotNull();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateParallelGatewayTest.java
@@ -255,13 +255,11 @@ public class MigrateParallelGatewayTest {
     ENGINE.job().ofInstance(processInstanceKey).withType("type2").complete();
 
     assertThat(
-            RecordingExporter.records()
+            RecordingExporter.processInstanceRecords()
                 .skipUntil(
                     r ->
-                        r.getValue() instanceof ProcessInstanceRecord
-                            && ((ProcessInstanceRecord) r.getValue()).getElementId().equals("task1")
-                            && r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED)
-                .processInstanceRecords()
+                        r.getIntent() == ProcessInstanceIntent.ELEMENT_COMPLETED
+                            && r.getValue().getElementId().equals("task1"))
                 .withIntent(ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN)
                 .withProcessInstanceKey(processInstanceKey)
                 .withElementType(BpmnElementType.SEQUENCE_FLOW)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementMigratedApplierTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.appliers;
 import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -28,13 +29,15 @@ public class ProcessInstanceElementMigratedApplierTest {
   private MutableProcessingState processingState;
 
   private MutableElementInstanceState elementInstanceState;
+  private ProcessState processState;
   private ProcessInstanceElementMigratedApplier processInstanceElementMigratedApplier;
 
   @BeforeEach
   public void setup() {
     elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
     processInstanceElementMigratedApplier =
-        new ProcessInstanceElementMigratedApplier(elementInstanceState);
+        new ProcessInstanceElementMigratedApplier(elementInstanceState, processState);
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

I used the existing `ELEMENT_MIGRATED`  event to apply the gateway migration. It also conforms with the migrating logic since we allow migrating the gateway to a new id. However, it was a little tricky to handle it in the applier. Because, we do not have the element instance created for the gateway yet. The element instance for the gateway is created only when all incoming sequence flows to the gateway are taken. For me, this way looks like the one that matches with the existing element migration implementation but if any, I am open to discuss alternatives to handle the gateway migration differently.

Please note that gateway mapping validations are not implemented in this PR to keep it smaller. They will be implemented in the next PR.

## Related issues

closes #25640
