### PR TITLE
fix: fetch all incidents at once

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/ElasticsearchIncidentUpdateRepository.java
@@ -374,6 +374,7 @@ public final class ElasticsearchIncidentUpdateRepository implements IncidentUpda
         .allowNoIndices(true)
         .ignoreUnavailable(true)
         .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
+        .size(incidentIds.size())
         .build();
   }
 

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/tasks/incident/OpenSearchIncidentUpdateRepository.java
@@ -429,6 +429,7 @@ public final class OpenSearchIncidentUpdateRepository implements IncidentUpdateR
         .allowNoIndices(true)
         .ignoreUnavailable(true)
         .sort(s -> s.field(f -> f.field(IncidentTemplate.KEY)))
+        .size(incidentIds.size())
         .build();
   }
 


### PR DESCRIPTION
## Description

This PR fixes a bug where we would only fetch 10 incidents at a time during the incident update process.

## Related issues

closes #25968 
