### PR TITLE
fix: add support remove auth permissions

### DIFF
--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
@@ -14,8 +14,7 @@ import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.SearchQueryResult;
-import io.camunda.security.entity.Permission;
-import java.util.Optional;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,18 +29,15 @@ public class AuthorizationReader extends AbstractEntityReader<AuthorizationEntit
     this.authorizationMapper = authorizationMapper;
   }
 
-  public Optional<AuthorizationEntity> findOne(
+  public List<AuthorizationEntity> find(
       final long ownerKey, final String ownerType, final String resourceType) {
-    final var result =
-        search(
+    return search(
             AuthorizationQuery.of(
                 b ->
                     b.filter(
                         f ->
-                            f.ownerKeys(ownerKey)
-                                .ownerType(ownerType)
-                                .resourceType(resourceType))));
-    return Optional.ofNullable(result.items()).flatMap(items -> items.stream().findFirst());
+                            f.ownerKeys(ownerKey).ownerType(ownerType).resourceType(resourceType))))
+        .items();
   }
 
   public SearchQueryResult<AuthorizationEntity> search(final AuthorizationQuery query) {
@@ -66,8 +62,7 @@ public class AuthorizationReader extends AbstractEntityReader<AuthorizationEntit
         model.ownerKey(),
         model.ownerType(),
         model.resourceType(),
-        model.permissions().stream()
-            .map(p -> new Permission(p.permissionType(), p.resourceIds()))
-            .toList());
+        model.permissionType(),
+        model.resourceId());
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/write/domain/AuthorizationDbModel.java
@@ -8,7 +8,7 @@
 package io.camunda.db.rdbms.write.domain;
 
 import io.camunda.util.ObjectBuilder;
-import java.util.List;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.function.Function;
 
 public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
@@ -16,7 +16,8 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
   private Long ownerKey;
   private String ownerType;
   private String resourceType;
-  private List<AuthorizationPermissionDbModel> permissions;
+  private PermissionType permissionType;
+  private String resourceId;
 
   public Long ownerKey() {
     return ownerKey;
@@ -42,12 +43,20 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     this.resourceType = resourceType;
   }
 
-  public List<AuthorizationPermissionDbModel> permissions() {
-    return permissions;
+  public PermissionType permissionType() {
+    return permissionType;
   }
 
-  public void permissions(final List<AuthorizationPermissionDbModel> permissions) {
-    this.permissions = permissions;
+  public void permissionType(final PermissionType permissionType) {
+    this.permissionType = permissionType;
+  }
+
+  public String resourceId() {
+    return resourceId;
+  }
+
+  public void resourceId(final String resourceId) {
+    this.resourceId = resourceId;
   }
 
   @Override
@@ -60,7 +69,8 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
                 .ownerKey(ownerKey)
                 .ownerType(ownerType)
                 .resourceType(resourceType)
-                .permissions(permissions))
+                .permissionType(permissionType)
+                .resourceId(resourceId))
         .build();
   }
 
@@ -69,7 +79,8 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
     private Long ownerKey;
     private String ownerType;
     private String resourceType;
-    private List<AuthorizationPermissionDbModel> permissions;
+    private PermissionType permissionType;
+    private String resourceId;
 
     public Builder() {}
 
@@ -88,8 +99,13 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       return this;
     }
 
-    public Builder permissions(final List<AuthorizationPermissionDbModel> permissions) {
-      this.permissions = permissions;
+    public Builder permissionType(final PermissionType permissionType) {
+      this.permissionType = permissionType;
+      return this;
+    }
+
+    public Builder resourceId(final String resourceId) {
+      this.resourceId = resourceId;
       return this;
     }
 
@@ -99,7 +115,8 @@ public class AuthorizationDbModel implements DbModel<AuthorizationDbModel> {
       model.ownerKey(ownerKey);
       model.ownerType(ownerType);
       model.resourceType(resourceType);
-      model.permissions(permissions);
+      model.permissionType(permissionType);
+      model.resourceId(resourceId);
       return model;
     }
   }

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -11,39 +11,25 @@
 <mapper namespace="io.camunda.db.rdbms.sql.AuthorizationMapper">
 
   <select id="count" parameterType="io.camunda.db.rdbms.read.domain.AuthorizationDbQuery">
-    SELECT COUNT(*) FROM (
-    SELECT DISTINCT OWNER_KEY, OWNER_TYPE, RESOURCE_TYPE
-    FROM AUTHORIZATIONS a
+    SELECT COUNT(*)
+    FROM AUTHORIZATIONS
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
-    ) t
   </select>
 
   <select id="search" parameterType="io.camunda.db.rdbms.read.domain.AuthorizationDbQuery"
     resultMap="io.camunda.db.rdbms.sql.AuthorizationMapper.authorizationResultMap">
     SELECT
-    t.OWNER_KEY,
-    t.OWNER_TYPE,
-    t.RESOURCE_TYPE,
-    a.PERMISSION_TYPE,
-    a.RESOURCE_ID
-    FROM (
-    SELECT * FROM (
-    SELECT DISTINCT
     OWNER_KEY,
     OWNER_TYPE,
-    RESOURCE_TYPE
+    RESOURCE_TYPE,
+    PERMISSION_TYPE,
+    RESOURCE_ID
     FROM AUTHORIZATIONS
     <include refid="io.camunda.db.rdbms.sql.AuthorizationMapper.searchFilter"/>
-    ) t
     <include refid="io.camunda.db.rdbms.sql.Commons.keySetPageFilter"/>
     <!-- inner orderBy for keyset pagination -->
     <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
     <include refid="io.camunda.db.rdbms.sql.Commons.paging"/>
-    ) t
-    JOIN AUTHORIZATIONS a ON t.OWNER_KEY = a.OWNER_KEY AND t.OWNER_TYPE = a.OWNER_TYPE AND
-    t.RESOURCE_TYPE = a.RESOURCE_TYPE
-    <!-- outer orderBy for actual sorting -->
-    <include refid="io.camunda.db.rdbms.sql.Commons.orderBy"/>
   </select>
 
   <sql id="searchFilter">
@@ -53,14 +39,13 @@
     <if test="filter.permissionType != null">AND PERMISSION_TYPE = #{filter.permissionType}</if>
     <if test="filter.ownerKeys != null and !filter.ownerKeys.isEmpty()">
       AND OWNER_KEY IN
-      <foreach collection="filter.ownerKeys" item="value" open="(" separator=", "
-        close=")">#{value}
+      <foreach collection="filter.ownerKeys" item="value" open="(" separator=", " close=")"> #{value}
       </foreach>
     </if>
     <if test="filter.resourceIds != null and !filter.resourceIds.isEmpty()">
       AND RESOURCE_ID IN
-      <foreach collection="filter.resourceIds" item="value" open="(" separator=", "
-        close=")">#{value}
+      <foreach collection="filter.resourceIds" item="value" open="(" separator=", " close=")">
+        #{value}
       </foreach>
     </if>
   </sql>
