### PR TITLE
test: migrate local e2e tests to Camunda exporter

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -7,6 +7,7 @@ env-up:
 	&& CAMUNDA_OPERATE_IMPORTERENABLED=false \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY=1 \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE=elasticsearch \
 	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200 \
 	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneCamunda" -Dspring.profiles.active=operate,broker,dev,dev-data,auth
@@ -79,15 +80,20 @@ env-clean: env-down
 .PHONY: start-e2e
 start-e2e:
 	curl --request DELETE --url http://localhost:9200/e2e* \
-	&& docker rm -f zeebe-e2e || true \
-	&& docker compose -f docker-compose.yml up --force-recreate -d zeebe-e2e \
-	&& mvn install -DskipTests=true -Dskip.fe.build=true -DskipQaBuild \
-	&& CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=localhost:26503 \
+	&& mvn install -DskipTests=true -Dskip.fe.build=true -DskipChecks -DskipQaBuild \
+	&& CAMUNDA_OPERATE_IMPORTERENABLED=false \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_CLASSNAME=io.camunda.exporter.CamundaExporter \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_SIZE=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_BULK_DELAY=1 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_TYPE=elasticsearch \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_CONNECT_URL=http://localhost:9200 \
+	ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX=e2eoperate \
+	ZEEBE_BROKER_BACKPRESSURE_ENABLED=false \
+	ZEEBE_BROKER_GATEWAY_NETWORK_PORT=26503 \
+	CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS=localhost:26503 \
 	CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_PREFIX=e2e \
 	CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX=e2eoperate \
-	CAMUNDA_OPERATE_IMPORTER_READERBACKOFF=0 \
-	CAMUNDA_OPERATE_IMPORTER_SCHEDULERBACKOFF=0 \
 	CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED=false \
 	SERVER_PORT=8081 \
-  MANAGEMENT_SERVER_PORT=9601 \
-	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate"
+	MANAGEMENT_SERVER_PORT=9601 \
+	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneCamunda" -Dspring.profiles.active=operate,broker,auth

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -44,23 +44,6 @@ services:
     volumes:
       - ./config/zeebe.cfg.yaml:/usr/local/zeebe/config/application.yaml
 
-  zeebe-e2e:
-    container_name: zeebe-e2e
-    image: camunda/zeebe:SNAPSHOT
-    environment:
-      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
-      - ZEEBE_HOST=${ZEEBE_HOST:-}
-      - ZEEBE_BROKER_EXPORTERS_CAMUNDAEXPORTER_ARGS_INDEX_PREFIX=e2e
-      - ZEEBE_BROKER_BACKPRESSURE_ENABLED=false
-      #- "JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
-    ports:
-      - 26503:26500
-      - 8001:8000
-      - 8086:8080
-    restart: always
-    volumes:
-      - ./config/zeebe.cfg.yaml:/usr/local/zeebe/config/application.yaml
-
   ldap-test-server:
     container_name: ldap-test-server
     image: rroemhild/test-openldap


### PR DESCRIPTION
## Description

This uses the single application approach (with broker and operate profiles) instead of zeebe in a docker container.

The behavior should remain the same: Camunda (Zeebe & Operate) can be started with `make start-e2e`. All data can be removed by stopping the application and starting again with `make start-e2e`.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/camunda/issues/25695
