### PR TITLE
fix: Fix page.firstSortValues returned by the search API

### DIFF
--- a/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
+++ b/authentication/src/test/java/io/camunda/authentication/CamundaUserDetailsServiceTest.java
@@ -61,6 +61,7 @@ public class CamundaUserDetailsServiceTest {
             new SearchQueryResult<>(
                 1,
                 List.of(new UserEntity(100L, TEST_USER_ID, "Foo Bar", "email@tested", "password1")),
+                null,
                 null));
 
     when(authorizationServices.findAll(any()))
@@ -94,7 +95,7 @@ public class CamundaUserDetailsServiceTest {
   public void testUserDetailsNotFound() {
     // given
     when(userService.search(any()))
-        .thenReturn(new SearchQueryResult<>(0, Collections.emptyList(), null));
+        .thenReturn(new SearchQueryResult<>(0, Collections.emptyList(), null, null));
     // when/then
     assertThatThrownBy(() -> userDetailsService.loadUserByUsername(TEST_USER_ID))
         .isInstanceOf(UsernameNotFoundException.class);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/ProcessDefinitionImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/ProcessDefinitionImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.impl.search.response;
 import io.camunda.zeebe.client.api.response.Process;
 import io.camunda.zeebe.client.api.search.response.ProcessDefinition;
 import io.camunda.zeebe.client.protocol.rest.ProcessDefinitionItem;
+import java.util.Objects;
 
 public class ProcessDefinitionImpl implements ProcessDefinition, Process {
 
@@ -77,5 +78,57 @@ public class ProcessDefinitionImpl implements ProcessDefinition, Process {
   @Override
   public String getBpmnProcessId() {
     return processDefinitionId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        processDefinitionKey,
+        name,
+        resourceName,
+        version,
+        versionTag,
+        processDefinitionId,
+        tenantId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessDefinitionImpl that = (ProcessDefinitionImpl) o;
+    return Objects.equals(processDefinitionKey, that.processDefinitionKey)
+        && Objects.equals(name, that.name)
+        && Objects.equals(resourceName, that.resourceName)
+        && Objects.equals(version, that.version)
+        && Objects.equals(versionTag, that.versionTag)
+        && Objects.equals(processDefinitionId, that.processDefinitionId)
+        && Objects.equals(tenantId, that.tenantId);
+  }
+
+  @Override
+  public String toString() {
+    return "ProcessDefinitionImpl{"
+        + "processDefinitionKey="
+        + processDefinitionKey
+        + ", name='"
+        + name
+        + '\''
+        + ", resourceName='"
+        + resourceName
+        + '\''
+        + ", version="
+        + version
+        + ", versionTag='"
+        + versionTag
+        + '\''
+        + ", processDefinitionId='"
+        + processDefinitionId
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + '}';
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AbstractEntityReader.java
@@ -17,12 +17,15 @@ import io.camunda.db.rdbms.read.domain.DbQuerySorting;
 import io.camunda.db.rdbms.read.domain.DbQuerySorting.SortingEntry;
 import io.camunda.db.rdbms.sql.columns.SearchColumn;
 import io.camunda.search.page.SearchQueryPage;
+import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.sort.SortOption;
 import io.camunda.search.sort.SortOption.FieldSorting;
 import io.camunda.search.sort.SortOrder;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 
 abstract class AbstractEntityReader<T> {
 
@@ -116,14 +119,37 @@ abstract class AbstractEntityReader<T> {
     return keySetPagination;
   }
 
-  public Object[] extractSortValues(final List<T> hits, final DbQuerySorting<T> sort) {
+  protected final SearchQueryResult<T> buildSearchQueryResult(
+      final long totalHits, final List<T> hits, final DbQuerySorting<T> dbSort) {
+    return new SearchQueryResult.Builder<T>()
+        .total(totalHits)
+        .items(hits)
+        .firstSortValues(extractFirstSortValues(hits, dbSort))
+        .lastSortValues(extractLastSortValues(hits, dbSort))
+        .build();
+  }
+
+  @VisibleForTesting
+  Object[] extractFirstSortValues(final List<T> hits, final DbQuerySorting<T> sort) {
+    return extractSortValues(hits, sort, List::getFirst);
+  }
+
+  @VisibleForTesting
+  Object[] extractLastSortValues(final List<T> hits, final DbQuerySorting<T> sort) {
+    return extractSortValues(hits, sort, List::getLast);
+  }
+
+  private Object[] extractSortValues(
+      final List<T> hits,
+      final DbQuerySorting<T> sort,
+      final Function<List<T>, T> firstOrLastGetter) {
     if (hits.isEmpty() || sort.orderings().isEmpty()) {
       return new Object[0];
     }
-
+    final T firstOrLast = firstOrLastGetter.apply(hits);
     final List<Object> sortOptions = new ArrayList<>();
     for (final SortingEntry<T> fieldSorting : sort.orderings()) {
-      sortOptions.add(fieldSorting.column().getPropertyValue(hits.getLast()));
+      sortOptions.add(fieldSorting.column().getPropertyValue(firstOrLast));
     }
 
     return sortOptions.toArray();

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/AuthorizationReader.java
@@ -58,7 +58,7 @@ public class AuthorizationReader extends AbstractEntityReader<AuthorizationEntit
     LOG.trace("[RDBMS DB] Search for authorizations with filter {}", dbQuery);
     final var totalHits = authorizationMapper.count(dbQuery);
     final var hits = authorizationMapper.search(dbQuery).stream().map(this::map).toList();
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   private AuthorizationEntity map(final AuthorizationDbModel model) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionDefinitionReader.java
@@ -46,6 +46,6 @@ public class DecisionDefinitionReader extends AbstractEntityReader<DecisionDefin
     LOG.trace("[RDBMS DB] Search for decision definition with filter {}", dbQuery);
     final var totalHits = decisionDefinitionMapper.count(dbQuery);
     final var hits = decisionDefinitionMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionInstanceReader.java
@@ -59,7 +59,7 @@ public class DecisionInstanceReader extends AbstractEntityReader<DecisionInstanc
     final var totalHits = decisionInstanceMapper.count(dbQuery);
     final var hits = enhanceEntities(decisionInstanceMapper.search(dbQuery), query.resultConfig());
 
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   /**

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/DecisionRequirementsReader.java
@@ -53,6 +53,6 @@ public class DecisionRequirementsReader extends AbstractEntityReader<DecisionReq
     LOG.trace("[RDBMS DB] Search for decision requirements with filter {}", dbQuery);
     final var totalHits = decisionRequirementsMapper.count(dbQuery);
     final var hits = decisionRequirementsMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FlowNodeInstanceReader.java
@@ -44,6 +44,6 @@ public class FlowNodeInstanceReader extends AbstractEntityReader<FlowNodeInstanc
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = flowNodeInstanceMapper.count(dbQuery);
     final var hits = flowNodeInstanceMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/FormReader.java
@@ -44,6 +44,6 @@ public class FormReader extends AbstractEntityReader<FormEntity> {
     LOG.trace("[RDBMS DB] Search for form with filter {}", dbQuery);
     final var totalHits = formMapper.count(dbQuery);
     final var hits = formMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/GroupReader.java
@@ -45,7 +45,7 @@ public class GroupReader extends AbstractEntityReader<GroupEntity> {
     LOG.trace("[RDBMS DB] Search for groups with filter {}", dbQuery);
     final var totalHits = groupMapper.count(dbQuery);
     final var hits = groupMapper.search(dbQuery).stream().map(this::map).toList();
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   private GroupEntity map(final GroupDbModel model) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/IncidentReader.java
@@ -42,6 +42,6 @@ public class IncidentReader extends AbstractEntityReader<IncidentEntity> {
     LOG.trace("[RDBMS DB] Search for incident with filter {}", dbQuery);
     final var totalHits = incidentMapper.count(dbQuery);
     final var hits = incidentMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/MappingReader.java
@@ -44,6 +44,6 @@ public class MappingReader extends AbstractEntityReader<MappingEntity> {
     LOG.trace("[RDBMS DB] Search for mapping with filter {}", dbQuery);
     final var totalHits = mappingMapper.count(dbQuery);
     final var hits = mappingMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessDefinitionReader.java
@@ -50,6 +50,6 @@ public class ProcessDefinitionReader extends AbstractEntityReader<ProcessDefinit
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processDefinitionMapper.count(dbQuery);
     final var hits = processDefinitionMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/ProcessInstanceReader.java
@@ -42,6 +42,6 @@ public class ProcessInstanceReader extends AbstractEntityReader<ProcessInstanceE
     LOG.trace("[RDBMS DB] Search for process instance with filter {}", dbQuery);
     final var totalHits = processInstanceMapper.count(dbQuery);
     final var hits = processInstanceMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/RoleReader.java
@@ -45,7 +45,7 @@ public class RoleReader extends AbstractEntityReader<RoleEntity> {
     LOG.trace("[RDBMS DB] Search for roles with filter {}", dbQuery);
     final var totalHits = roleMapper.count(dbQuery);
     final var hits = roleMapper.search(dbQuery).stream().map(this::map).toList();
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   private RoleEntity map(final RoleDbModel model) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/TenantReader.java
@@ -45,7 +45,7 @@ public class TenantReader extends AbstractEntityReader<TenantEntity> {
     LOG.trace("[RDBMS DB] Search for tenants with filter {}", dbQuery);
     final var totalHits = tenantMapper.count(dbQuery);
     final var hits = tenantMapper.search(dbQuery).stream().map(this::map).toList();
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   private TenantEntity map(final TenantDbModel model) {

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/UserReader.java
@@ -42,6 +42,6 @@ public class UserReader extends AbstractEntityReader<UserEntity> {
     LOG.trace("[RDBMS DB] Search for users with filter {}", dbQuery);
     final var totalHits = processDefinitionMapper.count(dbQuery);
     final var hits = processDefinitionMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 }

--- a/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
+++ b/db/rdbms/src/main/java/io/camunda/db/rdbms/read/service/VariableReader.java
@@ -49,7 +49,7 @@ public class VariableReader extends AbstractEntityReader<VariableEntity> {
     LOG.trace("[RDBMS DB] Search for variables with filter {}", query);
     final var totalHits = variableMapper.count(dbQuery);
     final var hits = variableMapper.search(dbQuery);
-    return new SearchQueryResult<>(totalHits.intValue(), hits, extractSortValues(hits, dbSort));
+    return buildSearchQueryResult(totalHits, hits, dbSort);
   }
 
   public record SearchResult(List<VariableEntity> hits, Integer total) {}

--- a/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
+++ b/db/rdbms/src/test/java/io/camunda/db/rdbms/read/service/AbstractEntityReaderTest.java
@@ -82,10 +82,13 @@ class AbstractEntityReaderTest {
                 b.addEntry(ProcessInstanceSearchColumn.PROCESS_DEFINITION_NAME, SortOrder.ASC)
                     .addEntry(ProcessInstanceSearchColumn.PROCESS_INSTANCE_KEY, SortOrder.ASC));
 
-    final var sortValues = reader.extractSortValues(searchResult, sorting);
+    final var firstSortValues = reader.extractFirstSortValues(searchResult, sorting);
+    final var lastSortValues = reader.extractLastSortValues(searchResult, sorting);
 
-    assertThat(sortValues).hasSize(2);
-    assertThat(sortValues).containsExactly("alice", 3L);
+    assertThat(firstSortValues).hasSize(2);
+    assertThat(firstSortValues).containsExactly("foo", 1L);
+    assertThat(lastSortValues).hasSize(2);
+    assertThat(lastSortValues).containsExactly("alice", 3L);
   }
 
   @Test

--- a/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/auth/BasicAuthIT.java
@@ -78,6 +78,7 @@ public class BasicAuthIT {
             new SearchQueryResult<>(
                 1,
                 List.of(new UserEntity(1L, USERNAME, "name", "", passwordEncoder.encode(PASSWORD))),
+                null,
                 null));
     when(tenantServices.getTenantsByMemberKey(anyLong()))
         .thenReturn(List.of(new TenantEntity(9L, "T1", "Tenant 1", Set.of())));

--- a/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/client/UserTaskQueryTest.java
@@ -414,14 +414,11 @@ class UserTaskQueryTest {
         .isLessThan(result.items().get(2).getCreationDate());
 
     // Assert First and Last Sort Value matches the first and last item
-
-    // FIXME - https://github.com/camunda/camunda/issues/26080
-    /*assertThat(result.page().firstSortValues())
-    .isEqualTo(
-        List.of(
-            OffsetDateTime.parse(firstItem.getCreationDate()).toInstant().toEpochMilli(),
-            firstItem.getUserTaskKey()));
-    */
+    assertThat(result.page().firstSortValues())
+        .isEqualTo(
+            List.of(
+                OffsetDateTime.parse(firstItem.getCreationDate()).toInstant().toEpochMilli(),
+                firstItem.getUserTaskKey()));
     assertThat(result.page().lastSortValues())
         .isEqualTo(
             List.of(

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/decisioninstance/DecisionInstanceIT.java
@@ -91,9 +91,16 @@ public class DecisionInstanceIT {
     assertThat(searchResult.total()).isEqualTo(20);
     assertThat(searchResult.items()).hasSize(5);
 
+    final var firstInstance = searchResult.items().getFirst();
+    assertThat(searchResult.firstSortValues()).hasSize(3);
+    assertThat(searchResult.firstSortValues())
+        .containsExactly(
+            firstInstance.evaluationDate(),
+            firstInstance.decisionDefinitionName(),
+            firstInstance.decisionInstanceId());
     final var lastInstance = searchResult.items().getLast();
-    assertThat(searchResult.sortValues()).hasSize(3);
-    assertThat(searchResult.sortValues())
+    assertThat(searchResult.lastSortValues()).hasSize(3);
+    assertThat(searchResult.lastSortValues())
         .containsExactly(
             lastInstance.evaluationDate(),
             lastInstance.decisionDefinitionName(),

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/incident/IncidentIT.java
@@ -116,9 +116,15 @@ public class IncidentIT {
     assertThat(searchResult.total()).isEqualTo(20);
     assertThat(searchResult.items()).hasSize(5);
 
+    final var firstInstance = searchResult.items().getFirst();
+    assertThat(searchResult.firstSortValues()).hasSize(3);
+    assertThat(searchResult.firstSortValues())
+        .containsExactly(
+            firstInstance.creationTime(), firstInstance.flowNodeId(), firstInstance.incidentKey());
+
     final var lastInstance = searchResult.items().getLast();
-    assertThat(searchResult.sortValues()).hasSize(3);
-    assertThat(searchResult.sortValues())
+    assertThat(searchResult.lastSortValues()).hasSize(3);
+    assertThat(searchResult.lastSortValues())
         .containsExactly(
             lastInstance.creationTime(), lastInstance.flowNodeId(), lastInstance.incidentKey());
   }

--- a/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/it/rdbms/db/processinstance/ProcessInstanceIT.java
@@ -166,9 +166,16 @@ public class ProcessInstanceIT {
     assertThat(searchResult.total()).isEqualTo(20);
     assertThat(searchResult.items()).hasSize(5);
 
+    final var firstInstance = searchResult.items().getFirst();
+    assertThat(searchResult.firstSortValues()).hasSize(3);
+    assertThat(searchResult.firstSortValues())
+        .containsExactly(
+            firstInstance.startDate(),
+            firstInstance.processDefinitionName(),
+            firstInstance.processInstanceKey());
     final var lastInstance = searchResult.items().getLast();
-    assertThat(searchResult.sortValues()).hasSize(3);
-    assertThat(searchResult.sortValues())
+    assertThat(searchResult.lastSortValues()).hasSize(3);
+    assertThat(searchResult.lastSortValues())
         .containsExactly(
             lastInstance.startDate(),
             lastInstance.processDefinitionName(),

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/SearchClientBasedQueryExecutor.java
@@ -51,7 +51,10 @@ public final class SearchClientBasedQueryExecutor {
     final SearchQueryResultTransformer<T, R> responseTransformer =
         (SearchQueryResultTransformer<T, R>) getSearchResultTransformer(documentClass);
     return executeSearch(
-        query, q -> responseTransformer.apply(searchClient.search(q, documentClass)));
+        query,
+        q ->
+            responseTransformer.apply(
+                searchClient.search(q, documentClass), !query.page().isNextPage()));
   }
 
   public <F extends FilterBase, S extends SortOption, T, R> List<R> findAll(

--- a/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
+++ b/search/search-client-query-transformer/src/main/java/io/camunda/search/clients/transformers/query/SearchQueryResultTransformer.java
@@ -12,6 +12,7 @@ import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.clients.transformers.ServiceTransformer;
 import io.camunda.search.query.SearchQueryResult;
 import io.camunda.search.query.SearchQueryResult.Builder;
+import io.camunda.search.query.TypedSearchQuery;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,17 @@ public final class SearchQueryResultTransformer<T, R> {
     this.documentToEntityMapper = documentToEntityMapper;
   }
 
+  /**
+   * Applies the transformation to the search query response.
+   *
+   * @param value The value to be transformed.
+   * @param reverse Indicates whether to reverse the order of the hits. This is required when the
+   *     query requests a previous page (see {@link
+   *     TypedSearchQueryTransformer#apply(TypedSearchQuery)}). In such cases, the search query is
+   *     executed with reverse sorting, and the response hits must be reversed again to restore the
+   *     correct order.
+   * @return The transformed search query result.
+   */
   public SearchQueryResult<R> apply(final SearchQueryResponse<T> value, final boolean reverse) {
     final var hits = reverse ? value.hits().reversed() : value.hits();
     final var items = of(hits);

--- a/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
+++ b/search/search-client-rdbms/src/main/java/io/camunda/search/rdbms/RdbmsSearchClient.java
@@ -196,7 +196,7 @@ public class RdbmsSearchClient
                 UserTaskDbQuery.of(
                     b -> b.filter(query.filter()).sort(query.sort()).page(query.page())));
 
-    return new SearchQueryResult<>(searchResult.total(), searchResult.hits(), null);
+    return new SearchQueryResult<>(searchResult.total(), searchResult.hits(), null, null);
   }
 
   @Override

--- a/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
+++ b/search/search-domain/src/main/java/io/camunda/search/query/SearchQueryResult.java
@@ -12,13 +12,15 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public record SearchQueryResult<T>(long total, List<T> items, Object[] sortValues) {
+public record SearchQueryResult<T>(
+    long total, List<T> items, Object[] firstSortValues, Object[] lastSortValues) {
 
   public static final class Builder<T> implements ObjectBuilder<SearchQueryResult<T>> {
 
     private long total;
     private List<T> items;
-    private Object[] sortValues;
+    private Object[] firstSortValues;
+    private Object[] lastSortValues;
 
     public Builder<T> total(final long value) {
       total = value;
@@ -30,15 +32,23 @@ public record SearchQueryResult<T>(long total, List<T> items, Object[] sortValue
       return this;
     }
 
-    public Builder<T> sortValues(final Object[] values) {
-      sortValues = values;
+    public Builder<T> firstSortValues(final Object[] values) {
+      firstSortValues = values;
+      return this;
+    }
+
+    public Builder<T> lastSortValues(final Object[] values) {
+      lastSortValues = values;
       return this;
     }
 
     @Override
     public SearchQueryResult<T> build() {
       return new SearchQueryResult<T>(
-          total, Objects.requireNonNullElse(items, Collections.emptyList()), sortValues);
+          total,
+          Objects.requireNonNullElse(items, Collections.emptyList()),
+          firstSortValues,
+          lastSortValues);
     }
   }
 }

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServiceTest.java
@@ -83,12 +83,12 @@ public final class DecisionDefinitionServiceTest {
     when(definitionEntity.decisionRequirementsKey()).thenReturn(42L);
     when(definitionEntity.decisionDefinitionId()).thenReturn("decId");
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null, null));
 
     final var requirementEntity = mock(DecisionRequirementsEntity.class);
     when(requirementEntity.xml()).thenReturn("<foo>bar</foo>");
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(requirementEntity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(requirementEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
         .thenReturn(true);
@@ -104,7 +104,7 @@ public final class DecisionDefinitionServiceTest {
   public void shouldThrowNotFoundExceptionOnUnmatchedDecisionKey() {
     // given
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null));
+        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
 
     // then
     final var exception =
@@ -124,9 +124,9 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(definitionEntity), null, null));
     when(decisionRequirementSearchClient.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null));
+        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
     when(securityContextProvider.isAuthorized(
             "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
         .thenReturn(true);
@@ -146,7 +146,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
         .thenReturn(true);
@@ -166,7 +166,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
         .thenReturn(false);
@@ -188,7 +188,7 @@ public final class DecisionDefinitionServiceTest {
     final var definitionResult = mock(SearchQueryResult.class);
     when(definitionResult.items()).thenReturn(List.of(definitionEntity));
     when(client.searchDecisionDefinitions(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null));
+        .thenReturn(new SearchQueryResult(1, List.of(definitionEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decId", authentication, Authorization.of(a -> a.decisionDefinition().read())))
         .thenReturn(false);

--- a/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionRequirementsServiceTest.java
@@ -67,7 +67,7 @@ public final class DecisionRequirementsServiceTest {
     when(decisionRequirementEntity.decisionRequirementsKey()).thenReturn(124L);
     when(decisionRequirementEntity.decisionRequirementsId()).thenReturn("decReqId");
     when(client.searchDecisionRequirements(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(decisionRequirementEntity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(decisionRequirementEntity), null, null));
     when(securityContextProvider.isAuthorized(
             "decReqId",
             authentication,

--- a/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/FlowNodeInstanceServiceTest.java
@@ -67,7 +67,7 @@ public final class FlowNodeInstanceServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchFlowNodeInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,
@@ -87,7 +87,7 @@ public final class FlowNodeInstanceServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchFlowNodeInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,

--- a/service/src/test/java/io/camunda/service/GroupServiceTest.java
+++ b/service/src/test/java/io/camunda/service/GroupServiceTest.java
@@ -91,7 +91,7 @@ public class GroupServiceTest {
   public void shouldReturnSingleGroup() {
     // given
     final var entity = mock(GroupEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchGroups(any())).thenReturn(result);
   }
 
@@ -99,7 +99,7 @@ public class GroupServiceTest {
   public void shouldReturnSingleGroupForGet() {
     // given
     final var entity = mock(GroupEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchGroups(any())).thenReturn(result);
 
     // when
@@ -113,7 +113,7 @@ public class GroupServiceTest {
   public void shouldThrowExceptionIfGroupNotFoundByKey() {
     // given
     final var key = 100L;
-    when(client.searchGroups(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+    when(client.searchGroups(any())).thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
 
     // when / then
     assertThat(services.findGroup(key)).isEmpty();
@@ -124,7 +124,8 @@ public class GroupServiceTest {
     // given
     final var group1 = mock(GroupEntity.class);
     final var group2 = mock(GroupEntity.class);
-    final var result = new SearchQueryResult<>(2, List.of(group1, group2), Arrays.array());
+    final var result =
+        new SearchQueryResult<>(2, List.of(group1, group2), Arrays.array(), Arrays.array());
     when(client.searchGroups(any())).thenReturn(result);
 
     // when

--- a/service/src/test/java/io/camunda/service/IncidentServiceTest.java
+++ b/service/src/test/java/io/camunda/service/IncidentServiceTest.java
@@ -67,7 +67,7 @@ public final class IncidentServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchIncidents(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,
@@ -87,7 +87,7 @@ public final class IncidentServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchIncidents(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,

--- a/service/src/test/java/io/camunda/service/MappingServicesTest.java
+++ b/service/src/test/java/io/camunda/service/MappingServicesTest.java
@@ -95,7 +95,7 @@ public class MappingServicesTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(MappingEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchMappings(any())).thenReturn(result);
   }
 
@@ -103,7 +103,7 @@ public class MappingServicesTest {
   public void shouldReturnSingleVariableForFind() {
     // given
     final var entity = mock(MappingEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchMappings(any())).thenReturn(result);
 
     // when
@@ -117,7 +117,7 @@ public class MappingServicesTest {
   public void shouldReturnEmptyWhenNotFoundByFind() {
     // given
     final var key = 100L;
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
     assertThat(services.findMapping(key)).isEmpty();
@@ -126,7 +126,7 @@ public class MappingServicesTest {
   @Test
   public void shouldThrowExceptionWhenNotFoundByGet() {
     // given
-    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+    when(client.searchMappings(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
     assertThrows(NotFoundException.class, () -> services.getMapping(1L));

--- a/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
+++ b/service/src/test/java/io/camunda/service/ProcessInstanceServiceTest.java
@@ -71,7 +71,7 @@ public final class ProcessInstanceServiceTest {
     when(entity.processInstanceKey()).thenReturn(key);
     when(entity.processDefinitionId()).thenReturn("processId");
     when(client.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult(1, List.of(entity), null, null));
     authorizeProcessReadInstance(true, "processId");
 
     // when
@@ -86,7 +86,7 @@ public final class ProcessInstanceServiceTest {
     // given
     final var key = 100L;
     when(client.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(0, List.of(), null));
+        .thenReturn(new SearchQueryResult<>(0, List.of(), null, null));
 
     // when / then
     final var exception =
@@ -101,7 +101,7 @@ public final class ProcessInstanceServiceTest {
     final var entity1 = mock(ProcessInstanceEntity.class);
     final var entity2 = mock(ProcessInstanceEntity.class);
     when(client.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(2, List.of(entity1, entity2), null));
+        .thenReturn(new SearchQueryResult<>(2, List.of(entity1, entity2), null, null));
 
     // when / then
     final var exception =
@@ -116,7 +116,7 @@ public final class ProcessInstanceServiceTest {
     final var entity = mock(ProcessInstanceEntity.class);
     when(entity.processDefinitionId()).thenReturn("processId");
     when(client.searchProcessInstances(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     authorizeProcessReadInstance(false, "processId");
     // when
     final Executable executeGetByKey = () -> services.getByKey(1L);

--- a/service/src/test/java/io/camunda/service/RoleServicesTest.java
+++ b/service/src/test/java/io/camunda/service/RoleServicesTest.java
@@ -70,7 +70,7 @@ public class RoleServicesTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(RoleEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchRoles(any())).thenReturn(result);
   }
 
@@ -78,7 +78,7 @@ public class RoleServicesTest {
   public void shouldReturnSingleVariableForGet() {
     // given
     final var entity = mock(RoleEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchRoles(any())).thenReturn(result);
 
     // when
@@ -92,7 +92,7 @@ public class RoleServicesTest {
   public void shouldThrownExceptionIfNotFoundByKey() {
     // given
     final var key = 100L;
-    when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+    when(client.searchRoles(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
     assertThat(services.findRole(key)).isEmpty();

--- a/service/src/test/java/io/camunda/service/TenantServiceTest.java
+++ b/service/src/test/java/io/camunda/service/TenantServiceTest.java
@@ -82,7 +82,8 @@ public class TenantServiceTest {
   @Test
   public void shouldReturnSingleTenant() {
     // given
-    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array());
+    final var result =
+        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
@@ -95,7 +96,8 @@ public class TenantServiceTest {
   @Test
   public void shouldReturnSingleVariableForGet() {
     // given
-    final var result = new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array());
+    final var result =
+        new SearchQueryResult<>(1, List.of(tenantEntity), Arrays.array(), Arrays.array());
     when(client.searchTenants(any())).thenReturn(result);
 
     // when
@@ -109,7 +111,7 @@ public class TenantServiceTest {
   public void shouldThrowExceptionIfNotFoundByKey() {
     // given
     final var key = 100L;
-    when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, List.of(), null));
+    when(client.searchTenants(any())).thenReturn(new SearchQueryResult(0, List.of(), null, null));
 
     // when / then
     final var exception =

--- a/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
+++ b/service/src/test/java/io/camunda/service/UserTaskServiceTest.java
@@ -148,7 +148,7 @@ public class UserTaskServiceTest {
     // given
     final var entity = mock(UserTaskEntity.class);
     when(entity.processDefinitionId()).thenReturn("bpid");
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchUserTasks(any())).thenReturn(result);
     authorizeReadUserTasksForProcess(false, "bpid");
 
@@ -168,7 +168,7 @@ public class UserTaskServiceTest {
     // given
     final var entity = mock(UserTaskEntity.class);
     when(entity.processDefinitionId()).thenReturn("bpid");
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchUserTasks(any())).thenReturn(result);
     authorizeReadUserTasksForProcess(false, "bpid");
 
@@ -221,6 +221,7 @@ public class UserTaskServiceTest {
   }
 
   private <T> SearchQueryResult<T> wrapWithSearchQueryResult(final T... entities) {
-    return new SearchQueryResult<>(entities.length, List.of(entities), Arrays.array());
+    return new SearchQueryResult<>(
+        entities.length, List.of(entities), Arrays.array(), Arrays.array());
   }
 }

--- a/service/src/test/java/io/camunda/service/VariableServiceTest.java
+++ b/service/src/test/java/io/camunda/service/VariableServiceTest.java
@@ -68,7 +68,7 @@ public class VariableServiceTest {
   public void shouldReturnSingleVariable() {
     // given
     final var entity = mock(VariableEntity.class);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchVariables(any())).thenReturn(result);
   }
 
@@ -78,7 +78,7 @@ public class VariableServiceTest {
     final var entity = mock(VariableEntity.class);
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
-    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array());
+    final var result = new SearchQueryResult<>(1, List.of(entity), Arrays.array(), Arrays.array());
     when(client.searchVariables(any())).thenReturn(result);
     when(securityContextProvider.isAuthorized(
             processId,
@@ -100,7 +100,7 @@ public class VariableServiceTest {
     final var processId = "processId";
     when(entity.processDefinitionId()).thenReturn(processId);
     when(client.searchVariables(any()))
-        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null));
+        .thenReturn(new SearchQueryResult<>(1, List.of(entity), null, null));
     when(securityContextProvider.isAuthorized(
             processId,
             authentication,

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -231,13 +231,15 @@ public final class SearchQueryResponseMapper {
   private static SearchQueryPageResponse toSearchQueryPageResponse(
       final SearchQueryResult<?> result) {
 
-    final List<Object> sortValues =
-        ofNullable(result.sortValues()).map(Arrays::asList).orElse(emptyList());
+    final List<Object> firstSortValues =
+        ofNullable(result.firstSortValues()).map(Arrays::asList).orElse(emptyList());
+    final List<Object> lastSortValues =
+        ofNullable(result.lastSortValues()).map(Arrays::asList).orElse(emptyList());
 
     return new SearchQueryPageResponse()
         .totalItems(result.total())
-        .firstSortValues(emptyList()) // FIXME https://github.com/camunda/camunda/issues/26080
-        .lastSortValues(sortValues);
+        .firstSortValues(firstSortValues)
+        .lastSortValues(lastSortValues);
   }
 
   private static List<ProcessDefinitionItem> toProcessDefinitions(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -57,7 +57,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -68,7 +68,8 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
       new Builder<DecisionDefinitionEntity>()
           .total(1L)
           .items(List.of(new DecisionDefinitionEntity(0L, "dId", "name", 1, "drId", 2L, "t")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   static final String DECISION_DEFINITIONS_SEARCH_URL = "/v2/decision-definitions/search";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionInstanceQueryControllerTest.java
@@ -69,7 +69,7 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                ],
                "page": {
                    "totalItems": 1,
-                   "firstSortValues": [],
+                   "firstSortValues": ["f"],
                    "lastSortValues": [
                        "v"
                    ]
@@ -98,7 +98,8 @@ public class DecisionInstanceQueryControllerTest extends RestControllerTest {
                       "result",
                       null,
                       null)))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   @MockBean private DecisionInstanceServices decisionInstanceServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -56,7 +56,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -66,7 +66,8 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
       new Builder<DecisionRequirementsEntity>()
           .total(1L)
           .items(List.of(new DecisionRequirementsEntity(0L, "id", "name", 1, "rN", null, "t")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   static final String DECISION_REQUIREMENTS_SEARCH_URL = "/v2/decision-requirements/search";

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/FlowNodeInstanceQueryControllerTest.java
@@ -61,7 +61,7 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -87,7 +87,8 @@ public class FlowNodeInstanceQueryControllerTest extends RestControllerTest {
                       null,
                       "bpmnProcessId",
                       "<default>")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   static final String EXPECTED_GET_RESPONSE =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/IncidentQueryControllerTest.java
@@ -58,7 +58,7 @@ public class IncidentQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -83,7 +83,8 @@ public class IncidentQueryControllerTest extends RestControllerTest {
                       IncidentState.ACTIVE,
                       101L,
                       "tenantId")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   static final String EXPECTED_GET_RESPONSE =

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessDefinitionQueryControllerTest.java
@@ -81,7 +81,7 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
           ],
           "page": {
               "totalItems": 1,
-              "firstSortValues": [],
+              "firstSortValues": ["f"],
               "lastSortValues": [
                   "v"
               ]
@@ -102,7 +102,8 @@ public class ProcessDefinitionQueryControllerTest extends RestControllerTest {
                       "alpha",
                       "<default>",
                       "formId")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
   private static final String FORM_ITEM_JSON =
       """

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -104,7 +104,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -116,7 +116,8 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
       new Builder<ProcessInstanceEntity>()
           .total(1L)
           .items(List.of(PROCESS_INSTANCE_ENTITY))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   @MockBean ProcessInstanceServices processInstanceServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -87,7 +87,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -111,7 +111,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
         ],
         "page": {
           "totalItems": 1,
-          "firstSortValues": [],
+          "firstSortValues": ["f"],
           "lastSortValues": [
             "v"
           ]
@@ -186,7 +186,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
                       Collections.emptyMap(), // customHeaders
                       50 // priority
                       )))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   private static final SearchQueryResult<VariableEntity> SEARCH_VAR_QUERY_RESULT =
@@ -196,7 +197,8 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               List.of(
                   new VariableEntity(
                       0L, "name", "value", "test", false, 1L, 2L, "bpid", "<default>")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   @MockBean UserTaskServices userTaskServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/VariablesQueryControllerTest.java
@@ -74,7 +74,7 @@ public class VariablesQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -86,7 +86,8 @@ public class VariablesQueryControllerTest extends RestControllerTest {
       new Builder<VariableEntity>()
           .total(1L)
           .items(List.of(new VariableEntity(0L, "n", "v", "v", false, 2L, 3L, "bpid", "<default>")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
   @MockBean VariableServices variableServices;
   @Captor ArgumentCaptor<VariableQuery> variableQueryCaptor;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/tenant/TenantQueryControllerTest.java
@@ -69,8 +69,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
          ],
          "page": {
            "totalItems": %d,
-           "firstSortValues": [],
-           "lastSortValues": []
+           "firstSortValues": ["f"],
+           "lastSortValues": ["v"]
          }
        }
       """
@@ -170,7 +170,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
         .thenReturn(
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(3)
-                .sortValues(new Object[] {})
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .items(TENANT_ENTITIES)
                 .build());
 
@@ -200,6 +201,8 @@ public class TenantQueryControllerTest extends RestControllerTest {
             new SearchQueryResult.Builder<TenantEntity>()
                 .total(TENANT_ENTITIES.size())
                 .items(TENANT_ENTITIES)
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .build());
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/AuthorizationQueryControllerTest.java
@@ -59,7 +59,7 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 1,
-               "firstSortValues": [],
+               "firstSortValues": ["f"],
                "lastSortValues": [
                  "v"
                ]
@@ -79,7 +79,8 @@ public class AuthorizationQueryControllerTest extends RestControllerTest {
                       OwnerTypeEnum.USER.getValue(),
                       ResourceTypeEnum.PROCESS_DEFINITION.getValue(),
                       List.of(new Permission(PermissionType.CREATE, Set.of("2"))))))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   @MockBean private AuthorizationServices authorizationServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/GroupQueryControllerTest.java
@@ -59,8 +59,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         ],
         "page":{
           "totalItems":3,
-          "firstSortValues":[],
-          "lastSortValues":[]
+          "firstSortValues":["f"],
+          "lastSortValues":["v"]
         }
       }
       """;
@@ -147,7 +147,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
         .thenReturn(
             new SearchQueryResult.Builder<GroupEntity>()
                 .total(3)
-                .sortValues(new Object[] {})
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
                         new GroupEntity(groupKey1, groupName1, Set.of()),
@@ -187,8 +188,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": [],
-               "lastSortValues": []
+               "firstSortValues": ["f"],
+               "lastSortValues": ["v"]
              }
            }"""
                 .formatted(groupKey1, groupName1, groupKey2, groupName2, groupKey3, groupName3));
@@ -214,6 +215,8 @@ public class GroupQueryControllerTest extends RestControllerTest {
                         new GroupEntity(groupKey1, groupName1, Set.of()),
                         new GroupEntity(groupKey2, groupName2, Set.of()),
                         new GroupEntity(groupKey3, groupName3, Set.of())))
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .build());
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/MappingQueryControllerTest.java
@@ -105,7 +105,8 @@ public class MappingQueryControllerTest extends RestControllerTest {
         .thenReturn(
             new SearchQueryResult.Builder<MappingEntity>()
                 .total(3)
-                .sortValues(new Object[] {})
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
                         new MappingEntity(100L, "Claim Name1", "Claim Value1"),
@@ -148,8 +149,8 @@ public class MappingQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": [],
-               "lastSortValues": []
+               "firstSortValues": ["f"],
+               "lastSortValues": ["v"]
              }
            }""");
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/RoleQueryControllerTest.java
@@ -103,7 +103,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
         .thenReturn(
             new SearchQueryResult.Builder<RoleEntity>()
                 .total(3)
-                .sortValues(new Object[] {})
+                .firstSortValues(new Object[] {"f"})
+                .lastSortValues(new Object[] {"v"})
                 .items(
                     List.of(
                         new RoleEntity(100L, "Role 1"),
@@ -143,8 +144,8 @@ public class RoleQueryControllerTest extends RestControllerTest {
              ],
              "page": {
                "totalItems": 3,
-               "firstSortValues": [],
-               "lastSortValues": []
+               "firstSortValues": ["f"],
+               "lastSortValues": ["v"]
              }
            }""");
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/usermanagement/UserQueryControllerTest.java
@@ -48,7 +48,7 @@ public class UserQueryControllerTest extends RestControllerTest {
               ],
               "page": {
                   "totalItems": 1,
-                  "firstSortValues": [],
+                  "firstSortValues": ["f"],
                   "lastSortValues": [
                       "v"
                   ]
@@ -60,7 +60,8 @@ public class UserQueryControllerTest extends RestControllerTest {
       new Builder<UserEntity>()
           .total(1L)
           .items(List.of(new UserEntity(1L, "username1", "name1", "email1", "password1")))
-          .sortValues(new Object[] {"v"})
+          .firstSortValues(new Object[] {"f"})
+          .lastSortValues(new Object[] {"v"})
           .build();
 
   @MockBean UserServices userServices;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
We need to return the `firstSortValues` in the search response so that it can be used to fetch the previous page

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #26080 