@@ -70,44 +55,24 @@
     <id column="OWNER_KEY" property="ownerKey"/>
     <id column="OWNER_TYPE" property="ownerType"/>
     <id column="RESOURCE_TYPE" property="resourceType"/>
-    <collection property="permissions"
-      ofType="io.camunda.db.rdbms.write.domain.AuthorizationPermissionDbModel"
-      javaType="java.util.List">
-      <id column="PERMISSION_TYPE" property="type"/>
-      <collection property="resourceIds" ofType="java.lang.String" javaType="java.util.Set">
-        <id column="RESOURCE_ID"/>
-      </collection>
-    </collection>
+    <id column="PERMISSION_TYPE" property="permissionType"/>
+    <id column="RESOURCE_ID" property="resourceId"/>
   </resultMap>
 
   <insert id="insert" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel"
     flushCache="true">
     INSERT INTO AUTHORIZATIONS (OWNER_KEY, OWNER_TYPE, RESOURCE_TYPE, PERMISSION_TYPE, RESOURCE_ID)
-    VALUES
-    <foreach collection="permissions" item="permission" separator=",">
-      <foreach collection="permission.resourceIds" item="resourceId" separator=",">
-        (#{ownerKey}, #{ownerType}, #{resourceType}, #{permission.type}, #{resourceId})
-      </foreach>
-    </foreach>
+    VALUES (#{ownerKey}, #{ownerType}, #{resourceType}, #{permissionType}, #{resourceId})
   </insert>
 
   <delete id="delete" parameterType="io.camunda.db.rdbms.write.domain.AuthorizationDbModel"
     flushCache="true">
-    DELETE
-    FROM AUTHORIZATIONS
+    DELETE FROM AUTHORIZATIONS
     WHERE OWNER_KEY = #{ownerKey}
-    AND OWNER_TYPE = #{ownerType}
-    AND RESOURCE_TYPE = #{resourceType}
-    <if test="permissions != null and !permissions.isEmpty()">
-      <foreach collection="permissions" item="permission" open=" AND (" separator=" OR " close=" ) ">
-        ( PERMISSION_TYPE = #{permission.type}
-        <if test="permission.resourceIds != null and !permission.resourceIds.isEmpty()">
-          <foreach collection="permission.resourceIds" item="resourceId" open=" AND RESOURCE_ID IN (" separator=", " close=" ) ">
-            #{resourceId}
-          </foreach>
-        </if>
-        )
-      </foreach>
-    </if>
+      AND OWNER_TYPE = #{ownerType}
+      AND RESOURCE_TYPE = #{resourceType}
+      AND PERMISSION_TYPE = #{permissionType}
+      AND RESOURCE_ID = #{resourceId}
   </delete>
+
 </mapper>

--- a/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
+++ b/db/rdbms/src/main/resources/mapper/AuthorizationsMapper.xml
@@ -33,13 +33,18 @@
   </select>
 
   <sql id="searchFilter">
-    WHERE 1 = 1
+<!--    <if test="filter.ownerType != null or filter.resourceType != null or filter.permissionType != null or-->
+<!--            (filter.ownerKeys != null and !filter.ownerKeys.isEmpty()) or-->
+<!--            (filter.resourceIds != null and !filter.resourceIds.isEmpty())">-->
+      WHERE 1 = 1
+<!--    </if>-->
     <if test="filter.ownerType != null">AND OWNER_TYPE = #{filter.ownerType}</if>
     <if test="filter.resourceType != null">AND RESOURCE_TYPE = #{filter.resourceType}</if>
     <if test="filter.permissionType != null">AND PERMISSION_TYPE = #{filter.permissionType}</if>
     <if test="filter.ownerKeys != null and !filter.ownerKeys.isEmpty()">
       AND OWNER_KEY IN
-      <foreach collection="filter.ownerKeys" item="value" open="(" separator=", " close=")"> #{value}
+      <foreach collection="filter.ownerKeys" item="value" open="(" separator=", "
+        close=")">#{value}
       </foreach>
     </if>
     <if test="filter.resourceIds != null and !filter.resourceIds.isEmpty()">

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -22,7 +22,6 @@ import io.camunda.search.entities.TenantEntity;
 import io.camunda.search.entities.UserEntity;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
-import io.camunda.security.entity.Permission;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.service.RoleServices;
 import io.camunda.service.TenantServices;
@@ -90,7 +89,8 @@ public class BasicAuthIT {
                     1L,
                     AuthorizationOwnerType.USER.name(),
                     AuthorizationResourceType.APPLICATION.name(),
-                    List.of(new Permission(PermissionType.ACCESS, Set.of("*"))))));
+                    PermissionType.ACCESS,
+                    "*")));
 
     when(roleServices.findAll(any())).thenReturn(List.of());
 

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/fixtures/AuthorizationFixtures.java
@@ -12,10 +12,8 @@ import io.camunda.client.protocol.rest.ResourceTypeEnum;
 import io.camunda.db.rdbms.write.RdbmsWriter;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel;
 import io.camunda.db.rdbms.write.domain.AuthorizationDbModel.Builder;
