### PR TITLE
Fix exporter index creation failures (already-exists exceptions)

### DIFF
--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -29,6 +29,7 @@ public final class ExporterTestContext implements Context {
   private Configuration configuration;
   private RecordFilter recordFilter;
   private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+  private int partitionId;
 
   @Override
   public MeterRegistry getMeterRegistry() {
@@ -52,12 +53,17 @@ public final class ExporterTestContext implements Context {
 
   @Override
   public int getPartitionId() {
-    return 0;
+    return partitionId;
   }
 
   @Override
   public void setFilter(final RecordFilter filter) {
     recordFilter = filter;
+  }
+
+  public ExporterTestContext setPartitionId(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
   }
 
   public ExporterTestContext setConfiguration(final Configuration configuration) {


### PR DESCRIPTION
## Description

Exporter failed and logged errors when starting in parallel with other partitions. All tried to created a schema. In general not a problem as failing caused retry and detected existing schema. But this causes noise and unnecessary error reports and red herings.

## PR 

 * Add new test to validate multiple exporter opens for multiple partitions
 * Add partition support on TestContext
 * Handle index creation for already exist exceptions

## Related issues

closes https://github.com/camunda/camunda/issues/25812
closes https://github.com/camunda/camunda/issues/25814
