### PR TITLE
Configured default mapping(s) to be created during initialization of Identity

### DIFF
--- a/dist/src/main/resources/application-auth-oidc.properties
+++ b/dist/src/main/resources/application-auth-oidc.properties
@@ -5,4 +5,7 @@ spring.security.oauth2.client.registration.oidcclient.redirect-uri=http://localh
 spring.security.oauth2.client.registration.oidcclient.provider=oidcclient
 spring.security.oauth2.client.registration.oidcclient.scope=openid,profile
 
+camunda.security.initialization.mappings[0].claimName=${INITIAL_CLAIM_NAME:oid}
+camunda.security.initialization.mappings[0].claimValue=${INITIAL_CLAIM_VALUE}
+
 spring.security.oauth2.client.provider.oidcclient.issuer-uri=http://auth.identity:9000

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.configuration;
+
+public class ConfiguredMapping {
+
+  private String claimName;
+  private String claimValue;
+
+  public ConfiguredMapping(final String claimName, final String claimValue) {
+    this.claimName = claimName;
+    this.claimValue = claimValue;
+  }
+
+  public String getClaimName() {
+    return claimName;
+  }
+
+  public void setClaimName(final String claimName) {
+    this.claimName = claimName;
+  }
+
+  public String getClaimValue() {
+    return claimValue;
+  }
+
+  public void setClaimValue(final String claimValue) {
+    this.claimValue = claimValue;
+  }
+}

--- a/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/ConfiguredMapping.java
@@ -7,12 +7,16 @@
  */
 package io.camunda.security.configuration;
 