-import io.camunda.db.rdbms.write.domain.AuthorizationPermissionDbModel;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 public final class AuthorizationFixtures extends CommonFixtures {
@@ -30,16 +28,8 @@ public final class AuthorizationFixtures extends CommonFixtures {
             .ownerKey(ownerKey)
             .ownerType(randomEnum(OwnerTypeEnum.class).name())
             .resourceType(randomEnum(ResourceTypeEnum.class).name())
-            .permissions(
-                List.of(
-                    new AuthorizationPermissionDbModel.Builder()
-                        .type(PermissionType.CREATE)
-                        .resourceIds(Set.of(nextStringId(), nextStringId()))
-                        .build(),
-                    new AuthorizationPermissionDbModel.Builder()
-                        .type(PermissionType.READ)
-                        .resourceIds(Set.of(nextStringId(), nextStringId()))
-                        .build()));
+            .permissionType(randomEnum(PermissionType.class))
+            .resourceId(nextStringId());
 
     return builderFunction.apply(builder).build();
   }
@@ -51,7 +41,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
   public static AuthorizationDbModel createAndSaveRandomAuthorization(
       final RdbmsWriter rdbmsWriter, final Function<Builder, Builder> builderFunction) {
     final var definition = AuthorizationFixtures.createRandomized(builderFunction);
-    rdbmsWriter.getAuthorizationWriter().addPermissions(definition);
+    rdbmsWriter.getAuthorizationWriter().addPermissions(List.of(definition));
     rdbmsWriter.flush();
     return definition;
   }
@@ -61,7 +51,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
     for (int i = 0; i < 20; i++) {
       rdbmsWriter
           .getAuthorizationWriter()
-          .addPermissions(AuthorizationFixtures.createRandomized(builderFunction));
+          .addPermissions(List.of(AuthorizationFixtures.createRandomized(builderFunction)));
     }
 
     rdbmsWriter.flush();
@@ -82,7 +72,7 @@ public final class AuthorizationFixtures extends CommonFixtures {
   public static void createAndSaveAuthorizations(
       final RdbmsWriter rdbmsWriter, final List<AuthorizationDbModel> userList) {
     for (final AuthorizationDbModel user : userList) {
-      rdbmsWriter.getAuthorizationWriter().addPermissions(user);
+      rdbmsWriter.getAuthorizationWriter().addPermissions(List.of(user));
     }
     rdbmsWriter.flush();
   }

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/entity/AuthorizationEntityTransformer.java
@@ -7,12 +7,8 @@
  */
 package io.camunda.search.clients.transformers.entity;
 
-import static java.util.Collections.emptyList;
-import static java.util.Optional.ofNullable;
-
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.entities.AuthorizationEntity;
-import java.util.List;
 
 public class AuthorizationEntityTransformer
     implements ServiceTransformer<
@@ -26,6 +22,7 @@ public class AuthorizationEntityTransformer
         value.getOwnerKey(),
         value.getOwnerType(),
         value.getResourceType(),
-        ofNullable(value.getPermissions()).map(List::copyOf).orElse(emptyList()));
+        value.getPermissionType(),
+        value.getResourceId());
   }
 }

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
@@ -155,7 +155,8 @@ class DocumentAuthorizationQueryStrategyTest {
 
     // then
     assertThat(result.query())
-        .isEqualTo(and(originalRequest.query(), stringTerms("bpmnProcessId", List.of("foo"))));
+        .isEqualTo(
+            and(originalRequest.query(), stringTerms("bpmnProcessId", List.of("foo", "bar"))));
     assertThat(authorizationQueryCaptor.getValue())
         .isEqualTo(
             authorizationSearchQuery(

--- a/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
+++ b/search/search-client-query-transformer/src/test/java/io/camunda/search/clients/auth/DocumentAuthorizationQueryStrategyTest.java
@@ -11,7 +11,6 @@ import static io.camunda.search.clients.query.SearchQueryBuilders.and;
 import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
 import static io.camunda.search.query.SearchQueryBuilders.authorizationSearchQuery;
 import static io.camunda.zeebe.protocol.record.value.AuthorizationResourceType.PROCESS_DEFINITION;
-import static io.camunda.zeebe.protocol.record.value.PermissionType.CREATE;
 import static io.camunda.zeebe.protocol.record.value.PermissionType.READ;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,9 +28,7 @@ import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.search.query.ProcessDefinitionQuery;
 import io.camunda.search.query.SearchQueryBase;
 import io.camunda.security.auth.SecurityContext;
-import io.camunda.security.entity.Permission;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -98,13 +95,9 @@ class DocumentAuthorizationQueryStrategyTest {
     when(authorizationSearchClient.findAllAuthorizations(any()))
         .thenReturn(
             List.of(
-                new AuthorizationEntity(
-                    null,
-                    null,
-                    null,
-                    List.of(
-                        new Permission(READ, Set.of("foo", "*")),
-                        new Permission(CREATE, Set.of("bar"))))));
+                new AuthorizationEntity(null, null, null, READ, "foo"),
+                new AuthorizationEntity(null, null, null, READ, "*"),
+                new AuthorizationEntity(null, null, null, READ, "bar")));
 
     // when
     final SearchQueryRequest result =
@@ -152,13 +145,8 @@ class DocumentAuthorizationQueryStrategyTest {
     when(authorizationSearchClient.findAllAuthorizations(authorizationQueryCaptor.capture()))
         .thenReturn(
             List.of(
-                new AuthorizationEntity(
-                    null,
-                    null,
-                    null,
-                    List.of(
-                        new Permission(READ, Set.of("foo")),
-                        new Permission(CREATE, Set.of("bar"))))));
+                new AuthorizationEntity(null, null, null, READ, "foo"),
+                new AuthorizationEntity(null, null, null, READ, "bar")));
 
     // when
     final SearchQueryRequest result =

--- a/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
+++ b/search/search-domain/src/main/java/io/camunda/search/entities/AuthorizationEntity.java
@@ -8,9 +8,12 @@
 package io.camunda.search.entities;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import io.camunda.security.entity.Permission;
-import java.util.List;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record AuthorizationEntity(
-    Long ownerKey, String ownerType, String resourceType, List<Permission> permissions) {}
+    Long ownerKey,
+    String ownerType,
+    String resourceType,
+    PermissionType permissionType,
+    String resourceId) {}

--- a/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
+++ b/security/security-services/src/main/java/io/camunda/security/impl/AuthorizationChecker.java
@@ -14,7 +14,6 @@ import io.camunda.search.entities.AuthorizationEntity;
 import io.camunda.search.query.AuthorizationQuery;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.SecurityContext;
-import io.camunda.security.entity.Permission;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.ArrayList;
@@ -57,13 +56,7 @@ public class AuthorizationChecker {
                             f.ownerKeys(ownerKeys)
                                 .resourceType(resourceType.name())
                                 .permissionType(permissionType))));
-    return authorizationEntities.stream()
-        .flatMap(
-            e ->
-                e.permissions().stream()
-                    .filter(permission -> permissionType.equals(permission.type()))
-                    .flatMap(permission -> permission.resourceIds().stream()))
-        .toList();
+    return authorizationEntities.stream().map(AuthorizationEntity::resourceId).toList();
   }
 
   /**
@@ -118,14 +111,8 @@ public class AuthorizationChecker {
                                 .resourceType(resourceType.name())
                                 .resourceIds(List.of(WILDCARD, resourceId)))));
 
-    return collectPermissionTypes(authorizationEntities);
-  }
-
-  private Set<PermissionType> collectPermissionTypes(
-      final List<AuthorizationEntity> authorizationEntities) {
     return authorizationEntities.stream()
-        .flatMap(a -> a.permissions().stream())
-        .map(Permission::type)
+        .map(AuthorizationEntity::permissionType)
         .collect(Collectors.toSet());
   }
 

--- a/service/src/main/java/io/camunda/service/AuthorizationServices.java
+++ b/service/src/main/java/io/camunda/service/AuthorizationServices.java
@@ -14,7 +14,6 @@ import io.camunda.search.query.SearchQueryBuilders;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.security.auth.Authentication;
 import io.camunda.security.auth.Authorization;
-import io.camunda.security.entity.Permission;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.security.SecurityContextProvider;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
@@ -80,10 +79,7 @@ public class AuthorizationServices
                             .permissionType(permissionType)
                             .resourceType(resourceType.name())));
     return findAll(authorizationQuery).stream()
-        .map(AuthorizationEntity::permissions)
-        .flatMap(List::stream)
-        .map(Permission::resourceIds)
-        .flatMap(Set::stream)
+        .map(AuthorizationEntity::resourceId)
         .collect(Collectors.toList());
   }
 

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/entities/usermanagement/AuthorizationEntity.java
@@ -7,18 +7,19 @@
  */
 package io.camunda.webapps.schema.entities.usermanagement;
 
