### PR TITLE
feat: implement camunda scoped variables for OIDC auth

### DIFF
--- a/dist/src/main/resources/application-auth-oidc.properties
+++ b/dist/src/main/resources/application-auth-oidc.properties
@@ -1,11 +1,11 @@
-spring.security.oauth2.client.registration.oidcclient.client-id=oidcclient2
-spring.security.oauth2.client.registration.oidcclient.client-secret=secret2
-spring.security.oauth2.client.registration.oidcclient.authorization-grant-type=authorization_code
-spring.security.oauth2.client.registration.oidcclient.redirect-uri=http://localhost:8080/login/oauth2/code/oidcclient2
+spring.security.oauth2.client.registration.oidcclient.client-id=${camunda.security.authentication.oidc.client-id:}
+spring.security.oauth2.client.registration.oidcclient.client-secret=${camunda.security.authentication.oidc.client-secret:}
+spring.security.oauth2.client.registration.oidcclient.authorization-grant-type=${camunda.security.authentication.oidc.grant-type:authorization_code}
+spring.security.oauth2.client.registration.oidcclient.redirect-uri=${camunda.security.authentication.oidc.redirect-uri:}
 spring.security.oauth2.client.registration.oidcclient.provider=oidcclient
-spring.security.oauth2.client.registration.oidcclient.scope=openid,profile
+spring.security.oauth2.client.registration.oidcclient.scope=${camunda.security.authentication.oidc.scopes:openid,profile}
 
 camunda.security.initialization.mappings[0].claimName=${INITIAL_CLAIM_NAME:oid}
 camunda.security.initialization.mappings[0].claimValue=${INITIAL_CLAIM_VALUE}
 
-spring.security.oauth2.client.provider.oidcclient.issuer-uri=http://auth.identity:9000
+spring.security.oauth2.client.provider.oidcclient.issuer-uri=${camunda.security.authentication.oidc.issuer-uri:}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As per the conversation in Slack, we currently only expose the default spring properties when configuring OIDC, these property variables can be awkward to work with.

This PR introduces a new set of camunda scoped properties (`camunda.security.auth.oidc.XYZ`) which map to the spring values. What this means is that I can either:

1. Use the Spring values as ENV variables
2. Use the Camunda values as properties
3. Use the Camunda values as ENV variables

I have tested this with env vars and it works as expected, I have not yet tested with a custom application properties file.