+import static io.camunda.security.util.ArgumentUtil.ensureNotNullOrEmpty;
+
 public class ConfiguredMapping {
 
   private String claimName;
   private String claimValue;
 
   public ConfiguredMapping(final String claimName, final String claimValue) {
+    ensureNotNullOrEmpty("claimName", claimName);
+    ensureNotNullOrEmpty("claimValue", claimValue);
     this.claimName = claimName;
     this.claimValue = claimValue;
   }
@@ -22,6 +26,7 @@ public class ConfiguredMapping {
   }
 
   public void setClaimName(final String claimName) {
+    ensureNotNullOrEmpty("claimName", claimName);
     this.claimName = claimName;
   }
 
@@ -30,6 +35,7 @@ public class ConfiguredMapping {
   }
 
   public void setClaimValue(final String claimValue) {
+    ensureNotNullOrEmpty("claimValue", claimValue);
     this.claimValue = claimValue;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
+++ b/security/security-core/src/main/java/io/camunda/security/configuration/InitializationConfiguration.java
@@ -18,6 +18,7 @@ public class InitializationConfiguration {
   public static final String DEFAULT_USER_EMAIL = "demo@demo.com";
 
   private List<ConfiguredUser> users = new ArrayList<>();
+  private List<ConfiguredMapping> mappings = new ArrayList<>();
 
   public List<ConfiguredUser> getUsers() {
     return users;
@@ -25,5 +26,13 @@ public class InitializationConfiguration {
 
   public void setUsers(final List<ConfiguredUser> users) {
     this.users = users;
+  }
+
+  public List<ConfiguredMapping> getMappings() {
+    return mappings;
+  }
+
+  public void setMappings(final List<ConfiguredMapping> mappings) {
+    this.mappings = mappings;
   }
 }

--- a/security/security-core/src/main/java/io/camunda/security/util/ArgumentUtil.java
+++ b/security/security-core/src/main/java/io/camunda/security/util/ArgumentUtil.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.security.util;
+
+public class ArgumentUtil {
+  public static void ensureNotNull(final String property, final Object value) {
+    if (value == null) {
+      throw new IllegalArgumentException(property + " must not be null");
+    }
+  }
+
+  public static void ensureNotEmpty(final String property, final String value) {
+    if (value.isEmpty()) {
+      throw new IllegalArgumentException(property + " must not be empty");
+    }
+  }
+
+  public static void ensureNotNullOrEmpty(final String property, final String value) {
+    ensureNotNull(property, value);
+    ensureNotEmpty(property, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -14,7 +14,9 @@ import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavi
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.authorization.PersistedMapping;
 import io.camunda.zeebe.engine.state.distribution.DistributionQueue;
+import io.camunda.zeebe.engine.state.immutable.MappingState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.RoleState;
 import io.camunda.zeebe.engine.state.immutable.TenantState;
@@ -22,12 +24,14 @@ import io.camunda.zeebe.engine.state.immutable.UserState;
 import io.camunda.zeebe.engine.state.user.PersistedUser;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.AuthorizationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.Permission;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -47,6 +51,7 @@ public final class IdentitySetupInitializeProcessor
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
   private final CommandDistributionBehavior commandDistributionBehavior;
+  private final MappingState mappingState;
 
   public IdentitySetupInitializeProcessor(
       final ProcessingState processingState,
@@ -56,6 +61,7 @@ public final class IdentitySetupInitializeProcessor
     roleState = processingState.getRoleState();
     userState = processingState.getUserState();
     tenantState = processingState.getTenantState();
+    mappingState = processingState.getMappingState();
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
     this.commandDistributionBehavior = commandDistributionBehavior;
@@ -105,7 +111,8 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         userKey -> {
                           user.setUserKey(userKey);
-                          assignUserToRole(role.getRoleKey(), userKey);
+                          assignEntityToRole(
+                              commandKey, role.getRoleKey(), userKey, EntityType.USER);
                         },
                         () -> {
                           final long userKey = keyGenerator.nextKey();
@@ -123,6 +130,25 @@ public final class IdentitySetupInitializeProcessor
               tenant.setTenantKey(tenantKey);
               createTenant(tenant);
             });
+
+    record.getMappings().stream()
+        .map(MappingRecord.class::cast)
+        .forEach(
+            mapping ->
+                mappingState
+                    .get(mapping.getClaimName(), mapping.getClaimValue())
+                    .map(PersistedMapping::getMappingKey)
+                    .ifPresentOrElse(
+                        mappingKey -> {
+                          mapping.setMappingKey(mappingKey);
+                          assignEntityToRole(
+                              commandKey, role.getRoleKey(), mappingKey, EntityType.MAPPING);
+                        },
+                        () -> {
+                          final long mappingKey = keyGenerator.nextKey();
+                          mapping.setMappingKey(mappingKey);
+                          createMapping(commandKey, mapping, role.getRoleKey());
+                        }));
   }
 
   private void createDistributedEntities(final long commandKey, final IdentitySetupRecord record) {
@@ -138,12 +164,32 @@ public final class IdentitySetupInitializeProcessor
                 userState
                     .getUser(user.getUserKey())
                     .ifPresentOrElse(
-                        userKey -> assignUserToRole(role.getRoleKey(), userKey.getUserKey()),
+                        userKey ->
+                            assignEntityToRole(
+                                commandKey,
+                                role.getRoleKey(),
+                                userKey.getUserKey(),
+                                EntityType.USER),
                         () -> createUser(user, role.getRoleKey())));
 
     if (tenantState.getTenantByKey(record.getDefaultTenant().getTenantKey()).isEmpty()) {
       createTenant(record.getDefaultTenant());
     }
+
+    record.getMappings().stream()
+        .map(MappingRecord.class::cast)
+        .forEach(
+            mapping ->
+                mappingState
+                    .get(mapping.getClaimName(), mapping.getClaimValue())
+                    .ifPresentOrElse(
+                        mappingKey ->
+                            assignEntityToRole(
+                                commandKey,
+                                role.getRoleKey(),
+                                mappingKey.getMappingKey(),
+                                EntityType.MAPPING),
+                        () -> createMapping(commandKey, mapping, role.getRoleKey())));
   }
 
   private void createRole(final RoleRecord role) {
@@ -153,21 +199,31 @@ public final class IdentitySetupInitializeProcessor
 
   private void createUser(final UserRecord user, final long roleKey) {
     stateWriter.appendFollowUpEvent(user.getUserKey(), UserIntent.CREATED, user);
-    assignUserToRole(roleKey, user.getUserKey());
+    assignEntityToRole(roleKey, user.getUserKey(), EntityType.USER);
   }
 
   private void createTenant(final TenantRecord tenant) {
     stateWriter.appendFollowUpEvent(tenant.getTenantKey(), TenantIntent.CREATED, tenant);
   }
 
-  private void assignUserToRole(final long roleKey, final long userKey) {
-    final var isAlreadyAssigned = roleState.getEntityType(roleKey, userKey).isPresent();
+  private void createMapping(
+      final long commandKey, final MappingRecord mapping, final long roleKey) {
+    stateWriter.appendFollowUpEvent(commandKey, MappingIntent.CREATED, mapping);
+    assignEntityToRole(commandKey, roleKey, mapping.getMappingKey(), EntityType.MAPPING);
+  }
+
+  private void assignEntityToRole(
+      final long commandKey,
+      final long roleKey,
+      final long entityKey,
+      final EntityType entityType) {
+    final var isAlreadyAssigned = roleState.getEntityType(roleKey, entityKey).isPresent();
     if (isAlreadyAssigned) {
       return;
     }
 
     final var record =
-        new RoleRecord().setRoleKey(roleKey).setEntityKey(userKey).setEntityType(EntityType.USER);
+        new RoleRecord().setRoleKey(roleKey).setEntityKey(entityKey).setEntityType(entityType);
     stateWriter.appendFollowUpEvent(roleKey, RoleIntent.ENTITY_ADDED, record);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/identity/IdentitySetupInitializeProcessor.java
@@ -111,8 +111,7 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         userKey -> {
                           user.setUserKey(userKey);
-                          assignEntityToRole(
-                              commandKey, role.getRoleKey(), userKey, EntityType.USER);
+                          assignEntityToRole(role.getRoleKey(), userKey, EntityType.USER);
                         },
                         () -> {
                           final long userKey = keyGenerator.nextKey();
@@ -141,13 +140,12 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         mappingKey -> {
                           mapping.setMappingKey(mappingKey);
-                          assignEntityToRole(
-                              commandKey, role.getRoleKey(), mappingKey, EntityType.MAPPING);
+                          assignEntityToRole(role.getRoleKey(), mappingKey, EntityType.MAPPING);
                         },
                         () -> {
                           final long mappingKey = keyGenerator.nextKey();
                           mapping.setMappingKey(mappingKey);
-                          createMapping(commandKey, mapping, role.getRoleKey());
+                          createMapping(mapping, role.getRoleKey());
                         }));
   }
 
@@ -166,10 +164,7 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         userKey ->
                             assignEntityToRole(
-                                commandKey,
-                                role.getRoleKey(),
-                                userKey.getUserKey(),
-                                EntityType.USER),
+                                role.getRoleKey(), userKey.getUserKey(), EntityType.USER),
                         () -> createUser(user, role.getRoleKey())));
 
     if (tenantState.getTenantByKey(record.getDefaultTenant().getTenantKey()).isEmpty()) {
@@ -185,11 +180,8 @@ public final class IdentitySetupInitializeProcessor
                     .ifPresentOrElse(
                         mappingKey ->
                             assignEntityToRole(
-                                commandKey,
-                                role.getRoleKey(),
-                                mappingKey.getMappingKey(),
-                                EntityType.MAPPING),
-                        () -> createMapping(commandKey, mapping, role.getRoleKey())));
+                                role.getRoleKey(), mappingKey.getMappingKey(), EntityType.MAPPING),
+                        () -> createMapping(mapping, role.getRoleKey())));
   }
 
   private void createRole(final RoleRecord role) {
@@ -206,17 +198,13 @@ public final class IdentitySetupInitializeProcessor
     stateWriter.appendFollowUpEvent(tenant.getTenantKey(), TenantIntent.CREATED, tenant);
   }
 