-import io.camunda.security.entity.Permission;
 import io.camunda.webapps.schema.entities.AbstractExporterEntity;
-import java.util.List;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
 
 public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEntity> {
 
   public static final String DEFAULT_TENANT_IDENTIFIER = "<default>";
+  // Composite ID: ownerKey + resourceType + permissionType + resourceId
   private String id;
   private Long ownerKey;
   private String ownerType;
   private String resourceType;
-  private List<Permission> permissions;
+  private PermissionType permissionType;
+  private String resourceId;
 
   public AuthorizationEntity() {}
 
@@ -60,12 +61,21 @@ public class AuthorizationEntity extends AbstractExporterEntity<AuthorizationEnt
     return this;
   }
 
-  public List<Permission> getPermissions() {
-    return permissions == null ? List.of() : permissions;
+  public PermissionType getPermissionType() {
+    return permissionType;
   }
 
-  public AuthorizationEntity setPermissions(final List<Permission> permissions) {
-    this.permissions = permissions;
+  public AuthorizationEntity setPermissionType(final PermissionType permissionType) {
+    this.permissionType = permissionType;
+    return this;
+  }
+
+  public String getResourceId() {
+    return resourceId;
+  }
+
+  public AuthorizationEntity setResourceId(final String resourceId) {
+    this.resourceId = resourceId;
     return this;
   }
 }

--- a/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/elasticsearch/create/index/camunda-authorization.json
@@ -14,16 +14,11 @@
       "resourceType": {
         "type": "keyword"
       },
-      "permissions": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "keyword"
-          },
-          "resourceIds": {
-            "type": "keyword"
-          }
-        }
+      "permissionType": {
+        "type": "keyword"
+      },
+      "resourceId": {
+        "type": "keyword"
       }
     }
   }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
@@ -14,16 +14,11 @@
       "resourceType": {
         "type": "keyword"
       },
-      "permissions": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "keyword"
-          },
-          "resourceIds": {
-            "type": "keyword"
-          }
-        }
+      "permissionType": {
+        "type": "keyword"
+      },
+      "resourceId": {
+        "type": "keyword"
       }
     }
   }

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/DefaultExporterResourceProvider.java
@@ -12,7 +12,8 @@ import io.camunda.exporter.cache.ExporterEntityCacheImpl;
 import io.camunda.exporter.cache.ExporterEntityCacheProvider;
 import io.camunda.exporter.config.ConnectionTypes;
 import io.camunda.exporter.config.ExporterConfiguration;
-import io.camunda.exporter.handlers.AuthorizationHandler;
+import io.camunda.exporter.handlers.AuthorizationPermissionAddedHandler;
+import io.camunda.exporter.handlers.AuthorizationPermissionRemovedHandler;
 import io.camunda.exporter.handlers.DecisionEvaluationHandler;
 import io.camunda.exporter.handlers.DecisionHandler;
 import io.camunda.exporter.handlers.DecisionRequirementsHandler;
