### PR TITLE
fix: eliminate duplicated snapshot request for indices (not template)

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -132,14 +132,13 @@ public class BackupPriorityConfiguration {
         List.of(
             // OPERATE
             new BatchOperationTemplate(indexPrefix, isElasticsearch),
-            new OperationTemplate(indexPrefix, isElasticsearch),
-            new UserTaskTemplate(indexPrefix, isElasticsearch));
+            new OperationTemplate(indexPrefix, isElasticsearch));
 
     final List<Prio4Backup> prio4 =
         List.of(
             // OPERATE
+            new DecisionIndex(indexPrefix, isElasticsearch),
             new DecisionInstanceTemplate(indexPrefix, isElasticsearch),
-            new EventTemplate(indexPrefix, isElasticsearch),
             new EventTemplate(indexPrefix, isElasticsearch),
             new FlowNodeInstanceTemplate(indexPrefix, isElasticsearch),
             new IncidentTemplate(indexPrefix, isElasticsearch),
@@ -147,6 +146,7 @@ public class BackupPriorityConfiguration {
             new MessageTemplate(indexPrefix, isElasticsearch),
             new PostImporterQueueTemplate(indexPrefix, isElasticsearch),
             new SequenceFlowTemplate(indexPrefix, isElasticsearch),
+            new UserTaskTemplate(indexPrefix, isElasticsearch),
             new VariableTemplate(indexPrefix, isElasticsearch),
             // TASKLIST
             new DraftTaskVariableTemplate(indexPrefix, isElasticsearch),
@@ -155,7 +155,6 @@ public class BackupPriorityConfiguration {
     final List<Prio5Backup> prio5 =
         List.of(
             // OPERATE
-            new DecisionIndex(indexPrefix, isElasticsearch),
             new DecisionRequirementsIndex(indexPrefix, isElasticsearch),
             new MetricIndex(indexPrefix, isElasticsearch),
             new ProcessIndex(indexPrefix, isElasticsearch),

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -121,6 +121,94 @@ class BackupPrioritiesTest {
   }
 
   @Test
+  public void testBackupPrioritiesIndicesSplitBySnapshot() {
+    final var configuration = new BackupPriorityConfiguration(new OperateProperties(), null);
+    final var priorities = configuration.backupPriorities();
+
+    final var indices = priorities.indicesSplitBySnapshot().toList();
+
+    assertThat(indices.size()).isEqualTo(8);
+    // PRIO 1
+    assertThat(indices.get(0).indices())
+        .containsExactlyInAnyOrder(
+            "operate-import-position-8.3.0_",
+            "tasklist-import-position-8.2.0_"); // ADD optimize-position-based-import-index_v3)
+    // PRIO 2
+    assertThat(indices.get(1).indices())
+        .containsExactlyInAnyOrder("operate-list-view-8.3.0_", "tasklist-task-8.5.0_");
+    // PRIO 2 TEMPLATES
+    assertThat(indices.get(2).indices())
+        .containsExactlyInAnyOrder(
+            "operate-list-view-8.3.0_*",
+            "-operate-list-view-8.3.0_",
+            "tasklist-task-8.5.0_*",
+            "-tasklist-task-8.5.0_");
+    // PRIO 3
+    assertThat(indices.get(3).indices())
+        .containsExactlyInAnyOrder("operate-batch-operation-1.0.0_", "operate-operation-8.4.1_");
+    // PRIO 4
+    assertThat(indices.get(4).indices())
+        .containsExactlyInAnyOrder(
+            "operate-decision-8.3.0_",
+            "operate-decision-instance-8.3.0_",
+            "operate-event-8.3.0_",
+            "operate-flownode-instance-8.3.1_",
+            "operate-job-8.6.0_",
+            "operate-incident-8.3.1_",
+            "operate-message-8.5.0_",
+            "operate-post-importer-queue-8.3.0_",
+            "operate-sequence-flow-8.3.0_",
+            "operate-user-task-8.5.0_",
+            "operate-variable-8.3.0_",
+            "tasklist-draft-task-variable-8.3.0_",
+            "tasklist-task-variable-8.3.0_");
+
+    // PRIO 4 TEMPLATES
+    assertThat(indices.get(5).indices())
+        .containsExactlyInAnyOrder(
+            "operate-event-8.3.0_*",
+            "-operate-event-8.3.0_",
+            "operate-flownode-instance-8.3.1_*",
+            "-operate-flownode-instance-8.3.1_",
+            "operate-incident-8.3.1_*",
+            "-operate-incident-8.3.1_",
+            "operate-job-8.6.0_*",
+            "-operate-job-8.6.0_",
+            "operate-message-8.5.0_*",
+            "-operate-message-8.5.0_",
+            "operate-post-importer-queue-8.3.0_*",
+            "-operate-post-importer-queue-8.3.0_",
+            "operate-sequence-flow-8.3.0_*",
+            "-operate-sequence-flow-8.3.0_",
+            "operate-user-task-8.5.0_*",
+            "-operate-user-task-8.5.0_",
+            "operate-variable-8.3.0_*",
+            "-operate-variable-8.3.0_",
+            "-operate-decision-instance-8.3.0_",
+            "operate-decision-instance-8.3.0_*",
+            "-tasklist-draft-task-variable-8.3.0_",
+            "tasklist-draft-task-variable-8.3.0_*",
+            "-tasklist-task-variable-8.3.0_",
+            "tasklist-task-variable-8.3.0_*");
+
+    // PRIO 5
+    assertThat(indices.get(6).indices())
+        .containsExactlyInAnyOrder(
+            "operate-decision-requirements-8.3.0_",
+            "operate-metric-8.3.0_",
+            "operate-process-8.3.0_",
+            "tasklist-form-8.4.0_",
+            "tasklist-metric-8.3.0_",
+            "camunda-authorization-8.7.0_",
+            "camunda-group-8.7.0_",
+            "camunda-mapping-8.7.0_",
+            "camunda-web-session-8.7.0_",
+            "camunda-role-8.7.0_",
+            "camunda-tenant-8.7.0_",
+            "camunda-user-8.7.0_");
+  }
+
+  @Test
   public void shouldFailIfIndexPrefixIsDifferent() {
     final var operateProperties = new OperateProperties();
     operateProperties.getElasticsearch().setIndexPrefix("operate-prefix");

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupService.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/BackupService.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.webapps.backup;
 
+import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
 import java.util.List;
 
 public interface BackupService {
@@ -20,5 +21,8 @@ public interface BackupService {
   List<GetBackupStateResponseDto> getBackups();
 
   record SnapshotRequest(
-      String repositoryName, String snapshotName, List<String> indices, Metadata metadata) {}
+      String repositoryName,
+      String snapshotName,
+      SnapshotIndexCollection indices,
+      Metadata metadata) {}
 }

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepository.java
@@ -247,7 +247,7 @@ public class ElasticsearchBackupRepository implements BackupRepository {
             b ->
                 b.repository(snapshotRequest.repositoryName())
                     .snapshot(snapshotRequest.snapshotName())
-                    .indices(snapshotRequest.indices())
+                    .indices(snapshotRequest.indices().indices())
                     // ignoreUnavailable = false - indices defined by their exact name MUST be
                     // present
                     // allowNoIndices = true - indices defined by wildcards, e.g. archived, MIGHT BE

--- a/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
+++ b/webapps-backup/src/main/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepository.java
@@ -229,7 +229,7 @@ public class OpensearchBackupRepository implements BackupRepository {
         createSnapshotRequestBuilder(
                 snapshotRequest.repositoryName(),
                 snapshotRequest.snapshotName(),
-                snapshotRequest.indices())
+                snapshotRequest.indices().indices())
             .ignoreUnavailable(
                 false) // ignoreUnavailable = false - indices defined by their exact name MUST be
             // present

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/elasticsearch/ElasticsearchBackupRepositoryTest.java
@@ -26,6 +26,7 @@ import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.Metadata;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.SnapshotNameProvider;
+import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.List;
@@ -182,7 +183,7 @@ public class ElasticsearchBackupRepositoryTest {
         new SnapshotRequest(
             "repo-name-1",
             snapshotNameProvider.getSnapshotName(metadata),
-            List.of("index-1", "index-2"),
+            new SnapshotIndexCollection(List.of("index-1", "index-2")),
             metadata);
     // 1 element array to bypass closures over final fields
     backupRepository.executeSnapshotting(

--- a/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
+++ b/webapps-backup/src/test/java/io/camunda/webapps/backup/repository/opensearch/OpensearchBackupRepositoryTest.java
@@ -22,6 +22,7 @@ import io.camunda.webapps.backup.BackupStateDto;
 import io.camunda.webapps.backup.Metadata;
 import io.camunda.webapps.backup.repository.BackupRepositoryProps;
 import io.camunda.webapps.backup.repository.elasticsearch.TestSnapshotProvider;
+import io.camunda.webapps.schema.descriptors.backup.SnapshotIndexCollection;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
@@ -112,7 +113,7 @@ class OpensearchBackupRepositoryTest {
         new BackupService.SnapshotRequest(
             "repo",
             "camunda_operate_1_2",
-            List.of("index-1", "index-2"),
+            new SnapshotIndexCollection(List.of("index-1", "index-2")),
             new Metadata(1L, "1", 1, 1));
     final Runnable onSuccess = () -> {};
     final Runnable onFailure = () -> fail("Should execute snapshot successfully.");
@@ -140,7 +141,7 @@ class OpensearchBackupRepositoryTest {
         new SnapshotRequest(
             "repo",
             "camunda_operate_1_2",
-            List.of("index-1", "index-2"),
+            new SnapshotIndexCollection(List.of("index-1", "index-2")),
             new Metadata(1L, "1", 1, 1));
     final Runnable onSuccess = () -> fail("Should execute snapshot with failures.");
     final Runnable onFailure = () -> {};

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/BackupPriorities.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.webapps.schema.descriptors.backup;
 
+import io.camunda.webapps.schema.descriptors.IndexTemplateDescriptor;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -20,5 +22,36 @@ public record BackupPriorities(
 
   public Stream<BackupPriority> allPriorities() {
     return Stream.of(prio1(), prio2(), prio3(), prio4(), prio5(), prio6()).flatMap(List::stream);
+  }
+
+  public Stream<SnapshotIndexCollection> indicesSplitBySnapshot() {
+    return Stream.of(
+        fullQualifiedName(prio1()),
+        fullQualifiedName(prio2()),
+        // dated indices
+        fullQualifiedNameWithMatcher(prio2()),
+        fullQualifiedName(prio3()),
+        fullQualifiedName(prio4()),
+        // dated indices
+        fullQualifiedNameWithMatcher(prio4()),
+        fullQualifiedName(prio5()),
+        fullQualifiedName(prio6()));
+  }
+
+  private static <A extends BackupPriority> SnapshotIndexCollection fullQualifiedName(
+      final Collection<A> backups) {
+    final var indices = backups.stream().map(BackupPriority::getFullQualifiedName).toList();
+    return new SnapshotIndexCollection(indices);
+  }
+
+  private static <A extends BackupPriority> SnapshotIndexCollection fullQualifiedNameWithMatcher(
+      final Collection<A> backups) {
+    final var indices =
+        backups.stream()
+            .filter(IndexTemplateDescriptor.class::isInstance)
+            .map(BackupPriority::getFullQualifiedName)
+            .flatMap(name -> Stream.of(name + "*", "-" + name))
+            .toList();
+    return new SnapshotIndexCollection(indices);
   }
 }

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/backup/SnapshotIndexCollection.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.webapps.schema.descriptors.backup;
+
+import java.util.List;
+
+public record SnapshotIndexCollection(List<String> indices) {}

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/index/DecisionIndex.java
@@ -7,11 +7,11 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.index;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio5Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateIndexDescriptor;
 import java.util.Optional;
 
-public class DecisionIndex extends OperateIndexDescriptor implements Prio5Backup {
+public class DecisionIndex extends OperateIndexDescriptor implements Prio4Backup {
 
   public static final String INDEX_NAME = "decision";
   public static final String ID = "id";

--- a/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/UserTaskTemplate.java
+++ b/webapps-schema/src/main/java/io/camunda/webapps/schema/descriptors/operate/template/UserTaskTemplate.java
@@ -7,13 +7,13 @@
  */
 package io.camunda.webapps.schema.descriptors.operate.template;
 
-import io.camunda.webapps.schema.descriptors.backup.Prio3Backup;
+import io.camunda.webapps.schema.descriptors.backup.Prio4Backup;
 import io.camunda.webapps.schema.descriptors.operate.OperateTemplateDescriptor;
 import io.camunda.webapps.schema.descriptors.operate.ProcessInstanceDependant;
 import java.util.Optional;
 
 public class UserTaskTemplate extends OperateTemplateDescriptor
-    implements ProcessInstanceDependant, Prio3Backup {
+    implements ProcessInstanceDependant, Prio4Backup {
 
   public static final String INDEX_NAME = "user-task";
 


### PR DESCRIPTION
## Description

Indices (that were not templates) where included twice in the snapshot requests, making it impossible to restore them.

Extracted the logic for generating the list of indices to be included in the requests from BackupServiceImpl to BackupProperties to ease the testing.

Added a unit test where each list of indices is checked. Comparing this with the original requirements some  discrepancies were found. Most of these discrepancies are related to indices not existing anymore or being renamed.

Notable changes compared to the table in this [comment](https://github.com/camunda/camunda/issues/24464#issuecomment-2517086937)
- These templates have been moved to the following  part of the snapshot:
  -  tasklist-draft-task-variable-8.3.0_
  -  -tasklist-draft-task-variable-8.3.0_
  -  tasklist-task-variable-8.3.0_
  -  -tasklist-task-variable-8.3.0_
- In the original table I don't see operate's template matchers, even though in the code they are included, see version [BackupService](https://github.com/camunda/camunda/blob/8.6.5/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupService.java#L168) from version 8.6.5:
```java
// dated indices
            prio3BackupTemplates.stream()
                .map(
                    index ->
                        new String[] {
                          ((TemplateDescriptor) index).getFullQualifiedName() + "*",
                          "-" + ((TemplateDescriptor) index).getFullQualifiedName()
                        })
                .flatMap(Arrays::stream)
                .toArray(String[]::new),
```
These template matchers from operate are:
- operate-event-8.3.0_*
- -operate-event-8.3.0_
- operate-flownode-instance-8.3.1_*
- -operate-flownode-instance-8.3.1_
- operate-incident-8.3.1_*
- -operate-incident-8.3.1_
- operate-job-8.6.0_*
- -operate-job-8.6.0_
- operate-message-8.5.0_*
- -operate-message-8.5.0_
- operate-post-importer-queue-8.3.0_*
- -operate-post-importer-queue-8.3.0_
- operate-sequence-flow-8.3.0_*
- -operate-sequence-flow-8.3.0_
- operate-user-task-8.5.0_*
- -operate-user-task-8.5.0_
- operate-variable-8.3.0_*
- -operate-variable-8.3.0_
- -operate-decision-instance-8.3.0_
- operate-decision-instance-8.3.0_*



## Related issues

relates #26066
