### PR TITLE
fix: AuthenticationConfiguration is not used except with broker modules

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/identity/AuthenticationConfiguration.java
@@ -10,8 +10,10 @@ package io.camunda.application.commons.identity;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
+@Configuration(proxyBeanMethods = false)
 @ComponentScan(basePackages = {"io.camunda.authentication"})
 @ConfigurationPropertiesScan(basePackages = {"io.camunda.authentication"})
 @Profile("auth-basic|auth-oidc")

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -39,7 +39,6 @@ import org.springframework.context.annotation.Profile;
     basePackages = {
       "io.camunda.zeebe.broker",
       "io.camunda.zeebe.shared",
-      "io.camunda.authentication"
     })
 @Profile("broker")
 public class BrokerModuleConfiguration implements CloseableSilently {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
`io.camunda.authentication` is scanned only with broker module.
So when I run Standalone gateway with `auth-basic` I get the following

```
***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 0 of constructor in io.camunda.zeebe.gateway.rest.controller.AuthenticationController required a bean of type 'io.camunda.authentication.service.CamundaUserService' that could not be found.


Action:

Consider defining a bean of type 'io.camunda.authentication.service.CamundaUserService' in your configuration.
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