@@ -147,7 +148,9 @@ public class DefaultExporterResourceProvider implements ExporterResourceProvider
             new UserCreatedUpdatedHandler(
                 indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
             new UserDeletedHandler(indexDescriptors.get(UserIndex.class).getFullQualifiedName()),
-            new AuthorizationHandler(
+            new AuthorizationPermissionAddedHandler(
+                indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
+            new AuthorizationPermissionRemovedHandler(
                 indexDescriptors.get(AuthorizationIndex.class).getFullQualifiedName()),
             new TenantCreateUpdateHandler(
                 indexDescriptors.get(TenantIndex.class).getFullQualifiedName()),

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationPermissionRemovedHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/AuthorizationPermissionRemovedHandler.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.security.entity.Permission;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AuthorizationPermissionRemovedHandler
+    implements ExportHandler<AuthorizationEntity, AuthorizationRecordValue> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(AuthorizationPermissionRemovedHandler.class);
+
+  private final String indexName;
+
+  public AuthorizationPermissionRemovedHandler(final String indexName) {
+    this.indexName = indexName;
+  }
+
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.AUTHORIZATION;
+  }
+
+  @Override
+  public Class<AuthorizationEntity> getEntityType() {
+    return AuthorizationEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<AuthorizationRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType())
+        && AuthorizationIntent.PERMISSION_REMOVED.equals(record.getIntent());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<AuthorizationRecordValue> record) {
+    return List.of(
+        String.format(
+            "%s-%s", record.getValue().getOwnerKey(), record.getValue().getResourceType().name()));
+  }
+
+  @Override
+  public AuthorizationEntity createNewEntity(final String id) {
+    return new AuthorizationEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(
+      final Record<AuthorizationRecordValue> record, final AuthorizationEntity entity) {
+    final AuthorizationRecordValue value = record.getValue();
+    entity
+        .setOwnerKey(value.getOwnerKey())
+        .setOwnerType(value.getOwnerType().name())
+        .setResourceType(value.getResourceType().name())
+        .setPermissions(getPermissions(value.getPermissions()));
+  }
+
+  @Override
+  public void flush(final AuthorizationEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    if (entity.getPermissions() == null || entity.getPermissions().isEmpty()) {
+      // No permissions to process
+      LOG.debug("No permissions to remove for entity ID {}", entity.getId());
+      return;
+    }
+
+    final String script =
+        """
+          if (ctx._source.permissions != null) {
+            for (p in params.inputPermissions) {
+              for (permission in ctx._source.permissions) {
+                if (permission.type == p.type) {
+                  // Remove matching resource IDs
+                  permission.resourceIds.removeAll(p.resourceIds);
+                }
+              }
+            }
+            // Remove permissions with empty resourceIds
+            ctx._source.permissions.removeIf(permission -> permission.resourceIds.isEmpty());
+            if (ctx._source.permissions.isEmpty()) {
+              ctx.op = 'delete';
+            }
+          }
+      """;
+
+    final List<Map<String, Object>> inputPermissions =
+        entity.getPermissions().stream()
+            .map(
+                permission -> {
+                  final Map<String, Object> map = new HashMap<>();
+                  map.put("type", permission.type().name());
+                  map.put("resourceIds", permission.resourceIds());
+                  return map;
+                })
+            .collect(Collectors.toList());
+
+    final Map<String, Object> params = new HashMap<>();
+    params.put("inputPermissions", inputPermissions);
+
+    LOG.debug("Updating permissions for entity ID {}", entity.getId());
+    batchRequest.updateWithScript(indexName, entity.getId(), script, params);
+  }
+
+  @Override
+  public String getIndexName() {
+    return indexName;
+  }
+
+  private List<Permission> getPermissions(final List<PermissionValue> permissionValues) {
+    return permissionValues.stream()
+        .map(
+            permissionValue ->
+                new Permission(
+                    permissionValue.getPermissionType(), permissionValue.getResourceIds()))
+        .collect(Collectors.toList());
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationPermissionAddedHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationPermissionAddedHandlerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class AuthorizationPermissionAddedHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-authorization";
+  private final AuthorizationPermissionAddedHandler underTest =
+      new AuthorizationPermissionAddedHandler(indexName);
+
+  @Test
+  void testGetHandledValueType() {
+    assertThat(underTest.getHandledValueType()).isEqualTo(ValueType.AUTHORIZATION);
+  }
+
+  @Test
+  void testGetEntityType() {
+    assertThat(underTest.getEntityType()).isEqualTo(AuthorizationEntity.class);
+  }
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.AUTHORIZATION, AuthorizationIntent.PERMISSION_ADDED);
+
+    // when
+    final boolean result = underTest.handlesRecord(record);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final AuthorizationRecordValue value = factory.generateObject(AuthorizationRecordValue.class);
+
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecord(ValueType.AUTHORIZATION, r -> r.withValue(value));
+
+    // when
+    final List<String> ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids)
+        .containsExactly(
+            String.format(
+                "%s-%s",
+                record.getValue().getOwnerKey(), record.getValue().getResourceType().name()));
+  }
+
+  @Test
+  void shouldCreateNewEntity() {
+    // when
+    final AuthorizationEntity entity = underTest.createNewEntity("123-USER");
+
+    // then
+    assertThat(entity).isNotNull();
+    assertThat(entity.getId()).isEqualTo("123-USER");
+  }
+
+  @Test
+  void shouldUpdateEntity() {
+    // given
+
+    final long recordKey = 123L;
+
+    final PermissionValue permissionValue =
+        ImmutablePermissionValue.builder()
+            .from(factory.generateObject(PermissionValue.class))
+            .withPermissionType(PermissionType.UPDATE)
+            .withResourceIds(List.of("resource1"))
+            .build();
+
+    final AuthorizationRecordValue authValue =
+        ImmutableAuthorizationRecordValue.builder()
+            .from(factory.generateObject(AuthorizationRecordValue.class))
+            .withPermissions(List.of(permissionValue))
+            .withOwnerKey(recordKey)
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.USER)
+            .build();
+
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecord(ValueType.AUTHORIZATION, r -> r.withValue(authValue));
+
+    final AuthorizationEntity entity = new AuthorizationEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getOwnerKey()).isEqualTo(recordKey);
+    assertThat(entity.getOwnerType()).isEqualTo("USER");
+    assertThat(entity.getResourceType()).isEqualTo("USER");
+
+    // Assert permissions
+    assertThat(entity.getPermissions()).hasSize(1);
+    assertThat(entity.getPermissions().get(0).type()).isEqualTo(PermissionType.UPDATE);
+    assertThat(entity.getPermissions().get(0).resourceIds()).containsExactly("resource1");
+  }
+
+  @Test
+  void shouldFlushEntity() throws PersistenceException {
+    // given
+    final AuthorizationEntity entity =
+        new AuthorizationEntity()
+            .setId("123-USER")
+            .setOwnerKey(123L)
+            .setOwnerType("USER")
+            .setResourceType("USER");
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    verify(mockRequest, times(1)).addWithId(indexName, entity.getId(), entity);
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationPermissionRemoveHandlerTest.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/handlers/AuthorizationPermissionRemoveHandlerTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.security.entity.Permission;
+import io.camunda.webapps.schema.entities.usermanagement.AuthorizationEntity;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
+import io.camunda.zeebe.protocol.record.value.AuthorizationOwnerType;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationRecordValue.PermissionValue;
+import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
+import io.camunda.zeebe.protocol.record.value.ImmutableAuthorizationRecordValue;
+import io.camunda.zeebe.protocol.record.value.ImmutablePermissionValue;
+import io.camunda.zeebe.protocol.record.value.PermissionType;
+import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AuthorizationPermissionRemoveHandlerTest {
+
+  private final ProtocolFactory factory = new ProtocolFactory();
+  private final String indexName = "test-authorization";
+  private final AuthorizationPermissionRemovedHandler underTest =
+      new AuthorizationPermissionRemovedHandler(indexName);
+
+  @Test
+  void shouldHandleRecord() {
+    // given
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecordWithIntent(
+            ValueType.AUTHORIZATION, AuthorizationIntent.PERMISSION_REMOVED);
+
+    // when
+    final boolean result = underTest.handlesRecord(record);
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void shouldGenerateIds() {
+    // given
+    final AuthorizationRecordValue value = factory.generateObject(AuthorizationRecordValue.class);
+
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecord(ValueType.AUTHORIZATION, r -> r.withValue(value));
+
+    // when
+    final List<String> ids = underTest.generateIds(record);
+
+    // then
+    assertThat(ids)
+        .containsExactly(
+            String.format(
+                "%s-%s",
+                record.getValue().getOwnerKey(), record.getValue().getResourceType().name()));
+  }
+
+  @Test
+  void shouldUpdateEntity() {
+    // given
+
+    final long recordKey = 123L;
+
+    final PermissionValue permissionValue =
+        ImmutablePermissionValue.builder()
+            .from(factory.generateObject(PermissionValue.class))
+            .withPermissionType(PermissionType.UPDATE)
+            .withResourceIds(List.of("resource1"))
+            .build();
+
+    final AuthorizationRecordValue authValue =
+        ImmutableAuthorizationRecordValue.builder()
+            .from(factory.generateObject(AuthorizationRecordValue.class))
+            .withPermissions(List.of(permissionValue))
+            .withOwnerKey(recordKey)
+            .withOwnerType(AuthorizationOwnerType.USER)
+            .withResourceType(AuthorizationResourceType.USER)
+            .build();
+
+    final Record<AuthorizationRecordValue> record =
+        factory.generateRecord(ValueType.AUTHORIZATION, r -> r.withValue(authValue));
+
+    final AuthorizationEntity entity = new AuthorizationEntity();
+
+    // when
+    underTest.updateEntity(record, entity);
+
+    // then
+    assertThat(entity.getOwnerKey()).isEqualTo(recordKey);
+    assertThat(entity.getOwnerType()).isEqualTo("USER");
+    assertThat(entity.getResourceType()).isEqualTo("USER");
+
+    // Assert permissions
+    assertThat(entity.getPermissions()).hasSize(1);
+    assertThat(entity.getPermissions().get(0).type()).isEqualTo(PermissionType.UPDATE);
+    assertThat(entity.getPermissions().get(0).resourceIds()).containsExactly("resource1");
+  }
+
+  @Test
+  void shouldFlushEntity() throws PersistenceException {
+    // given
+    final AuthorizationEntity entity =
+        new AuthorizationEntity()
+            .setId("123-DEPLOYMENT")
+            .setOwnerKey(123L)
+            .setOwnerType("USER")
+            .setResourceType("DEPLOYMENT")
+            .setPermissions(
+                List.of(new Permission(PermissionType.READ, Set.of("resource1", "resource2"))));
+
+    final BatchRequest mockRequest = mock(BatchRequest.class);
+
+    final String expectedScript =
+        """
+        if (ctx._source.permissions != null) {
+        for (p in params.inputPermissions) {
+          for (permission in ctx._source.permissions) {
+            if (permission.type == p.type) {
+              // Remove matching resource IDs
+              permission.resourceIds.removeAll(p.resourceIds);
+            }
+          }
+        }
+        // Remove permissions with empty resourceIds
+        ctx._source.permissions.removeIf(permission -> permission.resourceIds.isEmpty());
+        if (ctx._source.permissions.isEmpty()) {
+          ctx.op = 'delete';
+        }
+      }
+      """;
+
+    // Expected parameters
+
+    final Map<String, Object> inputPermissions =
+        Map.of(
+            "inputPermissions",
+            List.of(Map.of("type", "READ", "resourceIds", List.of("resource1", "resource2"))));
+    // when
+    underTest.flush(entity, mockRequest);
+
+    // then
+    final ArgumentCaptor<Map<String, Object>> actualParamsCaptor =
+        ArgumentCaptor.forClass(Map.class);
+
+    verify(mockRequest, times(1))
+        .updateWithScript(
+            eq(indexName), eq(entity.getId()), eq(expectedScript), actualParamsCaptor.capture());
+
+    assertThat(actualParamsCaptor.getValue())
+        .usingRecursiveComparison()
+        .ignoringCollectionOrder()
+        .isEqualTo(inputPermissions);
+  }
+}

--- a/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
+++ b/zeebe/exporters/rdbms-exporter/src/main/java/io/camunda/exporter/rdbms/AuthorizationExportHandler.java
@@ -45,13 +45,21 @@ public class AuthorizationExportHandler implements RdbmsExportHandler<Authorizat
     }
   }
 
