### PR TITLE
feat: do not flush while waiting for importer

### DIFF
--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
@@ -108,6 +108,10 @@ public final class ExporterTestController implements Controller {
     return Instant.ofEpochMilli(lastRanAtMs);
   }
 
+  public void resetLastRanAt() {
+    lastRanAtMs = 0;
+  }
+
   /**
    * Will run all tasks scheduled since the last time this was executed + the given duration.
    *

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/CamundaExporter.java
@@ -243,6 +243,10 @@ public class CamundaExporter implements Exporter {
   }
 
   private void flushAndReschedule() {
+    if (configuration.getIndex().shouldWaitForImporters() && !importersCompleted) {
+      scheduleDelayedFlush();
+      return;
+    }
     try {
       flush();
       updateLastExportedPosition(lastPosition);

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -532,6 +532,8 @@ final class CamundaExporterIT {
 
       camundaExporter.export(record);
 
+      controller.runScheduledTasks(Duration.ofMinutes(1));
+
       // then
       assertThat(controller.getPosition()).isEqualTo(-1);
       verify(controller, never()).updateLastExportedRecordPosition(eq(record.getPosition()), any());

--- a/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
+++ b/zeebe/exporters/camunda-exporter/src/test/java/io/camunda/exporter/CamundaExporterIT.java
@@ -505,6 +505,7 @@ final class CamundaExporterIT {
     @BeforeEach
     void setup() {
       controller.resetScheduledTasks();
+      controller.resetLastRanAt();
     }
 
     @TestTemplate
@@ -517,13 +518,15 @@ final class CamundaExporterIT {
       camundaExporter.configure(context);
       camundaExporter.open(controller);
 
+      controller.runScheduledTasks(Duration.ofSeconds(config.getBulk().getDelay()));
+
       // when
 
       // adds a not complete position index document so exporter sees importing as not yet completed
       indexImportPositionEntity("decision", false, clientAdapter);
       clientAdapter.refresh();
 
-      controller.runScheduledTasks(Duration.ofMinutes(1));
+      controller.runScheduledTasks(Duration.ofSeconds(config.getBulk().getDelay()));
 
       final var record =
           factory.generateRecord(
@@ -532,7 +535,7 @@ final class CamundaExporterIT {
 
       camundaExporter.export(record);
 
-      controller.runScheduledTasks(Duration.ofMinutes(1));
+      controller.runScheduledTasks(Duration.ofSeconds(config.getBulk().getDelay()));
 
       // then
       assertThat(controller.getPosition()).isEqualTo(-1);


### PR DESCRIPTION
## Checklist

- [x] While waiting for the importer(s) to complete flushing does not happen.

## Related issues

closes #26047 
