### PR TITLE
fix: check profile to decide if Tasklist|OperateProperties should be used

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/backup/BackupPriorityConfiguration.java
@@ -14,7 +14,7 @@ import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.conditions.DatabaseType;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.webapps.profiles.ProfileWebApp;
+import io.camunda.webapps.profiles.ProfileOperateTasklist;
 import io.camunda.webapps.schema.descriptors.backup.BackupPriorities;
 import io.camunda.webapps.schema.descriptors.backup.Prio1Backup;
 import io.camunda.webapps.schema.descriptors.backup.Prio2Backup;
@@ -53,6 +53,7 @@ import io.camunda.webapps.schema.descriptors.usermanagement.index.PersistentWebS
 import io.camunda.webapps.schema.descriptors.usermanagement.index.RoleIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.TenantIndex;
 import io.camunda.webapps.schema.descriptors.usermanagement.index.UserIndex;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,9 +63,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 
 @Configuration
-@ProfileWebApp
+@ProfileOperateTasklist
 public class BackupPriorityConfiguration {
 
   private static final Logger LOG = LoggerFactory.getLogger(BackupPriorityConfiguration.class);
@@ -73,19 +75,30 @@ public class BackupPriorityConfiguration {
 
   final OperateProperties operateProperties;
   final TasklistProperties tasklistProperties;
+  final String[] profiles;
 
   public BackupPriorityConfiguration(
       @Autowired(required = false) final OperateProperties operateProperties,
-      @Autowired(required = false) final TasklistProperties tasklistProperties) {
-    this.operateProperties = operateProperties;
-    this.tasklistProperties = tasklistProperties;
+      @Autowired(required = false) final TasklistProperties tasklistProperties,
+      @Autowired final Environment environment) {
+    profiles = environment.getActiveProfiles();
+    if (environment.matchesProfiles("operate")) {
+      this.operateProperties = operateProperties;
+    } else {
+      this.operateProperties = null;
+    }
+    if (environment.matchesProfiles("tasklist")) {
+      this.tasklistProperties = tasklistProperties;
+    } else {
+      this.tasklistProperties = null;
+    }
   }
 
-  private static <A> Function<Map<String, A>, String> differentConfigFor(final String field) {
+  private <A> Function<Map<String, A>, String> differentConfigFor(final String field) {
     return values ->
         String.format(
-            "Expected %s to be configured with the same value in operate and tasklist. Got %s.",
-            field, values);
+            "Expected %s to be configured with the same value in operate and tasklist. Got %s. Active profiles: %s",
+            field, values, Arrays.asList(profiles));
   }
 
   @Bean
@@ -108,7 +121,8 @@ public class BackupPriorityConfiguration {
                 differentConfigFor("database.type"),
                 Map.of(
                     "operate",
-                    Optional.of(DatabaseInfo.isCurrent(DatabaseType.Elasticsearch)),
+                    Optional.ofNullable(operateProperties)
+                        .map(ignored -> DatabaseInfo.isCurrent(DatabaseType.Elasticsearch)),
                     "tasklist",
                     Optional.ofNullable(tasklistProperties)
                         .map(prop -> prop.getDatabase().equals(TasklistProperties.ELASTIC_SEARCH))),

--- a/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
+++ b/dist/src/test/java/io/camunda/application/commons/backup/BackupPrioritiesTest.java
@@ -10,6 +10,9 @@ package io.camunda.application.commons.backup;
 import static com.tngtech.archunit.core.domain.JavaClass.Predicates.implement;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -24,8 +27,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.core.env.Environment;
 
 class BackupPrioritiesTest {
 
@@ -99,12 +101,13 @@ class BackupPrioritiesTest {
         .filter(arr -> !Arrays.stream(arr).allMatch(Objects::isNull));
   }
 
-  @MethodSource("properties")
-  @ParameterizedTest
-  public void testBackupPriorities(
-      final OperateProperties operateProperties, final TasklistProperties tasklistProperties) {
+  @Test
+  public void testBackupPriorities() {
     final var configuration =
-        new BackupPriorityConfiguration(operateProperties, tasklistProperties);
+        new BackupPriorityConfiguration(
+            new OperateProperties(),
+            new TasklistProperties(),
+            matchingProfiles("operate", "tasklist"));
     final var priorities = configuration.backupPriorities();
 
     final Set<String> allPriorities =
@@ -122,7 +125,8 @@ class BackupPrioritiesTest {
 
   @Test
   public void testBackupPrioritiesIndicesSplitBySnapshot() {
-    final var configuration = new BackupPriorityConfiguration(new OperateProperties(), null);
+    final var configuration =
+        new BackupPriorityConfiguration(new OperateProperties(), null, matchingProfiles("operate"));
     final var priorities = configuration.backupPriorities();
 
     final var indices = priorities.indicesSplitBySnapshot().toList();
@@ -215,10 +219,24 @@ class BackupPrioritiesTest {
     final var tasklistProperties = new TasklistProperties();
     tasklistProperties.getElasticsearch().setIndexPrefix("tasklist-prefix");
     final var configuration =
-        new BackupPriorityConfiguration(operateProperties, tasklistProperties);
+        new BackupPriorityConfiguration(
+            operateProperties, tasklistProperties, matchingProfiles("operate", "tasklist"));
     assertThatThrownBy(configuration::backupPriorities)
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("operate-prefix")
         .hasMessageContaining("tasklist-prefix");
+  }
+
+  public Environment matchingProfiles(final String... profiles) {
+    final var environment = mock(Environment.class);
+    final var profileSet = new HashSet<>(Arrays.asList(profiles));
+    when(environment.matchesProfiles(any()))
+        .thenAnswer(
+            arg -> {
+              final var profileArg = (String) arg.getArgument(0);
+              return profileSet.contains(profileArg);
+            });
+    when(environment.getActiveProfiles()).thenReturn(profiles);
+    return environment;
   }
 }


### PR DESCRIPTION
## Description
OperateProperties and TasklistProperties are always not null even if their profile is not enabled.
Checking the profile to decide if we should consider Operate|TasklistProperties for the backups