-  private AuthorizationDbModel map(final AuthorizationRecordValue authorization) {
-    return new AuthorizationDbModel.Builder()
-        .ownerKey(authorization.getOwnerKey())
-        .ownerType(authorization.getOwnerType().name())
-        .resourceType(authorization.getResourceType().name())
-        .permissions(mapPermissions(authorization.getPermissions()))
-        .build();
+  public List<AuthorizationDbModel> map(final AuthorizationRecordValue authorization) {
+    return authorization.getPermissions().stream()
+        .flatMap(
+            permission ->
+                permission.getResourceIds().stream()
+                    .map(
+                        resourceId ->
+                            new AuthorizationDbModel.Builder()
+                                .ownerKey(authorization.getOwnerKey())
+                                .ownerType(authorization.getOwnerType().name())
+                                .resourceType(authorization.getResourceType().name())
+                                .permissionType(permission.getPermissionType())
+                                .resourceId(resourceId)
+                                .build()))
+        .toList();
   }
 
   private List<AuthorizationPermissionDbModel> mapPermissions(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -18,14 +18,12 @@ import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
 import io.camunda.search.sort.AuthorizationSort;
 import io.camunda.security.auth.Authentication;
-import io.camunda.security.entity.Permission;
 import io.camunda.service.AuthorizationServices;
 import io.camunda.zeebe.gateway.protocol.rest.OwnerTypeEnum;
 import io.camunda.zeebe.gateway.protocol.rest.ResourceTypeEnum;
 import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,14 +45,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                  "ownerKey": "1",
                  "ownerType": "USER",
                  "resourceType": "PROCESS_DEFINITION",
-                 "permissions": [
-                   {
-                     "permissionType": "CREATE",
-                     "resourceIds": [
-                       "2"
-                     ]
-                   }
-                 ]
+                 "permissionType": "CREATE",
+                 "resourceId": "2"
                }
              ],
              "page": {
@@ -78,7 +70,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                       1L,
                       OwnerTypeEnum.USER.getValue(),
                       ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
-                      List.of(new Permission(PermissionType.CREATE, Set.of("2"))))))
+                      PermissionType.CREATE,
+                      "2")))
           .firstSortValues(new Object[] {"f"})
           .lastSortValues(new Object[] {"v"})
           .build();

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerAuthorizationPatchRequest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.AuthorizationIntent;
 import io.camunda.zeebe.protocol.record.value.AuthorizationResourceType;
 import io.camunda.zeebe.protocol.record.value.PermissionType;
-import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public class BrokerAuthorizationPatchRequest extends BrokerExecuteCommand<AuthorizationRecord> {
@@ -37,10 +36,14 @@ public class BrokerAuthorizationPatchRequest extends BrokerExecuteCommand<Author
     return this;
   }
 
-  public BrokerAuthorizationPatchRequest addPermissions(
-      final PermissionType permissionType, final Set<String> resourceIds) {
+  public BrokerAuthorizationPatchRequest setPermission(
+      final PermissionType permissionType, final String resourceId) {
+    if (requestDto.getPermissions() != null && !requestDto.getPermissions().isEmpty()) {
+      throw new IllegalArgumentException(
+          "Only one permission can be added at a time. Ensure the request is properly flattened.");
+    }
     requestDto.addPermission(
-        new Permission().setPermissionType(permissionType).addResourceIds(resourceIds));
+        new Permission().setPermissionType(permissionType).addResourceId(resourceId));
     return this;
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.it.authorization;
 
+import static io.camunda.client.protocol.rest.PermissionTypeEnum.UPDATE_USER_TASK;
+import static io.camunda.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
 import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -135,4 +137,123 @@ final class BasicAuthOverRestIT {
               "Insufficient permissions to perform operation 'CREATE' on resource 'DEPLOYMENT'");
     }
   }
