### PR TITLE
fix: search does not correctly return lastSortValues

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/ProcessDefinitionQueryTest.java
@@ -88,6 +88,76 @@ public class ProcessDefinitionQueryTest {
   }
 
   @Test
+  void shouldPaginateWithSortingByProcessDefinitionKey() {
+    // given
+    final var resultAll =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionKey().desc())
+            .send()
+            .join();
+
+    // when
+    final var firstPage =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionKey().desc())
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var secondPage =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionKey().desc())
+            .page(p -> p.limit(1).searchAfter(firstPage.page().lastSortValues()))
+            .send()
+            .join();
+
+    // then
+    assertThat(firstPage.items().size()).isEqualTo(1);
+    assertThat(firstPage.items().getFirst().getProcessDefinitionKey())
+        .isEqualTo(resultAll.items().get(0).getProcessDefinitionKey());
+    assertThat(secondPage.items().size()).isEqualTo(1);
+    assertThat(secondPage.items().getFirst().getProcessDefinitionKey())
+        .isEqualTo(resultAll.items().get(1).getProcessDefinitionKey());
+  }
+
+  @Test
+  void shouldPaginateWithSortingByProcessDefinitionId() {
+    // given
+    final var resultAll =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionId().desc())
+            .send()
+            .join();
+
+    // when
+    final var firstPage =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionId().desc())
+            .page(p -> p.limit(1))
+            .send()
+            .join();
+    final var secondPage =
+        zeebeClient
+            .newProcessDefinitionQuery()
+            .sort(s -> s.processDefinitionId().desc())
+            .page(p -> p.limit(1).searchAfter(firstPage.page().lastSortValues()))
+            .send()
+            .join();
+
+    // then
+    assertThat(firstPage.items().size()).isEqualTo(1);
+    assertThat(firstPage.items().getFirst().getProcessDefinitionKey())
+        .isEqualTo(resultAll.items().get(0).getProcessDefinitionKey());
+    assertThat(secondPage.items().size()).isEqualTo(1);
+    assertThat(secondPage.items().getFirst().getProcessDefinitionKey())
+        .isEqualTo(resultAll.items().get(1).getProcessDefinitionKey());
+  }
+
+  @Test
   void shouldThrownExceptionIfProcessDefinitionNotFoundByKey() {
     // given
     final long invalidProcessDefinitionKey = 0xC00L;

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import io.camunda.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.search.response.UserTask;
 import io.camunda.zeebe.client.protocol.rest.StringFilterProperty;
 import io.camunda.zeebe.client.protocol.rest.UserTaskVariableFilterRequest;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.InputStream;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Collections;
@@ -405,16 +407,26 @@ class UserTaskQueryTest {
     assertThat(result.items().size()).isEqualTo(8);
 
     // Assert that the creation date of item 0 is before item 1, and item 1 is before item 2
-    assertThat(result.items().get(0).getCreationDate())
-        .isLessThan(result.items().get(1).getCreationDate());
+    final UserTask firstItem = result.items().get(0);
+    final UserTask lastItem = result.items().get(7);
+    assertThat(firstItem.getCreationDate()).isLessThan(result.items().get(1).getCreationDate());
     assertThat(result.items().get(1).getCreationDate())
         .isLessThan(result.items().get(2).getCreationDate());
 
     // Assert First and Last Sort Value matches the first and last item
-    assertThat(
-        result.page().firstSortValues().get(0).equals(result.items().get(0).getCreationDate()));
-    assertThat(
-        result.page().lastSortValues().get(0).equals(result.items().get(6).getUserTaskKey()));
+
+    // FIXME - https://github.com/camunda/camunda/issues/26080
+    /*assertThat(result.page().firstSortValues())
+    .isEqualTo(
+        List.of(
+            OffsetDateTime.parse(firstItem.getCreationDate()).toInstant().toEpochMilli(),
+            firstItem.getUserTaskKey()));
+    */
+    assertThat(result.page().lastSortValues())
+        .isEqualTo(
+            List.of(
+                OffsetDateTime.parse(lastItem.getCreationDate()).toInstant().toEpochMilli(),
+                lastItem.getUserTaskKey()));
   }
 
   @Test

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.gateway.rest.ResponseMapper.formatDate;
+import static java.util.Collections.emptyList;
 import static java.util.Optional.ofNullable;
 
 import io.camunda.search.entities.AuthorizationEntity;
@@ -231,20 +232,12 @@ public final class SearchQueryResponseMapper {
       final SearchQueryResult<?> result) {
 
     final List<Object> sortValues =
-        ofNullable(result.sortValues()).map(Arrays::asList).orElse(Collections.emptyList());
-
-    final List<Object> firstSortValues =
-        sortValues.stream().findFirst().map(List::of).orElse(Collections.emptyList());
-
-    final List<Object> lastSortValues =
-        sortValues.isEmpty()
-            ? Collections.emptyList()
-            : List.of(sortValues.get(sortValues.size() - 1));
+        ofNullable(result.sortValues()).map(Arrays::asList).orElse(emptyList());
 
     return new SearchQueryPageResponse()
         .totalItems(result.total())
-        .firstSortValues(firstSortValues)
-        .lastSortValues(lastSortValues);
+        .firstSortValues(emptyList()) // FIXME https://github.com/camunda/camunda/issues/26080
+        .lastSortValues(sortValues);
   }
 
   private static List<ProcessDefinitionItem> toProcessDefinitions(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -57,7 +57,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -69,7 +69,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                ],
                "page": {
                    "totalItems": 1,
-                   "firstSortValues": ["v"],
+                   "firstSortValues": [],
                    "lastSortValues": [
                        "v"
                    ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -56,7 +56,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -61,7 +61,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -58,7 +58,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -81,7 +81,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           ],
           "page": {
               "totalItems": 1,
-              "firstSortValues": ["v"],
+              "firstSortValues": [],
               "lastSortValues": [
                   "v"
               ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -104,7 +104,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -87,7 +87,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]
@@ -111,7 +111,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         ],
         "page": {
           "totalItems": 1,
-          "firstSortValues": ["v"],
+          "firstSortValues": [],
           "lastSortValues": [
             "v"
           ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -74,7 +74,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -59,7 +59,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 1,
-               "firstSortValues": ["v"],
+               "firstSortValues": [],
                "lastSortValues": [
                  "v"
                ]

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -48,7 +48,7 @@ public class UserQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": ["v"],
+                  "firstSortValues": [],
                   "lastSortValues": [
                       "v"
                   ]


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
More details can be found in https://github.com/camunda/camunda/issues/26030#issuecomment-2539729696

The search does not correctly return `lastSortValues` and `firstSortValues`.
These fields, which contain a list, are required by the client to fetch the next and previous pages, respectively.

When sorting is applied in the search, these fields are expected to hold the sort values of the first and last items on the page. Since sorting by key is always appended to the query sent to Elasticsearch, the sortValues also include the key of the last item, besides the values of the sort fields provided by the client.

In this pull request, I just fix the issue reported in the bug ticket, which fixed with returning the right `lastSortValues`.

We still need a second fix (follow-up https://github.com/camunda/camunda/issues/26080 (still in draft)) as:
Currently in the [search result transformer](https://github.com/camunda/camunda/blob/94e8ae400f328a1fb49ea0882242bd8494f40c53/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java#L33-L38), we get only the sortValues of the last item of the page.

We also need to get the sortValues of the first item to pass it into `firstSortValues` returned in the response, to be used to fetch the previous page

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26030 
