### PR TITLE
feat: use `TASK_LISTENER_NO_RETRIES` error type for TL job incidents

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -46,8 +46,6 @@ import org.agrona.DirectBuffer;
 
 public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
 
-  public static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to cancel job with key '%d', but no such job was found";
   private static final DirectBuffer DEFAULT_ERROR_MESSAGE = wrapString("No more retries left.");
   private final IncidentRecord incidentEvent = new IncidentRecord();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -166,10 +166,12 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       incidentErrorMessage = jobErrorMessage;
     }
 
-    final ErrorType errorType =
-        value.getJobKind() == JobKind.EXECUTION_LISTENER
-            ? ErrorType.EXECUTION_LISTENER_NO_RETRIES
-            : ErrorType.JOB_NO_RETRIES;
+    final var errorType =
+        switch (value.getJobKind()) {
+          case JobKind.BPMN_ELEMENT -> ErrorType.JOB_NO_RETRIES;
+          case JobKind.EXECUTION_LISTENER -> ErrorType.EXECUTION_LISTENER_NO_RETRIES;
+          case JobKind.TASK_LISTENER -> ErrorType.TASK_LISTENER_NO_RETRIES;
+        };
 
     final var treePathProperties =
         new ElementTreePathBuilder()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/listeners/task/TaskListenerTest.java
@@ -443,7 +443,7 @@ public class TaskListenerTest {
             .getFirst();
     Assertions.assertThat(incident.getValue())
         .hasProcessInstanceKey(processInstanceKey)
-        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorType(ErrorType.TASK_LISTENER_NO_RETRIES)
         .hasErrorMessage("No more retries left.");
 
     // resolve incident & complete failed TL job

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/UserTaskListenersTest.java
@@ -213,7 +213,7 @@ public class UserTaskListenersTest {
             incident ->
                 assertThat(incident)
                     .hasJobKey(jobKey)
-                    .hasErrorType(ErrorType.JOB_NO_RETRIES)
+                    .hasErrorType(ErrorType.TASK_LISTENER_NO_RETRIES)
                     .extracting(
                         IncidentRecordValue::getErrorMessage, as(InstanceOfAssertFactories.STRING))
                     .startsWith("io.camunda.zeebe.client.api.command.ClientStatusException:")


### PR DESCRIPTION
## Description

This PR introduces the usage of a dedicated error type, `TASK_LISTENER_NO_RETRIES`, for task listener job incidents when retries are exhausted. Previously, the generic `JOB_NO_RETRIES` error type was used, making it difficult to distinguish incidents created due to task listener failures from other job failures.

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #23492
