### PR TITLE
Add Java client group delete command

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.client.api.command.CreateRoleCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateUserCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteDocumentCommandStep1;
+import io.camunda.zeebe.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -1165,6 +1166,23 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   UpdateGroupCommandStep1 newUpdateGroupCommand(long groupKey);
+
+  /**
+   * Command to delete a group.
+   *
+   * <pre>
+   *
+   *
+   * zeebeClient
+   *  .newDeleteGroupCommand(123L)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   *
+   * @return a builder for the command
+   */
+  DeleteGroupCommandStep1 newDeleteGroupCommand(long groupKey);
 
   /**
    * Command to create a user.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteGroupCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/DeleteGroupCommandStep1.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.DeleteGroupResponse;
+
+public interface DeleteGroupCommandStep1 extends FinalCommandStep<DeleteGroupResponse> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteGroupResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/DeleteGroupResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface DeleteGroupResponse {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -44,6 +44,7 @@ import io.camunda.zeebe.client.api.command.CreateRoleCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateUserCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteDocumentCommandStep1;
+import io.camunda.zeebe.client.api.command.DeleteGroupCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteTenantCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -114,6 +115,7 @@ import io.camunda.zeebe.client.impl.command.CreateRoleCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateTenantCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateUserCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteDocumentCommandImpl;
+import io.camunda.zeebe.client.impl.command.DeleteGroupCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteTenantCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployProcessCommandImpl;
@@ -718,6 +720,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public UpdateGroupCommandStep1 newUpdateGroupCommand(final long groupKey) {
     return new UpdateGroupCommandImpl(groupKey, httpClient, jsonMapper);
+  }
+
+  @Override
+  public DeleteGroupCommandStep1 newDeleteGroupCommand(final long groupKey) {
+    return new DeleteGroupCommandImpl(groupKey, httpClient);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteGroupCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteGroupCommandImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.DeleteGroupCommandStep1;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.DeleteGroupResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class DeleteGroupCommandImpl implements DeleteGroupCommandStep1 {
+
+  private final long groupKey;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public DeleteGroupCommandImpl(final long groupKey, final HttpClient httpClient) {
+    this.groupKey = groupKey;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<DeleteGroupResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<DeleteGroupResponse> send() {
+    final HttpZeebeFuture<DeleteGroupResponse> result = new HttpZeebeFuture<>();
+    httpClient.delete("/groups/" + groupKey, httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeleteGroupResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/DeleteGroupResponseImpl.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.response.DeleteGroupResponse;
+
+public class DeleteGroupResponseImpl implements DeleteGroupResponse {}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/group/DeleteGroupTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/group/DeleteGroupTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.group;
+
+import static io.camunda.zeebe.client.impl.http.HttpClientFactory.REST_API_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public class DeleteGroupTest extends ClientRestTest {
+
+  private static final long GROUP_KEY = 123L;
+
+  @Test
+  void shouldDeleteGroup() {
+    // when
+    client.newDeleteGroupCommand(GROUP_KEY).send().join();
+
+    // then
+    final String requestPath = RestGatewayService.getLastRequest().getUrl();
+    assertThat(requestPath).isEqualTo(REST_API_PATH + "/groups/" + GROUP_KEY);
+  }
+
+  @Test
+  void shouldRaiseExceptionOnNotFoundGroup() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+
+  @Test
+  void shouldHandleServerError() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Internal Server Error").status(500));
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 500: 'Internal Server Error'");
+  }
+
+  @Test
+  void shouldRaiseExceptionOnForbiddenRequest() {
+    // given
+    gatewayService.errorOnRequest(
+        REST_API_PATH + "/groups/" + GROUP_KEY,
+        () -> new ProblemDetail().title("Forbidden").status(403));
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(GROUP_KEY).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 403: 'Forbidden'");
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupDeleteRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/group/BrokerGroupDeleteRequest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.gateway.impl.broker.request.group;
 
 import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
-import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.group.GroupRecord;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.GroupIntent;
@@ -22,7 +21,6 @@ public class BrokerGroupDeleteRequest extends BrokerExecuteCommand<GroupRecord> 
     super(ValueType.GROUP, GroupIntent.DELETE);
     request.setKey(groupKey);
     requestDto.setGroupKey(groupKey);
-    setPartitionId(Protocol.DEPLOYMENT_PARTITION);
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteGroupTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/DeleteGroupTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+@AutoCloseResources
+class DeleteGroupTest {
+
+  private static final String GROUP_NAME = "groupName";
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource private ZeebeClient client;
+
+  private long groupKey;
+
+  @BeforeEach
+  void initClientAndInstances() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    groupKey = client.newCreateGroupCommand().name(GROUP_NAME).send().join().getGroupKey();
+  }
+
+  @Test
+  void shouldDeleteGroup() {
+    // when
+    client.newDeleteGroupCommand(groupKey).send().join();
+
+    // then
+    ZeebeAssertHelper.assertGroupDeleted(groupKey, group -> assertThat(group).hasName(GROUP_NAME));
+  }
+
+  @Test
+  void shouldRejectIfGroupDoesNotExist() {
+    // given
+    final long nonExistentGroupKey = Protocol.encodePartitionId(1, 111L);
+
+    // when / then
+    assertThatThrownBy(() -> client.newDeleteGroupCommand(nonExistentGroupKey).send().join())
+        .isInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'")
+        .hasMessageContaining(
+            "Expected to delete group with key '%d', but a group with this key does not exist."
+                .formatted(nonExistentGroupKey));
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeAssertHelper.java
@@ -422,6 +422,19 @@ public final class ZeebeAssertHelper {
     consumer.accept(groupRecordValue);
   }
 
+  public static void assertGroupDeleted(
+      final long groupKey, final Consumer<GroupRecordValue> consumer) {
+    final GroupRecordValue groupRecordValue =
+        RecordingExporter.groupRecords()
+            .withIntent(GroupIntent.DELETED)
+            .withGroupKey(groupKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(groupRecordValue).isNotNull();
+    consumer.accept(groupRecordValue);
+  }
+
   public static void assertUserCreated(final String username) {
     assertUserCreated(username, u -> {});
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Implements a Camunda Java client group delete command with client unit tests and Zeebe IT tests that cover the whole group delete feature.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25990
