### PR TITLE
[Backport stable/8.6] fix: parse unexpected REST responses in client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A generic interface for consuming API entities from an asynchronous data stream. This interface
@@ -71,6 +73,7 @@ public interface TypedApiEntityConsumer<T> {
    * Jackson's non-blocking parser to incrementally parse JSON data as it is streamed.
    */
   class JsonApiEntityConsumer<T> implements TypedApiEntityConsumer<T> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JsonApiEntityConsumer.class);
     private final ObjectMapper json;
     private final Class<T> type;
     private final NonBlockingByteBufferJsonParser parser;
@@ -124,11 +127,13 @@ public interface TypedApiEntityConsumer<T> {
         parser.close();
       } catch (final Exception e) {
         // log but otherwise ignore
+        LOGGER.warn("Failed to close JSON parser", e);
       }
       try {
         buffer.close();
       } catch (final IOException e) {
         // log but otherwise ignore
+        LOGGER.warn("Failed to close JSON buffer", e);
       }
       bufferedBytes = 0;
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -145,6 +145,7 @@ public interface TypedApiEntityConsumer<T> {
         generator.flush();
         return output.toString(StandardCharsets.UTF_8.name());
       } catch (final Exception ex) {
+        LOGGER.warn("Failed to serialize JSON string", ex);
         return "Original response cannot be constructed";
       }
     }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/TypedApiEntityConsumer.java
@@ -15,11 +15,13 @@
  */
 package io.camunda.zeebe.client.impl.http;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.json.async.NonBlockingByteBufferJsonParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.util.TokenBuffer;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -88,13 +90,23 @@ public interface TypedApiEntityConsumer<T> {
 
     @Override
     public ApiEntity<T> generateContent() throws IOException {
-      buffer.asParserOnFirstToken();
-
-      if (isResponse) {
-        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
+      try {
+        if (isResponse) {
+          return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), type));
+        }
+        return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
+      } catch (final IOException ioe) {
+        // write the original JSON response into an error response
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        final JsonGenerator generator = json.createGenerator(output);
+        buffer.serialize(generator);
+        generator.flush();
+        return ApiEntity.of(
+            new ProblemDetail()
+                .title("Unexpected server response")
+                .status(500)
+                .detail(output.toString(StandardCharsets.UTF_8.name())));
       }
-
-      return ApiEntity.of(json.readValue(buffer.asParserOnFirstToken(), ProblemDetail.class));
     }
 
     @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/http/ApiEntityConsumerTest.java
@@ -56,6 +56,54 @@ class ApiEntityConsumerTest {
   }
 
   @Test
+  void testJsonApiEntityConsumerWithValidJsonOtherTypeResponse() throws IOException {
+    // given
+    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with the correct content type
+    consumer.streamStart(ContentType.APPLICATION_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Error.class);
+    final ProblemDetail response = entity.problem();
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
+    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+  }
+
+  @Test
+  void testJsonApiEntityConsumerWithValidJsonOtherTypeErrorResponse() throws IOException {
+    // given
+    final String jsonResponse = "{\"foo\":\"test\",\"bar\":123}";
+    final ByteBuffer byteBuffer = ByteBuffer.wrap(jsonResponse.getBytes());
+    final ApiEntityConsumer<TestEntity> consumer =
+        new ApiEntityConsumer<>(new ObjectMapper(), TestEntity.class, 2048);
+
+    // when
+    // Start the stream with the correct content type
+    consumer.streamStart(ContentType.APPLICATION_PROBLEM_JSON);
+    // Feed the data
+    consumer.data(byteBuffer, true);
+    // Generate the content
+    final ApiEntity<TestEntity> entity = consumer.generateContent();
+
+    // then
+    assertThat(entity).isInstanceOf(Error.class);
+    final ProblemDetail response = entity.problem();
+    assertThat(response).isNotNull();
+    assertThat(response.getTitle()).isEqualTo("Unexpected server response");
+    assertThat(response.getDetail()).isEqualTo(jsonResponse);
+  }
+
+  @Test
   void testJsonApiEntityConsumerWithProblemDetailResponse() throws IOException {
     // given
     final String problemDetailResponse =


### PR DESCRIPTION
# Description
Backport of #25681 to `stable/8.6`.

relates to #25087
original author: @tmetzke