### PR TITLE
feat: add cluster purge endpoint to cluster API #25961

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -215,9 +215,7 @@ final class ClusterApiUtils {
               .partitionId(bootstrapOperation.partitionId())
               .priority(bootstrapOperation.priority());
       case final DeleteHistoryOperation deleteHistoryOperation ->
-          new Operation()
-              .operation(OperationEnum.DELETE_HISTORY)
-              .brokerId(Integer.parseInt(deleteHistoryOperation.memberId().id()));
+          new Operation().operation(OperationEnum.DELETE_HISTORY);
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -213,6 +214,10 @@ final class ClusterApiUtils {
               .brokerId(Integer.parseInt(bootstrapOperation.memberId().id()))
               .partitionId(bootstrapOperation.partitionId())
               .priority(bootstrapOperation.priority());
+      case final DeleteHistoryOperation deleteHistoryOperation ->
+          new Operation()
+              .operation(OperationEnum.DELETE_HISTORY)
+              .brokerId(Integer.parseInt(deleteHistoryOperation.memberId().id()));
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterApiUtils.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
@@ -206,6 +207,12 @@ final class ClusterApiUtils {
               .brokerId(Integer.parseInt(enableExporterOperation.memberId().id()))
               .partitionId(enableExporterOperation.partitionId())
               .exporterId(enableExporterOperation.exporterId());
+      case final PartitionBootstrapOperation bootstrapOperation ->
+          new Operation()
+              .operation(OperationEnum.PARTITION_BOOTSTRAP)
+              .brokerId(Integer.parseInt(bootstrapOperation.memberId().id()))
+              .partitionId(bootstrapOperation.partitionId())
+              .priority(bootstrapOperation.priority());
       default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
 import io.camunda.zeebe.management.cluster.ClusterConfigPatchRequest;
@@ -359,6 +360,16 @@ public class ClusterEndpoint {
           };
       case changes -> new ResponseEntity<>(HttpStatusCode.valueOf(404));
     };
+  }
+
+  @PostMapping(path = "/purge", produces = "application/json")
+  public ResponseEntity<?> purge(@RequestParam(defaultValue = "false") final boolean dryRun) {
+    try {
+      return ClusterApiUtils.mapOperationResponse(
+          requestSender.purge(new PurgeRequest(dryRun)).join());
+    } catch (final Exception error) {
+      return ClusterApiUtils.mapError(error);
+    }
   }
 
   public record PartitionAddRequest(int priority) {}

--- a/dist/src/main/resources/api/cluster/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster/cluster-api.yaml
@@ -89,6 +89,30 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /purge:
+    post:
+      summary: Purge data from the cluster
+      description: Purges data from Zeebe cluster and all exporters.
+        This operation is irreversible and will remove all data from the cluster!
+        During this operation all brokers will leave their partitions, data will be deleted,
+        and then the brokers will rejoin their partition with empty state, restoring the
+        original topology.
+      parameters:
+        - $ref: '#/components/parameters/DryRunParameter'
+      responses:
+        '202':
+          $ref: "#/components/responses/ClusterConfigPurgeResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
   /:
     get:
       summary: Get current topology
@@ -185,6 +209,13 @@ components:
 
     ClusterConfigPatchResponse:
       description: Request to reconfigure cluster is accepted.
+      content:
+        application.json:
+          schema:
+            $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+    ClusterConfigPurgeResponse:
+      description: Request to purge cluster data is accepted.
       content:
         application.json:
           schema:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -318,6 +318,7 @@ schemas:
           - PARTITION_DISABLE_EXPORTER
           - PARTITION_ENABLE_EXPORTER
           - PARTITION_BOOTSTRAP
+          - DELETE_HISTORY
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/dist/src/main/resources/api/cluster/components.yaml
+++ b/dist/src/main/resources/api/cluster/components.yaml
@@ -317,6 +317,7 @@ schemas:
           - UNKNOWN
           - PARTITION_DISABLE_EXPORTER
           - PARTITION_ENABLE_EXPORTER
+          - PARTITION_BOOTSTRAP
       brokerId:
         $ref: "components.yaml#/schemas/BrokerId"
       partitionId:

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -55,6 +56,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
       ClusterPatchRequest clusterPatchRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> purge(
+      PurgeRequest purgeRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
       ForceRemoveBrokersRequest forceRemoveBrokersRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -57,8 +57,7 @@ public interface ClusterConfigurationManagementApi {
   ActorFuture<ClusterConfigurationChangeResponse> patchCluster(
       ClusterPatchRequest clusterPatchRequest);
 
-  ActorFuture<ClusterConfigurationChangeResponse> purge(
-      PurgeRequest purgeRequest);
+  ActorFuture<ClusterConfigurationChangeResponse> purge(PurgeRequest purgeRequest);
 
   ActorFuture<ClusterConfigurationChangeResponse> forceRemoveBrokers(
       ForceRemoveBrokersRequest forceRemoveBrokersRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -35,8 +35,7 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
-  record PurgeRequest(boolean dryRun)
-      implements ClusterConfigurationManagementRequest {}
+  record PurgeRequest(boolean dryRun) implements ClusterConfigurationManagementRequest {}
 
   record BrokerScaleRequest(
       Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -35,6 +35,9 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
+  record PurgeRequest(boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record BrokerScaleRequest(
       Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)
       implements ClusterConfigurationManagementRequest {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationRequestsSerializer;
@@ -59,6 +60,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.REMOVE_MEMBER.topic(),
         removeMembersRequest,
         serializer::encodeRemoveMembersRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> purge(
+      final PurgeRequest purgeRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.PURGE.topic(),
+        purgeRequest,
+        serializer::encodePurgeRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -175,12 +175,9 @@ public final class ClusterConfigurationManagementRequestsHandler
   }
 
   @Override
-  public ActorFuture<ClusterConfigurationChangeResponse> purge(
-      final PurgeRequest purgeRequest) {
+  public ActorFuture<ClusterConfigurationChangeResponse> purge(final PurgeRequest purgeRequest) {
 
-    return handleRequest(
-        purgeRequest.dryRun(),
-        new PurgeRequestTransformer());
+    return handleRequest(purgeRequest.dryRun(), new PurgeRequestTransformer());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedException.InvalidRequest;
@@ -171,6 +172,15 @@ public final class ClusterConfigurationManagementRequestsHandler
             clusterPatchRequest.membersToRemove(),
             clusterPatchRequest.newPartitionCount(),
             clusterPatchRequest.newReplicationFactor()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> purge(
+      final PurgeRequest purgeRequest) {
+
+    return handleRequest(
+        purgeRequest.dryRun(),
+        new PurgeRequestTransformer());
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -96,7 +96,9 @@ public final class ClusterConfigurationManagementRequestsHandler
             Either.right(
                 List.of(
                     new PartitionLeaveOperation(
-                        leavePartitionRequest.memberId(), leavePartitionRequest.partitionId()))));
+                        leavePartitionRequest.memberId(),
+                        leavePartitionRequest.partitionId(),
+                        false))));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -49,6 +49,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerClusterScaleRequestHandler();
     registerClusterPatchRequestHandler();
     registerForceRemoveBrokersRequestHandler();
+    registerPurgeRequestHandler();
   }
 
   @Override
@@ -169,6 +170,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.FORCE_REMOVE_BROKERS.topic(),
         serializer::decodeForceRemoveBrokersRequest,
         request -> mapResponse(clusterConfigurationManagementApi.forceRemoveBrokers(request)),
+        this::encodeResponse);
+  }
+
+  private void registerPurgeRequestHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.PURGE.topic(),
+        serializer::decodePurgeRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.purge(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -22,7 +22,7 @@ public enum ClusterConfigurationRequestTopics {
 
   SCALE_CLUSTER("topology-cluster-scale"),
   PATCH_CLUSTER("topology-cluster-patch"),
-  PURGE("topology-purge"),
+  PURGE("topology-cluster-purge"),
   FORCE_REMOVE_BROKERS("topology-broker-force-remove");
 
   private final String topic;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -22,6 +22,7 @@ public enum ClusterConfigurationRequestTopics {
 
   SCALE_CLUSTER("topology-cluster-scale"),
   PATCH_CLUSTER("topology-cluster-patch"),
+  PURGE("topology-purge"),
   FORCE_REMOVE_BROKERS("topology-broker-force-remove");
 
   private final String topic;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.util.Either;
@@ -139,7 +140,8 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var primary =
         newMetadata.getPrimary().orElse(newMetadata.members().stream().findAny().orElseThrow());
     operations.add(
-        new PartitionBootstrapOperation(primary, partitionId, newMetadata.getPriority(primary)));
+        new PartitionBootstrapOperation(
+            primary, partitionId, newMetadata.getPriority(primary), ExportersConfig.empty()));
 
     // Join each remaining members to the partition
     for (final MemberId member : newMetadata.members()) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
-import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.util.Either;
@@ -140,8 +139,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var primary =
         newMetadata.getPrimary().orElse(newMetadata.members().stream().findAny().orElseThrow());
     operations.add(
-        new PartitionBootstrapOperation(
-            primary, partitionId, newMetadata.getPriority(primary), ExportersConfig.empty()));
+        new PartitionBootstrapOperation(primary, partitionId, newMetadata.getPriority(primary)));
 
     // Join each remaining members to the partition
     for (final MemberId member : newMetadata.members()) {
@@ -170,7 +168,7 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
     final var membersToLeave =
         oldMetadata.members().stream()
             .filter(member -> !newMetadata.members().contains(member))
-            .map(oldMember -> new PartitionLeaveOperation(oldMember, partitionId))
+            .map(oldMember -> new PartitionLeaveOperation(oldMember, partitionId, false))
             .toList();
     final var membersToChangePriority =
         oldMetadata.members().stream()

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -54,7 +55,9 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
       }
     }
 
-    // TODO Delete history (only coordinator node)
+    clusterConfiguration
+        .members()
+        .forEach((key, value) -> operations.add(new DeleteHistoryOperation(key)));
 
     primaries.forEach(
         (partitionId, bootstrapOperation) -> {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class PurgeRequestTransformer implements ConfigurationChangeRequest {
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+
+    // TODO Maybe select new primary here to use down there
+    final Map<Integer, PartitionBootstrapOperation> primaries = new HashMap<>();
+    final Map<Integer, List<PartitionJoinOperation>> followers = new HashMap<>();
+
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var member : clusterConfiguration.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partitions : member.getValue().partitions().entrySet()) {
+        final var partitionId = partitions.getKey();
+        operations.add(new PartitionLeaveOperation(memberId, partitionId));
+
+        if (!primaries.containsKey(partitionId)) {
+          primaries.put(
+              partitionId,
+              new PartitionBootstrapOperation(
+                  memberId, partitionId, partitions.getValue().priority()));
+        } else {
+          followers
+              .computeIfAbsent(partitionId, key -> new ArrayList<>())
+              .add(
+                  new PartitionJoinOperation(
+                      memberId, partitionId, partitions.getValue().priority()));
+        }
+      }
+    }
+
+    // TODO Delete history (only coordinator node)
+
+    primaries.forEach(
+        (partitionId, bootstrapOperation) -> {
+          operations.add(bootstrapOperation);
+        });
+    followers.forEach(
+        (partitionId, joinOperations) -> {
+          operations.addAll(joinOperations);
+        });
+
+    return Either.right(operations);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -7,17 +7,21 @@
  */
 package io.camunda.zeebe.dynamic.config.api;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 public final class PurgeRequestTransformer implements ConfigurationChangeRequest {
 
@@ -25,9 +29,11 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
 
-    // TODO Maybe select new primary here to use down there
-    final Map<Integer, PartitionBootstrapOperation> primaries = new HashMap<>();
-    final Map<Integer, List<PartitionJoinOperation>> followers = new HashMap<>();
+    final SortedMap<Integer, PartitionBootstrapOperation> primaries =
+        findBootstrapMembers(clusterConfiguration.members());
+
+    final Map<Integer, List<PartitionJoinOperation>> followers =
+        new TreeMap<>(Comparator.naturalOrder());
 
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
     for (final var member : clusterConfiguration.members().entrySet()) {
@@ -36,12 +42,9 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
         final var partitionId = partitions.getKey();
         operations.add(new PartitionLeaveOperation(memberId, partitionId));
 
-        if (!primaries.containsKey(partitionId)) {
-          primaries.put(
-              partitionId,
-              new PartitionBootstrapOperation(
-                  memberId, partitionId, partitions.getValue().priority()));
-        } else {
+        final var primaryForPartition = primaries.get(partitionId);
+
+        if (!primaryForPartition.memberId().equals(memberId)) {
           followers
               .computeIfAbsent(partitionId, key -> new ArrayList<>())
               .add(
@@ -63,5 +66,35 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
         });
 
     return Either.right(operations);
+  }
+
+  /**
+   * This method finds the leaders for each partition. Please note that when <a
+   * href="https://github.com/camunda/camunda/issues/14786">order of priority in priority
+   * election</a> is changed, this method must be updated.
+   */
+  private SortedMap<Integer, PartitionBootstrapOperation> findBootstrapMembers(
+      final Map<MemberId, MemberState> members) {
+
+    final SortedMap<Integer, PartitionBootstrapOperation> primaries =
+        new TreeMap<>(Comparator.naturalOrder());
+
+    members.forEach(
+        (memberId, memberState) -> {
+          memberState
+              .partitions()
+              .forEach(
+                  (partitionId, partitionState) -> {
+                    if (!primaries.containsKey(partitionId)
+                        || primaries.get(partitionId).priority() < partitionState.priority()) {
+                      primaries.put(
+                          partitionId,
+                          new PartitionBootstrapOperation(
+                              memberId, partitionId, partitionState.priority()));
+                    }
+                  });
+        });
+
+    return primaries;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PurgeRequestTransformer.java
@@ -16,19 +16,27 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.BiConsumer;
 
 public final class PurgeRequestTransformer implements ConfigurationChangeRequest {
 
   @Override
   public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
       final ClusterConfiguration clusterConfiguration) {
+
+    final var firstMember = clusterConfiguration.members().keySet().stream().findFirst();
+    if (firstMember.isEmpty()) {
+      return Either.right(new ArrayList<>());
+    }
 
     final SortedMap<Integer, PartitionBootstrapOperation> primaries =
         createBootstrapOperations(clusterConfiguration.members());
@@ -41,7 +49,7 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
       final var memberId = member.getKey();
       for (final var partitions : member.getValue().partitions().entrySet()) {
         final var partitionId = partitions.getKey();
-        operations.add(new PartitionLeaveOperation(memberId, partitionId));
+        operations.add(new PartitionLeaveOperation(memberId, partitionId, true));
 
         final var primaryForPartition = primaries.get(partitionId);
 
@@ -55,9 +63,7 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
       }
     }
 
-    clusterConfiguration
-        .members()
-        .forEach((key, value) -> operations.add(new DeleteHistoryOperation(key)));
+    operations.add(new DeleteHistoryOperation(firstMember.get()));
 
     primaries.forEach(
         (partitionId, bootstrapOperation) -> {
@@ -81,24 +87,25 @@ public final class PurgeRequestTransformer implements ConfigurationChangeRequest
 
     members.forEach(
         (memberId, memberState) -> {
-          memberState
-              .partitions()
-              .forEach(
-                  (partitionId, partitionState) -> {
-                    if (!primaries.containsKey(partitionId)
-                        || partitionState.hasHigherPriority(
-                            primaries.get(partitionId).priority())) {
-                      primaries.put(
-                          partitionId,
-                          new PartitionBootstrapOperation(
-                              memberId,
-                              partitionId,
-                              partitionState.priority(),
-                              partitionState.config().exporting()));
-                    }
-                  });
+          memberState.partitions().forEach(createBootstrapOperation(memberId, primaries));
         });
 
     return primaries;
+  }
+
+  private BiConsumer<Integer, PartitionState> createBootstrapOperation(
+      final MemberId memberId, final SortedMap<Integer, PartitionBootstrapOperation> primaries) {
+    return (partitionId, partitionState) -> {
+      if (!primaries.containsKey(partitionId)
+          || partitionState.hasHigherPriority(primaries.get(partitionId).priority())) {
+        primaries.put(
+            partitionId,
+            new PartitionBootstrapOperation(
+                memberId,
+                partitionId,
+                partitionState.priority(),
+                Optional.of(partitionState.config())));
+      }
+    };
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -87,6 +88,8 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               bootstrapOperation.priority(),
               bootstrapOperation.memberId(),
               partitionChangeExecutor);
+      case final DeleteHistoryOperation deleteHistoryOperation ->
+          new DeleteHistoryApplier(deleteHistoryOperation.memberId());
       case StartPartitionScaleUpOperation(
               final var ignoredMemberId,
               final var desiredPartitionCount) ->

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -47,7 +47,10 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               partitionChangeExecutor);
       case final PartitionLeaveOperation leaveOperation ->
           new PartitionLeaveApplier(
-              leaveOperation.partitionId(), leaveOperation.memberId(), partitionChangeExecutor);
+              leaveOperation.partitionId(),
+              leaveOperation.memberId(),
+              leaveOperation.isClusterPurge(),
+              partitionChangeExecutor);
       case final MemberJoinOperation memberJoinOperation ->
           new MemberJoinApplier(memberJoinOperation.memberId(), clusterMembershipChangeExecutor);
       case final MemberLeaveOperation memberLeaveOperation ->
@@ -87,7 +90,7 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               bootstrapOperation.partitionId(),
               bootstrapOperation.priority(),
               bootstrapOperation.memberId(),
-              bootstrapOperation.exporters(),
+              bootstrapOperation.config(),
               partitionChangeExecutor);
       case final DeleteHistoryOperation deleteHistoryOperation ->
           new DeleteHistoryApplier(deleteHistoryOperation.memberId());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -87,6 +87,7 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               bootstrapOperation.partitionId(),
               bootstrapOperation.priority(),
               bootstrapOperation.memberId(),
+              bootstrapOperation.exporters(),
               partitionChangeExecutor);
       case final DeleteHistoryOperation deleteHistoryOperation ->
           new DeleteHistoryApplier(deleteHistoryOperation.memberId());

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/DeleteHistoryApplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+final class DeleteHistoryApplier implements ClusterOperationApplier {
+
+  public DeleteHistoryApplier(final MemberId memberId) {}
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterConfiguration>> init(
+      final ClusterConfiguration currentClusterConfiguration) {
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterConfiguration>> apply() {
+    final var result = new CompletableActorFuture<UnaryOperator<ClusterConfiguration>>();
+    result.complete(UnaryOperator.identity());
+    return result;
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionBootstrapApplier.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
@@ -27,16 +28,19 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
   private final int priority;
   private final MemberId memberId;
   private final PartitionChangeExecutor partitionChangeExecutor;
+  private final ExportersConfig exporters;
   private DynamicPartitionConfig partitionConfig;
 
   public PartitionBootstrapApplier(
       final int partitionId,
       final int priority,
       final MemberId memberId,
+      final ExportersConfig exporters,
       final PartitionChangeExecutor partitionChangeExecutor) {
     this.partitionId = partitionId;
     this.priority = priority;
     this.memberId = memberId;
+    this.exporters = exporters;
     this.partitionChangeExecutor = partitionChangeExecutor;
   }
 
@@ -89,8 +93,8 @@ public class PartitionBootstrapApplier implements MemberOperationApplier {
             .findFirst()
             .map(Entry::getValue)
             .map(PartitionState::config)
-            // TODO Maybe use unInitialized instead of init, or change uninitialized
-            .orElse(DynamicPartitionConfig.init());
+            .orElse(new DynamicPartitionConfig(exporters));
+
     return Either.right(
         memberState ->
             memberState.addPartition(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.serializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.BrokerScaleRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.util.Either;
@@ -29,6 +30,8 @@ public interface ClusterConfigurationRequestsSerializer {
       ClusterConfigurationManagementRequest.ReassignPartitionsRequest reassignPartitionsRequest);
 
   byte[] encodeScaleRequest(BrokerScaleRequest scaleRequest);
+
+  byte[] encodePurgeRequest(PurgeRequest purgeRequest);
 
   byte[] encodeCancelChangeRequest(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);
@@ -81,6 +84,9 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedRequest);
 
   ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest decodeForceRemoveBrokersRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.PurgeRequest decodePurgeRequest(
       byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -86,8 +86,7 @@ public interface ClusterConfigurationRequestsSerializer {
   ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest decodeForceRemoveBrokersRequest(
       byte[] encodedRequest);
 
-  ClusterConfigurationManagementRequest.PurgeRequest decodePurgeRequest(
-      byte[] encodedRequest);
+  ClusterConfigurationManagementRequest.PurgeRequest decodePurgeRequest(byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -629,6 +629,8 @@ public class ProtoBufSerializer
       return new StartPartitionScaleUpOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),
           topologyChangeOperation.getInitiateScaleUpPartitions().getDesiredPartitionCount());
+    } else if (topologyChangeOperation.hasDeleteHistory()) {
+      return new DeleteHistoryOperation(MemberId.from(topologyChangeOperation.getMemberId()));
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -429,6 +429,7 @@ public class ProtoBufSerializer
               Topology.PartitionBootstrapOperation.newBuilder()
                   .setPartitionId(bootstrapOperation.partitionId())
                   .setPriority(bootstrapOperation.priority())
+                  .setExporterConfig(encodeExportingConfig(bootstrapOperation.exporters()))
                   .build());
       case final DeleteHistoryOperation deleteHistoryOperation ->
           builder.setDeleteHistory(Topology.DeleteHistoryOperation.newBuilder().build());
@@ -624,7 +625,9 @@ public class ProtoBufSerializer
       return new PartitionBootstrapOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),
           topologyChangeOperation.getPartitionBootstrap().getPartitionId(),
-          topologyChangeOperation.getPartitionBootstrap().getPriority());
+          topologyChangeOperation.getPartitionBootstrap().getPriority(),
+          decodeExportingConfig(
+              topologyChangeOperation.getPartitionBootstrap().getExporterConfig()));
     } else if (topologyChangeOperation.hasInitiateScaleUpPartitions()) {
       return new StartPartitionScaleUpOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
@@ -429,6 +430,8 @@ public class ProtoBufSerializer
                   .setPartitionId(bootstrapOperation.partitionId())
                   .setPriority(bootstrapOperation.priority())
                   .build());
+      case final DeleteHistoryOperation deleteHistoryOperation ->
+          builder.setDeleteHistory(Topology.DeleteHistoryOperation.newBuilder().build());
       case StartPartitionScaleUpOperation(
               final var ignoredMemberId,
               final var desiredPartitionCount) ->

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
@@ -704,6 +705,14 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodePurgeRequest(final PurgeRequest req) {
+    return Requests.PurgeRequest.newBuilder()
+        .setDryRun(req.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public byte[] encodeCancelChangeRequest(final CancelChangeRequest cancelChangeRequest) {
     return Requests.CancelTopologyChangeRequest.newBuilder()
         .setChangeId(cancelChangeRequest.changeId())
@@ -953,6 +962,17 @@ public class ProtoBufSerializer
               .map(MemberId::from)
               .collect(Collectors.toSet()),
           forceRemoveBrokersRequest.getDryRun());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public PurgeRequest decodePurgeRequest(final byte[] encodedRequest) {
+    try {
+      final var purgeRequest =
+          Requests.PurgeRequest.parseFrom(encodedRequest);
+      return new PurgeRequest(purgeRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -706,10 +706,7 @@ public class ProtoBufSerializer
 
   @Override
   public byte[] encodePurgeRequest(final PurgeRequest req) {
-    return Requests.PurgeRequest.newBuilder()
-        .setDryRun(req.dryRun())
-        .build()
-        .toByteArray();
+    return Requests.PurgeRequest.newBuilder().setDryRun(req.dryRun()).build().toByteArray();
   }
 
   @Override
@@ -970,8 +967,7 @@ public class ProtoBufSerializer
   @Override
   public PurgeRequest decodePurgeRequest(final byte[] encodedRequest) {
     try {
-      final var purgeRequest =
-          Requests.PurgeRequest.parseFrom(encodedRequest);
+      final var purgeRequest = Requests.PurgeRequest.parseFrom(encodedRequest);
       return new PurgeRequest(purgeRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -124,8 +124,11 @@ public sealed interface ClusterConfigurationChangeOperation {
      *
      * @param memberId the member id of the member that will apply this operation
      * @param partitionId id of the partition to bootstrap
+     * @param priority priority of the member in the partition
+     * @param exporters the exporters to initialize the partition with
      */
-    record PartitionBootstrapOperation(MemberId memberId, int partitionId, int priority)
+    record PartitionBootstrapOperation(
+        MemberId memberId, int partitionId, int priority, ExportersConfig exporters)
         implements PartitionChangeOperation {}
 
     /**

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -127,5 +127,13 @@ public sealed interface ClusterConfigurationChangeOperation {
      */
     record PartitionBootstrapOperation(MemberId memberId, int partitionId, int priority)
         implements PartitionChangeOperation {}
+
+    /**
+     * Operation to delete the history of the given member.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     */
+    record DeleteHistoryOperation(MemberId memberId)
+        implements ClusterConfigurationChangeOperation {}
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -71,8 +71,9 @@ public sealed interface ClusterConfigurationChangeOperation {
      *
      * @param memberId the member id of the member that will stop replicating the partition
      * @param partitionId id of the partition to leave
+     * @param isClusterPurge true if the operation is part of a cluster purge
      */
-    record PartitionLeaveOperation(MemberId memberId, int partitionId)
+    record PartitionLeaveOperation(MemberId memberId, int partitionId, boolean isClusterPurge)
         implements PartitionChangeOperation {}
 
     /**
@@ -125,11 +126,18 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param memberId the member id of the member that will apply this operation
      * @param partitionId id of the partition to bootstrap
      * @param priority priority of the member in the partition
-     * @param exporters the exporters to initialize the partition with
+     * @param config the config to initialize the partition with. If you don't provide one, the
+     *     config from partition 1 is used.
      */
     record PartitionBootstrapOperation(
-        MemberId memberId, int partitionId, int priority, ExportersConfig exporters)
-        implements PartitionChangeOperation {}
+        MemberId memberId, int partitionId, int priority, Optional<DynamicPartitionConfig> config)
+        implements PartitionChangeOperation {
+
+      public PartitionBootstrapOperation(
+          final MemberId memberId, final int partitionId, final int priority) {
+        this(memberId, partitionId, priority, Optional.empty());
+      }
+    }
 
     /**
      * Operation to delete the history of the given member.

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -45,6 +45,14 @@ public record PartitionState(State state, int priority, DynamicPartitionConfig c
     return new PartitionState(state, priority, configUpdater.apply(config));
   }
 
+  /**
+   * Please note that when <a href="https://github.com/camunda/camunda/issues/14786">order of
+   * priority in priority election</a> is changed, this method must be updated.
+   */
+  public boolean hasHigherPriority(final int priority) {
+    return this.priority > priority;
+  }
+
   public enum State {
     UNKNOWN,
     JOINING,

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -22,6 +22,10 @@ message JoinPartitionRequest {
   bool dryRun = 4;
 }
 
+message PurgeRequest {
+  bool dryRun = 1;
+}
+
 message LeavePartitionRequest {
   string memberId = 1;
   int32 partitionId = 2;

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -148,6 +148,7 @@ message PartitionEnableExporterOperation {
 message PartitionBootstrapOperation {
   int32 partitionId = 1;
   int32 priority = 2;
+  ExportersConfig exporterConfig = 3;
 }
 
 message StartPartitionScaleUpOperation {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -122,6 +122,7 @@ message PartitionJoinOperation {
 
 message PartitionLeaveOperation {
   int32 partitionId = 1;
+  bool isClusterPurge = 2;
 }
 
 message PartitionReconfigurePriorityOperation {
@@ -148,7 +149,7 @@ message PartitionEnableExporterOperation {
 message PartitionBootstrapOperation {
   int32 partitionId = 1;
   int32 priority = 2;
-  ExportersConfig exporterConfig = 3;
+  optional PartitionConfig config = 3;
 }
 
 message StartPartitionScaleUpOperation {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -106,6 +106,7 @@ message TopologyChangeOperation {
     PartitionEnableExporterOperation partitionEnableExporter = 10;
     PartitionBootstrapOperation partitionBootstrap = 11;
     StartPartitionScaleUpOperation initiateScaleUpPartitions = 12;
+    DeleteHistoryOperation deleteHistory = 13;
   }
 }
 
@@ -151,6 +152,10 @@ message PartitionBootstrapOperation {
 
 message StartPartitionScaleUpOperation {
   int32 desiredPartitionCount = 2;
+}
+
+message DeleteHistoryOperation {
+  int32 memberId = 1;
 }
 
 message MemberJoinOperation {}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -180,7 +180,7 @@ class ClusterConfigurationManagementIntegrationTest {
                 Either.right(
                     List.of(
                         new PartitionJoinOperation(MemberId.from("0"), 2, 1),
-                        new PartitionLeaveOperation(MemberId.from("1"), 1))))
+                        new PartitionLeaveOperation(MemberId.from("1"), 1, false))))
         .join();
 
     // then
@@ -212,7 +212,7 @@ class ClusterConfigurationManagementIntegrationTest {
                 Either.right(
                     List.of(
                         new PartitionJoinOperation(MemberId.from("0"), 2, 1),
-                        new PartitionLeaveOperation(MemberId.from("1"), 1),
+                        new PartitionLeaveOperation(MemberId.from("1"), 1, false),
                         new PartitionJoinOperation(MemberId.from("1"), 1, 1))))
         .join();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
@@ -197,7 +197,7 @@ final class ClusterConfigurationManagerTest {
     // when
     final ClusterConfiguration topologyFromOtherMember =
         initialTopology.startConfigurationChange(
-            List.of(new PartitionLeaveOperation(localMemberId, 1)));
+            List.of(new PartitionLeaveOperation(localMemberId, 1, false)));
     clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then
@@ -218,7 +218,7 @@ final class ClusterConfigurationManagerTest {
     // given
     final ClusterConfiguration topologyWithPendingOperation =
         initialTopology.startConfigurationChange(
-            List.of(new PartitionLeaveOperation(localMemberId, 1)));
+            List.of(new PartitionLeaveOperation(localMemberId, 1, false)));
     final ClusterConfigurationInitializer initializer =
         () -> CompletableActorFuture.completed(topologyWithPendingOperation);
 
@@ -249,7 +249,7 @@ final class ClusterConfigurationManagerTest {
     // when
     final ClusterConfiguration topologyFromOtherMember =
         initialTopology.startConfigurationChange(
-            List.of(new PartitionLeaveOperation(localMemberId, 1)));
+            List.of(new PartitionLeaveOperation(localMemberId, 1, false)));
     clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
-import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -162,24 +161,6 @@ final class ClusterConfigurationManagementApiTest {
     final List<ClusterConfigurationChangeOperation> expected =
         List.of(new MemberLeaveOperation(id1), new MemberLeaveOperation(id2));
     assertThat(changeStatus.plannedChanges()).containsExactlyElementsOf(expected);
-  }
-
-  @Test
-  void shouldPurgeCluster() {
-    // given
-    recordingCoordinator.setCurrentTopology(
-        initialTopology
-            .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .addMember(id2, MemberState.initializeAsActive(Map.of())));
-    final var request = new PurgeRequest(false);
-
-    // when
-    final var changeStatus = clientApi.purge(request).join().get();
-
-    // then
-    // TODO Why are the planned changes empty? Because the RecordingChangeCoordinator is used?
-    assertThat(changeStatus.plannedChanges()).hasSize(4);
-    assertThat(changeStatus.currentConfiguration()).isEqualTo(changeStatus.expectedConfiguration());
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterPatchRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ClusterScaleRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
@@ -161,6 +162,24 @@ final class ClusterConfigurationManagementApiTest {
     final List<ClusterConfigurationChangeOperation> expected =
         List.of(new MemberLeaveOperation(id1), new MemberLeaveOperation(id2));
     assertThat(changeStatus.plannedChanges()).containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  void shouldPurgeCluster() {
+    // given
+    recordingCoordinator.setCurrentTopology(
+        initialTopology
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .addMember(id2, MemberState.initializeAsActive(Map.of())));
+    final var request = new PurgeRequest(false);
+
+    // when
+    final var changeStatus = clientApi.purge(request).join().get();
+
+    // then
+    // TODO Why are the planned changes empty? Because the RecordingChangeCoordinator is used?
+    assertThat(changeStatus.plannedChanges()).hasSize(4);
+    assertThat(changeStatus.currentConfiguration()).isEqualTo(changeStatus.expectedConfiguration());
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -363,7 +363,7 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2),
-            new PartitionBootstrapOperation(id0, 3, 1));
+            new PartitionBootstrapOperation(id0, 3, 1, ExportersConfig.empty()));
   }
 
   @Test
@@ -387,7 +387,7 @@ final class ClusterConfigurationManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2),
-            new PartitionBootstrapOperation(id0, 3, 1));
+            new PartitionBootstrapOperation(id0, 3, 1, ExportersConfig.empty()));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -189,7 +189,8 @@ final class ClusterConfigurationManagementApiTest {
     final var changeStatus = clientApi.leavePartition(request).join().get();
 
     // then
-    assertThat(changeStatus.plannedChanges()).containsExactly(new PartitionLeaveOperation(id1, 1));
+    assertThat(changeStatus.plannedChanges())
+        .containsExactly(new PartitionLeaveOperation(id1, 1, false));
   }
 
   @Test
@@ -217,7 +218,7 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactly(
-            new PartitionJoinOperation(id2, 2, 1), new PartitionLeaveOperation(id1, 2));
+            new PartitionJoinOperation(id2, 2, 1), new PartitionLeaveOperation(id1, 2, false));
   }
 
   @Test
@@ -239,7 +240,7 @@ final class ClusterConfigurationManagementApiTest {
         .containsExactly(
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2));
+            new PartitionLeaveOperation(id0, 2, false));
   }
 
   @Test
@@ -308,8 +309,8 @@ final class ClusterConfigurationManagementApiTest {
     // then
     assertThat(changeStatus.plannedChanges())
         .containsExactlyInAnyOrder(
-            new PartitionLeaveOperation(id0, 2),
-            new PartitionLeaveOperation(id1, 1),
+            new PartitionLeaveOperation(id0, 2, false),
+            new PartitionLeaveOperation(id1, 1, false),
             new PartitionReconfigurePriorityOperation(id0, 1, 1),
             new PartitionReconfigurePriorityOperation(id1, 2, 1));
   }
@@ -362,8 +363,8 @@ final class ClusterConfigurationManagementApiTest {
         .containsExactly(
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2),
-            new PartitionBootstrapOperation(id0, 3, 1, ExportersConfig.empty()));
+            new PartitionLeaveOperation(id0, 2, false),
+            new PartitionBootstrapOperation(id0, 3, 1));
   }
 
   @Test
@@ -386,8 +387,8 @@ final class ClusterConfigurationManagementApiTest {
         .containsExactly(
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
-            new PartitionLeaveOperation(id0, 2),
-            new PartitionBootstrapOperation(id0, 3, 1, ExportersConfig.empty()));
+            new PartitionLeaveOperation(id0, 2, false),
+            new PartitionBootstrapOperation(id0, 3, 1));
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -56,7 +56,7 @@ final class ClusterPurgeRequestTransformerTest {
             operations -> {
               assertThat(operations).hasSize(10);
               assertThat(operations)
-                  .containsExactlyInAnyOrder(
+                  .containsExactly(
                       new PartitionLeaveOperation(id0, 0),
                       new PartitionLeaveOperation(id0, 1),
                       new PartitionLeaveOperation(id1, 0),
@@ -65,13 +65,13 @@ final class ClusterPurgeRequestTransformerTest {
                       new DeleteHistoryOperation(id1),
                       new PartitionBootstrapOperation(id0, 0, 2, ExportersConfig.empty()),
                       new PartitionBootstrapOperation(id1, 1, 2, ExportersConfig.empty()),
-                      new PartitionJoinOperation(id0, 1, 1),
-                      new PartitionJoinOperation(id1, 0, 1));
+                      new PartitionJoinOperation(id1, 0, 1),
+                      new PartitionJoinOperation(id0, 1, 1));
             });
   }
 
   @Test
-  void shouldPurgeClusterWithThreePartitions() {
+  void purgeClusterShouldBootstrapPartitionsInOrder() {
     // given
     final var transformer = new PurgeRequestTransformer();
 
@@ -97,7 +97,7 @@ final class ClusterPurgeRequestTransformerTest {
             operations -> {
               assertThat(operations).hasSize(14);
               assertThat(operations)
-                  .containsExactlyInAnyOrder(
+                  .containsExactly(
                       new PartitionLeaveOperation(id0, 0),
                       new PartitionLeaveOperation(id0, 1),
                       new PartitionLeaveOperation(id0, 2),
@@ -107,10 +107,10 @@ final class ClusterPurgeRequestTransformerTest {
                       new DeleteHistoryOperation(id0),
                       new DeleteHistoryOperation(id1),
                       new PartitionBootstrapOperation(id0, 0, 2, ExportersConfig.empty()),
-                      new PartitionBootstrapOperation(id0, 2, 2, ExportersConfig.empty()),
                       new PartitionBootstrapOperation(id1, 1, 2, ExportersConfig.empty()),
-                      new PartitionJoinOperation(id0, 1, 1),
+                      new PartitionBootstrapOperation(id0, 2, 2, ExportersConfig.empty()),
                       new PartitionJoinOperation(id1, 0, 1),
+                      new PartitionJoinOperation(id0, 1, 1),
                       new PartitionJoinOperation(id1, 2, 1));
             });
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ClusterPurgeRequestTransformerTest {
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
+  @Test
+  void shouldPurgeCluster() {
+    // given
+    final var transformer = new PurgeRequestTransformer();
+
+    final ClusterConfiguration currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)));
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    assertThat(result)
+        .isRight()
+        .right()
+        .satisfies(
+            operations -> {
+              assertThat(operations).hasSize(8);
+              assertThat(operations)
+                  .containsExactlyInAnyOrder(
+                      new PartitionLeaveOperation(id0, 0),
+                      new PartitionLeaveOperation(id0, 1),
+                      new PartitionLeaveOperation(id1, 0),
+                      new PartitionLeaveOperation(id1, 1),
+                      new PartitionBootstrapOperation(id0, 0, 2),
+                      new PartitionBootstrapOperation(id1, 1, 2),
+                      new PartitionJoinOperation(id0, 1, 1),
+                      new PartitionJoinOperation(id1, 0, 1));
+            });
+  }
+
+  @Test
+  void shouldPurgeClusterWithThreePartitions() {
+    // given
+    final var transformer = new PurgeRequestTransformer();
+
+    final ClusterConfiguration currentTopology =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(0, PartitionState.active(2, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(0, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
+
+    // when
+    final var result = transformer.operations(currentTopology);
+
+    // then
+    assertThat(result)
+        .isRight()
+        .right()
+        .satisfies(
+            operations -> {
+              assertThat(operations).hasSize(12);
+              assertThat(operations)
+                  .containsExactlyInAnyOrder(
+                      new PartitionLeaveOperation(id0, 0),
+                      new PartitionLeaveOperation(id0, 1),
+                      new PartitionLeaveOperation(id0, 2),
+                      new PartitionLeaveOperation(id1, 0),
+                      new PartitionLeaveOperation(id1, 1),
+                      new PartitionLeaveOperation(id1, 2),
+                      new PartitionBootstrapOperation(id0, 0, 2),
+                      new PartitionBootstrapOperation(id0, 2, 2),
+                      new PartitionBootstrapOperation(id1, 1, 2),
+                      new PartitionJoinOperation(id0, 1, 1),
+                      new PartitionJoinOperation(id1, 0, 1),
+                      new PartitionJoinOperation(id1, 2, 1));
+            });
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterPurgeRequestTransformerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.DeleteHistoryOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionBootstrapOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -50,13 +51,15 @@ final class ClusterPurgeRequestTransformerTest {
         .right()
         .satisfies(
             operations -> {
-              assertThat(operations).hasSize(8);
+              assertThat(operations).hasSize(10);
               assertThat(operations)
                   .containsExactlyInAnyOrder(
                       new PartitionLeaveOperation(id0, 0),
                       new PartitionLeaveOperation(id0, 1),
                       new PartitionLeaveOperation(id1, 0),
                       new PartitionLeaveOperation(id1, 1),
+                      new DeleteHistoryOperation(id0),
+                      new DeleteHistoryOperation(id1),
                       new PartitionBootstrapOperation(id0, 0, 2),
                       new PartitionBootstrapOperation(id1, 1, 2),
                       new PartitionJoinOperation(id0, 1, 1),
@@ -89,7 +92,7 @@ final class ClusterPurgeRequestTransformerTest {
         .right()
         .satisfies(
             operations -> {
-              assertThat(operations).hasSize(12);
+              assertThat(operations).hasSize(14);
               assertThat(operations)
                   .containsExactlyInAnyOrder(
                       new PartitionLeaveOperation(id0, 0),
@@ -98,6 +101,8 @@ final class ClusterPurgeRequestTransformerTest {
                       new PartitionLeaveOperation(id1, 0),
                       new PartitionLeaveOperation(id1, 1),
                       new PartitionLeaveOperation(id1, 2),
+                      new DeleteHistoryOperation(id0),
+                      new DeleteHistoryOperation(id1),
                       new PartitionBootstrapOperation(id0, 0, 2),
                       new PartitionBootstrapOperation(id0, 2, 2),
                       new PartitionBootstrapOperation(id1, 1, 2),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -47,7 +47,8 @@ final class ConfigurationChangeAppliersImplTest {
     final MemberId localMemberId = MemberId.from("1");
     return Stream.of(
         Arguments.of(new PartitionJoinOperation(localMemberId, 1, 1), PartitionJoinApplier.class),
-        Arguments.of(new PartitionLeaveOperation(localMemberId, 1), PartitionLeaveApplier.class),
+        Arguments.of(
+            new PartitionLeaveOperation(localMemberId, 1, false), PartitionLeaveApplier.class),
         Arguments.of(new MemberJoinOperation(localMemberId), MemberJoinApplier.class),
         Arguments.of(new MemberLeaveOperation(localMemberId), MemberLeaveApplier.class),
         Arguments.of(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImplTest.java
@@ -59,7 +59,7 @@ final class ConfigurationChangeCoordinatorImplTest {
     // when
     final var applyFuture =
         coordinator.applyOperations(
-            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1))));
+            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1, false))));
 
     // then
     assertThat(applyFuture)
@@ -96,8 +96,9 @@ final class ConfigurationChangeCoordinatorImplTest {
         coordinator.applyOperations(
             getTransformer(
                 List.of(
-                    new PartitionLeaveOperation(MemberId.from("1"), 1), // Valid operation
-                    new PartitionLeaveOperation(MemberId.from("1"), 1) // Duplicate leave not valid
+                    new PartitionLeaveOperation(MemberId.from("1"), 1, false), // Valid operation
+                    new PartitionLeaveOperation(
+                        MemberId.from("1"), 1, false) // Duplicate leave not valid
                     )));
 
     // then
@@ -114,12 +115,12 @@ final class ConfigurationChangeCoordinatorImplTest {
     // given
     clusterTopologyManager.setClusterTopology(
         initialTopology.startConfigurationChange(
-            List.of(new PartitionLeaveOperation(MemberId.from("1"), 1))));
+            List.of(new PartitionLeaveOperation(MemberId.from("1"), 1, false))));
 
     // when
     final var applyFuture =
         coordinator.applyOperations(
-            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1))));
+            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1, false))));
 
     // then
     assertThat(applyFuture)
@@ -187,7 +188,7 @@ final class ConfigurationChangeCoordinatorImplTest {
 
     final var simulationResult =
         coordinator.simulateOperations(
-            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1))));
+            getTransformer(List.of(new PartitionLeaveOperation(MemberId.from("1"), 1, false))));
 
     // then
     assertThat(simulationResult)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplierTest.java
@@ -35,7 +35,7 @@ final class PartitionLeaveApplierTest {
       mock(PartitionChangeExecutor.class);
   private final MemberId localMemberId = MemberId.from("1");
   final PartitionLeaveApplier partitionLeaveApplier =
-      new PartitionLeaveApplier(1, localMemberId, partitionChangeExecutor);
+      new PartitionLeaveApplier(1, localMemberId, false, partitionChangeExecutor);
   private final ClusterConfiguration initialClusterConfiguration =
       ClusterConfiguration.init()
           .addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
@@ -80,10 +80,15 @@ final class PartitionLeaveApplierTest {
             .updateMember(
                 localMemberId, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .startConfigurationChange(List.of(new DeleteHistoryOperation(localMemberId)));
+    final var partitionLeaveApplierForPurge =
+        new PartitionLeaveApplier(1, localMemberId, true, partitionChangeExecutor);
 
     // when
     final var resultingTopology =
-        partitionLeaveApplier.init(topologyWithOneReplica).get().apply(topologyWithOneReplica);
+        partitionLeaveApplierForPurge
+            .init(topologyWithOneReplica)
+            .get()
+            .apply(topologyWithOneReplica);
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(resultingTopology)

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ForceRemoveBrokersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.PurgeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.RemoveMembersRequest;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
@@ -179,6 +180,19 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeForceRemoveBrokersRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(forceRemoveBrokersRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodePurgeRequest() {
+    // given
+    final var purgeRequest = new PurgeRequest(true);
+
+    // when
+    final var encodedRequest = protoBufSerializer.encodePurgeRequest(purgeRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodePurgeRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(purgeRequest);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -172,8 +172,8 @@ class ClusterConfigurationTest {
             .addMember(member(1), MemberState.uninitialized())
             .startConfigurationChange(
                 List.of(
-                    new PartitionLeaveOperation(member(1), 1),
-                    new PartitionLeaveOperation(member(2), 2)));
+                    new PartitionLeaveOperation(member(1), 1, false),
+                    new PartitionLeaveOperation(member(2), 2, false)));
 
     // when
     final var updatedTopology =
@@ -192,7 +192,7 @@ class ClusterConfigurationTest {
     final var initialTopology =
         ClusterConfiguration.init()
             .addMember(member(1), MemberState.initializeAsActive(Map.of()))
-            .startConfigurationChange(List.of(new PartitionLeaveOperation(member(1), 1)));
+            .startConfigurationChange(List.of(new PartitionLeaveOperation(member(1), 1, false)));
 
     // when
     final var updatedTopology =
@@ -213,8 +213,8 @@ class ClusterConfigurationTest {
             .addMember(member(1), MemberState.uninitialized())
             .startConfigurationChange(
                 List.of(
-                    new PartitionLeaveOperation(member(1), 1),
-                    new PartitionLeaveOperation(member(2), 2)));
+                    new PartitionLeaveOperation(member(1), 1, false),
+                    new PartitionLeaveOperation(member(2), 2, false)));
 
     // when
     final var updatedTopology =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
@@ -104,5 +105,10 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<MemberId> memberIds() {
     return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
+  }
+
+  @Provide
+  Arbitrary<ExportersConfig> exportersConfigs() {
+    return Arbitraries.forType(ExportersConfig.class).enableRecursion();
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ClusterTopologyDomain.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.RoutingState;
@@ -110,5 +111,13 @@ public final class ClusterTopologyDomain extends DomainContextBase {
   @Provide
   Arbitrary<ExportersConfig> exportersConfigs() {
     return Arbitraries.forType(ExportersConfig.class).enableRecursion();
+  }
+
+  @Provide
+  Arbitrary<DynamicPartitionConfig> dynamicPartitionConfigs() {
+    return Arbitraries.forType(ExportersConfig.class)
+        .enableRecursion()
+        .map(DynamicPartitionConfig::new)
+        .filter(DynamicPartitionConfig::isInitialized);
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointErrorResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointErrorResponseIT.java
@@ -152,7 +152,10 @@ final class ClusterEndpointErrorResponseIT {
 
     static Stream<Arguments> provideRequests() {
       final List<Consumer<ClusterActuator>> operations =
-          List.of(ClusterActuator::getTopology, a -> a.scaleBrokers(List.of(0, 1)));
+          List.of(
+              actuator -> actuator.purge(false),
+              actuator -> actuator.scaleBrokers(List.of(0, 1)),
+              ClusterActuator::getTopology);
       return operations.stream().map(Arguments::of);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -95,7 +95,6 @@ final class ClusterEndpointIT {
                   OperationEnum.PARTITION_LEAVE,
                   OperationEnum.PARTITION_LEAVE,
                   OperationEnum.DELETE_HISTORY,
-                  OperationEnum.DELETE_HISTORY,
                   OperationEnum.PARTITION_BOOTSTRAP,
                   OperationEnum.PARTITION_BOOTSTRAP,
                   OperationEnum.PARTITION_JOIN,

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -87,9 +87,19 @@ final class ClusterEndpointIT {
       final var response = actuator.purge(false);
 
       // then
-      assertThat(response.getPlannedChanges()).isNotEmpty();
-      // TODO More assertions
-
+      assertThat(response.getPlannedChanges().stream().map(Operation::getOperation))
+          .containsExactlyElementsOf(
+              List.of(
+                  OperationEnum.PARTITION_LEAVE,
+                  OperationEnum.PARTITION_LEAVE,
+                  OperationEnum.PARTITION_LEAVE,
+                  OperationEnum.PARTITION_LEAVE,
+                  OperationEnum.DELETE_HISTORY,
+                  OperationEnum.DELETE_HISTORY,
+                  OperationEnum.PARTITION_BOOTSTRAP,
+                  OperationEnum.PARTITION_BOOTSTRAP,
+                  OperationEnum.PARTITION_JOIN,
+                  OperationEnum.PARTITION_JOIN));
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -84,11 +84,12 @@ final class ClusterEndpointIT {
       actuator = ClusterActuator.of(cluster.availableGateway());
 
       // when -- request a purge
-      assertThatCode(() -> actuator.purge(false))
-          // then
-          // TODO Change the assertion to check for planned changes once it's implemented.
-          .describedAs("Purging should fail with 400 Bad Request as it is not yet fully supported")
-          .isInstanceOf(FeignException.BadRequest.class);
+      final var response = actuator.purge(false);
+
+      // then
+      assertThat(response.getPlannedChanges()).isNotEmpty();
+      // TODO More assertions
+
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -88,9 +88,7 @@ final class ClusterEndpointIT {
           // then
           // TODO Change the assertion to check for planned changes once it's implemented.
           .describedAs("Purging should fail with 400 Bad Request as it is not yet fully supported")
-          .isInstanceOf(FeignException.BadRequest.class)
-          .hasMessageContaining(
-              "Expected to leave partition, but the partition 1 has only one replica");
+          .isInstanceOf(FeignException.BadRequest.class);
     }
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -78,26 +78,19 @@ final class ClusterEndpointIT {
   @Test
   void shouldRequestClusterPurge() {
     final ClusterActuator actuator;
-    try (final var cluster = createCluster(1)) {
+    try (final var cluster = createCluster(2)) {
       // given
       cluster.awaitCompleteTopology();
       actuator = ClusterActuator.of(cluster.availableGateway());
 
       // when -- request a purge
-      final var response = actuator.purge(false);
-
-      // then
-      assertThat(response.getExpectedTopology()).hasSize(BROKER_COUNT);
-      assertThat(response.getPlannedChanges())
-          .hasSize(4) // Should be 5, when DELETE_HISTORY is implemented
-          .asInstanceOf(InstanceOfAssertFactories.list(Operation.class))
-          .satisfies(
-              ops -> {
-                assertThat(ops.get(0).getOperation()).isEqualTo(OperationEnum.PARTITION_LEAVE);
-                assertThat(ops.get(1).getOperation()).isEqualTo(OperationEnum.PARTITION_LEAVE);
-                assertThat(ops.get(2).getOperation()).isEqualTo(OperationEnum.PARTITION_BOOTSTRAP);
-                assertThat(ops.get(3).getOperation()).isEqualTo(OperationEnum.PARTITION_BOOTSTRAP);
-              });
+      assertThatCode(() -> actuator.purge(false))
+          // then
+          // TODO Change the assertion to check for planned changes once it's implemented.
+          .describedAs("Purging should fail with 400 Bad Request as it is not yet fully supported")
+          .isInstanceOf(FeignException.BadRequest.class)
+          .hasMessageContaining(
+              "Expected to leave partition, but the partition 1 has only one replica");
     }
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -202,6 +202,5 @@ public interface ClusterActuator {
 
   @RequestLine("POST /purge?dryRun={dryRun}")
   @Headers({"Content-Type: application/json"})
-  PlannedOperationsResponse purge(
-      @Param boolean dryRun);
+  PlannedOperationsResponse purge(@Param boolean dryRun);
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -199,4 +199,9 @@ public interface ClusterActuator {
       @RequestBody final ClusterConfigPatchRequest request,
       @Param boolean dryRun,
       @Param boolean force);
+
+  @RequestLine("POST /purge?dryRun={dryRun}")
+  @Headers({"Content-Type: application/json"})
+  PlannedOperationsResponse purge(
+      @Param boolean dryRun);
 }


### PR DESCRIPTION
## Description

Extends the cluster API with a purge endpoint. Current implementation does not actually purge, but returns a change plan, although that change plan is missing at least the `DELETE_HISTORY` change. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #25961 
closes #25962
closes #25963 
closes #25964 