-  private void createMapping(
-      final long commandKey, final MappingRecord mapping, final long roleKey) {
-    stateWriter.appendFollowUpEvent(commandKey, MappingIntent.CREATED, mapping);
-    assignEntityToRole(commandKey, roleKey, mapping.getMappingKey(), EntityType.MAPPING);
+  private void createMapping(final MappingRecord mapping, final long roleKey) {
+    stateWriter.appendFollowUpEvent(mapping.getMappingKey(), MappingIntent.CREATED, mapping);
+    assignEntityToRole(roleKey, mapping.getMappingKey(), EntityType.MAPPING);
   }
 
   private void assignEntityToRole(
-      final long commandKey,
-      final long roleKey,
-      final long entityKey,
-      final EntityType entityType) {
+      final long roleKey, final long entityKey, final EntityType entityType) {
     final var isAlreadyAssigned = roleState.getEntityType(roleKey, entityKey).isPresent();
     if (isAlreadyAssigned) {
       return;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/user/IdentitySetupInitializer.java
@@ -11,6 +11,7 @@ import io.camunda.security.configuration.SecurityConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -86,6 +87,18 @@ public final class IdentitySetupInitializer implements StreamProcessorLifecycleA
     final var defaultTenant =
         new TenantRecord().setTenantId(DEFAULT_TENANT_ID).setName(DEFAULT_TENANT_NAME);
     setupRecord.setDefaultTenant(defaultTenant);
+
+    securityConfig
+        .getInitialization()
+        .getMappings()
+        .forEach(
+            mapping -> {
+              final var mappingrecord =
+                  new MappingRecord()
+                      .setClaimName(mapping.getClaimName())
+                      .setClaimValue(mapping.getClaimValue());
+              setupRecord.addMapping(mappingrecord);
+            });
 
     taskResultBuilder.appendCommandRecord(IdentitySetupIntent.INITIALIZE, setupRecord);
     return taskResultBuilder.build();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/authorization/IdentitySetupInitializeTest.java
@@ -12,12 +12,14 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
+import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.RoleIntent;
 import io.camunda.zeebe.protocol.record.intent.TenantIntent;
 import io.camunda.zeebe.protocol.record.intent.UserIntent;
@@ -25,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.EntityType;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -102,7 +105,7 @@ public class IdentitySetupInitializeTest {
         .hasTenantKey(tenantKey)
         .hasName(tenantName)
         .hasTenantId(tenantId);
-    assertUserIsAssignedToRole(roleKey, userKey);
+    assertThatEntityIsAssignedToRole(roleKey, userKey, EntityType.USER);
     assertThatAllPermissionsAreAddedToRole(roleKey);
   }
 
@@ -137,7 +140,8 @@ public class IdentitySetupInitializeTest {
 
     // then
     assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertUserIsAssignedToRole(initializeRecord.getValue().getDefaultRole().getRoleKey(), userKey);
+    assertThatEntityIsAssignedToRole(
+        initializeRecord.getValue().getDefaultRole().getRoleKey(), userKey, EntityType.USER);
   }
 
   @Test
@@ -163,8 +167,8 @@ public class IdentitySetupInitializeTest {
 
     // then
     assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertUserIsAssignedToRole(
-        roleKey, initializeRecord.getValue().getUsers().getFirst().getUserKey());
+    assertThatEntityIsAssignedToRole(
+        roleKey, initializeRecord.getValue().getUsers().getFirst().getUserKey(), EntityType.USER);
     Assertions.assertThat(
             RecordingExporter.records()
                 .limit(r -> r.getIntent() == IdentitySetupIntent.INITIALIZED)
@@ -230,13 +234,7 @@ public class IdentitySetupInitializeTest {
     // then
     assertRoleIsNotCreated(initializeRecord.getSourceRecordPosition());
     assertUserIsNotCreated(initializeRecord.getSourceRecordPosition());
-    assertUserIsAssignedToRole(roleKey, userKey);
-  }
-
-  private static void assertUserIsAssignedToRole(final long roleKey, final long userKey) {
-    final var roleRecord = RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).getFirst();
-    Assertions.assertThat(roleRecord.getKey()).isEqualTo(roleKey);
-    assertThat(roleRecord.getValue()).hasRoleKey(roleKey).hasEntityKey(userKey);
+    assertThatEntityIsAssignedToRole(roleKey, userKey, EntityType.USER);
   }
 
   @Test
@@ -309,6 +307,55 @@ public class IdentitySetupInitializeTest {
             tuple(user2.getUsername(), user2.getPassword(), user2.getName(), user2.getEmail()));
   }
 
+  @Test
+  public void shouldCreateConfiguredMappings() {
+    // given
+    final var role = new RoleRecord().setName(UUID.randomUUID().toString());
+    final var mapping1 =
+        new MappingRecord()
+            .setClaimName(UUID.randomUUID().toString())
+            .setClaimValue(UUID.randomUUID().toString());
+    final var mapping2 =
+        new MappingRecord()
+            .setClaimName(UUID.randomUUID().toString())
+            .setClaimValue(UUID.randomUUID().toString());
+
+    // when
+    final var initialized =
+        engine
+            .identitySetup()
+            .initialize()
+            .withRole(role)
+            .withMapping(mapping1)
+            .withMapping(mapping2)
+            .initialize()
+            .getValue();
+
+    // then
+    Assertions.assertThat(RecordingExporter.roleRecords(RoleIntent.CREATED).exists()).isTrue();
+    final var createdMappings =
+        RecordingExporter.mappingRecords(MappingIntent.CREATED).limit(2).toList().stream()
+            .map(Record::getValue)
+            .toList();
+    Assertions.assertThat(createdMappings)
+        .extracting(MappingRecordValue::getClaimName, MappingRecordValue::getClaimValue)
+        .containsExactly(
+            tuple(mapping1.getClaimName(), mapping1.getClaimValue()),
+            tuple(mapping2.getClaimName(), mapping2.getClaimValue()));
+    Assertions.assertThat(createdMappings)
+        .satisfiesExactly(
+            m1 ->
+                assertThatEntityIsAssignedToRole(
+                    initialized.getDefaultRole().getRoleKey(),
+                    m1.getMappingKey(),
+                    EntityType.MAPPING),
+            m2 ->
+                assertThatEntityIsAssignedToRole(
+                    initialized.getDefaultRole().getRoleKey(),
+                    m2.getMappingKey(),
+                    EntityType.MAPPING));
+  }
+
   private static void assertThatAllPermissionsAreAddedToRole(final long roleKey) {
     final var addedPermissions =
         RecordingExporter.authorizationRecords(AuthorizationIntent.PERMISSION_ADDED)
@@ -373,5 +420,16 @@ public class IdentitySetupInitializeTest {
                 .withIntent(RoleIntent.ENTITY_ADDED)
                 .toList())
         .isEmpty();
+  }
+
+  private void assertThatEntityIsAssignedToRole(
+      final long roleKey, final long entityKey, final EntityType entityType) {
+    final var roleRecord =
+        RecordingExporter.roleRecords(RoleIntent.ENTITY_ADDED).withEntityKey(entityKey).getFirst();
+    Assertions.assertThat(roleRecord.getKey()).isEqualTo(roleKey);
+    assertThat(roleRecord.getValue())
+        .hasRoleKey(roleKey)
+        .hasEntityKey(entityKey)
+        .hasEntityType(entityType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionIdempotencyTest.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.engine.processing.user.UserDeleteProcessor;
 import io.camunda.zeebe.engine.processing.user.UserUpdateProcessor;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -539,6 +540,11 @@ public class CommandDistributionIdempotencyTest {
                                 .setTenantKey(3L)
                                 .setTenantId("tenant-id")
                                 .setName("tenant-name"))
+                        .withMapping(
+                            new MappingRecord()
+                                .setMappingKey(4)
+                                .setClaimName("claimName")
+                                .setClaimValue("claimValue"))
                         .initialize(),
                 1),
             IdentitySetupInitializeProcessor.class

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/IdentitySetupClient.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.util.client;
 
 import io.camunda.zeebe.protocol.impl.record.value.authorization.IdentitySetupRecord;
+import io.camunda.zeebe.protocol.impl.record.value.authorization.MappingRecord;
 import io.camunda.zeebe.protocol.impl.record.value.authorization.RoleRecord;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
@@ -65,6 +66,11 @@ public final class IdentitySetupClient {
 
     public IdentitySetupInitializeClient withTenant(final TenantRecord tenant) {
       record.setDefaultTenant(tenant);
+      return this;
+    }
+
+    public IdentitySetupInitializeClient withMapping(final MappingRecord mapping) {
+      record.addMapping(mapping);
       return this;
     }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -28,7 +28,7 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
       new ArrayProperty<>("mappings", MappingRecord::new);
 
   public IdentitySetupRecord() {
-    super(3);
+    super(4);
     declareProperty(defaultRoleProp)
         .declareProperty(usersProp)
         .declareProperty(defaultTenantProp)

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/authorization/IdentitySetupRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.tenant.TenantRecord;
 import io.camunda.zeebe.protocol.impl.record.value.user.UserRecord;
 import io.camunda.zeebe.protocol.record.value.IdentitySetupRecordValue;
+import io.camunda.zeebe.protocol.record.value.MappingRecordValue;
 import io.camunda.zeebe.protocol.record.value.UserRecordValue;
 import java.util.List;
 
@@ -23,10 +24,15 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
   private final ArrayProperty<UserRecord> usersProp = new ArrayProperty<>("users", UserRecord::new);
   private final ObjectProperty<TenantRecord> defaultTenantProp =
       new ObjectProperty<>("defaultTenant", new TenantRecord());
+  private final ArrayProperty<MappingRecord> mappingsProp =
+      new ArrayProperty<>("mappings", MappingRecord::new);
 
   public IdentitySetupRecord() {
     super(3);
-    declareProperty(defaultRoleProp).declareProperty(usersProp).declareProperty(defaultTenantProp);
+    declareProperty(defaultRoleProp)
+        .declareProperty(usersProp)
+        .declareProperty(defaultTenantProp)
+        .declareProperty(mappingsProp);
   }
 
   @Override
@@ -49,6 +55,11 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
     return defaultTenantProp.getValue();
   }
 
+  @Override
+  public List<MappingRecordValue> getMappings() {
+    return mappingsProp.stream().map(MappingRecordValue.class::cast).toList();
+  }
+
   public IdentitySetupRecord setDefaultTenant(final TenantRecord tenant) {
     defaultTenantProp.getValue().copyFrom(tenant);
     return this;
@@ -56,6 +67,11 @@ public class IdentitySetupRecord extends UnifiedRecordValue implements IdentityS
 
   public IdentitySetupRecord addUser(final UserRecord user) {
     usersProp.add().copyFrom(user);
+    return this;
+  }
+
+  public IdentitySetupRecord addMapping(final MappingRecord mapping) {
+    mappingsProp.add().copyFrom(mapping);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3025,12 +3025,14 @@ final class JsonSerializableToJsonTest {
                         new MappingRecord()
                             .setMappingKey(6)
                             .setClaimName("claim1")
-                            .setClaimValue("value1"))
+                            .setClaimValue("value1")
+                            .setName("Claim 1"))
                     .addMapping(
                         new MappingRecord()
                             .setMappingKey(7)
                             .setClaimName("claim2")
-                            .setClaimValue("value2")),
+                            .setClaimValue("value2")
+                            .setName("Claim 2")),
         """
       {
         "defaultRole": {
@@ -3068,12 +3070,14 @@ final class JsonSerializableToJsonTest {
           {
             "mappingKey": 6,
             "claimName": "claim1",
-            "claimValue": "value1"
+            "claimValue": "value1",
+            "name": "Claim 1"
           },
           {
             "mappingKey": 7,
             "claimName": "claim2",
-            "claimValue": "value2"
+            "claimValue": "value2",
+            "name": "Claim 2"
           }
         ]
       }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -3020,7 +3020,17 @@ final class JsonSerializableToJsonTest {
                             .setPassword("qux")
                             .setUserType(UserType.REGULAR))
                     .setDefaultTenant(
-                        new TenantRecord().setTenantKey(5).setTenantId("id").setName("name")),
+                        new TenantRecord().setTenantKey(5).setTenantId("id").setName("name"))
+                    .addMapping(
+                        new MappingRecord()
+                            .setMappingKey(6)
+                            .setClaimName("claim1")
+                            .setClaimValue("value1"))
+                    .addMapping(
+                        new MappingRecord()
+                            .setMappingKey(7)
+                            .setClaimName("claim2")
+                            .setClaimValue("value2")),
         """
       {
         "defaultRole": {
@@ -3053,7 +3063,19 @@ final class JsonSerializableToJsonTest {
           "name": "name",
           "entityKey": -1,
           "entityType": "UNSPECIFIED"
-        }
+        },
+        "mappings": [
+          {
+            "mappingKey": 6,
+            "claimName": "claim1",
+            "claimValue": "value1"
+          },
+          {
+            "mappingKey": 7,
+            "claimName": "claim2",
+            "claimValue": "value2"
+          }
+        ]
       }
       """
       },
@@ -3078,7 +3100,8 @@ final class JsonSerializableToJsonTest {
               "name": "",
               "entityKey": -1,
               "entityType": "UNSPECIFIED"
-          }
+          },
+          "mappings": []
       }
       """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IdentitySetupRecordValue.java
@@ -29,4 +29,6 @@ public interface IdentitySetupRecordValue extends RecordValue {
   List<UserRecordValue> getUsers();
 
   TenantRecordValue getDefaultTenant();
+
+  List<MappingRecordValue> getMappings();
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.IdentitySetupIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MappingIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
@@ -492,6 +493,10 @@ public final class RecordingExporter implements Exporter {
 
   public static MappingRecordStream mappingRecords() {
     return new MappingRecordStream(records(ValueType.MAPPING, MappingRecordValue.class));
+  }
+
+  public static MappingRecordStream mappingRecords(final MappingIntent intent) {
+    return mappingRecords().withIntent(intent);
   }
 
   public static GroupRecordStream groupRecords() {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Similar to how we initialize users on startup, we also need a way to initialize mappings on startup. This PR adds the configuration options for this and creates the mappings in the intialize processor. The default mappings get assigned the Admin role to give them permissions.

In the auth-oidc properties file we provide some default values for this. This is a guideline for users, similar to what happened in old identity.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26019
