### PR TITLE
Fix opensearch breaking schemas

### DIFF
--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-authorization.json
@@ -15,6 +15,7 @@
         "type": "keyword"
       },
       "permissions": {
+        "type": "object",
         "properties": {
           "type": {
             "type": "keyword"

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-group.json
@@ -16,7 +16,6 @@
       },
       "join": {
         "type": "join",
-        "eager_global_ordinals": true,
         "relations": {
           "group": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-role.json
@@ -16,7 +16,6 @@
       },
       "join": {
         "type": "join",
-        "eager_global_ordinals": true,
         "relations": {
           "role": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/index/camunda-tenant.json
@@ -19,7 +19,6 @@
       },
       "join": {
         "type": "join",
-        "eager_global_ordinals": true,
         "relations": {
           "tenant": ["member"]
         }

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
@@ -95,7 +95,7 @@
       },
       "customHeaders": {
         "type": "object",
-        "dynamic": true
+        "dynamic": "true"
       },
       "priority": {
         "type": "integer"

--- a/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
+++ b/webapps-schema/src/main/resources/schema/opensearch/create/template/tasklist-task.json
@@ -4,7 +4,6 @@
     "properties": {
       "join": {
         "type": "join",
-        "eager_global_ordinals": true,
         "relations": {
           "task": [
             "localVariable"

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -28,6 +28,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Collection;
@@ -388,6 +389,7 @@ public class SchemaManagerIT {
   }
 
   @TestTemplate
+  @RegressionTest("https://github.com/camunda/camunda/issues/26056")
   void shouldNotHaveValidationIssuesWithTheSameIndices(
       final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter) {
     config.setCreateSchema(true);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/schema/SchemaManagerIT.java
@@ -28,7 +28,7 @@ import io.camunda.search.connect.es.ElasticsearchConnector;
 import io.camunda.search.connect.os.OpensearchConnector;
 import io.camunda.webapps.schema.descriptors.IndexDescriptor;
 import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
-import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.test.util.junit.RegressionTestTemplate;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Collection;
@@ -388,8 +388,7 @@ public class SchemaManagerIT {
     assertThat(mappingsMatch(updatedIndex.get("mappings"), newMappingsFile)).isTrue();
   }
 
-  @TestTemplate
-  @RegressionTest("https://github.com/camunda/camunda/issues/26056")
+  @RegressionTestTemplate("https://github.com/camunda/camunda/issues/26056")
   void shouldNotHaveValidationIssuesWithTheSameIndices(
       final ExporterConfiguration config, final SearchClientAdapter searchClientAdapter) {
     config.setCreateSchema(true);

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/RegressionTestTemplate.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/RegressionTestTemplate.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.TestTemplate;
+
+@Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@TestTemplate
+public @interface RegressionTestTemplate {
+  /** The GitHub issue URL where the regression is described, and for which this is a test. */
+  String value();
+}


### PR DESCRIPTION
## Description

If a schema is created in opensearch according to a json file, when comparing the returned mapping from the opensearch client to the json file there should not be a schema validation error.

The issue is already fixed by opensearch on Nov 13 https://github.com/Xtansia/opensearch-java/blob/0e386f4b508b995bdfc14780ea1f2a955ad41596/java-client/src/generated/java/org/opensearch/client/opensearch/_types/mapping/JoinProperty.java, they added eager_global_ordinals to the join serialisation. The only issue is that they haven't added to a release which they appear to do every 2-3 weeks.

For now to fix the breaking issue the field will be removed from affected schemas and when an opensearch-java client version is released with the fix we can add the eager_global_ordinals option back with the updated client

## Checklist

- [x] Indices created by a schema file will not trigger an index validation error which comparing against the schema file
- [x] Add a test to catch the issue of schema files clashing against their created indices.

## Related issues

relates to #26056 