+
+  //todo
+//  @Test
+//  void shouldCorrectlyAddAndRemovePermissionsStepByStep() {
+//    // given
+//    final var processInstanceKey = createProcessInstance(PROCESS_ID);
+//    final var processInstanceKey2 = createProcessInstance(PROCESS_ID_2);
+//    final var userTaskKey = getUserTaskKey(processInstanceKey);
+//    final var userTaskKey2 = getUserTaskKey(processInstanceKey2);
+//    final var username = UUID.randomUUID().toString();
+//    final var password = "password";
+//    final long user = authUtil.createUser(username, password);
+//
+//    try (final var client = authUtil.createClient(username, password)) {
+//      // Step 1: Add permissions for two resources
+//      authUtil
+//          .getDefaultClient()
+//          .newAddPermissionsCommand(user)
+//          .resourceType(PROCESS_DEFINITION)
+//          .permission(UPDATE_USER_TASK)
+//          .resourceIds(List.of(PROCESS_ID, PROCESS_ID_2))
+//          .send()
+//          .join();
+//
+//      // Step 2: Verify permissions work
+//      client
+//          .newUserTaskAssignCommand(userTaskKey)
+//          .assignee("assignee")
+//          .allowOverride(true)
+//          .send()
+//          .join();
+//      client
+//          .newUserTaskAssignCommand(userTaskKey2)
+//          .assignee("assignee")
+//          .allowOverride(true)
+//          .send()
+//          .join();
+//
+//      // Step 3: Remove permission for the first resource
+//      authUtil
+//          .getDefaultClient()
+//          .newRemovePermissionsCommand(user)
+//          .resourceType(PROCESS_DEFINITION)
+//          .permission(UPDATE_USER_TASK)
+//          .resourceIds(List.of(PROCESS_ID))
+//          .send()
+//          .join();
+//
+//      // Step 4: Verify permission still works for the second resource
+//      client
+//          .newUserTaskAssignCommand(userTaskKey2)
+//          .assignee("assignee")
+//          .allowOverride(true)
+//          .send()
+//          .join();
+//
+//      // Step 5: Verify unauthorized exception after first permission removed
+//      final var response =
+//          client
+//              .newUserTaskAssignCommand(userTaskKey)
+//              .assignee("assignee")
+//              .allowOverride(true)
+//              .send();
+//
+//      // then
+//      assertThatThrownBy(response::join)
+//          .isInstanceOf(ProblemException.class)
+//          .hasMessageContaining("title: FORBIDDEN")
+//          .hasMessageContaining("status: 403")
+//          .hasMessageContaining(
+//              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, processId]'");
+//
+//      // Step 6: Remove permission for the remaining resource
+//      authUtil
+//          .getDefaultClient()
+//          .newRemovePermissionsCommand(user)
+//          .resourceType(PROCESS_DEFINITION)
+//          .permission(UPDATE_USER_TASK)
+//          .resourceIds(List.of(PROCESS_ID_2))
+//          .send()
+//          .join();
+//
+//      // Step 6: Verify unauthorized exception after all permissions are removed
+//      final var response2 =
+//          client
+//              .newUserTaskAssignCommand(userTaskKey)
+//              .assignee("assignee")
+//              .allowOverride(true)
+//              .send();
+//
+//      // then
+//      assertThatThrownBy(response2::join)
+//          .isInstanceOf(ProblemException.class)
+//          .hasMessageContaining("title: FORBIDDEN")
+//          .hasMessageContaining("status: 403")
+//          .hasMessageContaining(
+//              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, processId]");
+//    }
+//  }
+//
+//  private long createProcessInstance(final String bpmnProcessId) {
+//    return defaultUserClient
+//        .newCreateInstanceCommand()
+//        .bpmnProcessId(bpmnProcessId)
+//        .latestVersion()
+//        .send()
+//        .join()
+//        .getProcessInstanceKey();
+//  }
+//
+//  private static long getUserTaskKey(final long processInstanceKey) {
+//    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+//        .withProcessInstanceKey(processInstanceKey)
+//        .withElementId(USER_TASK_ID)
+//        .limit(1)
+//        .findFirst()
+//        .orElseThrow()
+//        .getKey();
+//  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/authorization/BasicAuthOverRestIT.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.it.authorization;
 
-import static io.camunda.client.protocol.rest.PermissionTypeEnum.UPDATE_USER_TASK;
-import static io.camunda.client.protocol.rest.ResourceTypeEnum.PROCESS_DEFINITION;
 import static io.camunda.zeebe.it.util.AuthorizationsUtil.createClient;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -138,122 +136,125 @@ final class BasicAuthOverRestIT {
     }
   }
 
-  //todo
-//  @Test
-//  void shouldCorrectlyAddAndRemovePermissionsStepByStep() {
-//    // given
-//    final var processInstanceKey = createProcessInstance(PROCESS_ID);
-//    final var processInstanceKey2 = createProcessInstance(PROCESS_ID_2);
-//    final var userTaskKey = getUserTaskKey(processInstanceKey);
-//    final var userTaskKey2 = getUserTaskKey(processInstanceKey2);
-//    final var username = UUID.randomUUID().toString();
-//    final var password = "password";
-//    final long user = authUtil.createUser(username, password);
-//
-//    try (final var client = authUtil.createClient(username, password)) {
-//      // Step 1: Add permissions for two resources
-//      authUtil
-//          .getDefaultClient()
-//          .newAddPermissionsCommand(user)
-//          .resourceType(PROCESS_DEFINITION)
-//          .permission(UPDATE_USER_TASK)
-//          .resourceIds(List.of(PROCESS_ID, PROCESS_ID_2))
-//          .send()
-//          .join();
-//
-//      // Step 2: Verify permissions work
-//      client
-//          .newUserTaskAssignCommand(userTaskKey)
-//          .assignee("assignee")
-//          .allowOverride(true)
-//          .send()
-//          .join();
-//      client
-//          .newUserTaskAssignCommand(userTaskKey2)
-//          .assignee("assignee")
-//          .allowOverride(true)
-//          .send()
-//          .join();
-//
-//      // Step 3: Remove permission for the first resource
-//      authUtil
-//          .getDefaultClient()
-//          .newRemovePermissionsCommand(user)
-//          .resourceType(PROCESS_DEFINITION)
-//          .permission(UPDATE_USER_TASK)
-//          .resourceIds(List.of(PROCESS_ID))
-//          .send()
-//          .join();
-//
-//      // Step 4: Verify permission still works for the second resource
-//      client
-//          .newUserTaskAssignCommand(userTaskKey2)
-//          .assignee("assignee")
-//          .allowOverride(true)
-//          .send()
-//          .join();
-//
-//      // Step 5: Verify unauthorized exception after first permission removed
-//      final var response =
-//          client
-//              .newUserTaskAssignCommand(userTaskKey)
-//              .assignee("assignee")
-//              .allowOverride(true)
-//              .send();
-//
-//      // then
-//      assertThatThrownBy(response::join)
-//          .isInstanceOf(ProblemException.class)
-//          .hasMessageContaining("title: FORBIDDEN")
-//          .hasMessageContaining("status: 403")
-//          .hasMessageContaining(
-//              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, processId]'");
-//
-//      // Step 6: Remove permission for the remaining resource
-//      authUtil
-//          .getDefaultClient()
-//          .newRemovePermissionsCommand(user)
-//          .resourceType(PROCESS_DEFINITION)
-//          .permission(UPDATE_USER_TASK)
-//          .resourceIds(List.of(PROCESS_ID_2))
-//          .send()
-//          .join();
-//
-//      // Step 6: Verify unauthorized exception after all permissions are removed
-//      final var response2 =
-//          client
-//              .newUserTaskAssignCommand(userTaskKey)
-//              .assignee("assignee")
-//              .allowOverride(true)
-//              .send();
-//
-//      // then
-//      assertThatThrownBy(response2::join)
-//          .isInstanceOf(ProblemException.class)
-//          .hasMessageContaining("title: FORBIDDEN")
-//          .hasMessageContaining("status: 403")
-//          .hasMessageContaining(
-//              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource identifiers are one of '[*, processId]");
-//    }
-//  }
-//
-//  private long createProcessInstance(final String bpmnProcessId) {
-//    return defaultUserClient
-//        .newCreateInstanceCommand()
-//        .bpmnProcessId(bpmnProcessId)
-//        .latestVersion()
-//        .send()
-//        .join()
-//        .getProcessInstanceKey();
-//  }
-//
-//  private static long getUserTaskKey(final long processInstanceKey) {
-//    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
-//        .withProcessInstanceKey(processInstanceKey)
-//        .withElementId(USER_TASK_ID)
-//        .limit(1)
-//        .findFirst()
-//        .orElseThrow()
-//        .getKey();
-//  }
+  //  @Test
+  //  void shouldCorrectlyAddAndRemovePermissionsStepByStep() {
+  //    // given
+  //    final var processInstanceKey = createProcessInstance(PROCESS_ID);
+  //    final var processInstanceKey2 = createProcessInstance(PROCESS_ID_2);
+  //    final var userTaskKey = getUserTaskKey(processInstanceKey);
+  //    final var userTaskKey2 = getUserTaskKey(processInstanceKey2);
+  //    final var username = UUID.randomUUID().toString();
+  //    final var password = "password";
+  //    final long user = authUtil.createUser(username, password);
+  //
+  //    try (final var client = authUtil.createClient(username, password)) {
+  //      // Step 1: Add permissions for two resources
+  //      authUtil
+  //          .getDefaultClient()
+  //          .newAddPermissionsCommand(user)
+  //          .resourceType(PROCESS_DEFINITION)
+  //          .permission(UPDATE_USER_TASK)
+  //          .resourceIds(List.of(PROCESS_ID, PROCESS_ID_2))
+  //          .send()
+  //          .join();
+  //
+  //      // Step 2: Verify permissions work
+  //      client
+  //          .newUserTaskAssignCommand(userTaskKey)
+  //          .assignee("assignee")
+  //          .allowOverride(true)
+  //          .send()
+  //          .join();
+  //      client
+  //          .newUserTaskAssignCommand(userTaskKey2)
+  //          .assignee("assignee")
+  //          .allowOverride(true)
+  //          .send()
+  //          .join();
+  //
+  //      // Step 3: Remove permission for the first resource
+  //      authUtil
+  //          .getDefaultClient()
+  //          .newRemovePermissionsCommand(user)
+  //          .resourceType(PROCESS_DEFINITION)
+  //          .permission(UPDATE_USER_TASK)
+  //          .resourceIds(List.of(PROCESS_ID))
+  //          .send()
+  //          .join();
+  //
+  //      // Step 4: Verify permission still works for the second resource
+  //      client
+  //          .newUserTaskAssignCommand(userTaskKey2)
+  //          .assignee("assignee")
+  //          .allowOverride(true)
+  //          .send()
+  //          .join();
+  //
+  //      // Step 5: Verify unauthorized exception after first permission removed
+  //      final var response =
+  //          client
+  //              .newUserTaskAssignCommand(userTaskKey)
+  //              .assignee("assignee")
+  //              .allowOverride(true)
+  //              .send();
+  //
+  //      // then
+  //      assertThatThrownBy(response::join)
+  //          .isInstanceOf(ProblemException.class)
+  //          .hasMessageContaining("title: FORBIDDEN")
+  //          .hasMessageContaining("status: 403")
+  //          .hasMessageContaining(
+  //              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to
+  // perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource
+  // identifiers are one of '[*, processId]'");
+  //
+  //      // Step 6: Remove permission for the remaining resource
+  //      authUtil
+  //          .getDefaultClient()
+  //          .newRemovePermissionsCommand(user)
+  //          .resourceType(PROCESS_DEFINITION)
+  //          .permission(UPDATE_USER_TASK)
+  //          .resourceIds(List.of(PROCESS_ID_2))
+  //          .send()
+  //          .join();
+  //
+  //      // Step 6: Verify unauthorized exception after all permissions are removed
+  //      final var response2 =
+  //          client
+  //              .newUserTaskAssignCommand(userTaskKey)
+  //              .assignee("assignee")
+  //              .allowOverride(true)
+  //              .send();
+  //
+  //      // then
+  //      assertThatThrownBy(response2::join)
+  //          .isInstanceOf(ProblemException.class)
+  //          .hasMessageContaining("title: FORBIDDEN")
+  //          .hasMessageContaining("status: 403")
+  //          .hasMessageContaining(
+  //              "Command 'ASSIGN' rejected with code 'FORBIDDEN': Insufficient permissions to
+  // perform operation 'UPDATE_USER_TASK' on resource 'PROCESS_DEFINITION', required resource
+  // identifiers are one of '[*, processId]");
+  //    }
+  //  }
+  //
+  //  private long createProcessInstance(final String bpmnProcessId) {
+  //    return defaultUserClient
+  //        .newCreateInstanceCommand()
+  //        .bpmnProcessId(bpmnProcessId)
+  //        .latestVersion()
+  //        .send()
+  //        .join()
+  //        .getProcessInstanceKey();
+  //  }
+  //
+  //  private static long getUserTaskKey(final long processInstanceKey) {
+  //    return RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+  //        .withProcessInstanceKey(processInstanceKey)
+  //        .withElementId(USER_TASK_ID)
+  //        .limit(1)
+  //        .findFirst()
+  //        .orElseThrow()
+  //        .getKey();
+  //  }
 }


### PR DESCRIPTION
## Description

in this PR added handler for remove auth permissions;

 - Renamed `AuthorizationHandler` to `AuthorizationPermissionAddedHandler` for clarity.
 - Added `AuthorizationPermissionRemovedHandler` using an Elasticsearch update script to remove resource IDs cleanly and handle empty permissions.
 - Added unit tests for both handlers and updated integration tests to verify add/remove permission flows.

**Why I remove permissions by using the script :** 

The script avoids complex changes in entity logic by directly modifying permissions at the document level in Elasticsearch. This approach prevents the new methods in the authorization state and adding logic to auth processor. It also avoids introducing new events like `update` for the add/remove operations, or adding update logic to a separate handler, which would complicate the existing logic or do logic not clear.

While removing a few resource IDs could technically be seen as an update, for the user, it behaves as a clear "remove permission" operation. Using the script keeps the code clean, focused, and easier to maintain without breaking the current flow of add and remove events.


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

